### PR TITLE
chore(sandbox): add EngineKind::is_container and use it at external engine branches

### DIFF
--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -680,16 +680,16 @@ fn push_typed(out: &mut String, s: &str) {
 }
 
 /// The agent binary handed to `launch_agent`, decided by the *resolved*
-/// engine's kind: under docker it's the provider's in-image command name
-/// (`claude` / `codex` — the image carries its own install; a resolved host path
-/// would be meaningless, or missing, inside the container), under seatbelt the
-/// host-resolved absolute path as always. Keyed off the resolved engine rather
+/// engine's kind: under a container engine it's the provider's in-image command
+/// name (`claude` / `codex` — the image carries its own install; a resolved host
+/// path would be meaningless, or missing, inside the container), under seatbelt
+/// the host-resolved absolute path as always. Keyed off the resolved engine rather
 /// than the stamped setting; a docker-stamped agent whose daemon is down never
 /// reaches here — `sandbox::engine_for` fails the spawn instead of degrading to
 /// seatbelt — so the resolved engine always matches the launch boundary.
 ///
 /// Docker reaches here only for a provider `DockerProvider::from_id` accepts
-/// (the `supervisor::lifecycle` gate ran first), so the `None` arm is defensive.
+/// (the `supervisor::lifecycle` gate ran first), so the `None` case is defensive.
 fn agent_bin_for(
     provider: &str,
     bin: &str,
@@ -697,12 +697,11 @@ fn agent_bin_for(
     engine: &dyn SandboxEngine,
     home: &Path,
 ) -> Result<String> {
-    match engine.kind() {
-        EngineKind::Docker => sandbox::docker::DockerProvider::from_id(provider)
+    if engine.kind().is_container() {
+        sandbox::docker::DockerProvider::from_id(provider)
             .map(|p| p.image_bin().to_string())
-            .ok_or_else(|| {
-                Error::Other(format!("{label} isn't available in Docker sandboxes yet"))
-            }),
-        EngineKind::SandboxExec => resolve_agent_bin(provider, bin, label, home),
+            .ok_or_else(|| Error::Other(format!("{label} isn't available in Docker sandboxes yet")))
+    } else {
+        resolve_agent_bin(provider, bin, label, home)
     }
 }

--- a/src-tauri/src/codegraph/mod.rs
+++ b/src-tauri/src/codegraph/mod.rs
@@ -148,7 +148,7 @@ fn wants_codegraph(
     existing_names: &[&str],
 ) -> bool {
     enabled
-        && engine != EngineKind::Docker
+        && !engine.is_container()
         && can_receive_mcp
         && !existing_names
             .iter()

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -26,6 +26,18 @@ impl EngineKind {
         }
     }
 
+    /// Whether this engine runs the agent inside a container. Call sites outside
+    /// the sandbox module ask this instead of matching `Docker` directly, so a
+    /// second container engine updates one place. Matched exhaustively: a new
+    /// variant forces the decision here rather than silently landing on a
+    /// default.
+    pub fn is_container(self) -> bool {
+        match self {
+            Self::Docker => true,
+            Self::SandboxExec => false,
+        }
+    }
+
     /// Parse a `sandbox_engine` settings value. `None` for unknown values so
     /// callers pick their own fallback (spawn paths default to seatbelt).
     pub fn from_setting(value: &str) -> Option<Self> {
@@ -163,6 +175,12 @@ mod tests {
         for &kind in EngineKind::ALL {
             assert_eq!(EngineKind::from_setting(kind.as_setting()), Some(kind));
         }
+    }
+
+    #[test]
+    fn only_docker_is_a_container_engine() {
+        assert!(EngineKind::Docker.is_container());
+        assert!(!EngineKind::SandboxExec.is_container());
     }
 
     #[test]

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -9,7 +9,6 @@ use crate::error::{Error, Result};
 use crate::git;
 use crate::sandbox::docker;
 use crate::sandbox::provision::{self, CheckoutSpec};
-use crate::sandbox::EngineKind;
 use crate::workspace::{
     agent_parent_dir, repo_checkout_path, AgentRecord, AgentStatus, ArchiveMetadata,
     ArchivedRepoSnapshot, DiffStats, TrackedRepo,
@@ -447,7 +446,7 @@ async fn choose_restore_branch_name(repo_path: &Path, desired: &str) -> String {
 ///    here. Detached on purpose: archive must not wait on a Docker
 ///    round-trip to report success to the user.
 fn reap_agent_containers(agent_id: &str, record: Option<&AgentRecord>, op: &'static str) {
-    if record.map(stamped_engine) == Some(EngineKind::SandboxExec) {
+    if record.is_some_and(|r| !stamped_engine(r).is_container()) {
         return;
     }
     let agent_id = agent_id.to_string();

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -53,8 +53,7 @@ pub(super) fn stamped_engine(record: &AgentRecord) -> EngineKind {
 /// unsupported provider. Consults the capability lookup rather than string-
 /// matching a single provider id.
 fn ensure_engine_supports_provider(engine: EngineKind, provider: &str) -> Result<()> {
-    if engine == EngineKind::Docker && sandbox::docker::DockerProvider::from_id(provider).is_none()
-    {
+    if engine.is_container() && sandbox::docker::DockerProvider::from_id(provider).is_none() {
         let label = per_turn_descriptor(provider)
             .map(|d| d.label())
             .unwrap_or(provider);
@@ -604,7 +603,7 @@ impl Supervisor {
         // uses the normal (`--shared`) clone path. A later restore relaunches
         // the container and re-provisions via `--shared` + mount.
         let record = self.workspace.agent(agent_id)?;
-        let self_contained = stamped_engine(&record) == EngineKind::Docker;
+        let self_contained = stamped_engine(&record).is_container();
         self.attach_repo_checkout(&app, agent_id, repo_path, self_contained)
             .await
     }


### PR DESCRIPTION
Groundwork for adding Podman as a third sandbox engine (PR 1 of the series).

Several call sites outside `sandbox/` spelled "is this a container engine?" as `== EngineKind::Docker` (or its seatbelt-only mirror). This adds a single predicate, `EngineKind::is_container()`, and converts those sites to it, so a future container engine updates one place instead of growing `|| Podman` matches ad hoc.

## Changes

- `sandbox/engine.rs`: new `EngineKind::is_container()` with an exhaustive match — a new variant fails to compile until it declares itself — plus a unit test.
- `agent/spawn.rs` (`agent_bin_for`): container → in-image command name, else host-resolved binary. Error copy unchanged.
- `codegraph/mod.rs`: codegraph MCP injection skipped for container agents via the predicate.
- `supervisor/lifecycle.rs`: the provider-support gate and the self-contained-checkout decision now key on `is_container()`.
- `supervisor/disposition.rs` (`reap_agent_containers`): gate generalized to "record proves this agent never had a container", preserving the exact `None` (missing record) behavior.

Deliberately untouched: `lib.rs` `set_sandbox_engine`'s Docker-availability probe — that branch is genuinely Docker-specific and gets its Podman arm when the Podman probe lands.

Pure refactor, zero behavior change: 1428 tests pass, rustfmt and clippy clean.