### PR TITLE
feat(roadmap): decision log — rejected items keep their row and rationale

### DIFF
--- a/src-tauri/migrations/0037_roadmap_close_reason.sql
+++ b/src-tauri/migrations/0037_roadmap_close_reason.sql
@@ -1,0 +1,29 @@
+-- The decision log: why an item was ruled off the board.
+--
+-- Why this exists: until now, ruling an item off the board deleted its row —
+-- the PM's discard ask, once accepted, called the same DELETE as the trash
+-- button, and the item's whole history cascaded away with it. That made the
+-- board's most consequential decisions its least documented ones: "we are not
+-- doing this, and here is why" evaporated the moment it was made, so the PM's
+-- next session could re-propose the same work and nobody could say it had
+-- already been turned down. So items ruled off the board now become `rejected`
+-- instead of gone: the row stays, the trail stays, and this column carries the
+-- reason in force. Reopening clears it — an item back on the board owes nobody
+-- an epitaph.
+--
+-- NULL for every row that hasn't been rejected; `Some` exactly when `status`
+-- is 'rejected', the same pairing discipline as `hold_reason`/`held_by` (0033).
+-- Written only by the typed reject command and the discard ruling — the column
+-- is deliberately absent from the generic patch surface, so no edit can rule an
+-- item off the board by accident.
+--
+-- `status` needs no schema change of its own: it is a plain TEXT column with no
+-- CHECK constraint (see 0035's rebuild), so the new 'rejected' spelling is a
+-- code-level fact, enforced by the enum that reads and writes it.
+--
+-- Plain ADD COLUMN, deliberately, like 0036: no table rebuild. A nullable TEXT
+-- column with no constraint and no default is the one shape SQLite adds in O(1).
+--
+-- The hard delete (`roadmap_delete_item`) survives this migration unchanged —
+-- it is typo cleanup, not a ruling, and rows removed by it still record nothing.
+ALTER TABLE roadmap_items ADD COLUMN close_reason TEXT;

--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -70,6 +70,7 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0034_roadmap_briefs.sql"),
     include_str!("../../migrations/0035_roadmap_items_drop_dormant.sql"),
     include_str!("../../migrations/0036_roadmap_issue_url.sql"),
+    include_str!("../../migrations/0037_roadmap_close_reason.sql"),
 ];
 
 pub(crate) fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/instructions/roadmap.md
+++ b/src-tauri/src/instructions/roadmap.md
@@ -37,7 +37,11 @@ cat "$FLETCH_RPC_DIR/responses/$ID.json"
 ```
 
 Optional filter: `{"op":"roadmap_list","args":{"status":["open","done"]}}`.
-Statuses are `proposed | open | queued | active | in_review | done`.
+Statuses are `proposed | open | queued | active | in_review | done | rejected`.
+`rejected` is the decision log: an item ruled off the board keeps its row and
+its history, with the reason it was turned down. Read those before proposing —
+a rejected item is a direction the user already said no to, and only the user
+can reopen it.
 
 The array is in **board order**, which is also **dispatch order**: the queue
 builds items top to bottom (dependencies permitting), so the position of a code
@@ -48,7 +52,8 @@ Empty fields are omitted rather than sent as null. Per item:
 - `last_event` — the newest thing that happened to this item, when anything has:
   `kind` (`created | proposed | accepted | edited | queued |
   unqueued | dispatched | pr_opened | run_failed | run_canceled | run_deleted |
-  shipped | pr_closed | blocked | held | released | note`), the `detail` that kind carries when it
+  shipped | pr_closed | blocked | held | released | rejected | reopened |
+  note`), the `detail` that kind carries when it
   carries one (a failure reason, a PR url, a hold's reason, the text of a note),
   and `age` — how long ago, coarse
   (`"4m"`, `"2h"`, `"3d"`; absent means within the last minute). This is how you
@@ -58,8 +63,10 @@ Empty fields are omitted rather than sent as null. Per item:
   not a failure — three cancelled runs are not a failing pattern — and `pr_closed`
   means a pull request was closed unmerged and the item is back on the board.
   `blocked` is the one that will not resolve on its own: a dependency loop, a
-  missing workflow, a project with no repo, a pull request that stopped
-  answering. It is waiting on a person.
+  missing workflow, a project with no repo, a dependency that was rejected, a
+  pull request that stopped answering. It is waiting on a person. `rejected`
+  carries the reason the item was ruled off the board — a decision, already
+  made; `reopened` says the user reversed it and the item is back at `open`.
 - `pr` — `{"url"}` for an item whose run opened a pull request. `status` already
   says whether that PR is still open (`in_review`) or landed (`done`). You cannot
   read the diff from here; the URL is what you cite when you tell the user to
@@ -176,8 +183,10 @@ ask is dropped and the user is told which loop it would have made — read a fre
 ### `roadmap_propose_discard` — propose retiring an item
 
 When a ticket is obsolete — superseded, out of scope, wrong from the start —
-propose discarding it. `reason` is required: you are asking to remove work
-someone agreed to, so say why.
+propose discarding it. `reason` is required, and it outlives the ruling: an
+accepted discard does not delete the row, it marks the item `rejected` with
+your reason as the record of why. You are asking to rule out work someone
+agreed to, so write the sentence the decision log should keep.
 
 ```sh
 ID=$(uuidgen)
@@ -193,7 +202,9 @@ Rules for both, enforced by the app:
 
 - Only items that are `proposed`, `open`, or `queued` can be reshaped. An item
   that is `active` or `in_review` is being built or judged — the refusal names
-  its status; wait for it to settle back onto the board.
+  its status; wait for it to settle back onto the board. A `rejected` item was
+  ruled off the board: don't lobby it by proposal — if you think the decision
+  was wrong, say so in the conversation, and the user can reopen it.
 - One pending ask per item. Proposing again **replaces** your outstanding ask
   for that item, so send the whole change you want, not increments.
 - The ask is not the deed: the board applies nothing until the user accepts,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1675,6 +1675,8 @@ pub fn run() {
             roadmap::roadmap_release_project,
             roadmap::roadmap_get_project_hold,
             roadmap::roadmap_reclaim_item,
+            roadmap::roadmap_reject_item,
+            roadmap::roadmap_reopen_item,
             roadmap::roadmap_delete_item,
             roadmap::roadmap_list_item_events,
             roadmap::roadmap_latest_events,

--- a/src-tauri/src/roadmap/drainer.rs
+++ b/src-tauri/src/roadmap/drainer.rs
@@ -1035,14 +1035,48 @@ fn plan_and_claim(conn: &Connection, project_id: &str, cap: usize) -> Claim {
             // member waits on the next, so this item is skipped on every tick
             // from here to the end of the app's life. That is a durable fact
             // about the board, so it lands as a `blocked` event naming the loop
-            // (see .context/roadmap-pm-plan.md, A4).
+            // (see .context/roadmap-pm-plan.md, A4). A dependency that was
+            // *rejected* is the same kind of standing fact wearing a waiting
+            // note's clothes: the code still resolves, is never `done`, and no
+            // run is ever coming to make it so — only the user editing the dep
+            // list ends it, so it takes the durable path too.
             return match deps::find_cycle(&deps::graph_of(&items), &item.code) {
                 Some(cycle) => Claim::wedge(
                     conn,
                     item,
                     format!("Stuck in a dependency loop: {}", deps::loop_path(&cycle)),
                 ),
-                None => Claim::note(item, format!("Waiting on {}", waiting_on.join(", "))),
+                None => {
+                    let rejected: Vec<&str> = waiting_on
+                        .iter()
+                        .filter(|code| {
+                            items
+                                .iter()
+                                .any(|i| &i.code == *code && i.status == ItemStatus::Rejected)
+                        })
+                        .map(String::as_str)
+                        .collect();
+                    match rejected.as_slice() {
+                        [] => Claim::note(item, format!("Waiting on {}", waiting_on.join(", "))),
+                        [code] => Claim::wedge(
+                            conn,
+                            item,
+                            format!(
+                                "Waiting on {code}, which was rejected — remove or replace \
+                                 that dependency."
+                            ),
+                        ),
+                        many => Claim::wedge(
+                            conn,
+                            item,
+                            format!(
+                                "Waiting on {}, which were rejected — remove or replace \
+                                 those dependencies.",
+                                many.join(", ")
+                            ),
+                        ),
+                    }
+                }
             };
         }
         // Nothing to say: an empty queue is silence, and being at capacity is

--- a/src-tauri/src/roadmap/drainer/tests.rs
+++ b/src-tauri/src/roadmap/drainer/tests.rs
@@ -35,6 +35,7 @@ fn item(code: &str, rank: f64) -> RoadmapItem {
         hold_reason: None,
         held_by: None,
         held_at: None,
+        close_reason: None,
         issue_url: None,
         created_at: 0,
         updated_at: 0,
@@ -195,6 +196,33 @@ fn a_dependant_of_a_held_done_item_stays_blocked() {
             &known
         ),
         Decision::Dispatch(0)
+    );
+}
+
+/// Ruled off the board is not shipped: a dependant must never fork on work
+/// that was decided against. The rejected item's code stays `known` (the row
+/// still exists), so the dependant blocks — it does not sail through the
+/// deleted-dep hole, and it does not dispatch.
+#[test]
+fn a_rejected_item_is_never_a_landed_dependency() {
+    let mut dep = item("FLT-100", 1.0);
+    dep.status = ItemStatus::Rejected;
+    dep.close_reason = Some("out of scope".into());
+    let mut dependant = item("FLT-101", 2.0);
+    dependant.deps = vec!["FLT-100".into()];
+
+    let board = vec![dep, dependant];
+    let known = codes(&["FLT-100", "FLT-101"]);
+    assert!(
+        done_codes(&board).is_empty(),
+        "a rejected item satisfies nobody's dependency"
+    );
+    assert_eq!(
+        pick_next(&dispatchable(&board), 0, 1, &done_codes(&board), &known),
+        Decision::Blocked {
+            item_id: "id-FLT-101".into(),
+            waiting_on: vec!["FLT-100".into()],
+        }
     );
 }
 
@@ -1002,6 +1030,71 @@ fn a_wedged_queue_head_records_one_blocked_event_not_one_per_tick() {
         "a durable line must not repeat per tick"
     );
     assert_eq!(events::list_for_item(&conn, &a.id).unwrap().len(), 1);
+}
+
+/// A dep still being built is a wait; a dep the user *rejected* is a wedge.
+/// The code is known, never done, and no run is ever coming to make it so —
+/// only editing the dep list ends it. So the same "Waiting on" shape flips
+/// from the transient note to the durable line the moment the ruling lands,
+/// and lands once, not once a tick.
+#[test]
+fn a_dependant_of_a_rejected_item_wedges_durably() {
+    let conn = test_conn();
+    let dep = db_item(&conn, ItemStatus::Active);
+    let dependant = db_item(&conn, ItemStatus::Queued);
+    set_deps(&conn, &dependant, &[&dep.code]);
+
+    // While the dep is being built the wait resolves itself: a note, no row.
+    let Claim::Note { text, recorded, .. } = plan_and_claim(&conn, "p1", 1) else {
+        panic!("expected a waiting note");
+    };
+    assert!(text.contains(&dep.code), "{text}");
+    assert!(recorded.is_none(), "a dep still being built is transient");
+
+    // The user rules the dep off the board: the same wait is now standing.
+    store::reject(&conn, &dep.id, "not doing this").unwrap();
+    let Claim::Note {
+        item,
+        text,
+        recorded,
+    } = plan_and_claim(&conn, "p1", 1)
+    else {
+        panic!("expected a note about the wedged dependant");
+    };
+    assert_eq!(item.id, dependant.id);
+    assert!(
+        text.contains(&dep.code) && text.contains("rejected"),
+        "the wedge names the dep and the decision: {text}"
+    );
+    assert!(text.contains("remove or replace"), "{text}");
+    let event = recorded.expect("a dep nobody will build is a durable blockage");
+    assert_eq!(event.kind, EventKind::Blocked);
+    assert_eq!(event.actor, EventActor::Drainer);
+    assert_eq!(event.detail.as_deref(), Some(text.as_str()));
+
+    // Once, not once a tick — the same dedup every standing wedge gets.
+    let Claim::Note { recorded, .. } = plan_and_claim(&conn, "p1", 1) else {
+        panic!("expected a note");
+    };
+    assert!(
+        recorded.is_none(),
+        "a durable line must not repeat per tick"
+    );
+    assert_eq!(
+        events::list_for_item(&conn, &dependant.id).unwrap().len(),
+        1
+    );
+
+    // Reopening the dep turns the standing wedge back into an ordinary wait.
+    store::reopen(&conn, &dep.id).unwrap();
+    let Claim::Note { text, recorded, .. } = plan_and_claim(&conn, "p1", 1) else {
+        panic!("expected a waiting note");
+    };
+    assert!(!text.contains("rejected"), "{text}");
+    assert!(
+        recorded.is_none(),
+        "waiting on live work is transient again"
+    );
 }
 
 /// The partition, over every condition this function can reach: *standing*

--- a/src-tauri/src/roadmap/events.rs
+++ b/src-tauri/src/roadmap/events.rs
@@ -64,11 +64,15 @@ crate::db_enum! {
     /// perfectly alive). See [`super::drainer::release_kind`] for the mapping and
     /// .context/roadmap-pm-plan.md (review finding S1) for the argument.
     ///
-    /// No variant without a writer: `discarded` was declared and never written —
-    /// discarding an item deletes the row (its history cascades away with it)
-    /// and declining a PM proposal writes a `note` — so it is gone rather than
-    /// left as a kind the frontend must label and nothing produces. `abandoned`
-    /// went the same way when its one writer started naming its fact.
+    /// No variant without a writer: an early `discarded` kind was declared and
+    /// never written, so it was removed rather than left as a kind the frontend
+    /// must label and nothing produces; `abandoned` went the same way when its
+    /// one writer started naming its fact. `rejected` is not that kind reborn —
+    /// it has two writers from the day it exists (the typed reject command and
+    /// the PM discard ruling), because ruling an item off the board now keeps
+    /// the row as the decision log instead of deleting it. Only the *hard*
+    /// delete (`roadmap_delete_item`, typo cleanup) still removes rows, and it
+    /// still records nothing — its trail cascades away with the row.
     ///
     /// `held`/`released` are the odd pair: they name no status move at all (a
     /// hold stops autonomous progress and leaves the row exactly where it is —
@@ -95,6 +99,8 @@ crate::db_enum! {
         Blocked     => "blocked",
         Held        => "held",
         Released    => "released",
+        Rejected    => "rejected",
+        Reopened    => "reopened",
         Note        => "note",
     }
 }
@@ -568,7 +574,7 @@ mod tests {
     /// macro produces no iterator, and a missing entry here would quietly weaken
     /// them — so the count is asserted against both the frontend's union and the
     /// instructions' list.
-    const ALL_KINDS: [EventKind; 17] = [
+    const ALL_KINDS: [EventKind; 19] = [
         EventKind::Created,
         EventKind::Proposed,
         EventKind::Accepted,
@@ -585,6 +591,8 @@ mod tests {
         EventKind::Blocked,
         EventKind::Held,
         EventKind::Released,
+        EventKind::Rejected,
+        EventKind::Reopened,
         EventKind::Note,
     ];
 

--- a/src-tauri/src/roadmap/merge_sweep/tests.rs
+++ b/src-tauri/src/roadmap/merge_sweep/tests.rs
@@ -31,6 +31,7 @@ fn in_review(code: &str, number: Option<i64>) -> RoadmapItem {
         hold_reason: None,
         held_by: None,
         held_at: None,
+        close_reason: None,
         issue_url: None,
         created_at: 10,
         updated_at: 10,

--- a/src-tauri/src/roadmap/mod.rs
+++ b/src-tauri/src/roadmap/mod.rs
@@ -349,6 +349,17 @@ fn update_and_record(
     expect_status: Option<ItemStatus>,
     queue: bool,
 ) -> Result<(Option<ItemUpdate>, Option<ItemEvent>), String> {
+    // `rejected` is not a status a generic edit may write: it would land with a
+    // NULL `close_reason` and a bare "Edited" line — a decision-log entry with
+    // no decision, the exact row migration 0037 promises cannot exist. The one
+    // door is the typed reject command, which demands the reason.
+    if patch.status == Some(ItemStatus::Rejected) {
+        return Err(
+            "an item is ruled off the board with roadmap_reject_item, which requires a \
+             reason — not a status edit"
+                .into(),
+        );
+    }
     if let Some(new_deps) = &patch.deps {
         // A row that is already gone falls through to the normal "no longer
         // exists" path below rather than being refused for its deps.
@@ -1081,6 +1092,17 @@ fn reject_item(
                 .into(),
         );
     }
+    // Same ceiling as a hold's reason, for the same reason: this line renders on
+    // a card and in the PM's listing. The ruling belongs here; the argument for
+    // it belongs in the conversation.
+    let length = reason.chars().count();
+    if length > holds::MAX_REASON {
+        return Err(format!(
+            "`reason` is {length} characters — keep it under {}. Say the ruling; the \
+             argument for it belongs in the conversation",
+            holds::MAX_REASON
+        ));
+    }
     let current = store::get(conn, item_id)
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("roadmap item {item_id} no longer exists"))?;
@@ -1137,7 +1159,7 @@ pub async fn roadmap_reopen_item(
     app: AppHandle,
     db: tauri::State<'_, Db>,
 ) -> Result<RoadmapItem, String> {
-    let (item, event) = {
+    let (item, event, corrections) = {
         let conn = db.lock();
         reopen_item(&conn, &item_id)?
     };
@@ -1149,6 +1171,9 @@ pub async fn roadmap_reopen_item(
         emit_item_event(&app, event);
         // A dependant wedged on this item's rejection is merely waiting again.
         drainer::nudge();
+    }
+    for note in &corrections {
+        emit_item_event(&app, note);
     }
     Ok(item)
 }
@@ -1162,14 +1187,14 @@ pub async fn roadmap_reopen_item(
 fn reopen_item(
     conn: &Connection,
     item_id: &str,
-) -> Result<(RoadmapItem, Option<ItemEvent>), String> {
+) -> Result<(RoadmapItem, Option<ItemEvent>, Vec<ItemEvent>), String> {
     // Read before the flip: the detail the `reopened` event quotes is the
     // reason the write is about to clear.
     let current = store::get(conn, item_id)
         .map_err(|e| e.to_string())?
         .ok_or_else(|| format!("roadmap item {item_id} no longer exists"))?;
     let Some(item) = store::reopen(conn, item_id).map_err(|e| e.to_string())? else {
-        return Ok((current, None));
+        return Ok((current, None, Vec::new()));
     };
     // `close_reason` is `Some` exactly when the row is rejected, but a row
     // written before that invariant held costs a shorter line, not a panic.
@@ -1186,7 +1211,62 @@ fn reopen_item(
         Some(&detail),
     )
     .map_err(|e| e.to_string())?;
-    Ok((item, Some(event)))
+    let corrections = correct_wedged_dependants(conn, &item)?;
+    Ok((item, Some(event), corrections))
+}
+
+/// Un-say the rejection on the items that were told about it. The drainer
+/// writes a *durable* `blocked` line on a queued dependant when its dep is
+/// rejected ("…which was rejected — remove or replace that dependency"), and
+/// that line is what "Needs you" and the PM's `last_event` read — so once the
+/// dep is reopened, the trail is asserting an instruction that is no longer
+/// true, and nothing else would ever correct it (the drainer's re-derived note
+/// flips back, the durable trail doesn't). One `note` per wedged dependant
+/// displaces the stale line; it also un-jams [`drainer`]'s wedge dedup, which
+/// compares against the latest event — so a later re-rejection writes a fresh
+/// wedge instead of being swallowed as "already said".
+///
+/// Only dependants whose latest durable line IS that wedge get one: a dependant
+/// the drainer never got to (or one wedged on something else since) has no
+/// false line to correct, and a note there would be noise.
+fn correct_wedged_dependants(
+    conn: &Connection,
+    reopened: &RoadmapItem,
+) -> Result<Vec<ItemEvent>, String> {
+    let board = store::list(conn, &reopened.project_id).map_err(|e| e.to_string())?;
+    let mut notes = Vec::new();
+    for dep in board
+        .iter()
+        .filter(|i| i.status == ItemStatus::Queued && i.deps.contains(&reopened.code))
+    {
+        let latest = events::list_for_item(conn, &dep.id)
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .next();
+        let wedged = latest.is_some_and(|e| {
+            e.kind == EventKind::Blocked
+                && e.detail
+                    .as_deref()
+                    .is_some_and(|d| d.contains(&reopened.code) && d.contains("rejected"))
+        });
+        if !wedged {
+            continue;
+        }
+        let note = events::record(
+            conn,
+            &dep.id,
+            &dep.project_id,
+            EventActor::User,
+            EventKind::Note,
+            Some(&format!(
+                "{} was reopened — waiting on it normally again",
+                reopened.code
+            )),
+        )
+        .map_err(|e| e.to_string())?;
+        notes.push(note);
+    }
+    Ok(notes)
 }
 
 /// Delete an item. Silent when the row is already gone — the caller's intent
@@ -2387,7 +2467,7 @@ mod tests {
         let it = with_status(&conn, ItemStatus::Queued);
         reject_item(&conn, &it.id, "parked for the rewrite").unwrap();
 
-        let (item, event) = reopen_item(&conn, &it.id).unwrap();
+        let (item, event, _) = reopen_item(&conn, &it.id).unwrap();
         assert_eq!(item.status, ItemStatus::Open);
         assert_eq!(
             item.close_reason, None,
@@ -2404,7 +2484,7 @@ mod tests {
         assert_eq!(events::list_for_item(&conn, &it.id).unwrap().len(), 2);
 
         // A second click races the first and loses cleanly: no second stamp.
-        let (again, event) = reopen_item(&conn, &it.id).unwrap();
+        let (again, event, _) = reopen_item(&conn, &it.id).unwrap();
         assert_eq!(again.status, ItemStatus::Open);
         assert!(event.is_none());
     }
@@ -2418,12 +2498,138 @@ mod tests {
         let conn = test_conn();
         for status in [ItemStatus::Open, ItemStatus::Queued, ItemStatus::Done] {
             let it = with_status(&conn, status);
-            let (item, event) = reopen_item(&conn, &it.id).unwrap();
+            let (item, event, _) = reopen_item(&conn, &it.id).unwrap();
             assert_eq!(item.status, status, "the row comes back as it actually is");
             assert!(event.is_none());
             assert!(events::list_for_item(&conn, &it.id).unwrap().is_empty());
         }
         assert!(reopen_item(&conn, "no-such-item").is_err());
+    }
+
+    /// Reopening un-says the rejection on the items that were told about it.
+    /// The drainer's rejected-dep wedge is a *durable* line — "Needs you" and
+    /// the PM's `last_event` read it — and nothing else corrects it once the
+    /// dep is back: the corrective note must displace it, which is also what
+    /// lets a later re-rejection write a fresh wedge (the drainer's dedup
+    /// compares against the latest event).
+    #[test]
+    fn reopening_corrects_the_wedge_on_queued_dependants() {
+        let conn = test_conn();
+        let dep = with_status(&conn, ItemStatus::Open);
+        // A queued dependant the drainer wedged, and two rows that must NOT be
+        // touched: a queued item with no dep on it, and an open dependant.
+        let wedged = with_status(&conn, ItemStatus::Queued);
+        store::update(
+            &conn,
+            &wedged.id,
+            &ItemPatch {
+                deps: Some(vec![dep.code.clone()]),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let unrelated = with_status(&conn, ItemStatus::Queued);
+        let unwedged = with_status(&conn, ItemStatus::Open);
+        store::update(
+            &conn,
+            &unwedged.id,
+            &ItemPatch {
+                deps: Some(vec![dep.code.clone()]),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        reject_item(&conn, &dep.id, "parked").unwrap();
+        // The wedge, exactly as the drainer records it.
+        events::record(
+            &conn,
+            &wedged.id,
+            "p1",
+            EventActor::Drainer,
+            EventKind::Blocked,
+            Some(&format!(
+                "Waiting on {}, which was rejected — remove or replace that dependency.",
+                dep.code
+            )),
+        )
+        .unwrap();
+
+        let (_, _, corrections) = reopen_item(&conn, &dep.id).unwrap();
+        assert_eq!(corrections.len(), 1, "only the wedged dependant is told");
+        assert_eq!(corrections[0].item_id, wedged.id);
+        assert_eq!(corrections[0].kind, EventKind::Note);
+
+        // The note is now the dependant's latest line — which is what clears
+        // "Needs you", fixes the PM's `last_event`, and un-jams the drainer's
+        // wedge dedup for a future re-rejection.
+        let latest = events::list_for_item(&conn, &wedged.id).unwrap();
+        assert_eq!(latest[0].kind, EventKind::Note);
+        assert_eq!(
+            latest[0].detail.as_deref(),
+            Some(format!("{} was reopened — waiting on it normally again", dep.code).as_str())
+        );
+        assert!(events::list_for_item(&conn, &unrelated.id)
+            .unwrap()
+            .is_empty());
+        assert!(events::list_for_item(&conn, &unwedged.id)
+            .unwrap()
+            .is_empty());
+    }
+
+    /// A legacy held-while-rejected row (hand-edited, or written before the
+    /// hold gate existed) comes back to the board unheld: [`store::reject`]
+    /// enforces "a rejection supersedes a pause" going in, [`store::reopen`]
+    /// enforces it coming out.
+    #[test]
+    fn reopening_clears_a_legacy_hold() {
+        let conn = test_conn();
+        let it = with_status(&conn, ItemStatus::Open);
+        reject_item(&conn, &it.id, "parked").unwrap();
+        conn.execute(
+            "UPDATE roadmap_items SET hold_reason = 'stale', held_by = 'pm', held_at = 1
+             WHERE id = ?1",
+            [&it.id],
+        )
+        .unwrap();
+
+        let (item, _, _) = reopen_item(&conn, &it.id).unwrap();
+        assert_eq!(item.hold_reason, None, "no secret pause survives a reopen");
+        assert_eq!(item.held_by, None);
+        assert_eq!(item.held_at, None);
+    }
+
+    /// `rejected` is unreachable by generic edit: it would land without a
+    /// reason and without a `rejected` line — a decision-log entry with no
+    /// decision. The typed command is the only door.
+    #[test]
+    fn a_generic_status_patch_cannot_reject() {
+        let conn = test_conn();
+        let it = with_status(&conn, ItemStatus::Open);
+        let err = update_and_record(
+            &conn,
+            &it.id,
+            &status_patch(ItemStatus::Rejected),
+            None,
+            false,
+        )
+        .unwrap_err();
+        assert!(err.contains("roadmap_reject_item"), "{err}");
+        let row = store::get(&conn, &it.id).unwrap().unwrap();
+        assert_eq!(row.status, ItemStatus::Open, "nothing written");
+        assert!(events::list_for_item(&conn, &it.id).unwrap().is_empty());
+    }
+
+    /// The reason shares a hold's ceiling: it renders as one line on the card
+    /// and in the PM's listing, and past that it's the argument, not the
+    /// ruling. Counted in characters, like the hold's, so an em-dash costs one.
+    #[test]
+    fn an_oversize_reason_refuses_the_rejection() {
+        let conn = test_conn();
+        let it = with_status(&conn, ItemStatus::Open);
+        let err = reject_item(&conn, &it.id, &"x".repeat(holds::MAX_REASON + 1)).unwrap_err();
+        assert!(err.contains("characters"), "{err}");
+        assert!(reject_item(&conn, &it.id, &"—".repeat(holds::MAX_REASON)).is_ok());
     }
 
     /// A pending update proposal for a test item, straight through the DAO —

--- a/src-tauri/src/roadmap/mod.rs
+++ b/src-tauri/src/roadmap/mod.rs
@@ -1024,12 +1024,179 @@ fn reclaim(conn: &Connection, item_id: &str) -> Result<(RoadmapItem, ItemEvent),
     Ok((item, event))
 }
 
+// ───────────────────────── the decision log ─────────────────────────────
+
+/// Rule an item off the board — the decision that used to be a delete, kept as
+/// a row instead. The item becomes `rejected` with `close_reason` = why, its
+/// trail intact and a `rejected` line appended, so "we are not doing this, and
+/// here is why" survives to be read — by the card, by the PM's next session,
+/// and by whoever wonders in three months. Reopening
+/// ([`roadmap_reopen_item`]) is the undo.
+///
+/// The reason is mandatory: the row this leaves behind *is* the decision log,
+/// and a rejection that can't say why is just a slower delete. Allowed from the
+/// pre-work statuses only (`proposed | open | queued` — a queued item leaves
+/// the queue by being rejected); an `active`/`in_review` item has an agent on
+/// it, and a `done` one already shipped — neither can be un-decided from here.
+///
+/// A rejection supersedes a pause: any hold is cleared (the trail keeps the
+/// hold's history), the agent stamp comes off, and a pending PM proposal on the
+/// item is consumed — a dead item's ask shouldn't haunt anything.
+#[tauri::command]
+pub async fn roadmap_reject_item(
+    item_id: String,
+    reason: String,
+    app: AppHandle,
+    db: tauri::State<'_, Db>,
+) -> Result<RoadmapItem, String> {
+    let (item, event, pending) = {
+        let conn = db.lock();
+        reject_item(&conn, &item_id, &reason)?
+    };
+    emit_item(&app, &item);
+    emit_item_event(&app, &event);
+    if let Some(p) = &pending {
+        emit_proposal_deleted(&app, &p.id);
+    }
+    // A rejected item leaves the queue, and a dependant waiting on it is now
+    // wedged rather than waiting — the drainer should say which within a beat,
+    // not a tick.
+    drainer::nudge();
+    Ok(item)
+}
+
+/// The one write behind [`roadmap_reject_item`]: check the gate, consume any
+/// pending proposal, flip the row, and record the ruling — one lock scope, so a
+/// row that says it is rejected always carries the line saying why.
+fn reject_item(
+    conn: &Connection,
+    item_id: &str,
+    reason: &str,
+) -> Result<(RoadmapItem, ItemEvent, Option<Proposal>), String> {
+    let reason = reason.trim();
+    if reason.is_empty() {
+        return Err(
+            "`reason` is required — the rejected row is the decision log, and the reason \
+             is the decision"
+                .into(),
+        );
+    }
+    let current = store::get(conn, item_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("roadmap item {item_id} no longer exists"))?;
+    match current.status {
+        ItemStatus::Proposed | ItemStatus::Open | ItemStatus::Queued => {}
+        ItemStatus::Active | ItemStatus::InReview => {
+            return Err(format!(
+                "{} is {} — an agent is on it; cancel or settle the run before ruling \
+                 this off the board",
+                current.code,
+                current.status.as_str()
+            ))
+        }
+        ItemStatus::Done => {
+            return Err(format!(
+                "{} is done — shipped work can't be un-decided",
+                current.code
+            ))
+        }
+        ItemStatus::Rejected => {
+            return Err(format!("{} is already rejected", current.code));
+        }
+    }
+    // Consumed under the same lock as the ruling, like the delete path: the
+    // board would otherwise count a ghost proposal forever.
+    let pending = proposals::for_item(conn, item_id).map_err(|e| e.to_string())?;
+    if let Some(p) = &pending {
+        proposals::delete(conn, &p.id).map_err(|e| e.to_string())?;
+    }
+    let item = store::reject(conn, item_id, reason)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("roadmap item {item_id} no longer exists"))?;
+    let event = events::record(
+        conn,
+        &item.id,
+        &item.project_id,
+        EventActor::User,
+        EventKind::Rejected,
+        Some(reason),
+    )
+    .map_err(|e| e.to_string())?;
+    Ok((item, event, pending))
+}
+
+/// Put a rejected item back on the board, at `open` — the decision log's undo,
+/// and the only exit from `rejected`.
+///
+/// Records a `reopened` event whose detail quotes the reason being shed
+/// ("was rejected — …"), so the trail reads as a pair — why we ruled it off,
+/// and that we changed our mind — rather than as an unexplained resurrection.
+#[tauri::command]
+pub async fn roadmap_reopen_item(
+    item_id: String,
+    app: AppHandle,
+    db: tauri::State<'_, Db>,
+) -> Result<RoadmapItem, String> {
+    let (item, event) = {
+        let conn = db.lock();
+        reopen_item(&conn, &item_id)?
+    };
+    emit_item(&app, &item);
+    // No event when the row wasn't rejected: like a release on an unheld row,
+    // reopening something already open is a no-op, and a `reopened` line for it
+    // would be a fact that never happened.
+    if let Some(event) = &event {
+        emit_item_event(&app, event);
+        // A dependant wedged on this item's rejection is merely waiting again.
+        drainer::nudge();
+    }
+    Ok(item)
+}
+
+/// The one write behind [`roadmap_reopen_item`]: the guarded flip and its
+/// record, in the caller's single lock scope. The precondition rides
+/// [`store::reopen`]'s own `WHERE` (`status = rejected`), so a stale click —
+/// the item was already reopened, or was never rejected — misses cleanly:
+/// nothing is written, nothing is stamped, and the caller gets the row as it
+/// actually is.
+fn reopen_item(
+    conn: &Connection,
+    item_id: &str,
+) -> Result<(RoadmapItem, Option<ItemEvent>), String> {
+    // Read before the flip: the detail the `reopened` event quotes is the
+    // reason the write is about to clear.
+    let current = store::get(conn, item_id)
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("roadmap item {item_id} no longer exists"))?;
+    let Some(item) = store::reopen(conn, item_id).map_err(|e| e.to_string())? else {
+        return Ok((current, None));
+    };
+    // `close_reason` is `Some` exactly when the row is rejected, but a row
+    // written before that invariant held costs a shorter line, not a panic.
+    let detail = match &current.close_reason {
+        Some(reason) => format!("was rejected — {reason}"),
+        None => "was rejected".to_string(),
+    };
+    let event = events::record(
+        conn,
+        &item.id,
+        &item.project_id,
+        EventActor::User,
+        EventKind::Reopened,
+        Some(&detail),
+    )
+    .map_err(|e| e.to_string())?;
+    Ok((item, Some(event)))
+}
+
 /// Delete an item. Silent when the row is already gone — the caller's intent
 /// ("this should not be on the board") is satisfied either way.
 ///
-/// Deletion records no history event on purpose: `roadmap_item_events` cascades
-/// with the row, so a deleted item (including a discarded proposal) takes its
-/// trail with it — an item ruled off the board needs no history.
+/// This is typo cleanup, not a ruling: the write for "we decided against this"
+/// is [`roadmap_reject_item`], which keeps the row and the reason. Deletion
+/// records no history event on purpose — `roadmap_item_events` cascades with
+/// the row, so a deleted item takes its trail with it, which is exactly right
+/// for a row that should never have existed and exactly wrong for a decision.
 ///
 /// One thing does have to outlive the row: a *routed issue's* refusal. A ghost
 /// the issue funnel created carries the tracker URL it came from
@@ -1117,15 +1284,15 @@ pub async fn roadmap_list_proposals(
 /// What ruling on a proposal did, decided under one lock scope so the check,
 /// the write, and the history it records can never disagree.
 enum Ruling {
-    /// The patch landed; emit the row and the `edited` event. Boxed: a ruling
-    /// is almost always this variant, but the enum's size is set by it, and
-    /// the row + event pair dwarfs the other arms.
+    /// The row changed; emit it and its event. Both kinds of ask land here — an
+    /// update's patch, and a discard's rejection (the item stays on the board as
+    /// the decision log, `rejected` with the PM's note as its `close_reason`).
+    /// Boxed: a ruling is almost always this variant, but the enum's size is
+    /// set by it, and the row + event pair dwarfs the other arm.
     Updated {
         item: Box<RoadmapItem>,
         event: Box<ItemEvent>,
     },
-    /// The item was deleted at the PM's ask; emit the deletion.
-    Discarded { item_id: String },
     /// The board outran the ask — the item went `active`+ since the PM
     /// proposed, or the dep list it asked for no longer resolves (or would now
     /// close a loop). The proposal was deleted without applying, and the message
@@ -1141,14 +1308,19 @@ enum Ruling {
 /// A held item still passes. It is paused, not sealed — see the predicate's docs.
 fn proposal_gate(item: &RoadmapItem) -> Result<(), String> {
     if item.status.is_rulable() {
-        Ok(())
-    } else {
-        Err(format!(
-            "{} is {} — an item being built or reviewed can't be reshaped by proposal",
-            item.code,
-            item.status.as_str()
-        ))
+        return Ok(());
     }
+    // Name the actual objection, not a generic one: "being built or reviewed"
+    // said of a shipped or rejected item would make the bar's refusal read as a
+    // bug rather than an answer.
+    let why = match item.status {
+        ItemStatus::Done => "shipped work can't be reshaped by proposal",
+        ItemStatus::Rejected => {
+            "an item ruled off the board can't be reshaped by proposal — reopen it first"
+        }
+        _ => "an item being built or reviewed can't be reshaped by proposal",
+    };
+    Err(format!("{} is {} — {why}", item.code, item.status.as_str()))
 }
 
 /// The ruling's history line: the PM's rationale rides along, prefixed with
@@ -1220,11 +1392,34 @@ fn accept_proposal(conn: &Connection, proposal_id: &str) -> Result<Ruling, Strin
             })
         }
         ProposalKind::Discard => {
-            // No event: the row's deletion cascades its history (and this
-            // proposal) away — an item ruled off the board needs no trail,
-            // exactly like `roadmap_delete_item`.
-            store::delete(conn, &item.id).map_err(|e| e.to_string())?;
-            Ok(Ruling::Discarded { item_id: item.id })
+            // An accepted discard used to delete the row — "an item ruled off
+            // the board needs no trail". The decision log reverses that: ruled-
+            // off items ARE the trail, so the row stays, `rejected`, with the
+            // PM's rationale as its `close_reason`. The op requires a note, so
+            // the fallback is for a stored ask that predates the requirement.
+            let reason = proposal
+                .note
+                .as_deref()
+                .unwrap_or("discarded at the PM's ask");
+            let rejected = store::reject(conn, &item.id, reason)
+                .map_err(|e| e.to_string())?
+                .ok_or("the item this proposal targets no longer exists")?;
+            let event = events::record(
+                conn,
+                &rejected.id,
+                &rejected.project_id,
+                // The ruling writes history, not the ask — same doctrine as the
+                // Update arm above.
+                EventActor::User,
+                EventKind::Rejected,
+                Some(&ruling_detail("Rejected", proposal.note.as_deref())),
+            )
+            .map_err(|e| e.to_string())?;
+            proposals::delete(conn, proposal_id).map_err(|e| e.to_string())?;
+            Ok(Ruling::Updated {
+                item: Box::new(rejected),
+                event: Box::new(event),
+            })
         }
     }
 }
@@ -1248,14 +1443,10 @@ pub async fn roadmap_accept_proposal(
         Ruling::Updated { item, event } => {
             emit_item(&app, &item);
             emit_item_event(&app, &event);
-            // The patch can change horizon or deps, which can unblock (or
-            // re-order) whatever is queued behind this item.
-            drainer::nudge();
-            Ok(())
-        }
-        Ruling::Discarded { item_id } => {
-            emit_item_deleted(&app, &item_id);
-            // A deleted item can be the dep something queued was waiting on.
+            // A patch can change horizon or deps, which can unblock (or
+            // re-order) whatever is queued behind this item; a discard takes a
+            // row out of the queue and wedges its dependants, which the drainer
+            // should say within a beat.
             drainer::nudge();
             Ok(())
         }
@@ -2078,6 +2269,163 @@ mod tests {
         assert!(reclaim(&conn, "no-such-item").is_err());
     }
 
+    // ────────────────────────── the decision log ────────────────────────
+
+    /// The ruling that used to be a delete: every pre-work status may be ruled
+    /// off the board, and the row that stays says why — trimmed, on the row
+    /// *and* as the `rejected` line's detail, so the card and the trail quote
+    /// the same sentence.
+    #[test]
+    fn rejecting_keeps_the_row_and_the_reason_from_any_prework_status() {
+        let conn = test_conn();
+        for status in [ItemStatus::Proposed, ItemStatus::Open, ItemStatus::Queued] {
+            let it = with_status(&conn, status);
+            let (item, event, pending) =
+                reject_item(&conn, &it.id, "  out of scope for v1  ").unwrap();
+            assert_eq!(item.status, ItemStatus::Rejected);
+            assert_eq!(item.close_reason.as_deref(), Some("out of scope for v1"));
+            assert!(pending.is_none(), "nothing was pending on this item");
+            assert_eq!(event.kind, EventKind::Rejected);
+            assert_eq!(event.actor, EventActor::User);
+            assert_eq!(event.detail.as_deref(), Some("out of scope for v1"));
+            assert_eq!(events::list_for_item(&conn, &it.id).unwrap(), vec![event]);
+        }
+    }
+
+    /// A rejection supersedes a pause: the hold trio and the agent stamp come
+    /// off with the status flip. The trail keeps the hold's history — the row
+    /// only ever carries the state in force, and `rejected` is now that state.
+    #[test]
+    fn rejecting_clears_a_hold_and_the_agent_stamp() {
+        let conn = test_conn();
+        let it = with_status(&conn, ItemStatus::Open);
+        holds::hold_item(&conn, &it.id, "direction unclear", EventActor::Pm).unwrap();
+        store::update(
+            &conn,
+            &it.id,
+            &ItemPatch {
+                agent_id: Some(Some("w1".into())),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let (item, _, _) = reject_item(&conn, &it.id, "not doing this after all").unwrap();
+        assert!(!item.is_held());
+        assert_eq!(item.held_by, None);
+        assert_eq!(item.held_at, None);
+        assert_eq!(item.agent_id, None);
+        assert_eq!(
+            item.close_reason.as_deref(),
+            Some("not doing this after all")
+        );
+    }
+
+    /// A blank reason refuses the whole rejection: the rejected row is the
+    /// decision log, and a rejection that can't say why is just a slower
+    /// delete. Nothing is written on refusal.
+    #[test]
+    fn a_blank_reason_refuses_the_rejection() {
+        let conn = test_conn();
+        let it = with_status(&conn, ItemStatus::Open);
+        let err = reject_item(&conn, &it.id, "   ").unwrap_err();
+        assert!(err.contains("reason"), "{err}");
+        let row = store::get(&conn, &it.id).unwrap().unwrap();
+        assert_eq!(row.status, ItemStatus::Open);
+        assert_eq!(row.close_reason, None);
+        assert!(events::list_for_item(&conn, &it.id).unwrap().is_empty());
+    }
+
+    /// The gate, naming the status it refuses for: an `active`/`in_review`
+    /// item has an agent on it, a `done` one already shipped, and a `rejected`
+    /// one has already been ruled on. A refusal writes nothing.
+    #[test]
+    fn rejecting_refuses_inflight_shipped_and_already_rejected_items() {
+        let conn = test_conn();
+        for status in [
+            ItemStatus::Active,
+            ItemStatus::InReview,
+            ItemStatus::Done,
+            ItemStatus::Rejected,
+        ] {
+            let it = with_status(&conn, status);
+            let err = reject_item(&conn, &it.id, "changed our minds").unwrap_err();
+            assert!(err.contains(&it.code), "{err}");
+            assert!(err.contains(status.as_str()), "{err}");
+            let row = store::get(&conn, &it.id).unwrap().unwrap();
+            assert_eq!(row.status, status, "a refusal writes nothing");
+            assert_eq!(row.close_reason, None);
+            assert!(events::list_for_item(&conn, &it.id).unwrap().is_empty());
+        }
+        assert!(reject_item(&conn, "no-such-item", "why").is_err());
+    }
+
+    /// A dead item's ask shouldn't haunt anything: rejecting consumes the
+    /// item's pending proposal, and hands it back so the caller can announce
+    /// the deletion the board is watching for.
+    #[test]
+    fn rejecting_consumes_the_items_pending_proposal() {
+        let conn = test_conn();
+        let it = with_status(&conn, ItemStatus::Open);
+        let p = pending_update(&conn, &it, Some("reshape it"));
+
+        let (_, _, pending) = reject_item(&conn, &it.id, "no longer relevant").unwrap();
+        assert_eq!(
+            pending.map(|p| p.id),
+            Some(p.id.clone()),
+            "returned so the caller can emit `roadmap:proposal-deleted`"
+        );
+        assert!(proposals::get(&conn, &p.id).unwrap().is_none());
+    }
+
+    /// The decision log's undo: reopening lands the item back at `open` (not
+    /// back in the queue — re-queueing is a fresh decision), sheds the reason,
+    /// and quotes it in the trail so the pair reads honestly.
+    #[test]
+    fn reopening_returns_a_rejected_item_to_the_board() {
+        let conn = test_conn();
+        let it = with_status(&conn, ItemStatus::Queued);
+        reject_item(&conn, &it.id, "parked for the rewrite").unwrap();
+
+        let (item, event) = reopen_item(&conn, &it.id).unwrap();
+        assert_eq!(item.status, ItemStatus::Open);
+        assert_eq!(
+            item.close_reason, None,
+            "an item back in play owes nobody an epitaph"
+        );
+        let event = event.expect("a real reopen records itself");
+        assert_eq!(event.kind, EventKind::Reopened);
+        assert_eq!(event.actor, EventActor::User);
+        assert_eq!(
+            event.detail.as_deref(),
+            Some("was rejected — parked for the rewrite")
+        );
+        // The trail keeps the pair: why it left the board, and that it's back.
+        assert_eq!(events::list_for_item(&conn, &it.id).unwrap().len(), 2);
+
+        // A second click races the first and loses cleanly: no second stamp.
+        let (again, event) = reopen_item(&conn, &it.id).unwrap();
+        assert_eq!(again.status, ItemStatus::Open);
+        assert!(event.is_none());
+    }
+
+    /// Reopening something nobody rejected is a no-op that doesn't stamp: the
+    /// precondition rides the write's own `WHERE`, so a stale click can't move
+    /// a row that isn't rejected or invent history for a reopen that never
+    /// happened.
+    #[test]
+    fn reopening_an_unrejected_item_is_a_noop_that_records_nothing() {
+        let conn = test_conn();
+        for status in [ItemStatus::Open, ItemStatus::Queued, ItemStatus::Done] {
+            let it = with_status(&conn, status);
+            let (item, event) = reopen_item(&conn, &it.id).unwrap();
+            assert_eq!(item.status, status, "the row comes back as it actually is");
+            assert!(event.is_none());
+            assert!(events::list_for_item(&conn, &it.id).unwrap().is_empty());
+        }
+        assert!(reopen_item(&conn, "no-such-item").is_err());
+    }
+
     /// A pending update proposal for a test item, straight through the DAO —
     /// the RPC op's validation is exercised in `rpc::roadmap`'s own tests.
     fn pending_update(conn: &Connection, item: &RoadmapItem, note: Option<&str>) -> Proposal {
@@ -2144,10 +2492,11 @@ mod tests {
         assert!(events::list_for_item(&conn, &it.id).unwrap().is_empty());
     }
 
-    /// Accepting a discard deletes the item row; its history and the proposal
-    /// itself cascade away with it.
+    /// Accepting a discard keeps the row as the decision log: `rejected`, with
+    /// the PM's rationale as its `close_reason` and a `rejected` line in the
+    /// trail — where it used to delete the row and everything it knew.
     #[test]
-    fn accepting_a_discard_deletes_the_row() {
+    fn accepting_a_discard_keeps_the_row_as_rejected() {
         let conn = test_conn();
         let it = with_status(&conn, ItemStatus::Open);
         let p = proposals::upsert(
@@ -2160,12 +2509,23 @@ mod tests {
         )
         .unwrap();
 
-        let Ruling::Discarded { item_id } = accept_proposal(&conn, &p.id).unwrap() else {
-            panic!("expected Discarded");
+        let Ruling::Updated { item, event } = accept_proposal(&conn, &p.id).unwrap() else {
+            panic!("expected Updated");
         };
-        assert_eq!(item_id, it.id);
-        assert!(store::get(&conn, &it.id).unwrap().is_none());
+        assert_eq!(item.id, it.id, "the row survives the ruling");
+        assert_eq!(item.status, ItemStatus::Rejected);
+        assert_eq!(item.close_reason.as_deref(), Some("superseded by MCA-101"));
+        // The ruling writes history, not the ask — the user rejected, carrying
+        // the PM's rationale.
+        assert_eq!(event.kind, EventKind::Rejected);
+        assert_eq!(event.actor, EventActor::User);
+        assert_eq!(
+            event.detail.as_deref(),
+            Some("Rejected a PM proposal — superseded by MCA-101")
+        );
         assert!(proposals::get(&conn, &p.id).unwrap().is_none());
+        // Ruling twice is refused, not replayed.
+        assert!(accept_proposal(&conn, &p.id).is_err());
     }
 
     /// Accepting an order rewrites every orderable row's rank as 1.0, 2.0, …

--- a/src-tauri/src/roadmap/order.rs
+++ b/src-tauri/src/roadmap/order.rs
@@ -128,9 +128,12 @@ pub fn validate_order(codes: &[String], items: &[RoadmapItem]) -> Result<Vec<Str
         ));
     }
     if !closed.is_empty() {
+        // Three ways out of the order, one refusal: dispatched work's place is
+        // settled, shipped work has left the board, and a rejected item was
+        // ruled off it — none of them has a queue position to argue about.
         return Err(format!(
-            "{} — an item being built or reviewed has already been dispatched, so its place in \
-             the order is settled; list only the proposed, open, and queued ones",
+            "{} — dispatched, shipped, or rejected items have no place in the queue \
+             order; list only the proposed, open, and queued ones",
             closed.join(", ")
         ));
     }
@@ -266,6 +269,7 @@ mod tests {
         let c = item(&conn, ItemStatus::Proposed); // FLE-102
         let building = item(&conn, ItemStatus::Active); // FLE-103
         let shipped = item(&conn, ItemStatus::Done); // FLE-104
+        let ruled_off = item(&conn, ItemStatus::Rejected); // FLE-105
         let items = crate::roadmap::store::list(&conn, "p1").unwrap();
 
         // The whole orderable set, in an order of the PM's choosing: resolved to
@@ -293,6 +297,16 @@ mod tests {
             (
                 codes(&[&a.code, &b.code, &c.code, &shipped.code]),
                 "FLE-104 is done",
+            ),
+            // A ruled-off item has no queue position to argue about — and the
+            // refusal must say "rejected", not claim it was dispatched.
+            (
+                codes(&[&a.code, &b.code, &c.code, &ruled_off.code]),
+                "FLE-105 is rejected",
+            ),
+            (
+                codes(&[&a.code, &b.code, &c.code, &ruled_off.code]),
+                "rejected items have no place",
             ),
             // The same code twice — an order that names a position twice is not
             // an order.

--- a/src-tauri/src/roadmap/pr_review.rs
+++ b/src-tauri/src/roadmap/pr_review.rs
@@ -157,6 +157,7 @@ mod tests {
             hold_reason: None,
             held_by: None,
             held_at: None,
+            close_reason: None,
             issue_url: None,
             updated_at: 1,
         }

--- a/src-tauri/src/roadmap/review.rs
+++ b/src-tauri/src/roadmap/review.rs
@@ -809,6 +809,7 @@ mod tests {
             hold_reason: None,
             held_by: None,
             held_at: None,
+            close_reason: None,
             issue_url: None,
             created_at: 0,
             updated_at: 0,

--- a/src-tauri/src/roadmap/store.rs
+++ b/src-tauri/src/roadmap/store.rs
@@ -242,6 +242,56 @@ pub fn delete(conn: &Connection, id: &str) -> rusqlite::Result<bool> {
     Ok(n > 0)
 }
 
+/// Rule an item off the board: `status = rejected`, `close_reason` = why, and
+/// every claim on the row's future cleared in the same statement — the hold
+/// trio (a rejection supersedes a pause; the trail keeps the hold's history)
+/// and the agent stamp (nobody builds a rejected item). `None` when the row is
+/// gone.
+///
+/// Deliberately its own SQL rather than [`ItemPatch`] fields, for the same
+/// reason as [`super::holds::hold_item`]: `close_reason` is absent from the
+/// patch surface, so no generic edit can rule an item off the board — only the
+/// typed reject command and the discard ruling can express this write. The
+/// status gate (which statuses may be rejected at all) is the caller's, checked
+/// under the same connection lock this runs in.
+pub fn reject(conn: &Connection, id: &str, reason: &str) -> rusqlite::Result<Option<RoadmapItem>> {
+    conn.execute(
+        "UPDATE roadmap_items
+            SET status = ?1, close_reason = ?2,
+                hold_reason = NULL, held_by = NULL, held_at = NULL,
+                agent_id = NULL, updated_at = ?3
+          WHERE id = ?4",
+        params![ItemStatus::Rejected.as_str(), reason, now_millis(), id],
+    )?;
+    get(conn, id)
+}
+
+/// Put a rejected item back on the board: `rejected → open`, `close_reason`
+/// cleared — an item back in play owes nobody an epitaph; the trail keeps the
+/// reason it just shed.
+///
+/// The `status = rejected` precondition rides the `UPDATE`'s own `WHERE`, like
+/// [`update_where_status`], so the check and the write are one statement:
+/// `None` means the row moved on (or was never rejected, or is gone), and the
+/// caller treats that as a miss rather than reopening something else.
+pub fn reopen(conn: &Connection, id: &str) -> rusqlite::Result<Option<RoadmapItem>> {
+    let changed = conn.execute(
+        "UPDATE roadmap_items
+            SET status = ?1, close_reason = NULL, updated_at = ?2
+          WHERE id = ?3 AND status = ?4",
+        params![
+            ItemStatus::Open.as_str(),
+            now_millis(),
+            id,
+            ItemStatus::Rejected.as_str()
+        ],
+    )?;
+    if changed == 0 {
+        return Ok(None);
+    }
+    get(conn, id)
+}
+
 /// `project_settings` key holding the tracker issues the user has *turned down* —
 /// a JSON array of URLs.
 ///

--- a/src-tauri/src/roadmap/store.rs
+++ b/src-tauri/src/roadmap/store.rs
@@ -268,7 +268,10 @@ pub fn reject(conn: &Connection, id: &str, reason: &str) -> rusqlite::Result<Opt
 
 /// Put a rejected item back on the board: `rejected → open`, `close_reason`
 /// cleared — an item back in play owes nobody an epitaph; the trail keeps the
-/// reason it just shed.
+/// reason it just shed. The hold trio is cleared in the same statement:
+/// [`reject`] enforces "a rejection supersedes a pause" going in, and this
+/// enforces it coming out, so a hand-edited or legacy held-while-rejected row
+/// can't return to the board secretly paused.
 ///
 /// The `status = rejected` precondition rides the `UPDATE`'s own `WHERE`, like
 /// [`update_where_status`], so the check and the write are one statement:
@@ -277,7 +280,9 @@ pub fn reject(conn: &Connection, id: &str, reason: &str) -> rusqlite::Result<Opt
 pub fn reopen(conn: &Connection, id: &str) -> rusqlite::Result<Option<RoadmapItem>> {
     let changed = conn.execute(
         "UPDATE roadmap_items
-            SET status = ?1, close_reason = NULL, updated_at = ?2
+            SET status = ?1, close_reason = NULL,
+                hold_reason = NULL, held_by = NULL, held_at = NULL,
+                updated_at = ?2
           WHERE id = ?3 AND status = ?4",
         params![
             ItemStatus::Open.as_str(),

--- a/src-tauri/src/roadmap/types.rs
+++ b/src-tauri/src/roadmap/types.rs
@@ -27,6 +27,13 @@ crate::db_enum! {
     /// Item lifecycle: `proposed → open → queued → active → in_review → done`.
     /// `proposed` is a PM suggestion the user hasn't accepted (a ghost row);
     /// `done` items leave the board and become the header's "shipped" count.
+    ///
+    /// `rejected` sits off that line: an item ruled off the board — the decision
+    /// log's status. Reached only from the pre-work statuses (a shipped item
+    /// can't be un-decided, and an `active`/`in_review` one has an agent on it),
+    /// and left only by reopening, which lands the item back at `open`. The row
+    /// and its trail survive the ruling; that survival is the point (see
+    /// migration 0037).
     ItemStatus {
         Proposed => "proposed",
         Open     => "open",
@@ -34,6 +41,7 @@ crate::db_enum! {
         Active   => "active",
         InReview => "in_review",
         Done     => "done",
+        Rejected => "rejected",
     }
 }
 
@@ -42,7 +50,9 @@ impl ItemStatus {
     ///
     /// Anything from `active` on is being built or judged: its shape belongs to
     /// the run now, and reshaping it mid-flight would make the PR answer a brief
-    /// nobody wrote. The one predicate both gates read — the PM-side refusal
+    /// nobody wrote. A `rejected` item is out for the opposite reason — it has
+    /// been ruled off the board, and nothing proposes onto a corpse; reopening
+    /// it is the user's move, not an ask. The one predicate both gates read — the PM-side refusal
     /// (`rpc::roadmap::proposable`, which won't park an ask it knows the user
     /// can't rule) and the ruling-side one (`roadmap::proposal_gate`, which
     /// re-checks at click time because the board moves in between). They keep
@@ -108,6 +118,12 @@ pub struct RoadmapItem {
     /// exactly when `hold_reason` is.
     pub held_by: Option<super::events::EventActor>,
     pub held_at: Option<i64>,
+    /// Why this item was ruled off the board, `Some` exactly when `status` is
+    /// `rejected` (see migration 0037). Written only by the typed reject command
+    /// and the PM discard ruling — deliberately absent from [`ItemPatch`] and
+    /// [`NewItem`], so no generic edit can silently reject an item; reopening
+    /// clears it, and the durable trail keeps the reason it cleared.
+    pub close_reason: Option<String>,
     /// The tracker issue this row was routed from, or `None` for a row nobody
     /// imported (migration 0036). The issue funnel's dedup key: "is this issue
     /// already on that board?" is answered by matching this column, *not* by
@@ -128,7 +144,8 @@ pub struct RoadmapItem {
 /// queries can't disagree about what is available.
 pub(crate) const COLUMNS: &str = "id, project_id, code, title, why, horizon, status, \
      rank, area, source, accept_json, deps_json, agent_id, workflow_def_id, run_id, \
-     pr_url, pr_number, hold_reason, held_by, held_at, issue_url, created_at, updated_at";
+     pr_url, pr_number, hold_reason, held_by, held_at, close_reason, issue_url, \
+     created_at, updated_at";
 
 impl RoadmapItem {
     pub fn from_row(r: &Row) -> rusqlite::Result<Self> {
@@ -153,6 +170,7 @@ impl RoadmapItem {
             hold_reason: r.get("hold_reason")?,
             held_by: opt_enum_col(r, "held_by", super::events::EventActor::from_db)?,
             held_at: r.get("held_at")?,
+            close_reason: r.get("close_reason")?,
             issue_url: r.get("issue_url")?,
             created_at: r.get("created_at")?,
             updated_at: r.get("updated_at")?,
@@ -359,6 +377,24 @@ mod tests {
         );
         assert_eq!(p.run_id, None, "an absent key means 'leave alone'");
         assert_eq!(p.title, None);
+    }
+
+    /// The shared rulability set, pinned: asks land only on the three pre-work
+    /// statuses. `rejected` is excluded like `done` — an item ruled off the
+    /// board takes no proposals; reopening it is the user's move, not an ask.
+    #[test]
+    fn only_pre_work_statuses_are_rulable() {
+        for status in [ItemStatus::Proposed, ItemStatus::Open, ItemStatus::Queued] {
+            assert!(status.is_rulable(), "{status:?}");
+        }
+        for status in [
+            ItemStatus::Active,
+            ItemStatus::InReview,
+            ItemStatus::Done,
+            ItemStatus::Rejected,
+        ] {
+            assert!(!status.is_rulable(), "{status:?}");
+        }
     }
 
     /// `agent_id` is not patchable from the wire, however it is spelled. The

--- a/src-tauri/src/rpc/roadmap.rs
+++ b/src-tauri/src/rpc/roadmap.rs
@@ -657,7 +657,9 @@ fn propose_op(
 
 /// Find the item an ask targets and check it may still be reshaped. Anything
 /// from `active` on belongs to its run: a proposal against it would be ruled
-/// on against work that no longer matches the diff.
+/// on against work that no longer matches the diff. A `rejected` item is out
+/// for the opposite reason — the user ruled it off the board, and an ask
+/// against it would be lobbying against a decision already made.
 fn proposable<'a>(items: &'a [RoadmapItem], code: &str) -> Result<&'a RoadmapItem, String> {
     let item = items.iter().find(|i| i.code == code).ok_or_else(|| {
         format!("no item {code:?} on this board — `roadmap_list` shows what exists")
@@ -665,9 +667,16 @@ fn proposable<'a>(items: &'a [RoadmapItem], code: &str) -> Result<&'a RoadmapIte
     if rulable(item.status) {
         Ok(item)
     } else {
+        // Name the actual objection: telling the PM a rejected item is "being
+        // built" would invite it to wait for a run that is never coming.
+        let why = match item.status {
+            ItemStatus::Done => "shipped work can't be reshaped by proposal",
+            ItemStatus::Rejected => "the user ruled it off the board; only the user can reopen it",
+            _ => "an item being built or reviewed can't be reshaped by proposal",
+        };
         Err(format!(
-            "{} is {} — an item being built or reviewed can't be reshaped by proposal; \
-             use the codes `roadmap_list` shows as proposed, open, or queued",
+            "{} is {} — {why}; use the codes `roadmap_list` shows as proposed, open, \
+             or queued",
             item.code,
             item.status.as_str()
         ))

--- a/src-tauri/src/rpc/roadmap.rs
+++ b/src-tauri/src/rpc/roadmap.rs
@@ -344,6 +344,13 @@ fn compact(
         }
         o.insert("held".into(), Value::Object(h));
     }
+    // Why a rejected row was ruled off, on the row itself: `last_event` also
+    // says it right after the ruling, but a later note displaces it there, and
+    // the instructions tell the PM to *read the reason before proposing* — a
+    // fact it must be able to read cannot live only in a queue position.
+    if let Some(reason) = &item.close_reason {
+        o.insert("close_reason".into(), json!(reason));
+    }
     // Quoted only while the item can still be ruled: an ask whose item has
     // advanced past the gate has no card to rule it from, and quoting it
     // forever would read as "still waiting on the user" when nothing is.
@@ -958,9 +965,10 @@ enum Held {
 /// hold, so every release is a user action by construction and an agent can never
 /// undo its own brake.
 ///
-/// Like `roadmap_note`, the target may be at **any** status: the moment a hold is
-/// most worth placing is usually mid-run, on the `active` item whose PR is about
-/// to answer the wrong question — exactly the item a proposal is refused on.
+/// Like `roadmap_note`, the target may be at any *working* status: the moment a
+/// hold is most worth placing is usually mid-run, on the `active` item whose PR
+/// is about to answer the wrong question — exactly the item a proposal is
+/// refused on. Only `rejected` is refused (see the gate below).
 /// Holding an already-held scope replaces the reason and records another `held`,
 /// so the trail keeps what was superseded.
 fn hold_op(
@@ -1017,6 +1025,17 @@ fn hold_op(
              {PROJECT_SCOPE:?} to hold the whole board"
         ));
     };
+    // The one status a hold may not land on: a rejected item has no queue to
+    // stop and no card rendering a Release button, so the hold would be both
+    // pointless and invisible — and it would ambush the user by surviving into
+    // a reopen. (Every *working* status stays holdable; see the op doc.)
+    if item.status == ItemStatus::Rejected {
+        return err(format!(
+            "{} was rejected — a ruled-off item has nothing to pause; ask the user to \
+             reopen it first",
+            item.code
+        ));
+    }
     // One write path for both doors: the command layer's `hold_item` places the
     // hold and records the `held` line in this same guard, so a held row can
     // never exist without the line saying who stopped it.
@@ -2160,6 +2179,51 @@ mod tests {
             json!({"scope": "MCA-100", "reason": "y".repeat(holds::MAX_REASON)}),
         );
         assert!(resp.ok, "{resp:?}");
+    }
+
+    /// A rejected item can't be held: there's no queue to stop, no card
+    /// rendering a Release button, and the hold would ambush the user by
+    /// surviving into a reopen. The refusal points at the way out.
+    #[test]
+    fn a_rejected_item_cannot_be_held() {
+        let db = test_db("p1");
+        assert!(propose(&db, one_item("target")).ok); // MCA-100
+        {
+            let conn = db.lock();
+            let item = &store::list(&conn, "p1").unwrap()[0];
+            store::reject(&conn, &item.id, "not needed").unwrap();
+        }
+
+        let (resp, held) = hold(&db, json!({"scope": "MCA-100", "reason": "wait"}));
+        assert!(!resp.ok);
+        let e = resp.error.unwrap();
+        assert!(e.contains("was rejected"), "{e}");
+        assert!(e.contains("reopen"), "the refusal names the way out: {e}");
+        assert!(held.is_none());
+        let rows = store::list(&db.lock(), "p1").unwrap();
+        assert!(!rows[0].is_held(), "nothing written");
+    }
+
+    /// The listing carries a rejected row's `close_reason` on the row itself.
+    /// `last_event` says it too — but only until the next note displaces it,
+    /// and the instructions tell the PM to read the reason before proposing.
+    #[test]
+    fn list_carries_a_rejected_rows_reason() {
+        let db = test_db("p1");
+        assert!(propose(&db, one_item("target")).ok); // MCA-100
+        {
+            let conn = db.lock();
+            let item = &store::list(&conn, "p1").unwrap()[0];
+            store::reject(&conn, &item.id, "superseded by the settings redesign").unwrap();
+        }
+
+        let resp = list(&db, Value::Null);
+        let rows: Vec<Value> = serde_json::from_str(&resp.stdout.unwrap()).unwrap();
+        assert_eq!(rows[0]["status"], "rejected");
+        assert_eq!(
+            rows[0]["close_reason"],
+            "superseded by the settings redesign"
+        );
     }
 
     /// Holding an already-held scope replaces the reason, at both scopes. The

--- a/src/api/domains/roadmap.ts
+++ b/src/api/domains/roadmap.ts
@@ -103,6 +103,18 @@ export const roadmapApi = {
    *  none to release, so every release comes through here. Writes a `released`
    *  event whose detail is the reason being lifted. Returns the stored row. */
   roadmapReleaseItem: (itemId: string) => invoke<RoadmapItem>("roadmap_release_item", { itemId }),
+  /** Rule an item off the board: status `rejected`, with the required reason
+   *  stored as `close_reason` — the decision log keeps the row and its history
+   *  where a delete would erase both. Allowed from `proposed`/`open`/`queued`;
+   *  the backend refuses anything dispatched (`active`/`in_review`) or shipped,
+   *  with a message saying so. Writes a `rejected` event carrying the reason.
+   *  Returns the stored row. */
+  roadmapRejectItem: (itemId: string, reason: string) =>
+    invoke<RoadmapItem>("roadmap_reject_item", { itemId, reason }),
+  /** Put a rejected item back on the board (`rejected → open`), clearing its
+   *  `close_reason`. Only from `rejected` — everything else already is on the
+   *  board or shipped. Writes a `reopened` event. Returns the stored row. */
+  roadmapReopenItem: (itemId: string) => invoke<RoadmapItem>("roadmap_reopen_item", { itemId }),
   /** The project's hold, or `null` when the board is running. Fetched with the
    *  item snapshot; live changes arrive on `roadmap:project-hold` /
    *  `roadmap:project-hold-released`. */

--- a/src/api/types/roadmap.ts
+++ b/src/api/types/roadmap.ts
@@ -18,8 +18,18 @@ export type ItemSource = "user" | "pm" | "linear" | "github";
 
 /** Item lifecycle. `proposed` is a PM suggestion the user hasn't accepted yet
  *  (a ghost row); `active` means an agent is on it right now; `done` items leave
- *  the board and become the header's "shipped" count. */
-export type ItemStatus = "proposed" | "open" | "queued" | "active" | "in_review" | "done";
+ *  the board and become the header's "shipped" count. `rejected` items leave the
+ *  horizons and live in the board's collapsed "Not doing" section — ruled off
+ *  rather than deleted, so the decision and its reason survive, and the item can
+ *  be reopened. */
+export type ItemStatus =
+  | "proposed"
+  | "open"
+  | "queued"
+  | "active"
+  | "in_review"
+  | "done"
+  | "rejected";
 
 /** One `roadmap_items` row. */
 export interface RoadmapItem {
@@ -61,6 +71,11 @@ export interface RoadmapItem {
    *  exactly when `hold_reason` is. */
   held_by: RoadmapEventActor | null;
   held_at: number | null;
+  /** Why this item was ruled off the board, or null while it hasn't been.
+   *  Non-null exactly when `status` is `rejected` — the reason is required
+   *  (`roadmapRejectItem` refuses a blank one), because a "Not doing" row with
+   *  no why is a decision nobody can revisit. Cleared by a reopen. */
+  close_reason: string | null;
   /** The tracker issue this row was routed from, or null for a row nobody
    *  imported (migration 0036).
    *
@@ -176,6 +191,12 @@ export type RoadmapEventActor = "user" | "pm" | "drainer" | "sweep";
  *  `held`/`released` name no status move at all — a hold stops autonomous
  *  progress and leaves the row where it is — so for those two the `detail` is
  *  the whole record: the reason it was held, and the reason a release lifts.
+ *
+ *  `rejected`/`reopened` are the decision log's pair: ruling an item off the
+ *  board (the detail is the required `close_reason`) and putting it back
+ *  (`rejected → open`). Unlike a discard, a rejection keeps the row and its
+ *  trail — which is the point.
+ *
  *  Every kind must have a label in `EVENT_LABEL` (itemHistory.ts), which is what
  *  keeps a new kind from rendering as "undefined" on the card. */
 export type RoadmapEventKind =
@@ -195,6 +216,8 @@ export type RoadmapEventKind =
   | "blocked"
   | "held"
   | "released"
+  | "rejected"
+  | "reopened"
   | "note";
 
 /** One durable history row (`roadmap_item_events`, mirroring
@@ -303,7 +326,11 @@ export interface RoadmapItemUpdate {
  *  Neither is `agent_id`: the hand-off and its undo are typed commands
  *  (`roadmapHandOffItem` / `roadmapReclaimItem`) because each writes a history
  *  note naming the agent, where a patch would record a bare "Edited". The
- *  backend ignores the key even if something sends it. */
+ *  backend ignores the key even if something sends it.
+ *
+ *  Rejection and its undo are typed commands too (`roadmapRejectItem` /
+ *  `roadmapReopenItem`), for the same reason: a rejection carries a required
+ *  reason the trail must keep, where a bare status patch would record none. */
 export interface RoadmapItemPatch {
   title?: string;
   why?: string;

--- a/src/components/ProjectScreen/Roadmap/Board/HoldControl.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/HoldControl.tsx
@@ -3,17 +3,14 @@
 //
 // Their own file rather than more branches inside ItemCard: the chip is the
 // ghostbar's grammar (a band between the header and the body, ruled on without an
-// expand), and placing a hold needs a *reason*, which means a small piece of local
-// state no other part of the card has. The reason prompt reuses the strip's inline
-// pattern — an input that appears in place, ⌘↵/Enter to commit, Escape to back
-// out — so writing a hold reason feels like answering a question inline, not like
-// opening a form.
+// expand), and placing a hold needs a *reason* — the inline ask lives in
+// ReasonAction.tsx, shared with Reject, so the two reasoned commands stay one
+// gesture.
 
-import { type KeyboardEvent, useState } from "react";
 import type { RoadmapEventActor } from "@/api";
 import { Icon } from "@/components/Icon";
 import { Button } from "@/components/ui/Button";
-import { TextInput } from "@/components/ui/TextInput";
+import { ReasonAction } from "./ReasonAction";
 
 /** Who stopped it, in the words the card uses elsewhere. The distinction matters:
  *  a hold the PM placed is news, one the user placed is a note to self. */
@@ -51,57 +48,17 @@ export function HoldChip({
   );
 }
 
-/** "Hold" as a secondary action, with the reason asked for in place.
- *
- *  The reason is required by the backend, so it is asked for here rather than
- *  sent blank and refused: a hold with no reason leaves the user a Release button
- *  and no idea what it undoes. Committing with an empty box simply does nothing,
- *  which is the same answer as Cancel and needs no error state to say so. */
+/** "Hold" as a secondary action, with the reason asked for in place
+ *  (ReasonAction): a hold with no reason leaves the user a Release button and
+ *  no idea what it undoes. */
 export function HoldAction({ onHold }: { onHold: (reason: string) => void }) {
-  const [reason, setReason] = useState<string | null>(null);
-
-  if (reason == null) {
-    return (
-      <Button
-        variant="ghost"
-        size="sm"
-        tip="Stop the queue from building this until you release it"
-        onClick={() => setReason("")}
-      >
-        <Icon name="pause" size={11} /> Hold
-      </Button>
-    );
-  }
-
-  const commit = () => {
-    const text = reason.trim();
-    if (text) onHold(text);
-    setReason(null);
-  };
-  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === "Enter") commit();
-    if (e.key === "Escape") setReason(null);
-  };
-
   return (
-    <span className="rm-hold-ask flex-center">
-      <TextInput
-        // The input appears exactly where the button the user just pressed was,
-        // so the caret belongs in it — otherwise the gesture is click, then click
-        // again, to type the thing they opened the box to type.
-        autoFocus
-        className="rm-hold-input"
-        placeholder="What has to be agreed first?"
-        value={reason}
-        onChange={(e) => setReason(e.target.value)}
-        onKeyDown={onKeyDown}
-      />
-      <Button variant="ghost" size="sm" onClick={() => setReason(null)}>
-        Cancel
-      </Button>
-      <Button variant="primary" size="sm" onClick={commit}>
-        <Icon name="pause" size={11} /> Hold
-      </Button>
-    </span>
+    <ReasonAction
+      icon="pause"
+      label="Hold"
+      tip="Stop the queue from building this until you release it"
+      placeholder="What has to be agreed first?"
+      onCommit={onHold}
+    />
   );
 }

--- a/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ItemCard.tsx
@@ -20,6 +20,7 @@ import type { BoardItem, ItemSource, ItemStatus } from "../types";
 import { reviewGate } from "../useItemReviews";
 import { DecisionBar } from "./DecisionBar";
 import { HoldAction, HoldChip } from "./HoldControl";
+import { ReasonAction } from "./ReasonAction";
 import type { CardDnd } from "./useBoardDnd";
 
 /** Where the item came from, as a one-glyph tag. */
@@ -50,6 +51,14 @@ const STATE: Partial<Record<ItemStatus, { label: string; cls: string; tip: strin
     // done" on the card is the manual fallback for when the watch can't see
     // the merge (revoked token, deleted PR).
     tip: "Its run opened a pull request — merge it and this ships on its own",
+  },
+  // Rejected rows normally render in the board's "Not doing" section rather
+  // than as cards — this entry is what keeps a card that does hold one (a
+  // future surface, a race during the move) from drawing an unlabeled row.
+  rejected: {
+    label: "Not doing",
+    cls: "x",
+    tip: "Ruled off the board — its reason is kept in the Not doing section",
   },
 };
 
@@ -112,6 +121,11 @@ interface Props {
    *  for inline. Absent for a ghost (nothing is going to build a row nobody has
    *  accepted — rule on it first) and on a read-only board. */
   onHold?: (reason: string) => void;
+  /** Rule the item off the board, with the required reason asked for inline —
+   *  it moves to the "Not doing" section instead of being deleted. Only for the
+   *  statuses the backend allows (`proposed`/`open`/`queued`): anything
+   *  dispatched is the run's to finish first. */
+  onReject?: (reason: string) => void;
   /** Lift this item's hold. Only on a held row, and never available to the PM —
    *  releasing is the user's alone. */
   onRelease?: () => void;
@@ -180,6 +194,7 @@ export function ItemCard({
   onMergePr,
   onFixReview,
   onHold,
+  onReject,
   onRelease,
   onOpenRun,
   run,
@@ -531,6 +546,21 @@ export function ItemCard({
                 <Button variant="primary" size="sm" onClick={onMergePr}>
                   <Icon name="merge" size={11} /> Merge
                 </Button>
+              )}
+              {/* The way off the board that keeps the record: the item lands in
+                  "Not doing" with the reason, instead of being deleted without
+                  one. The ellipsis is the promise that a click only opens the
+                  question — same inline ask as Hold's, because both commands
+                  refuse a blank reason. */}
+              {onReject && (
+                <ReasonAction
+                  icon="archive"
+                  label="Reject…"
+                  commitLabel="Reject"
+                  tip="Take this off the board — it moves to Not doing with your reason"
+                  placeholder="Why isn't this being done?"
+                  onCommit={onReject}
+                />
               )}
               {/* The user's own brake, next to the button it stops. A secondary
                   action: most rows never need it, and the one that does needs a

--- a/src/components/ProjectScreen/Roadmap/Board/NotDoing.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/NotDoing.tsx
@@ -1,0 +1,86 @@
+// Board/NotDoing.tsx — the decision log: items ruled off the board, kept with
+// their reason instead of deleted.
+//
+// A collapsed disclosure under the horizon groups, deliberately quiet — this is
+// an archive of decisions, not a fourth column, so it opens on demand and its
+// rows carry no chips, no drag, no expandable body. What a row owes the reader
+// is exactly the ruling: the code (still linkable from the PM chat), the title,
+// the close_reason — and the one gesture that reverses it.
+
+import { useState } from "react";
+import type { RoadmapItem } from "@/api";
+import { Icon } from "@/components/Icon";
+import { Button } from "@/components/ui/Button";
+
+export function NotDoing({
+  items,
+  focusCode,
+  onReopen,
+  rowRef,
+}: {
+  /** Rejected rows, newest ruling first (see partition.ts `rejectedRows`). */
+  items: readonly RoadmapItem[];
+  /** The board's jumped-to code, so a reveal that lands here is visible. */
+  focusCode?: string | null;
+  /** Put an item back on the board (`rejected → open`). Absent on a read-only
+   *  board. */
+  onReopen?: (id: string) => void;
+  /** Registers each row for the board's scroll-into-view, same as the cards. */
+  rowRef?: (code: string, el: HTMLElement | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  // A reveal can name a rejected row (revealTarget calls every non-shipped row
+  // "board"), and a closed section would swallow the jump. Latched during
+  // render, not in an effect: the row's ref must be mounted before the board's
+  // scroll effect goes looking for it, and an effect here would run too late.
+  const focused = focusCode != null && items.some((i) => i.code === focusCode);
+  if (focused && !open) setOpen(true);
+
+  if (items.length === 0) return null;
+  return (
+    <section className="rm-nd">
+      <button
+        type="button"
+        className="rm-nd-h flex-center text-xs"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+      >
+        <Icon name="archive" size={11} />
+        <span className="rm-nd-l mono">Not doing</span>
+        <span className="rm-nd-c mono">{items.length}</span>
+        <Icon name="chevD" size={9} className="rm-nd-chev" />
+      </button>
+      {open && (
+        <ul className="rm-nd-list">
+          {items.map((i) => (
+            <li
+              key={i.code}
+              className={`rm-nd-row ${focusCode === i.code ? "focus" : ""}`}
+              ref={(el) => rowRef?.(i.code, el)}
+            >
+              <div className="rm-nd-line flex-center">
+                <span className="rm-code mono text-xs">{i.code}</span>
+                <span className="rm-nd-t text-sm truncate">{i.title}</span>
+                <span className="grow" />
+                {onReopen && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    tip="Put it back on the board as open"
+                    onClick={() => onReopen(i.id)}
+                  >
+                    <Icon name="archiveRestore" size={11} /> Reopen
+                  </Button>
+                )}
+              </div>
+              {/* Non-null exactly while the row is rejected — the reason is the
+                  log's whole value, so it gets its own line rather than a
+                  truncating tail. */}
+              {i.close_reason && <div className="rm-nd-why text-xs">{i.close_reason}</div>}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Board/NotDoing.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/NotDoing.tsx
@@ -30,11 +30,12 @@ export function NotDoing({
 }) {
   const [open, setOpen] = useState(false);
   // A reveal can name a rejected row (revealTarget calls every non-shipped row
-  // "board"), and a closed section would swallow the jump. Latched during
-  // render, not in an effect: the row's ref must be mounted before the board's
-  // scroll effect goes looking for it, and an effect here would run too late.
+  // "board"), and a closed section would swallow the jump. Derived, not
+  // latched: the rows must be mounted in the same render the board's scroll
+  // effect goes looking for them, so the focus forces `shown` directly — no
+  // effect (too late) and no render-phase setState.
   const focused = focusCode != null && items.some((i) => i.code === focusCode);
-  if (focused && !open) setOpen(true);
+  const shown = open || focused;
 
   if (items.length === 0) return null;
   return (
@@ -42,15 +43,15 @@ export function NotDoing({
       <button
         type="button"
         className="rm-nd-h flex-center text-xs"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
+        onClick={() => setOpen(!shown)}
+        aria-expanded={shown}
       >
         <Icon name="archive" size={11} />
         <span className="rm-nd-l mono">Not doing</span>
         <span className="rm-nd-c mono">{items.length}</span>
         <Icon name="chevD" size={9} className="rm-nd-chev" />
       </button>
-      {open && (
+      {shown && (
         <ul className="rm-nd-list">
           {items.map((i) => (
             <li

--- a/src/components/ProjectScreen/Roadmap/Board/ReasonAction.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/ReasonAction.tsx
@@ -1,0 +1,79 @@
+// Board/ReasonAction.tsx — a secondary card action whose command requires a
+// reason, asked for in place.
+//
+// Extracted from HoldControl's HoldAction when Reject needed the same gesture:
+// both commands refuse a blank reason backend-side, so it is asked for here
+// rather than sent blank and bounced. The prompt reuses the strip's inline
+// pattern — an input that appears exactly where the button was, Enter to
+// commit, Escape to back out — so writing a reason feels like answering a
+// question inline, not like opening a form. Committing with an empty box
+// simply does nothing, which is the same answer as Cancel and needs no error
+// state to say so.
+
+import { type KeyboardEvent, useState } from "react";
+import { Icon, type IconName } from "@/components/Icon";
+import { Button } from "@/components/ui/Button";
+import { TextInput } from "@/components/ui/TextInput";
+
+export function ReasonAction({
+  icon,
+  label,
+  commitLabel = label,
+  tip,
+  placeholder,
+  onCommit,
+}: {
+  icon: IconName;
+  /** The idle button's text ("Hold", "Reject…"). */
+  label: string;
+  /** The commit button's text, when the ellipsis convention makes the idle
+   *  label wrong for it. Defaults to `label`. */
+  commitLabel?: string;
+  tip: string;
+  /** The question the input asks — each command owes a different one. */
+  placeholder: string;
+  /** Called with the trimmed, non-blank reason. */
+  onCommit: (reason: string) => void;
+}) {
+  const [reason, setReason] = useState<string | null>(null);
+
+  if (reason == null) {
+    return (
+      <Button variant="ghost" size="sm" tip={tip} onClick={() => setReason("")}>
+        <Icon name={icon} size={11} /> {label}
+      </Button>
+    );
+  }
+
+  const commit = () => {
+    const text = reason.trim();
+    if (text) onCommit(text);
+    setReason(null);
+  };
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") commit();
+    if (e.key === "Escape") setReason(null);
+  };
+
+  return (
+    <span className="rm-hold-ask flex-center">
+      <TextInput
+        // The input appears exactly where the button the user just pressed was,
+        // so the caret belongs in it — otherwise the gesture is click, then click
+        // again, to type the thing they opened the box to type.
+        autoFocus
+        className="rm-hold-input"
+        placeholder={placeholder}
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        onKeyDown={onKeyDown}
+      />
+      <Button variant="ghost" size="sm" onClick={() => setReason(null)}>
+        Cancel
+      </Button>
+      <Button variant="primary" size="sm" onClick={commit}>
+        <Icon name={icon} size={11} /> {commitLabel}
+      </Button>
+    </span>
+  );
+}

--- a/src/components/ProjectScreen/Roadmap/Board/index.tsx
+++ b/src/components/ProjectScreen/Roadmap/Board/index.tsx
@@ -17,6 +17,7 @@ import { EmptyBoard } from "./EmptyBoard";
 import { HorizonGroup } from "./HorizonGroup";
 import { ItemCard } from "./ItemCard";
 import { ItemDialog } from "./ItemDialog";
+import { NotDoing } from "./NotDoing";
 import { OrderProposalBar } from "./OrderProposalBar";
 import { ProductBrief } from "./ProductBrief";
 import { ProjectHoldBanner } from "./ProjectHoldBanner";
@@ -48,6 +49,7 @@ export function Board({
     projectId,
     items,
     ghosts,
+    rejected,
     proposals,
     orderProposal,
     orderable,
@@ -91,6 +93,8 @@ export function Board({
     projectHold,
     holdItem,
     releaseItem,
+    rejectItem,
+    reopenItem,
     releaseProject,
     workflows,
   } = roadmap;
@@ -130,7 +134,9 @@ export function Board({
   /** The row the form is editing, if it isn't creating one. */
   const editRow = editing?.item ?? null;
   const scroll = useRef<HTMLDivElement>(null);
-  const rows = useRef<Record<string, HTMLDivElement | null>>({});
+  // HTMLElement, not HTMLDivElement: the Not-doing rows register here too (a
+  // reveal can land on a rejected item), and those are list items.
+  const rows = useRef<Record<string, HTMLElement | null>>({});
 
   // Bring a jumped-to row into the upper third of the viewport.
   useEffect(() => {
@@ -352,6 +358,9 @@ export function Board({
             onDecline={readOnly ? undefined : () => void rejectBrief()}
           />
         ) : blank ? (
+          // Deliberately still shown over a non-empty decision log below: a
+          // board whose every item was rejected has nothing to *work*, which is
+          // what this state claims.
           <EmptyBoard readOnly={readOnly} onAdd={() => openNew("next")} />
         ) : (
           HORIZONS.map((h) => {
@@ -511,6 +520,18 @@ export function Board({
                           ? (reason: string) => holdItem(row.id, reason)
                           : undefined
                       }
+                      onReject={
+                        // The three statuses the backend allows — the ones the
+                        // queue hasn't dispatched. A ghost gets it too (rejecting
+                        // a suggestion with a reason is the decision log's whole
+                        // point; Discard remains the traceless alternative),
+                        // which is why this reads `!readOnly` rather than
+                        // `writable`.
+                        !readOnly &&
+                        (it.status === "proposed" || it.status === "open" || it.status === "queued")
+                          ? (reason: string) => rejectItem(row.id, reason)
+                          : undefined
+                      }
                       onRelease={
                         writable && row.hold_reason ? () => releaseItem(row.id) : undefined
                       }
@@ -525,6 +546,21 @@ export function Board({
               </HorizonGroup>
             );
           })
+        )}
+        {/* The decision log, under the last group: rejected items keep their
+            row and their reason here instead of being deleted. Outside the
+            `blank` ternary on purpose — a board whose only rows are rejected
+            still owes the reader its record — and it renders nothing when the
+            log is empty. */}
+        {tab === "roadmap" && (
+          <NotDoing
+            items={rejected}
+            focusCode={focusCode}
+            onReopen={readOnly ? undefined : (id) => void reopenItem(id)}
+            rowRef={(code, el) => {
+              rows.current[code] = el;
+            }}
+          />
         )}
       </div>
 

--- a/src/components/ProjectScreen/Roadmap/InFlightRail/select.test.ts
+++ b/src/components/ProjectScreen/Roadmap/InFlightRail/select.test.ts
@@ -25,6 +25,7 @@ function item(over: Partial<RoadmapItem> & { id: string }): RoadmapItem {
     hold_reason: null,
     held_by: null,
     held_at: null,
+    close_reason: null,
     issue_url: null,
     created_at: 0,
     updated_at: 0,

--- a/src/components/ProjectScreen/Roadmap/NeedsYou/select.test.ts
+++ b/src/components/ProjectScreen/Roadmap/NeedsYou/select.test.ts
@@ -31,6 +31,7 @@ function item(over: Partial<RoadmapItem> & { id: string }): RoadmapItem {
     hold_reason: null,
     held_by: null,
     held_at: null,
+    close_reason: null,
     issue_url: null,
     created_at: 0,
     updated_at: 0,

--- a/src/components/ProjectScreen/Roadmap/Roadmap.css
+++ b/src/components/ProjectScreen/Roadmap/Roadmap.css
@@ -29,6 +29,8 @@
 .rm-board-ro .grow,
 .rm-props .grow,
 .rm-decbar .grow,
+.rm-hold .grow,
+.rm-nd-line .grow,
 .rm-dialog .modal-foot .grow,
 .rm-composer-wrap .composer-foot .grow {
   flex: 1;
@@ -1024,6 +1026,81 @@
   font-style: italic;
 }
 
+/* ── not doing ──
+   The decision log: items ruled off the board keep their code, title and
+   close_reason here instead of being deleted. Everything about it is quieter
+   than the groups above — fg-3 header, bg-1 rows, collapsed by default —
+   because this is an archive to consult, not a fourth column to work. */
+.rm-nd {
+  margin-top: 26px;
+  padding-top: 10px;
+  border-top: 1px solid var(--bd-soft);
+}
+.rm-nd-h {
+  width: 100%;
+  gap: 7px;
+  padding: 0 4px;
+  color: var(--fg-3);
+  text-align: left;
+  transition: var(--transition-ui);
+}
+.rm-nd-h:hover {
+  color: var(--fg-2);
+}
+/* The group headers' lettering, one shade down — same vocabulary, less claim. */
+.rm-nd-l {
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.rm-nd-c {
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
+}
+.rm-nd-chev {
+  flex-shrink: 0;
+  opacity: 0.75;
+  transition: transform 0.15s var(--ease);
+}
+.rm-nd-h[aria-expanded="true"] .rm-nd-chev {
+  transform: rotate(180deg);
+}
+.rm-nd-list {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+/* bg-1, not the cards' bg-2: a log row must read as settled, not as one more
+   card competing with the groups above it. */
+.rm-nd-row {
+  padding: 6px 10px;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+  background: var(--bg-1);
+  transition: border-color 0.14s var(--ease);
+}
+/* A reveal landed here — the same ring-for-a-moment the cards get, reduced to
+   the accent edge (there is no pulse to earn on an archived row). */
+.rm-nd-row.focus {
+  border-color: var(--accent-line);
+}
+.rm-nd-line {
+  gap: 9px;
+}
+.rm-nd-t {
+  min-width: 0;
+  color: var(--fg-2);
+}
+.rm-nd-why {
+  margin-top: 2px;
+  color: var(--fg-3);
+  line-height: var(--lh-snug);
+  text-wrap: pretty;
+}
+
 /* ── chips ───────────────────────────────────────────────────────────
    Every small tag on this surface — filled pills on the row header, bare
    icon+label meta in the footer and the strips — is built from one block, so
@@ -1179,6 +1256,12 @@
 .rm-state.st-r {
   color: var(--info);
   background: color-mix(in oklch, var(--info), transparent 88%);
+}
+/* Ruled off the board. Neutral like `queued`, not a warn: a rejection is a
+   decision made, not a condition waiting on anyone. */
+.rm-state.st-x {
+  color: var(--fg-3);
+  background: var(--bg-3);
 }
 
 /* Provenance glyph. A fixed square so the chevron after it sits on the same

--- a/src/components/ProjectScreen/Roadmap/itemHistory.test.ts
+++ b/src/components/ProjectScreen/Roadmap/itemHistory.test.ts
@@ -84,6 +84,15 @@ describe("eventLine", () => {
     ).toBe("PR closed — nothing merged — the item is back on the board");
   });
 
+  it("labels the decision log's pair", () => {
+    // A rejection's detail is the required close_reason — the line must quote
+    // it, because on a reopened item this trail is where the reason survives.
+    expect(eventLine(event({ id: "a", kind: "rejected", detail: "duplicate of FLT-9" }))).toBe(
+      "Rejected — duplicate of FLT-9",
+    );
+    expect(eventLine(event({ id: "b", kind: "reopened" }))).toBe("Reopened");
+  });
+
   it("labels a hand-built item's opening line", () => {
     // `created` is the user-typed row's `proposed`. The label map is typed
     // `Record<RoadmapEventKind, …>`, so omitting it would fail `tsc` — this only

--- a/src/components/ProjectScreen/Roadmap/itemHistory.ts
+++ b/src/components/ProjectScreen/Roadmap/itemHistory.ts
@@ -35,6 +35,8 @@ export const EVENT_LABEL: Record<RoadmapEventKind, string> = {
   blocked: "Blocked",
   held: "Held",
   released: "Released",
+  rejected: "Rejected",
+  reopened: "Reopened",
   note: "Note",
 };
 

--- a/src/components/ProjectScreen/Roadmap/partition.test.ts
+++ b/src/components/ProjectScreen/Roadmap/partition.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import type { ItemStatus, RoadmapItem } from "@/api";
+import { isOnBoard, isOrderable, isRejected, isShipped, rejectedRows } from "./partition";
+
+function item(over: Partial<RoadmapItem> & { id: string }): RoadmapItem {
+  return {
+    project_id: "p1",
+    code: over.id.toUpperCase(),
+    title: "t",
+    why: "",
+    horizon: "next",
+    status: "open",
+    rank: 1,
+    area: null,
+    source: "user",
+    accept: [],
+    deps: [],
+    agent_id: null,
+    workflow_def_id: null,
+    run_id: null,
+    pr_url: null,
+    pr_number: null,
+    hold_reason: null,
+    held_by: null,
+    held_at: null,
+    close_reason: null,
+    issue_url: null,
+    created_at: 0,
+    updated_at: 0,
+    ...over,
+  };
+}
+
+const at = (status: ItemStatus) => item({ id: status, status });
+
+describe("the status partition", () => {
+  it("keeps a rejected item off the horizon groups without calling it shipped", () => {
+    // The regression this file exists for: `status !== "done"` used to be the
+    // whole answer, which would have drawn rejected rows in the groups and
+    // inflated their counts.
+    const rejected = item({ id: "x", status: "rejected", close_reason: "duplicate" });
+    expect(isOnBoard(rejected)).toBe(false);
+    expect(isShipped(rejected)).toBe(false);
+    expect(isRejected(rejected)).toBe(true);
+  });
+
+  it("boards every working status and only counts done as shipped", () => {
+    for (const status of ["proposed", "open", "queued", "active", "in_review"] as const) {
+      expect(isOnBoard(at(status))).toBe(true);
+      expect(isShipped(at(status))).toBe(false);
+    }
+    expect(isOnBoard(at("done"))).toBe(false);
+    expect(isShipped(at("done"))).toBe(true);
+  });
+
+  it("never lets a rejected row into the orderable set", () => {
+    // The drag's domain and the PM order ask's reference — the backend's
+    // `order::is_orderable` excludes rejected too, and the two must agree.
+    expect(isOrderable(at("rejected"))).toBe(false);
+    expect(isOrderable(at("open"))).toBe(true);
+  });
+});
+
+describe("rejectedRows", () => {
+  it("lists only rejected rows, newest ruling first", () => {
+    const older = item({ id: "a", status: "rejected", close_reason: "r", updated_at: 10 });
+    const newer = item({ id: "b", status: "rejected", close_reason: "r", updated_at: 20 });
+    const open = item({ id: "c", updated_at: 30 });
+    expect(rejectedRows([older, open, newer]).map((r) => r.id)).toEqual(["b", "a"]);
+  });
+});

--- a/src/components/ProjectScreen/Roadmap/partition.ts
+++ b/src/components/ProjectScreen/Roadmap/partition.ts
@@ -1,0 +1,43 @@
+// Where a status puts a row on this surface — the one partition the horizon
+// groups, the header counts and the "Not doing" section all read.
+//
+// Pure and in its own file (like ruling.ts) because three different numbers are
+// derived from it — the group counts, the header's shipped count, the decision
+// log's length — and a predicate inlined in the hook is exactly how one of them
+// drifts: when `rejected` arrived, every `status !== "done"` in the hook would
+// have silently kept counting rejected rows as open work.
+
+import type { RoadmapItem } from "@/api";
+
+/** Shipped. The item leaves the board entirely and survives only as the
+ *  header's count (and the Activity tab's record). */
+export const isShipped = (i: RoadmapItem) => i.status === "done";
+
+/** Ruled off the board, with the reason kept (`close_reason`). Not deleted:
+ *  the row and its history survive in the board's collapsed "Not doing"
+ *  section, from which it can be reopened. In no horizon group and no count —
+ *  a rejected item is not open work. */
+export const isRejected = (i: RoadmapItem) => i.status === "rejected";
+
+/** On the board proper — in a horizon group, counted, joinable by the strips.
+ *  Everything but the two departures above: `done` left forward, `rejected`
+ *  left sideways. */
+export const isOnBoard = (i: RoadmapItem) => !isShipped(i) && !isRejected(i);
+
+/** A row the PM has suggested and the user hasn't ruled on. Drawn as a ghost:
+ *  in its target horizon, but counted for nothing. */
+export const isProposed = (i: RoadmapItem) => i.status === "proposed";
+
+/** Can this row's position in the order be changed — by a drag, or by an
+ *  accepted PM reordering? Everything from `active` on has been dispatched, so
+ *  its place in the queue is settled and moving it would mean nothing (the same
+ *  three statuses the backend's `order::is_orderable` allows). */
+export const isOrderable = (i: RoadmapItem) =>
+  i.status === "proposed" || i.status === "open" || i.status === "queued";
+
+/** The decision log, newest ruling first. `updated_at` rather than a dedicated
+ *  timestamp: rejecting is the row's last write (nothing else touches a
+ *  rejected item until a reopen removes it from this list), so the two agree. */
+export function rejectedRows(rows: readonly RoadmapItem[]): RoadmapItem[] {
+  return rows.filter(isRejected).sort((a, b) => b.updated_at - a.updated_at);
+}

--- a/src/components/ProjectScreen/Roadmap/proposalDiff.test.ts
+++ b/src/components/ProjectScreen/Roadmap/proposalDiff.test.ts
@@ -24,6 +24,7 @@ function item(over: Partial<RoadmapItem> = {}): RoadmapItem {
     hold_reason: null,
     held_by: null,
     held_at: null,
+    close_reason: null,
     issue_url: null,
     created_at: 0,
     updated_at: 0,

--- a/src/components/ProjectScreen/Roadmap/reviewPrompt.test.ts
+++ b/src/components/ProjectScreen/Roadmap/reviewPrompt.test.ts
@@ -25,6 +25,7 @@ function item(over: Partial<RoadmapItem> = {}): RoadmapItem {
     hold_reason: null,
     held_by: null,
     held_at: null,
+    close_reason: null,
     issue_url: null,
     updated_at: 0,
     ...over,

--- a/src/components/ProjectScreen/Roadmap/useItemReviews.test.ts
+++ b/src/components/ProjectScreen/Roadmap/useItemReviews.test.ts
@@ -25,6 +25,7 @@ function item(over: Partial<RoadmapItem> = {}): RoadmapItem {
     hold_reason: null,
     held_by: null,
     held_at: null,
+    close_reason: null,
     issue_url: null,
     updated_at: 0,
     ...over,

--- a/src/components/ProjectScreen/Roadmap/useRoadmap.ts
+++ b/src/components/ProjectScreen/Roadmap/useRoadmap.ts
@@ -19,8 +19,9 @@
 // src-tauri/src/rpc/roadmap.rs) writes real rows with `status: "proposed"`, and
 // they arrive here on the same `roadmap:item` event as everything else — so the
 // board grows ghost rows live while the PM is still talking. Accepting one is a
-// status patch (`proposed → open`); discarding it is a delete. Those two are
-// the only ways a proposed row leaves that state.
+// status patch (`proposed → open`); discarding it is a delete; rejecting it
+// (`roadmapRejectItem`) parks it in the decision log with a reason. Those three
+// are the only ways a proposed row leaves that state.
 //
 // Queueing works the same way, one status further along: `open → queued` is the
 // user handing an item to the Rust drainer (src-tauri/src/roadmap/drainer.rs),
@@ -82,6 +83,7 @@ import { useAppStore } from "@/store";
 import { useRuns } from "@/workflows/run/useRuns";
 import { insertEvent, mergeSnapshot } from "./itemHistory";
 import { buildNeedsYou, mergeLatest, upsertLatest } from "./NeedsYou/select";
+import { isOnBoard, isOrderable, isProposed, isShipped, rejectedRows } from "./partition";
 import { revealRefusal, revealTarget } from "./reveal";
 import { reviewFeedbackPrompt } from "./reviewPrompt";
 import type { Horizon } from "./types";
@@ -95,21 +97,6 @@ const LANDED_MS = 2200;
 const FOCUS_MS = 2200;
 
 export type BoardTab = "roadmap" | "brief";
-
-/** A shipped item leaves the board entirely and survives only as the header's
- *  count, so "on the board" is every status but `done`. */
-const isOnBoard = (i: RoadmapItem) => i.status !== "done";
-
-/** A row the PM has suggested and the user hasn't ruled on. Drawn as a ghost:
- *  in its target horizon, but counted for nothing. */
-const isProposed = (i: RoadmapItem) => i.status === "proposed";
-
-/** Can this row's position in the order be changed — by a drag, or by an
- *  accepted PM reordering? Everything from `active` on has been dispatched, so
- *  its place in the queue is settled and moving it would mean nothing (the same
- *  three statuses the backend's `order::is_orderable` allows). */
-const isOrderable = (i: RoadmapItem) =>
-  i.status === "proposed" || i.status === "open" || i.status === "queued";
 
 export function useRoadmap(repoPath: string) {
   // The board is per project, not per repo: a multi-repo project has one
@@ -532,13 +519,16 @@ export function useRoadmap(repoPath: string) {
   );
 
   // ── derived ────────────────────────────────────────────────────────
-  /** The rows the board renders — everything but the shipped ones. The strip
-   *  joins against these for the same reason the proposal lookup does: a card
-   *  about a row nothing draws is a decision the user can't reach. */
+  /** The rows the horizon groups render — neither shipped nor rejected. The
+   *  strip joins against these for the same reason the proposal lookup does: a
+   *  card about a row nothing draws is a decision the user can't reach. */
   const onBoard = useMemo(() => rows.filter(isOnBoard), [rows]);
   const items = useMemo(() => onBoard.filter((r) => !isProposed(r)).map(toBoardItem), [onBoard]);
   /** Shipped items aren't on the board; the header carries the count. */
-  const shipped = useMemo(() => rows.filter((r) => !isOnBoard(r)).length, [rows]);
+  const shipped = useMemo(() => rows.filter(isShipped).length, [rows]);
+  /** The decision log: items ruled off the board, newest ruling first — the
+   *  collapsed "Not doing" section under the horizon groups. */
+  const rejected = useMemo(() => rejectedRows(rows), [rows]);
 
   /** The PM's outstanding proposals, drawn on the board as ghosts until the
    *  user accepts or discards them. Kept out of `items` so they don't move a
@@ -547,11 +537,12 @@ export function useRoadmap(repoPath: string) {
 
   /** The PM's pending asks against existing items, by the item they target —
    *  the shape the card lookup wants, and one-per-item by construction (the
-   *  backend replaces an item's ask in place). Restricted to items the board
-   *  actually renders: an ask whose item advanced to `done` has no card to
-   *  rule it from, and counting or quoting it would make a single orphan both
-   *  invisible and immortal. The row itself survives in the DB; it comes back
-   *  into view if the item ever returns to the board. */
+   *  backend replaces an item's ask in place). Restricted to items the horizon
+   *  groups actually render: an ask whose item advanced to `done` — or was
+   *  rejected — has no card to rule it from, and counting or quoting it would
+   *  make a single orphan both invisible and immortal. The row itself survives
+   *  in the DB; it comes back into view if the item ever returns to the board
+   *  (a rejected one on reopen). */
   const proposals = useMemo(() => {
     const visible = new Set(onBoard.map((r) => r.id));
     const by = new Map<string, RoadmapProposal>();
@@ -901,6 +892,30 @@ export function useRoadmap(repoPath: string) {
     [guarded, upsert],
   );
 
+  /** Rule an item off the board, with the required reason. Not a delete: the
+   *  row keeps its code and its history and moves to the "Not doing" section,
+   *  so the decision can be read later and undone (`reopenItem`). The backend
+   *  refuses anything already dispatched or shipped — for those the lever is
+   *  the run or nothing — and that refusal lands on the error bar. */
+  const rejectItem = useCallback(
+    (id: string, reason: string) =>
+      guarded(async () => {
+        upsert(await api.roadmapRejectItem(id, reason));
+      }),
+    [guarded, upsert],
+  );
+
+  /** Put a rejected item back on the board (`rejected → open`). The reason is
+   *  cleared off the row but survives on the trail as the `rejected` event, so
+   *  "why was this off the board" still has an answer. */
+  const reopenItem = useCallback(
+    (id: string) =>
+      guarded(async () => {
+        upsert(await api.roadmapReopenItem(id));
+      }),
+    [guarded, upsert],
+  );
+
   /** Take a handed-off item back off its agent — the undo of "Send to an agent".
    *  Clears `agent_id` and lands a history note naming the agent; the row is then
    *  the queue's to dispatch again. The backend re-checks the gate (something to
@@ -1099,6 +1114,9 @@ export function useRoadmap(repoPath: string) {
     ghosts,
     counts,
     shipped,
+    /** The decision log — rejected items, newest ruling first. Rendered as the
+     *  board's collapsed "Not doing" section, never in a horizon group. */
+    rejected,
     loading,
     /** No project row for this repo — the board can be read but not written,
      *  so the write affordances stay out of the way. [`makeProject`] is the way
@@ -1178,6 +1196,8 @@ export function useRoadmap(repoPath: string) {
     sendReviewFeedback,
     holdItem,
     releaseItem,
+    rejectItem,
+    reopenItem,
     holdProject,
     releaseProject,
     /** Definitions + the project default, for the queue affordance and the

--- a/src/rowSync.test.ts
+++ b/src/rowSync.test.ts
@@ -25,6 +25,7 @@ function item(over: Partial<RoadmapItem> & { id: string }): RoadmapItem {
     hold_reason: null,
     held_by: null,
     held_at: null,
+    close_reason: null,
     issue_url: null,
     created_at: 0,
     updated_at: 0,


### PR DESCRIPTION
## What

Items ruled off the roadmap are no longer silently deleted — they become `rejected` with a mandatory reason, keep their full history trail, and can be reopened. This is the first piece of the shared product-context work: "we decided not to build X, because Y" becomes a durable, queryable fact instead of a vanished row.

## How

**Backend**
- Migration 0037: nullable `close_reason` on `roadmap_items` (status had no CHECK constraint, so `'rejected'` needed no schema change).
- `ItemStatus::Rejected` + `EventKind::Rejected`/`Reopened`. `close_reason` is deliberately absent from `ItemPatch`/`NewItem` — only the typed commands and the discard ruling write it, mirroring `hold_reason`.
- New `roadmap_reject_item` / `roadmap_reopen_item` command pair, shaped like hold/release: one lock scope, emits after drop. Reject requires a non-blank reason, is allowed from proposed/open/queued, refuses active/in_review/done, clears any hold and `agent_id`, and consumes a pending proposal. Reopen is precondition-guarded (`WHERE status='rejected'`) and clears the reason.
- **`accept_proposal`'s Discard arm no longer deletes.** The item lands `rejected` with the PM's (already-mandatory) rationale as `close_reason`. `Ruling::Discarded` had no remaining constructor and was removed.
- `is_rulable` excludes `rejected` — nothing proposes onto a corpse; the PM-side gate follows via the shared predicate, and its refusal message now names the real objection per status (pre-existing sloppiness: it said "being built" even for `done`).
- Drainer: a queued item waiting on a *rejected* dep is now a standing wedge ("…which was rejected — remove or replace that dependency", one durable event, deduped across ticks) instead of a transient "Waiting on FLE-x" forever. Rejected never satisfies a dep.
- PM instructions (`roadmap.md`) updated: discard semantics, the two new event kinds, and "don't lobby a rejected item by proposal".

**Frontend**
- Board: rejected rows leave the horizon groups and counts (`shipped` now counts `done` explicitly — it was "everything not on board" and would have silently absorbed rejected) and live in a collapsed **"Not doing"** section at the bottom: code, title, reason, Reopen. Reveal-targeting a rejected code latches the section open.
- "Reject…" card action for proposed/open/queued with a required inline reason — the hold flow's reason gesture, extracted into a shared `ReasonAction` used by both Hold and Reject.
- Status partition extracted from `useRoadmap` into a pure, tested `partition.ts`; optimistic reject/reopen mutations; event labels for the two new kinds.

## Verification

- `cargo test`: **1411 passed** (10 added, the delete-asserting discard test rewritten to assert the decision log); clippy and rustfmt clean.
- `vitest`: **999 passed** across 94 files (partition + history-label tests added); rtk tsc and biome clean.

## Noted, deferred (design-level, untouched code)

- Dep validation still accepts a dep on a rejected item at write time (it lands, then wedges with a fix-it message). Refusing at write time would be kinder — a small `deps.rs` follow-up.
- The issue funnel treats a rejected issue-routed row as "On roadmap" in the inbox — coherent (the decision stands, dedup by `issue_url` holds), but the wording doesn't distinguish "rejected" from "planned".