### PR TITLE
chore(sandbox): extract runtime-neutral container layer out of docker/

### DIFF
--- a/src-tauri/src/sandbox/container/auth.rs
+++ b/src-tauri/src/sandbox/container/auth.rs
@@ -21,7 +21,7 @@
 //!    a usable token counts (see [`usable_oauth_token`]); no Keychain / no login
 //!    (Linux, CI) falls through. See [`keychain_token`].
 //! 2. A `claude setup-token` value captured into the app's secret store
-//!    ([`TOKEN_SETTING`], auto-populated by [`super::setup_token`]) →
+//!    ([`TOKEN_SETTING`], auto-populated by [`crate::sandbox::docker::setup_token`]) →
 //!    `CLAUDE_CODE_OAUTH_TOKEN`. The fallback for hosts without a readable
 //!    Keychain login.
 //! 3. The app's process env or the login-shell probe exports a credential —

--- a/src-tauri/src/sandbox/container/images.rs
+++ b/src-tauri/src/sandbox/container/images.rs
@@ -1,0 +1,471 @@
+//! The embedded agent images' *content*: what a container runs, one image per
+//! supported provider (see [`ContainerProvider`]).
+//!
+//! The Dockerfile and entrypoint are compiled into the binary and each image's
+//! tag is derived from its content (`<repo>:<sha256[..12]>`, e.g.
+//! `fletch-agent:…` for claude, `fletch-agent-codex:…` for codex), so shipping a
+//! change to either automatically produces a new tag — the stale image is
+//! never referenced again and the next spawn rebuilds. No version bookkeeping,
+//! no manual invalidation. Provider images share their base layers (identical
+//! `FROM` + apt step), so a second provider costs only its own install layer.
+//!
+//! Every embedded image also carries [`AGENT_IMAGE_LABEL`] so superseded images
+//! (old hashes after a Dockerfile revision, untagged leftovers after a rebuild)
+//! can be garbage-collected.
+//!
+//! Content only: nothing here talks to a container runtime. Building, inspecting,
+//! the freshness TTL, and the GC all live in `sandbox::docker::image`.
+
+use super::ContainerProvider;
+
+/// The base every provider image builds on (enforced by a test over
+/// [`image_spec`]). Named as a constant rather than left implicit in the five
+/// Dockerfile literals because the reclamation path needs to know which tag a
+/// `--pull` is able to move under us — see `image::reap_superseded_base`.
+pub(crate) const BASE_IMAGE: &str = "node:22-slim";
+
+/// The agent container image. Debian-slim keeps apt available for the tools
+/// claude needs at runtime (`git`, `rg`, `jq`, `procps` for /proc-based
+/// process introspection) while staying small; node 22 is claude-code's
+/// supported runtime. The `chmod` guarantees the entrypoint is executable
+/// regardless of the mode `COPY` picked up from the build context (context
+/// files are written at build time on the host — see `image::ensure_image`).
+pub(crate) const DOCKERFILE: &str = r#"FROM node:22-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates ripgrep jq procps \
+ && rm -rf /var/lib/apt/lists/*
+LABEL fletch.agent=claude
+RUN npm install -g @anthropic-ai/claude-code
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+"#;
+
+/// PID-1 shim. The container gets `HOME=<host home>` (a path that does not
+/// exist in the image), so the entrypoint creates it and seeds the minimal
+/// `~/.claude.json` claude needs to skip interactive onboarding. Seeding is
+/// conditional and the file is container-ephemeral by design: bind-mounting the
+/// real `~/.claude.json` would break on claude's atomic rename-replace writes.
+pub(crate) const ENTRYPOINT_SH: &str = r#"#!/bin/sh
+set -e
+mkdir -p "$HOME"
+if [ ! -f "$HOME/.claude.json" ]; then
+  printf '{"hasCompletedOnboarding": true}\n' > "$HOME/.claude.json"
+fi
+exec "$@"
+"#;
+
+/// Codex's image. Shares [`DOCKERFILE`]'s base byte-for-byte — same `FROM
+/// node:22-slim` and the same apt line — so Docker's layer cache is reused
+/// across the two images; only the provider install step differs
+/// (`@openai/codex` instead of `@anthropic-ai/claude-code`). Codex authenticates
+/// from the read-write `~/.codex` mount (auth.json) and/or `OPENAI_API_KEY`, so
+/// the image carries no provider config of its own.
+pub(crate) const CODEX_DOCKERFILE: &str = r#"FROM node:22-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates ripgrep jq procps \
+ && rm -rf /var/lib/apt/lists/*
+LABEL fletch.agent=codex
+RUN npm install -g @openai/codex
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+"#;
+
+/// Codex's PID-1 shim: create `HOME` and exec, nothing more. Unlike claude,
+/// codex needs no onboarding seed — `codex exec` runs non-interactively with
+/// `--skip-git-repo-check` and `approval_policy="never"` (see
+/// `agent::codex_build_args`), and its credentials come from the mounted
+/// `~/.codex/auth.json` rather than a config file we'd seed here.
+pub(crate) const CODEX_ENTRYPOINT_SH: &str = r#"#!/bin/sh
+set -e
+mkdir -p "$HOME"
+exec "$@"
+"#;
+
+/// OpenCode's image. Shares [`DOCKERFILE`]'s base byte-for-byte (same `FROM
+/// node:22-slim` and apt line) for layer-cache reuse; only the install step
+/// differs (`opencode-ai`, whose `bin` resolves to a per-arch native binary via
+/// npm optional deps — arm64 and x86-64 both publish one). OpenCode authenticates
+/// from the read-write data-dir mount (its accounts DB / `auth.json`) and/or a
+/// provider API-key env var, so the image carries no provider config.
+pub(crate) const OPENCODE_DOCKERFILE: &str = r#"FROM node:22-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates ripgrep jq procps \
+ && rm -rf /var/lib/apt/lists/*
+LABEL fletch.agent=opencode
+RUN npm install -g opencode-ai
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+"#;
+
+/// OpenCode's PID-1 shim: create `HOME` and exec. `opencode run --format json
+/// --dangerously-skip-permissions` (see `agent::opencode_build_args`) is fully
+/// non-interactive, and credentials arrive on the read-write data-dir mount or as
+/// a forwarded API-key env var, so nothing is seeded here.
+pub(crate) const OPENCODE_ENTRYPOINT_SH: &str = r#"#!/bin/sh
+set -e
+mkdir -p "$HOME"
+exec "$@"
+"#;
+
+/// Pi's image. Shares [`DOCKERFILE`]'s base byte-for-byte for cache reuse; only
+/// the install step differs. Pi ships as a pure-node CLI (`@earendil-works/
+/// pi-coding-agent`, bin `pi` → a `dist/cli.js` launcher), so the same package
+/// runs on every arch node:22-slim supports. Pi authenticates from the read-write
+/// `~/.pi` mount (`~/.pi/agent/auth.json`) and/or a provider API-key env var.
+pub(crate) const PI_DOCKERFILE: &str = r#"FROM node:22-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates ripgrep jq procps \
+ && rm -rf /var/lib/apt/lists/*
+LABEL fletch.agent=pi
+RUN npm install -g @earendil-works/pi-coding-agent
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+"#;
+
+/// Pi's PID-1 shim: create `HOME` and exec. `pi -p --mode json` (see
+/// `agent::pi_build_args`) runs one turn non-interactively and auto-runs tools;
+/// credentials come from the mounted `~/.pi/agent/auth.json` or a forwarded
+/// API-key env var, so nothing is seeded here.
+pub(crate) const PI_ENTRYPOINT_SH: &str = r#"#!/bin/sh
+set -e
+mkdir -p "$HOME"
+exec "$@"
+"#;
+
+/// Cursor's image. Shares [`DOCKERFILE`]'s base byte-for-byte (same `FROM
+/// node:22-slim` and apt line) for layer-cache reuse; only the install step
+/// differs. Unlike the other providers, cursor-agent ships not as an npm package
+/// but via its official installer (`https://cursor.com/install`), which detects
+/// `linux/arm64` and downloads a self-contained bundle (its own node runtime +
+/// per-arch native modules) into `~/.local`; we symlink its `cursor-agent`
+/// launcher onto PATH so the in-image `agent_bin` resolves, then run
+/// `--version` so a build fails loudly if the installer ever relocates the
+/// binary — `ln -s` happily creates a dangling link, and without the check
+/// that drift would only surface as exit-127 launches. The installer pins
+/// whatever version its script currently references — no worse than the `latest`
+/// npm installs the other images use: the Dockerfile *text* is constant so the
+/// content-addressed tag is stable, while a re-pull may fetch a newer bundle
+/// (contents drift under a stable tag — an accepted, documented tradeoff shared
+/// with every `npm install -g <pkg>` here). Cursor authenticates in-container from
+/// a forwarded `CURSOR_API_KEY` (see [`launch_auth`](super::launch_auth)):
+/// `cursor-agent login` stores its tokens in the host OS keychain, which a
+/// container can't read, so the image carries no provider config of its own.
+pub(crate) const CURSOR_DOCKERFILE: &str = r#"FROM node:22-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates ripgrep jq procps \
+ && rm -rf /var/lib/apt/lists/*
+LABEL fletch.agent=cursor
+RUN curl -fsSL https://cursor.com/install | bash \
+ && ln -s /root/.local/bin/cursor-agent /usr/local/bin/cursor-agent \
+ && cursor-agent --version
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+"#;
+
+/// Cursor's PID-1 shim: create `HOME` and exec. `cursor-agent -p --output-format
+/// stream-json --force --trust` (see `agent::cursor_build_args`) runs one turn
+/// non-interactively; credentials arrive as the forwarded `CURSOR_API_KEY` env
+/// var and its transcripts land on the read-write `~/.cursor` mount, so nothing is
+/// seeded here.
+pub(crate) const CURSOR_ENTRYPOINT_SH: &str = r#"#!/bin/sh
+set -e
+mkdir -p "$HOME"
+exec "$@"
+"#;
+
+/// Label key baked into every embedded agent image (`LABEL
+/// fletch.agent=<provider>` in the Dockerfiles above). It is the image GC's
+/// authority: only images carrying it — or, transitionally, pre-label images
+/// in a Fletch-owned repo — are ever candidates for removal (see
+/// `cleanup::sweep_stale_images`). The user's `docker_image` override never
+/// gets the label (it is never built by us), so it can't be attributed to
+/// Fletch and is structurally safe from the GC.
+pub(crate) const AGENT_IMAGE_LABEL: &str = "fletch.agent";
+
+/// The image build inputs for a provider: repo name plus the Dockerfile and
+/// entrypoint whose combined content addresses the tag. Every spec's Dockerfile
+/// carries `LABEL fletch.agent=<provider>` so the image GC can attribute it
+/// (enforced by a test); each provider gets its own repo.
+pub(crate) struct ImageSpec {
+    pub(crate) repo: &'static str,
+    pub(crate) dockerfile: &'static str,
+    pub(crate) entrypoint: &'static str,
+}
+
+/// Per-provider image inputs. Claude's spec is the pre-existing embedded image
+/// verbatim (see the byte-identity guard in tests); codex gets its own repo and
+/// install step, sharing claude's base layers.
+pub(crate) fn image_spec(provider: ContainerProvider) -> ImageSpec {
+    match provider {
+        ContainerProvider::Claude => ImageSpec {
+            repo: "fletch-agent",
+            dockerfile: DOCKERFILE,
+            entrypoint: ENTRYPOINT_SH,
+        },
+        ContainerProvider::Codex => ImageSpec {
+            repo: "fletch-agent-codex",
+            dockerfile: CODEX_DOCKERFILE,
+            entrypoint: CODEX_ENTRYPOINT_SH,
+        },
+        ContainerProvider::Opencode => ImageSpec {
+            repo: "fletch-agent-opencode",
+            dockerfile: OPENCODE_DOCKERFILE,
+            entrypoint: OPENCODE_ENTRYPOINT_SH,
+        },
+        ContainerProvider::Pi => ImageSpec {
+            repo: "fletch-agent-pi",
+            dockerfile: PI_DOCKERFILE,
+            entrypoint: PI_ENTRYPOINT_SH,
+        },
+        ContainerProvider::Cursor => ImageSpec {
+            repo: "fletch-agent-cursor",
+            dockerfile: CURSOR_DOCKERFILE,
+            entrypoint: CURSOR_ENTRYPOINT_SH,
+        },
+    }
+}
+
+/// The content-addressed tag for a provider's embedded image.
+pub(crate) fn image_tag(provider: ContainerProvider) -> String {
+    let spec = image_spec(provider);
+    tag_for(spec.repo, spec.dockerfile, spec.entrypoint)
+}
+
+/// The repo (image name without tag) of a provider's embedded image. With
+/// [`image_tag`] this is the GC's vocabulary of Fletch-owned names: the repos
+/// are chosen by this module and are not meaningful outside Fletch, so a
+/// non-current tag under one of them is attributable to us even on legacy
+/// images built before [`AGENT_IMAGE_LABEL`] existed.
+pub(crate) fn image_repo(provider: ContainerProvider) -> &'static str {
+    image_spec(provider).repo
+}
+
+/// `<repo>:<sha256(dockerfile + entrypoint)[..12]>` — 12 hex chars, the same
+/// abbreviation depth docker itself uses for short ids. The hash covers only the
+/// dockerfile+entrypoint content (not the repo), so claude's tail is unchanged
+/// from before the repo argument existed as long as its content is.
+pub(crate) fn tag_for(repo: &str, dockerfile: &str, entrypoint: &str) -> String {
+    use sha2::Digest;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(dockerfile.as_bytes());
+    hasher.update(entrypoint.as_bytes());
+    let digest = hasher.finalize();
+    let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
+    format!("{repo}:{}", &hex[..12])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every provider image builds on [`BASE_IMAGE`]. This is the invariant
+    /// `image::reap_superseded_base` rests on: it only ever inspects and
+    /// reclaims that one tag, so a spec that quietly moved to a different base
+    /// would orphan images nothing reclaims.
+    #[test]
+    fn every_spec_builds_on_the_declared_base() {
+        let from = format!("FROM {BASE_IMAGE}\n");
+        for provider in ContainerProvider::ALL {
+            assert!(
+                image_spec(provider).dockerfile.starts_with(&from),
+                "{provider:?} must build FROM {BASE_IMAGE}",
+            );
+        }
+    }
+
+    #[test]
+    fn tag_is_content_addressed() {
+        let tag = tag_for("fletch-agent", "FROM a\n", "#!/bin/sh\n");
+        let (repo, hash) = tag.split_once(':').unwrap();
+        assert_eq!(repo, "fletch-agent");
+        assert_eq!(hash.len(), 12);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+
+        // Deterministic, and any content change moves the tag.
+        assert_eq!(tag, tag_for("fletch-agent", "FROM a\n", "#!/bin/sh\n"));
+        assert_ne!(tag, tag_for("fletch-agent", "FROM b\n", "#!/bin/sh\n"));
+        assert_ne!(tag, tag_for("fletch-agent", "FROM a\n", "#!/bin/bash\n"));
+        // The repo is a prefix, not part of the hash: a different repo with the
+        // same content shares the tail (so a repo rename can't force a rebuild).
+        assert_eq!(
+            tag_for("fletch-agent", "FROM a\n", "#!/bin/sh\n")
+                .split_once(':')
+                .unwrap()
+                .1,
+            tag_for("other", "FROM a\n", "#!/bin/sh\n")
+                .split_once(':')
+                .unwrap()
+                .1,
+        );
+    }
+
+    /// Golden guard: claude's image content is pinned byte-for-byte so an
+    /// *accidental* edit can't silently move the content-addressed tag and
+    /// force every user through a cold rebuild. Deliberate changes update the
+    /// frozen bytes here and record why:
+    ///
+    /// - image-lifecycle PR: added `LABEL fletch.agent=claude` so the image GC
+    ///   can attribute Fletch's images by label instead of guessing from
+    ///   names. One planned rehash → one rebuild for every user on update,
+    ///   accepted (and the GC reaps the superseded image).
+    #[test]
+    fn claude_image_is_unchanged() {
+        // Frozen bytes (do not "fix" to match an accidentally changed constant
+        // — update the constant back instead; deliberate changes update these
+        // bytes and the doc comment above).
+        const FROZEN_DOCKERFILE: &str = "FROM node:22-slim\nRUN apt-get update && apt-get install -y --no-install-recommends \\\n    git curl ca-certificates ripgrep jq procps \\\n && rm -rf /var/lib/apt/lists/*\nLABEL fletch.agent=claude\nRUN npm install -g @anthropic-ai/claude-code\nCOPY entrypoint.sh /entrypoint.sh\nRUN chmod +x /entrypoint.sh\nENTRYPOINT [\"/entrypoint.sh\"]\n";
+        const FROZEN_ENTRYPOINT: &str = "#!/bin/sh\nset -e\nmkdir -p \"$HOME\"\nif [ ! -f \"$HOME/.claude.json\" ]; then\n  printf '{\"hasCompletedOnboarding\": true}\\n' > \"$HOME/.claude.json\"\nfi\nexec \"$@\"\n";
+        assert_eq!(DOCKERFILE, FROZEN_DOCKERFILE, "claude Dockerfile changed");
+        assert_eq!(
+            ENTRYPOINT_SH, FROZEN_ENTRYPOINT,
+            "claude entrypoint changed"
+        );
+        assert!(image_tag(ContainerProvider::Claude).starts_with("fletch-agent:"));
+    }
+
+    /// Codex gets its own repo and a distinct tag, and shares claude's base
+    /// layers (identical `FROM` + apt line) so the cache is reused.
+    #[test]
+    fn codex_image_is_distinct_and_shares_base() {
+        let codex = image_tag(ContainerProvider::Codex);
+        assert!(codex.starts_with("fletch-agent-codex:"), "{codex}");
+        assert_ne!(codex, image_tag(ContainerProvider::Claude));
+
+        // Base layers shared: the FROM line and the apt install line are
+        // byte-identical, so Docker reuses those layers across both images.
+        // (The per-provider `LABEL fletch.agent=…` sits after the base and is
+        // deliberately excluded — it differs by construction.)
+        assert_eq!(
+            base_layers(DOCKERFILE),
+            base_layers(CODEX_DOCKERFILE),
+            "base layers must match for cache reuse"
+        );
+        // Provider-specific install step differs.
+        assert!(CODEX_DOCKERFILE.contains("@openai/codex"));
+        assert!(!CODEX_DOCKERFILE.contains("claude-code"));
+    }
+
+    /// The base layers (`FROM` + the shared apt step, through the apt-list
+    /// cleanup) that every provider image must share byte-for-byte so Docker's
+    /// layer cache is reused. Stops at the apt cleanup rather than the install
+    /// `RUN` so it's install-agnostic — npm-installed providers and cursor's
+    /// curl-installer image both compare equal on the base.
+    fn base_layers(dockerfile: &str) -> Vec<&str> {
+        let mut out = Vec::new();
+        for line in dockerfile.lines() {
+            out.push(line);
+            if line.contains("rm -rf /var/lib/apt/lists") {
+                break;
+            }
+        }
+        out
+    }
+
+    /// OpenCode and Pi each get their own repo + distinct tag, share claude's base
+    /// layers (cache reuse), and install only their own package — no other
+    /// provider's CLI leaks into either image.
+    #[test]
+    fn opencode_and_pi_images_are_distinct_and_share_base() {
+        let claude = image_tag(ContainerProvider::Claude);
+        let base = base_layers(DOCKERFILE);
+
+        for (provider, prefix, pkg) in [
+            (
+                ContainerProvider::Opencode,
+                "fletch-agent-opencode:",
+                "opencode-ai",
+            ),
+            (
+                ContainerProvider::Pi,
+                "fletch-agent-pi:",
+                "@earendil-works/pi-coding-agent",
+            ),
+        ] {
+            let tag = image_tag(provider);
+            assert!(tag.starts_with(prefix), "{tag}");
+            assert_ne!(tag, claude);
+            let dockerfile = image_spec(provider).dockerfile;
+            assert_eq!(
+                base_layers(dockerfile),
+                base,
+                "base layers must match for cache reuse"
+            );
+            assert!(dockerfile.contains(pkg), "{provider:?} must install {pkg}");
+            // No cross-contamination with the other providers' install steps.
+            assert!(!dockerfile.contains("claude-code"));
+            assert!(!dockerfile.contains("@openai/codex"));
+        }
+
+        // The two new tags are distinct from each other, too.
+        assert_ne!(
+            image_tag(ContainerProvider::Opencode),
+            image_tag(ContainerProvider::Pi)
+        );
+    }
+
+    /// Cursor gets its own repo + distinct tag and shares claude's base layers
+    /// (cache reuse) even though it installs via the official curl installer
+    /// rather than npm — the base-sharing invariant is install-agnostic. No other
+    /// provider's package leaks into the image.
+    #[test]
+    fn cursor_image_is_distinct_and_shares_base() {
+        let cursor = image_tag(ContainerProvider::Cursor);
+        assert!(cursor.starts_with("fletch-agent-cursor:"), "{cursor}");
+        for other in [
+            ContainerProvider::Claude,
+            ContainerProvider::Codex,
+            ContainerProvider::Opencode,
+            ContainerProvider::Pi,
+        ] {
+            assert_ne!(
+                cursor,
+                image_tag(other),
+                "cursor tag collides with {other:?}"
+            );
+        }
+        // Base (FROM + apt) byte-identical despite the curl-installer install step.
+        assert_eq!(
+            base_layers(CURSOR_DOCKERFILE),
+            base_layers(DOCKERFILE),
+            "base layers must match for cache reuse",
+        );
+        // Installs cursor-agent via its official installer; no other provider's pkg.
+        assert!(CURSOR_DOCKERFILE.contains("cursor.com/install"));
+        assert!(CURSOR_DOCKERFILE.contains("cursor-agent"));
+        assert!(!CURSOR_DOCKERFILE.contains("claude-code"));
+        assert!(!CURSOR_DOCKERFILE.contains("@openai/codex"));
+        assert!(!CURSOR_DOCKERFILE.contains("opencode-ai"));
+        assert!(!CURSOR_DOCKERFILE.contains("pi-coding-agent"));
+    }
+
+    /// Every provider's Dockerfile carries `LABEL fletch.agent=<provider id>`
+    /// — the GC's attribution authority. The value must round-trip through
+    /// `ContainerProvider::from_id` so label values and provider ids can't drift.
+    #[test]
+    fn every_dockerfile_carries_the_agent_label() {
+        for provider in ContainerProvider::ALL {
+            let dockerfile = image_spec(provider).dockerfile;
+            let value = dockerfile
+                .lines()
+                .find_map(|l| l.strip_prefix(&format!("LABEL {AGENT_IMAGE_LABEL}=")))
+                .unwrap_or_else(|| {
+                    panic!("{provider:?} Dockerfile is missing the fletch.agent label")
+                });
+            assert_eq!(
+                ContainerProvider::from_id(value.trim()),
+                Some(provider),
+                "{provider:?} label value must be its provider id",
+            );
+            // `id()` is `from_id`'s inverse — the version trigger keys the
+            // host probe and loop guard on it, so drift would silently
+            // disable (or cross-wire) the trigger.
+            assert_eq!(provider.id(), value.trim());
+            assert_eq!(ContainerProvider::from_id(provider.id()), Some(provider));
+        }
+    }
+}

--- a/src-tauri/src/sandbox/container/labels.rs
+++ b/src-tauri/src/sandbox/container/labels.rs
@@ -1,0 +1,27 @@
+//! The labels every Fletch container carries, so a later sweep can attribute
+//! it: `fletch.host-pid=<pid>` (which app instance owns it) and
+//! `fletch.agent-id=<id>` (which agent it runs). Stamped at launch by
+//! [`run_args`](super::run_args) and consumed by the runtime's sweeps (see
+//! `sandbox::docker::cleanup`).
+
+/// Label carrying the owning Fletch instance's pid.
+pub(crate) const HOST_PID_LABEL: &str = "fletch.host-pid";
+
+/// Label carrying the agent id a container runs. The startup orphan sweep
+/// keys on [`HOST_PID_LABEL`] alone (it asks "whose instance is dead?", not
+/// "which agent?"); this label is the handle for the other question —
+/// `cleanup::remove_agent_containers` uses it to tear down one named agent's
+/// containers on archive/discard. It is also the only stable handle there is:
+/// container *names* carry a random nonce (`engine::util::container_name`),
+/// so nothing outside the launching process can reconstruct them.
+pub(crate) const AGENT_ID_LABEL: &str = "fletch.agent-id";
+
+/// `fletch.host-pid=<our pid>` — the `--label` value stamped on a container run.
+pub(crate) fn host_pid_label() -> String {
+    format!("{HOST_PID_LABEL}={}", std::process::id())
+}
+
+/// `fletch.agent-id=<agent_id>` — sibling of [`host_pid_label`].
+pub(crate) fn agent_id_label(agent_id: &str) -> String {
+    format!("{AGENT_ID_LABEL}={agent_id}")
+}

--- a/src-tauri/src/sandbox/container/launch_auth.rs
+++ b/src-tauri/src/sandbox/container/launch_auth.rs
@@ -5,13 +5,13 @@
 
 use std::path::Path;
 
+use super::auth::ContainerAuth;
 use crate::error::{Error, Result};
-use crate::sandbox::docker::auth::ContainerAuth;
 
 /// Launch-blocking message when the container auth chain resolves nothing.
 /// Kept as one stable, matchable string the frontend keys its Settings
 /// call-to-action on; the wording tells the user exactly what to do.
-pub(super) const NO_CONTAINER_AUTH_MSG: &str = "No Anthropic credentials for containers — open Settings → General → Sandbox and connect Claude for containers (claude setup-token).";
+pub(crate) const NO_CONTAINER_AUTH_MSG: &str = "No Anthropic credentials for containers — open Settings → General → Sandbox and connect Claude for containers (claude setup-token).";
 
 /// Fold the D1 auth-chain outcome ([`resolve`]) into the docker CLI's
 /// process env, from which [`run_args`]' bare `-e NAME` flags forward it into
@@ -20,10 +20,10 @@ pub(super) const NO_CONTAINER_AUTH_MSG: &str = "No Anthropic credentials for con
 /// `Debug` redacts values so even `?source` cannot leak one. When the chain
 /// yields nothing the launch fails fast with [`NO_CONTAINER_AUTH_MSG`].
 ///
-/// [`resolve`]: crate::sandbox::docker::auth::resolve
+/// [`resolve`]: crate::sandbox::container::auth::resolve
 /// [`run_args`]: super::run_args::run_args
-/// [`AuthSource`]: crate::sandbox::docker::auth::AuthSource
-pub(super) fn apply_container_auth(
+/// [`AuthSource`]: crate::sandbox::container::auth::AuthSource
+pub(crate) fn apply_container_auth(
     env: &mut Vec<(String, String)>,
     auth: ContainerAuth,
 ) -> Result<()> {
@@ -44,18 +44,18 @@ pub(super) fn apply_container_auth(
 /// `auth.json` in its config dir and `OPENAI_API_KEY` unset. Mirrors
 /// [`NO_CONTAINER_AUTH_MSG`]'s fail-fast: an unauthenticated container boots
 /// straight into a login prompt it can't answer inside the sandbox.
-pub(super) const NO_CODEX_AUTH_MSG: &str =
+pub(crate) const NO_CODEX_AUTH_MSG: &str =
     "No Codex credentials for containers — sign in with `codex` on the host (writes ~/.codex/auth.json) or set OPENAI_API_KEY.";
 
 /// Launch-blocking message when opencode has no usable credential: no accounts DB
 /// / auth.json on its data-dir mount and no known provider API key set. Same
 /// fail-fast rationale as [`NO_CODEX_AUTH_MSG`].
-pub(super) const NO_OPENCODE_AUTH_MSG: &str =
+pub(crate) const NO_OPENCODE_AUTH_MSG: &str =
     "No OpenCode credentials for containers — sign in with `opencode auth login` on the host or set a provider API key (e.g. ANTHROPIC_API_KEY or OPENAI_API_KEY).";
 
 /// Launch-blocking message when pi has no usable credential: no
 /// `~/.pi/agent/auth.json` on its mount and no known provider API key set.
-pub(super) const NO_PI_AUTH_MSG: &str =
+pub(crate) const NO_PI_AUTH_MSG: &str =
     "No Pi credentials for containers — sign in with `pi` on the host (writes ~/.pi/agent/auth.json) or set a provider API key (e.g. ANTHROPIC_API_KEY or OPENAI_API_KEY).";
 
 /// Launch-blocking message when cursor has no usable credential. Unlike the other
@@ -64,7 +64,7 @@ pub(super) const NO_PI_AUTH_MSG: &str =
 /// which a Linux container can't read, and `~/.cursor` carries only identity
 /// metadata — not a bearer token. So `CURSOR_API_KEY` is the sole container
 /// credential; fail fast (before touching the filesystem) when it's unset.
-pub(super) const NO_CURSOR_AUTH_MSG: &str =
+pub(crate) const NO_CURSOR_AUTH_MSG: &str =
     "No Cursor credentials for containers — set CURSOR_API_KEY (create one at cursor.com/dashboard). `cursor-agent login` stores its token in the host keychain, which containers can't read.";
 
 /// Provider API-key env vars the multi-provider CLIs (opencode, pi) read to
@@ -99,7 +99,7 @@ const MULTI_PROVIDER_API_KEY_ENV: &[&str] = &[
 ///
 /// Unlike claude, no ANTHROPIC_*/CLAUDE_* var is injected: codex authenticates
 /// against OpenAI, and forwarding those would be dead weight at best.
-pub(super) fn prepare_codex_launch(
+pub(crate) fn prepare_codex_launch(
     env: &mut Vec<(String, String)>,
     config_dir: &Path,
     api_key: Option<&str>,
@@ -127,7 +127,7 @@ pub(super) fn prepare_codex_launch(
 /// `OPENAI_API_KEY` (if any) and whether `auth.json` exists on the mount. A
 /// non-blank key is forwarded (trimmed); the mounted `auth.json` carries auth on
 /// its own with nothing to inject. Neither present → the launch-blocking error.
-pub(super) fn codex_auth_env(
+pub(crate) fn codex_auth_env(
     api_key: Option<&str>,
     auth_file: bool,
 ) -> Result<Vec<(String, String)>> {
@@ -145,7 +145,7 @@ pub(super) fn codex_auth_env(
 /// `lookup` (a var name → value resolver, `std::env::var` in production, a fixture
 /// in tests), each as a `(name, value)` to forward. Order follows the constant so
 /// forwarding is deterministic.
-pub(super) fn present_api_keys(lookup: impl Fn(&str) -> Option<String>) -> Vec<(String, String)> {
+pub(crate) fn present_api_keys(lookup: impl Fn(&str) -> Option<String>) -> Vec<(String, String)> {
     MULTI_PROVIDER_API_KEY_ENV
         .iter()
         .filter_map(|&name| {
@@ -161,7 +161,7 @@ pub(super) fn present_api_keys(lookup: impl Fn(&str) -> Option<String>) -> Vec<(
 /// present → the caller's launch-blocking message. Returns the keys to forward
 /// (empty when the mount carries the login and no key is set), mirroring
 /// [`codex_auth_env`]'s shape.
-pub(super) fn multi_provider_auth_env(
+pub(crate) fn multi_provider_auth_env(
     api_keys: Vec<(String, String)>,
     credential_on_mount: bool,
     no_auth_msg: &str,
@@ -181,7 +181,7 @@ pub(super) fn multi_provider_auth_env(
 /// the dir created rather than required. Neither present → fail the launch before
 /// touching the filesystem. Auth values ride the process env and forward by bare
 /// `-e` (invariant 3); only booleans are logged.
-pub(super) fn prepare_opencode_launch(
+pub(crate) fn prepare_opencode_launch(
     env: &mut Vec<(String, String)>,
     data_dir: &Path,
     api_keys: Vec<(String, String)>,
@@ -213,7 +213,7 @@ pub(super) fn prepare_opencode_launch(
 /// forwarded when set. Either alone suffices, so a key-only user who never ran pi
 /// gets `~/.pi` created rather than required. Neither present → fail the launch
 /// before touching the filesystem. Only booleans are logged.
-pub(super) fn prepare_pi_launch(
+pub(crate) fn prepare_pi_launch(
     env: &mut Vec<(String, String)>,
     data_dir: &Path,
     api_keys: Vec<(String, String)>,
@@ -248,7 +248,7 @@ pub(super) fn prepare_pi_launch(
 /// the identical host path), so the dir is created for the bind even though it
 /// carries no auth. Fails the launch when `CURSOR_API_KEY` is unset, before
 /// touching the filesystem. Only a boolean is logged, never the key.
-pub(super) fn prepare_cursor_launch(
+pub(crate) fn prepare_cursor_launch(
     env: &mut Vec<(String, String)>,
     config_dir: &Path,
     api_key: Option<&str>,
@@ -274,7 +274,7 @@ pub(super) fn prepare_cursor_launch(
 /// else — unset or blank — is the launch-blocking error, because cursor's login
 /// token lives in the host keychain and can't reach the container by any other
 /// path (see [`NO_CURSOR_AUTH_MSG`]).
-pub(super) fn cursor_auth_env(api_key: Option<&str>) -> Result<Vec<(String, String)>> {
+pub(crate) fn cursor_auth_env(api_key: Option<&str>) -> Result<Vec<(String, String)>> {
     match api_key.map(str::trim).filter(|k| !k.is_empty()) {
         Some(key) => Ok(vec![("CURSOR_API_KEY".to_string(), key.to_string())]),
         None => Err(Error::Other(NO_CURSOR_AUTH_MSG.to_string())),

--- a/src-tauri/src/sandbox/container/mod.rs
+++ b/src-tauri/src/sandbox/container/mod.rs
@@ -1,0 +1,31 @@
+//! Runtime-neutral container launch policy: everything about running an agent
+//! in a container that is not specific to one container runtime.
+//!
+//! `sandbox::docker` is the Docker *runtime* — binary resolution, the daemon
+//! probe, `docker build`/`run`/`rm` invocations, and the `SandboxEngine` impl.
+//! What lives here is the policy those invocations carry out, expressed as pure
+//! data and pure functions so a sibling runtime (podman) can reuse it verbatim:
+//!
+//! - [`provider`] — which providers can run in a container at all
+//!   ([`ContainerProvider`]), their ids and in-image binaries.
+//! - [`run_args`] — the `run` argv builder: mounts at identical host paths, the
+//!   per-provider config/data mounts, and the bare `-e NAME` auth forwards.
+//! - [`labels`] — the `fletch.host-pid` / `fletch.agent-id` labels every
+//!   container carries so orphan and per-agent sweeps can attribute it.
+//! - [`images`] — the embedded Dockerfiles/entrypoints and their
+//!   content-addressed tags. Content only: nothing here builds or inspects.
+//! - [`auth`] — the Anthropic credential chain for containerized agents.
+//! - [`launch_auth`] — per-provider launch preparation: folding resolved
+//!   credentials into the CLI process env and failing fast without one.
+//! - [`proc`] — bounded subprocess execution (timeouts, line forwarding), the
+//!   machinery every runtime CLI invocation is funneled through.
+
+pub mod auth;
+pub(crate) mod images;
+pub(crate) mod labels;
+pub(crate) mod launch_auth;
+pub(crate) mod proc;
+pub(crate) mod provider;
+pub(crate) mod run_args;
+
+pub use provider::ContainerProvider;

--- a/src-tauri/src/sandbox/container/proc.rs
+++ b/src-tauri/src/sandbox/container/proc.rs
@@ -1,0 +1,155 @@
+//! Bounded subprocess execution: run a command to completion under a hard
+//! timeout, or stream its output line by line while it runs.
+//!
+//! Every container-runtime CLI invocation goes through here, because an
+//! unbounded call cannot be allowed to wedge the thread that issued it (UI
+//! polling, the startup sweep): a stopped Docker Desktop, for one, leaves a
+//! socket that accepts connections and then hangs. Callers pass an explicit
+//! timeout and get a clear "timed out" error instead. Nothing here knows which
+//! runtime it is running — see `sandbox::docker::cli` for the Docker wrappers.
+
+use std::process::{Command, Output, Stdio};
+use std::time::Duration;
+
+use crate::error::{Error, Result};
+
+/// Forward each line of `reader` to `on_line`, retaining a bounded tail for
+/// error reporting.
+pub(crate) fn forward_lines(
+    reader: impl std::io::Read,
+    on_line: &(dyn Fn(&str) + Send + Sync),
+    tail: &std::sync::Mutex<std::collections::VecDeque<String>>,
+) {
+    use std::io::BufRead;
+    const TAIL_LINES: usize = 20;
+    for line in std::io::BufReader::new(reader).lines() {
+        let Ok(line) = line else { break };
+        on_line(&line);
+        let mut tail = tail.lock().unwrap();
+        if tail.len() == TAIL_LINES {
+            tail.pop_front();
+        }
+        tail.push_back(line);
+    }
+}
+
+/// Poll `child` until it exits or `timeout` passes; on expiry kill it so a
+/// hung CLI (daemon gone mid-call) doesn't outlive the error we return.
+pub(crate) fn wait_with_deadline(
+    child: &mut std::process::Child,
+    timeout: Duration,
+    what: &str,
+) -> Result<std::process::ExitStatus> {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if let Some(status) = child.try_wait()? {
+            return Ok(status);
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait(); // reap; readers see EOF and finish
+            return Err(timeout_error(what, timeout));
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Run any command to completion under `timeout`, capturing output. Both
+/// pipes are drained on scoped threads (so a chatty child can't deadlock on
+/// a full pipe) while this thread keeps ownership of the `Child` and waits
+/// with a deadline — on expiry [`wait_with_deadline`] kills and reaps it on
+/// any platform, the pipes hit EOF, and the readers finish: nothing outlives
+/// the error we return.
+pub(crate) fn run_with_timeout(mut cmd: Command, timeout: Duration, what: &str) -> Result<Output> {
+    fn read_all(mut reader: impl std::io::Read) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let _ = reader.read_to_end(&mut buf);
+        buf
+    }
+
+    cmd.stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    let mut child = cmd.spawn()?;
+    let stdout = child.stdout.take().expect("stdout piped above");
+    let stderr = child.stderr.take().expect("stderr piped above");
+    std::thread::scope(|scope| {
+        let stdout = scope.spawn(move || read_all(stdout));
+        let stderr = scope.spawn(move || read_all(stderr));
+        let status = wait_with_deadline(&mut child, timeout, what)?;
+        Ok(Output {
+            status,
+            stdout: stdout.join().expect("stdout reader panicked"),
+            stderr: stderr.join().expect("stderr reader panicked"),
+        })
+    })
+}
+
+fn timeout_error(what: &str, timeout: Duration) -> Error {
+    Error::Other(format!(
+        "{what} timed out after {:.0?} — is the Docker daemon responding?",
+        timeout,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The property every runtime invocation relies on: a hung child comes
+    /// back as a bounded error, and the child is killed rather than orphaned.
+    #[test]
+    fn run_with_timeout_kills_hung_child() {
+        let mut cmd = Command::new("/bin/sleep");
+        cmd.arg("30");
+        let started = std::time::Instant::now();
+        let err = run_with_timeout(cmd, Duration::from_millis(200), "sleep")
+            .expect_err("a 30s sleep must trip a 200ms timeout");
+        assert!(
+            started.elapsed() < Duration::from_secs(5),
+            "timeout must not wait for the child's natural exit",
+        );
+        assert!(err.to_string().contains("timed out"), "got: {err}");
+    }
+
+    #[test]
+    fn run_with_timeout_captures_output_of_fast_child() {
+        let mut cmd = Command::new("/bin/echo");
+        cmd.arg("hello");
+        let out = run_with_timeout(cmd, Duration::from_secs(5), "echo").unwrap();
+        assert!(out.status.success());
+        assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "hello");
+    }
+
+    /// Streaming runs deliver lines to the callback and fail loudly (with the
+    /// output tail) on a non-zero exit — the contract `docker build` needs.
+    #[test]
+    fn streaming_forwards_lines_and_reports_failure_tail() {
+        let lines = std::sync::Mutex::new(Vec::new());
+        let on_line = |line: &str| lines.lock().unwrap().push(line.to_string());
+
+        // Use /bin/sh directly (not via docker) to exercise the machinery.
+        let mut child = Command::new("/bin/sh")
+            .args(["-c", "echo one; echo two >&2; exit 3"])
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdout = child.stdout.take().unwrap();
+        let stderr = child.stderr.take().unwrap();
+        let tail = std::sync::Mutex::new(std::collections::VecDeque::new());
+        let status = std::thread::scope(|scope| {
+            scope.spawn(|| forward_lines(stdout, &on_line, &tail));
+            scope.spawn(|| forward_lines(stderr, &on_line, &tail));
+            wait_with_deadline(&mut child, Duration::from_secs(5), "sh")
+        })
+        .unwrap();
+
+        assert_eq!(status.code(), Some(3));
+        let mut seen = lines.lock().unwrap().clone();
+        seen.sort();
+        assert_eq!(seen, vec!["one".to_string(), "two".to_string()]);
+        assert_eq!(tail.lock().unwrap().len(), 2);
+    }
+}

--- a/src-tauri/src/sandbox/container/provider.rs
+++ b/src-tauri/src/sandbox/container/provider.rs
@@ -1,0 +1,88 @@
+//! Which providers Fletch can run inside a container, and the facts about each
+//! one that every container runtime needs.
+
+/// A provider Fletch can run inside a container sandbox. This is the single
+/// capability gate the rest of the app consults instead of string-matching
+/// `provider == "claude"`: [`supervisor::lifecycle::ensure_engine_supports_provider`]
+/// refuses anything [`from_id`](ContainerProvider::from_id) doesn't recognize, and
+/// the launch path (`sandbox::docker::engine`) branches on the variant for the
+/// provider-specific image ([`images`](super::images)), config-dir mount, and
+/// auth. Everything else about a container (workspace / RPC / object-store
+/// mounts, naming, teardown) is provider-agnostic.
+///
+/// Seatbelt runs six providers; containers are being brought up one at a time as
+/// each gets its image + config-mount + auth wired — claude, codex, opencode, pi,
+/// and cursor so far. antigravity remains gated: its CLI (`agy`) has no
+/// non-interactive credential path — auth is browser OAuth with its tokens in the
+/// host keychain and no API-key env fallback (maintainer-confirmed), so a fresh
+/// container cannot authenticate. See `ensure_engine_supports_provider`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ContainerProvider {
+    Claude,
+    Codex,
+    Opencode,
+    Pi,
+    Cursor,
+}
+
+impl ContainerProvider {
+    /// Every container-supported provider. The image GC derives "the current
+    /// expected images" from this list, so a variant missing here would make
+    /// the GC treat that provider's live image as stale — when adding a
+    /// variant, extend this list (the exhaustive `match` in
+    /// [`images::image_spec`](super::images::image_spec) will already force you
+    /// into that file).
+    pub const ALL: [Self; 5] = [
+        Self::Claude,
+        Self::Codex,
+        Self::Opencode,
+        Self::Pi,
+        Self::Cursor,
+    ];
+
+    /// Map a provider id (as stamped on `AgentRecord.provider` / used by the
+    /// frontend) to its container support, or `None` when the provider has no
+    /// container support yet — the launch gate turns `None` into the
+    /// user-facing "isn't available in Docker sandboxes yet" refusal.
+    pub fn from_id(provider: &str) -> Option<Self> {
+        match provider {
+            "claude" => Some(Self::Claude),
+            "codex" => Some(Self::Codex),
+            "opencode" => Some(Self::Opencode),
+            "pi" => Some(Self::Pi),
+            "cursor" => Some(Self::Cursor),
+            _ => None,
+        }
+    }
+
+    /// The provider id string — [`from_id`](Self::from_id)'s inverse
+    /// (round-trip enforced by a test in [`images`](super::images)). Used where
+    /// a variant must key string-indexed state shared with the rest of the app,
+    /// e.g. the host version probe (`agent::cached_provider_version`) and the
+    /// persisted version-refresh loop guard (see `sandbox::docker::engine`).
+    pub fn id(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Opencode => "opencode",
+            Self::Pi => "pi",
+            Self::Cursor => "cursor",
+        }
+    }
+
+    /// The command name on the image's PATH — what this provider's npm package
+    /// installs as its executable. Handed to `launch_agent` as the in-image
+    /// `agent_bin` (a host-resolved absolute path would be meaningless inside
+    /// the container). Matches the provider's `bin` field for both supported
+    /// providers today, but named explicitly so it stays an image fact, not a
+    /// coincidence.
+    pub fn image_bin(self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::Codex => "codex",
+            Self::Opencode => "opencode",
+            Self::Pi => "pi",
+            Self::Cursor => "cursor-agent",
+        }
+    }
+}

--- a/src-tauri/src/sandbox/container/run_args.rs
+++ b/src-tauri/src/sandbox/container/run_args.rs
@@ -1,4 +1,4 @@
-//! The `docker run` argv builder: the provider-agnostic `--rm --init` shape,
+//! The container `run` argv builder: the provider-agnostic `--rm --init` shape,
 //! the mounts at identical host paths (invariant 1), the per-provider config/
 //! data mounts, and the bare `-e NAME` forwards (invariant 3). Pure over its
 //! [`RunSpec`] so the argv shape is unit-testable without a daemon.
@@ -6,10 +6,11 @@
 use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
-use crate::sandbox::docker::cleanup;
 use crate::sandbox::policy::{
     CLAUDE_CREDENTIALS_FILE, CLAUDE_EPHEMERAL_RUNTIME_SUBDIRS, CLAUDE_PROJECTS_SUBDIR,
 };
+
+use super::labels;
 
 /// The one file under a claude config dir that stays writable when the dir is
 /// bind-mounted read-only: claude's OAuth refresh rewrites the rotated token
@@ -17,7 +18,7 @@ use crate::sandbox::policy::{
 /// write to land on the host. Mounted read-write on top of the read-only dir.
 /// The name is shared with seatbelt via [`CLAUDE_CREDENTIALS_FILE`] so
 /// the two engines can't drift.
-pub(super) const CREDENTIALS_FILE: &str = CLAUDE_CREDENTIALS_FILE;
+pub(crate) const CREDENTIALS_FILE: &str = CLAUDE_CREDENTIALS_FILE;
 
 /// Subdirs of a claude config dir that Claude Code creates and writes *afresh
 /// every session* — the per-session env store (`mkdir session-env/<id>` at
@@ -60,7 +61,7 @@ const PROJECTS_SUBDIR: &str = CLAUDE_PROJECTS_SUBDIR;
 /// carve-outs treatment is unique; the other three are read-write binds at
 /// identical host paths, differing only in which dirs they mount and which env
 /// var (if any) they forward.
-pub(super) enum ProviderMounts<'a> {
+pub(crate) enum ProviderMounts<'a> {
     /// Claude: `~/.claude` (and any non-default `CLAUDE_CONFIG_DIR`) bind-mounted
     /// **read-only** except a writable `.credentials.json` overlay and the
     /// per-agent `projects/` transcript bind (invariant 5); see
@@ -112,7 +113,7 @@ pub(super) enum ProviderMounts<'a> {
 
 /// Everything [`run_args`] needs, bundled so the builder is pure and the argv
 /// shape unit-testable without a daemon.
-pub(super) struct RunSpec<'a> {
+pub(crate) struct RunSpec<'a> {
     pub interactive: bool,
     pub name: &'a str,
     pub agent_id: &'a str,
@@ -140,7 +141,7 @@ pub(super) struct RunSpec<'a> {
     /// credential the chain didn't pick must not reach the container and
     /// override the resolved login.
     ///
-    /// [`resolve`]: crate::sandbox::docker::auth::resolve
+    /// [`resolve`]: crate::sandbox::container::auth::resolve
     pub auth_vars: &'a [&'a str],
 }
 
@@ -149,7 +150,7 @@ pub(super) struct RunSpec<'a> {
 /// `prefix_args` contract of [`SandboxEngine::launch_agent`].
 ///
 /// [`SandboxEngine::launch_agent`]: crate::sandbox::engine::SandboxEngine::launch_agent
-pub(super) fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
+pub(crate) fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
     let mut args: Vec<String> = vec!["run".into(), "--rm".into(), "--init".into()];
     if spec.interactive {
         args.push("-t".into());
@@ -158,9 +159,9 @@ pub(super) fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
     args.push("--name".into());
     args.push(spec.name.into());
     args.push("--label".into());
-    args.push(cleanup::host_pid_label());
+    args.push(labels::host_pid_label());
     args.push("--label".into());
-    args.push(cleanup::agent_id_label(spec.agent_id));
+    args.push(labels::agent_id_label(spec.agent_id));
     // Mounts at identical host paths (invariant 1). Exactly these — nothing
     // else from the host enters the container. The workspace and RPC mailbox
     // are read-write; the claude config dir(s) are read-only except their
@@ -293,7 +294,7 @@ fn push_rw_bind(args: &mut Vec<String>, dir: &Path) {
 /// [`EPHEMERAL_RUNTIME_SUBDIRS`] tmpfs targets plus `projects/` (the read-write
 /// per-agent transcript bind). Creating empty dirs is harmless — the overlay
 /// shadows each, so nothing the agent writes there lands on this shared dir.
-pub(super) fn prepare_config_mount_dir(dir: &Path) -> Result<()> {
+pub(crate) fn prepare_config_mount_dir(dir: &Path) -> Result<()> {
     let overlays = EPHEMERAL_RUNTIME_SUBDIRS
         .iter()
         .copied()

--- a/src-tauri/src/sandbox/docker/cleanup.rs
+++ b/src-tauri/src/sandbox/docker/cleanup.rs
@@ -1,7 +1,9 @@
-//! Container labels, the dead-instance orphan sweep, and the stale-image GC.
+//! The dead-instance orphan sweep and the stale-image GC.
 //!
 //! Every container Fletch launches carries `fletch.host-pid=<pid>` (which app
-//! instance owns it) and `fletch.agent-id=<id>` (which agent it runs). If the
+//! instance owns it) and `fletch.agent-id=<id>` (which agent it runs) — the
+//! labels themselves are runtime-neutral and live in
+//! [`container::labels`](crate::sandbox::container::labels). If the
 //! app dies without cleanup — crash, force-quit, SIGKILL — its containers keep
 //! running; the next startup sweeps them by the same pid-liveness rule the
 //! nested-root sweeps use (`sandbox/seatbelt.rs`): remove only containers
@@ -26,27 +28,12 @@ use crate::error::{Error, Result};
 
 use super::{cli, engine, image, DockerProvider};
 
-/// Label carrying the owning Fletch instance's pid.
-pub const HOST_PID_LABEL: &str = "fletch.host-pid";
-
-/// Label carrying the agent id a container runs. The startup orphan sweep
-/// keys on [`HOST_PID_LABEL`] alone (it asks "whose instance is dead?", not
-/// "which agent?"); this label is the handle for the other question —
-/// [`remove_agent_containers`] uses it to tear down one named agent's
-/// containers on archive/discard. It is also the only stable handle there is:
-/// container *names* carry a random nonce (`engine::util::container_name`),
-/// so nothing outside the launching process can reconstruct them.
-pub const AGENT_ID_LABEL: &str = "fletch.agent-id";
-
-/// `fletch.host-pid=<our pid>` — the `--label` value stamped on `docker run`.
-pub fn host_pid_label() -> String {
-    format!("{HOST_PID_LABEL}={}", std::process::id())
-}
-
-/// `fletch.agent-id=<agent_id>` — sibling of [`host_pid_label`].
-pub fn agent_id_label(agent_id: &str) -> String {
-    format!("{AGENT_ID_LABEL}={agent_id}")
-}
+/// The labels `docker run` stamps and every sweep here queries. Re-exported so
+/// the `cleanup::host_pid_label` / `cleanup::HOST_PID_LABEL` paths this module's
+/// callers already use keep resolving from their runtime-neutral home.
+pub(super) use crate::sandbox::container::labels::{
+    agent_id_label, host_pid_label, HOST_PID_LABEL,
+};
 
 /// The `--filter` argument selecting one agent's containers. Built from
 /// [`agent_id_label`] so the query can never drift from what `docker run`

--- a/src-tauri/src/sandbox/docker/cli.rs
+++ b/src-tauri/src/sandbox/docker/cli.rs
@@ -10,12 +10,16 @@
 //! 2. **Bound every call.** A stopped Docker Desktop leaves a socket that
 //!    accepts connections and then hangs; an unbounded `docker` call would
 //!    wedge whatever thread issued it (UI polling, startup sweep). Callers
-//!    pass an explicit timeout and get a clear "timed out" error instead.
+//!    pass an explicit timeout and get a clear "timed out" error instead. The
+//!    bounding machinery itself is runtime-neutral and lives in
+//!    [`container::proc`](crate::sandbox::container::proc); what's here is the
+//!    thin Docker-specific layer over it.
 
 use std::process::{Command, Output, Stdio};
 use std::time::Duration;
 
 use crate::error::{Error, Result};
+use crate::sandbox::container::proc::{forward_lines, run_with_timeout, wait_with_deadline};
 
 /// Absolute path of the docker CLI, or `None` when it isn't installed.
 /// Resolved fresh on every call (the underlying login-shell env is cached, so
@@ -84,145 +88,4 @@ pub(super) fn run_docker_streaming(
         )));
     }
     Ok(())
-}
-
-/// Forward each line of `reader` to `on_line`, retaining a bounded tail for
-/// error reporting.
-fn forward_lines(
-    reader: impl std::io::Read,
-    on_line: &(dyn Fn(&str) + Send + Sync),
-    tail: &std::sync::Mutex<std::collections::VecDeque<String>>,
-) {
-    use std::io::BufRead;
-    const TAIL_LINES: usize = 20;
-    for line in std::io::BufReader::new(reader).lines() {
-        let Ok(line) = line else { break };
-        on_line(&line);
-        let mut tail = tail.lock().unwrap();
-        if tail.len() == TAIL_LINES {
-            tail.pop_front();
-        }
-        tail.push_back(line);
-    }
-}
-
-/// Poll `child` until it exits or `timeout` passes; on expiry kill it so a
-/// hung docker CLI (daemon gone mid-call) doesn't outlive the error we return.
-fn wait_with_deadline(
-    child: &mut std::process::Child,
-    timeout: Duration,
-    what: &str,
-) -> Result<std::process::ExitStatus> {
-    let deadline = std::time::Instant::now() + timeout;
-    loop {
-        if let Some(status) = child.try_wait()? {
-            return Ok(status);
-        }
-        if std::time::Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait(); // reap; readers see EOF and finish
-            return Err(timeout_error(what, timeout));
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-}
-
-/// Run any command to completion under `timeout`, capturing output. Both
-/// pipes are drained on scoped threads (so a chatty child can't deadlock on
-/// a full pipe) while this thread keeps ownership of the `Child` and waits
-/// with a deadline — on expiry [`wait_with_deadline`] kills and reaps it on
-/// any platform, the pipes hit EOF, and the readers finish: nothing outlives
-/// the error we return.
-fn run_with_timeout(mut cmd: Command, timeout: Duration, what: &str) -> Result<Output> {
-    fn read_all(mut reader: impl std::io::Read) -> Vec<u8> {
-        let mut buf = Vec::new();
-        let _ = reader.read_to_end(&mut buf);
-        buf
-    }
-
-    cmd.stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let mut child = cmd.spawn()?;
-    let stdout = child.stdout.take().expect("stdout piped above");
-    let stderr = child.stderr.take().expect("stderr piped above");
-    std::thread::scope(|scope| {
-        let stdout = scope.spawn(move || read_all(stdout));
-        let stderr = scope.spawn(move || read_all(stderr));
-        let status = wait_with_deadline(&mut child, timeout, what)?;
-        Ok(Output {
-            status,
-            stdout: stdout.join().expect("stdout reader panicked"),
-            stderr: stderr.join().expect("stderr reader panicked"),
-        })
-    })
-}
-
-fn timeout_error(what: &str, timeout: Duration) -> Error {
-    Error::Other(format!(
-        "{what} timed out after {:.0?} — is the Docker daemon responding?",
-        timeout,
-    ))
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// The property every docker invocation relies on: a hung child comes
-    /// back as a bounded error, and the child is killed rather than orphaned.
-    #[test]
-    fn run_with_timeout_kills_hung_child() {
-        let mut cmd = Command::new("/bin/sleep");
-        cmd.arg("30");
-        let started = std::time::Instant::now();
-        let err = run_with_timeout(cmd, Duration::from_millis(200), "sleep")
-            .expect_err("a 30s sleep must trip a 200ms timeout");
-        assert!(
-            started.elapsed() < Duration::from_secs(5),
-            "timeout must not wait for the child's natural exit",
-        );
-        assert!(err.to_string().contains("timed out"), "got: {err}");
-    }
-
-    #[test]
-    fn run_with_timeout_captures_output_of_fast_child() {
-        let mut cmd = Command::new("/bin/echo");
-        cmd.arg("hello");
-        let out = run_with_timeout(cmd, Duration::from_secs(5), "echo").unwrap();
-        assert!(out.status.success());
-        assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "hello");
-    }
-
-    /// Streaming runs deliver lines to the callback and fail loudly (with the
-    /// output tail) on a non-zero exit — the contract `docker build` needs.
-    #[test]
-    fn streaming_forwards_lines_and_reports_failure_tail() {
-        let lines = std::sync::Mutex::new(Vec::new());
-        let on_line = |line: &str| lines.lock().unwrap().push(line.to_string());
-
-        // Use /bin/sh directly (not via docker) to exercise the machinery.
-        let mut child = Command::new("/bin/sh")
-            .args(["-c", "echo one; echo two >&2; exit 3"])
-            .stdin(Stdio::null())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-            .unwrap();
-        let stdout = child.stdout.take().unwrap();
-        let stderr = child.stderr.take().unwrap();
-        let tail = std::sync::Mutex::new(std::collections::VecDeque::new());
-        let status = std::thread::scope(|scope| {
-            scope.spawn(|| forward_lines(stdout, &on_line, &tail));
-            scope.spawn(|| forward_lines(stderr, &on_line, &tail));
-            wait_with_deadline(&mut child, Duration::from_secs(5), "sh")
-        })
-        .unwrap();
-
-        assert_eq!(status.code(), Some(3));
-        let mut seen = lines.lock().unwrap().clone();
-        seen.sort();
-        assert_eq!(seen, vec!["one".to_string(), "two".to_string()]);
-        assert_eq!(tail.lock().unwrap().len(), 2);
-    }
 }

--- a/src-tauri/src/sandbox/docker/engine/mod.rs
+++ b/src-tauri/src/sandbox/docker/engine/mod.rs
@@ -55,10 +55,13 @@
 //!
 //! Layout: this module folder splits the engine into
 //! - [`settings`] — launch knobs and the version-refresh guard
-//! - [`auth`] — per-provider container auth
 //! - [`config_dir`] — non-default config-dir detection and borrowed object stores
-//! - [`run_args`] — the `docker run` argv builder
 //! - [`util`] — naming, liveness, exit codes
+//!
+//! Per-provider container auth
+//! ([`container::launch_auth`](crate::sandbox::container::launch_auth)) and the
+//! `run` argv builder ([`container::run_args`](crate::sandbox::container::run_args))
+//! are runtime-neutral and live outside this folder.
 //!
 //! The `DockerEngine` struct and its `SandboxEngine` impl stay here.
 
@@ -74,9 +77,7 @@ use crate::sandbox::policy::{codex_home_dir, opencode_config_dir, opencode_data_
 
 use super::{cli, image, DockerProvider};
 
-mod auth;
 mod config_dir;
-mod run_args;
 mod settings;
 #[cfg(test)]
 mod tests;
@@ -91,15 +92,17 @@ pub use settings::{
 // Consumed by sibling docker submodules (`image`, `cleanup`) at `engine::X`.
 pub(super) use settings::{image_override, record_version_refresh, version_refresh_attempted};
 
-use auth::{
+use crate::sandbox::container::launch_auth::{
     apply_container_auth, prepare_codex_launch, prepare_cursor_launch, prepare_opencode_launch,
     prepare_pi_launch, present_api_keys,
+};
+use crate::sandbox::container::run_args::{
+    prepare_config_mount_dir, run_args, ProviderMounts, RunSpec, CREDENTIALS_FILE,
 };
 use config_dir::{
     borrowed_object_stores, codex_home_is_nondefault, nondefault_claude_config_dir,
     xdg_base_is_nondefault,
 };
-use run_args::{prepare_config_mount_dir, run_args, ProviderMounts, RunSpec, CREDENTIALS_FILE};
 use settings::{DEFAULT_CPUS, DEFAULT_MEMORY, LAUNCH_SETTINGS};
 use util::{container_gone_within, container_name, describe_exit_code, non_blank};
 
@@ -334,7 +337,7 @@ impl SandboxEngine for DockerEngine {
                 projects_src = Some(ps);
 
                 auth_start = env.len();
-                apply_container_auth(&mut env, crate::sandbox::docker::auth::resolve())?;
+                apply_container_auth(&mut env, crate::sandbox::container::auth::resolve())?;
             }
             DockerProvider::Codex => {
                 // Codex's config dir is bind-mounted read-write: auth.json token

--- a/src-tauri/src/sandbox/docker/engine/tests.rs
+++ b/src-tauri/src/sandbox/docker/engine/tests.rs
@@ -2,13 +2,13 @@ use super::*;
 
 use std::path::{Path, PathBuf};
 
-use super::super::auth::ContainerAuth;
-use super::auth::{
+use super::config_dir::config_dir_is_default;
+use super::util::container_running;
+use crate::sandbox::container::auth::ContainerAuth;
+use crate::sandbox::container::launch_auth::{
     codex_auth_env, cursor_auth_env, multi_provider_auth_env, NO_CODEX_AUTH_MSG,
     NO_CONTAINER_AUTH_MSG, NO_CURSOR_AUTH_MSG, NO_OPENCODE_AUTH_MSG, NO_PI_AUTH_MSG,
 };
-use super::config_dir::config_dir_is_default;
-use super::util::container_running;
 
 /// The version-refresh loop guard: exact-pair matching, per-provider
 /// isolation, persistence callback on record, and safe recording before

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -1,13 +1,8 @@
-//! The embedded agent images: what containers run, built on demand, one image
-//! per supported provider (see [`DockerProvider`]).
-//!
-//! The Dockerfile and entrypoint are compiled into the binary and each image's
-//! tag is derived from its content (`<repo>:<sha256[..12]>`, e.g.
-//! `fletch-agent:…` for claude, `fletch-agent-codex:…` for codex), so shipping a
-//! change to either automatically produces a new tag — the stale image is
-//! never referenced again and the next spawn rebuilds. No version bookkeeping,
-//! no manual invalidation. Provider images share their base layers (identical
-//! `FROM` + apt step), so a second provider costs only its own install layer.
+//! Building, inspecting and reclaiming the embedded agent images — one image
+//! per supported provider (see [`DockerProvider`]). Their *content* (the
+//! Dockerfiles, entrypoints and content-addressed tags) is runtime-neutral and
+//! lives in [`container::images`](crate::sandbox::container::images); everything
+//! here shells out to docker.
 //!
 //! Content addressing alone would freeze the *packages inside* an image
 //! forever, though: every image installs "latest at build time" (npm installs,
@@ -34,183 +29,20 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use crate::error::Result;
+use crate::sandbox::container::images::{image_spec, BASE_IMAGE};
 
 use super::cli;
 use super::progress::{self, BuildEvent};
 use super::DockerProvider;
 
+/// The image content this module builds from, re-exported so the
+/// `image::image_tag` / `image::image_repo` / `image::AGENT_IMAGE_LABEL` paths
+/// [`super::cleanup`]'s GC uses keep resolving.
+pub(super) use crate::sandbox::container::images::{image_repo, image_tag, AGENT_IMAGE_LABEL};
+
 /// Progress sink for image builds: called once per docker output line. Callers
 /// pass a tracing forwarder to log build output, or `&|_| {}` to ignore it.
 pub type Progress<'a> = &'a (dyn Fn(&str) + Send + Sync);
-
-/// The base every provider image builds on (enforced by a test over
-/// [`image_spec`]). Named as a constant rather than left implicit in the five
-/// Dockerfile literals because the reclamation path needs to know which tag a
-/// `--pull` is able to move under us — see [`reap_superseded_base`].
-pub const BASE_IMAGE: &str = "node:22-slim";
-
-/// The agent container image. Debian-slim keeps apt available for the tools
-/// claude needs at runtime (`git`, `rg`, `jq`, `procps` for /proc-based
-/// process introspection) while staying small; node 22 is claude-code's
-/// supported runtime. The `chmod` guarantees the entrypoint is executable
-/// regardless of the mode `COPY` picked up from the build context (context
-/// files are written at build time on the host — see [`ensure_image`]).
-pub const DOCKERFILE: &str = r#"FROM node:22-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl ca-certificates ripgrep jq procps \
- && rm -rf /var/lib/apt/lists/*
-LABEL fletch.agent=claude
-RUN npm install -g @anthropic-ai/claude-code
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
-"#;
-
-/// PID-1 shim. The container gets `HOME=<host home>` (a path that does not
-/// exist in the image), so the entrypoint creates it and seeds the minimal
-/// `~/.claude.json` claude needs to skip interactive onboarding. Seeding is
-/// conditional and the file is container-ephemeral by design: bind-mounting the
-/// real `~/.claude.json` would break on claude's atomic rename-replace writes.
-pub const ENTRYPOINT_SH: &str = r#"#!/bin/sh
-set -e
-mkdir -p "$HOME"
-if [ ! -f "$HOME/.claude.json" ]; then
-  printf '{"hasCompletedOnboarding": true}\n' > "$HOME/.claude.json"
-fi
-exec "$@"
-"#;
-
-/// Codex's image. Shares [`DOCKERFILE`]'s base byte-for-byte — same `FROM
-/// node:22-slim` and the same apt line — so Docker's layer cache is reused
-/// across the two images; only the provider install step differs
-/// (`@openai/codex` instead of `@anthropic-ai/claude-code`). Codex authenticates
-/// from the read-write `~/.codex` mount (auth.json) and/or `OPENAI_API_KEY`, so
-/// the image carries no provider config of its own.
-pub const CODEX_DOCKERFILE: &str = r#"FROM node:22-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl ca-certificates ripgrep jq procps \
- && rm -rf /var/lib/apt/lists/*
-LABEL fletch.agent=codex
-RUN npm install -g @openai/codex
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
-"#;
-
-/// Codex's PID-1 shim: create `HOME` and exec, nothing more. Unlike claude,
-/// codex needs no onboarding seed — `codex exec` runs non-interactively with
-/// `--skip-git-repo-check` and `approval_policy="never"` (see
-/// `agent::codex_build_args`), and its credentials come from the mounted
-/// `~/.codex/auth.json` rather than a config file we'd seed here.
-pub const CODEX_ENTRYPOINT_SH: &str = r#"#!/bin/sh
-set -e
-mkdir -p "$HOME"
-exec "$@"
-"#;
-
-/// OpenCode's image. Shares [`DOCKERFILE`]'s base byte-for-byte (same `FROM
-/// node:22-slim` and apt line) for layer-cache reuse; only the install step
-/// differs (`opencode-ai`, whose `bin` resolves to a per-arch native binary via
-/// npm optional deps — arm64 and x86-64 both publish one). OpenCode authenticates
-/// from the read-write data-dir mount (its accounts DB / `auth.json`) and/or a
-/// provider API-key env var, so the image carries no provider config.
-pub const OPENCODE_DOCKERFILE: &str = r#"FROM node:22-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl ca-certificates ripgrep jq procps \
- && rm -rf /var/lib/apt/lists/*
-LABEL fletch.agent=opencode
-RUN npm install -g opencode-ai
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
-"#;
-
-/// OpenCode's PID-1 shim: create `HOME` and exec. `opencode run --format json
-/// --dangerously-skip-permissions` (see `agent::opencode_build_args`) is fully
-/// non-interactive, and credentials arrive on the read-write data-dir mount or as
-/// a forwarded API-key env var, so nothing is seeded here.
-pub const OPENCODE_ENTRYPOINT_SH: &str = r#"#!/bin/sh
-set -e
-mkdir -p "$HOME"
-exec "$@"
-"#;
-
-/// Pi's image. Shares [`DOCKERFILE`]'s base byte-for-byte for cache reuse; only
-/// the install step differs. Pi ships as a pure-node CLI (`@earendil-works/
-/// pi-coding-agent`, bin `pi` → a `dist/cli.js` launcher), so the same package
-/// runs on every arch node:22-slim supports. Pi authenticates from the read-write
-/// `~/.pi` mount (`~/.pi/agent/auth.json`) and/or a provider API-key env var.
-pub const PI_DOCKERFILE: &str = r#"FROM node:22-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl ca-certificates ripgrep jq procps \
- && rm -rf /var/lib/apt/lists/*
-LABEL fletch.agent=pi
-RUN npm install -g @earendil-works/pi-coding-agent
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
-"#;
-
-/// Pi's PID-1 shim: create `HOME` and exec. `pi -p --mode json` (see
-/// `agent::pi_build_args`) runs one turn non-interactively and auto-runs tools;
-/// credentials come from the mounted `~/.pi/agent/auth.json` or a forwarded
-/// API-key env var, so nothing is seeded here.
-pub const PI_ENTRYPOINT_SH: &str = r#"#!/bin/sh
-set -e
-mkdir -p "$HOME"
-exec "$@"
-"#;
-
-/// Cursor's image. Shares [`DOCKERFILE`]'s base byte-for-byte (same `FROM
-/// node:22-slim` and apt line) for layer-cache reuse; only the install step
-/// differs. Unlike the other providers, cursor-agent ships not as an npm package
-/// but via its official installer (`https://cursor.com/install`), which detects
-/// `linux/arm64` and downloads a self-contained bundle (its own node runtime +
-/// per-arch native modules) into `~/.local`; we symlink its `cursor-agent`
-/// launcher onto PATH so the in-image `agent_bin` resolves, then run
-/// `--version` so a build fails loudly if the installer ever relocates the
-/// binary — `ln -s` happily creates a dangling link, and without the check
-/// that drift would only surface as exit-127 launches. The installer pins
-/// whatever version its script currently references — no worse than the `latest`
-/// npm installs the other images use: the Dockerfile *text* is constant so the
-/// content-addressed tag is stable, while a re-pull may fetch a newer bundle
-/// (contents drift under a stable tag — an accepted, documented tradeoff shared
-/// with every `npm install -g <pkg>` here). Cursor authenticates in-container from
-/// a forwarded `CURSOR_API_KEY` (see [`super::engine`]): `cursor-agent login`
-/// stores its tokens in the host OS keychain, which a container can't read, so the
-/// image carries no provider config of its own.
-pub const CURSOR_DOCKERFILE: &str = r#"FROM node:22-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl ca-certificates ripgrep jq procps \
- && rm -rf /var/lib/apt/lists/*
-LABEL fletch.agent=cursor
-RUN curl -fsSL https://cursor.com/install | bash \
- && ln -s /root/.local/bin/cursor-agent /usr/local/bin/cursor-agent \
- && cursor-agent --version
-COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
-ENTRYPOINT ["/entrypoint.sh"]
-"#;
-
-/// Cursor's PID-1 shim: create `HOME` and exec. `cursor-agent -p --output-format
-/// stream-json --force --trust` (see `agent::cursor_build_args`) runs one turn
-/// non-interactively; credentials arrive as the forwarded `CURSOR_API_KEY` env
-/// var and its transcripts land on the read-write `~/.cursor` mount, so nothing is
-/// seeded here.
-pub const CURSOR_ENTRYPOINT_SH: &str = r#"#!/bin/sh
-set -e
-mkdir -p "$HOME"
-exec "$@"
-"#;
-
-/// Label key baked into every embedded agent image (`LABEL
-/// fletch.agent=<provider>` in the Dockerfiles above). It is the image GC's
-/// authority: only images carrying it — or, transitionally, pre-label images
-/// in a Fletch-owned repo — are ever candidates for removal (see
-/// `cleanup::sweep_stale_images`). The user's `docker_image` override never
-/// gets the label (it is never built by us), so it can't be attributed to
-/// Fletch and is structurally safe from the GC.
-pub const AGENT_IMAGE_LABEL: &str = "fletch.agent";
 
 /// Dogma: **an agent image is never older than a week.** The images install
 /// "latest at build time" (npm installs, cursor's installer), so their
@@ -219,49 +51,6 @@ pub const AGENT_IMAGE_LABEL: &str = "fletch.agent";
 /// never a launch blocker — and is rebuilt under the same tag off-thread
 /// (see [`refresh_in_background_if_stale`]). Deliberately not a setting.
 pub const IMAGE_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
-
-/// The image build inputs for a provider: repo name plus the Dockerfile and
-/// entrypoint whose combined content addresses the tag. Every spec's Dockerfile
-/// carries `LABEL fletch.agent=<provider>` so the image GC can attribute it
-/// (enforced by a test); each provider gets its own repo.
-struct ImageSpec {
-    repo: &'static str,
-    dockerfile: &'static str,
-    entrypoint: &'static str,
-}
-
-/// Per-provider image inputs. Claude's spec is the pre-existing embedded image
-/// verbatim (see the byte-identity guard in tests); codex gets its own repo and
-/// install step, sharing claude's base layers.
-fn image_spec(provider: DockerProvider) -> ImageSpec {
-    match provider {
-        DockerProvider::Claude => ImageSpec {
-            repo: "fletch-agent",
-            dockerfile: DOCKERFILE,
-            entrypoint: ENTRYPOINT_SH,
-        },
-        DockerProvider::Codex => ImageSpec {
-            repo: "fletch-agent-codex",
-            dockerfile: CODEX_DOCKERFILE,
-            entrypoint: CODEX_ENTRYPOINT_SH,
-        },
-        DockerProvider::Opencode => ImageSpec {
-            repo: "fletch-agent-opencode",
-            dockerfile: OPENCODE_DOCKERFILE,
-            entrypoint: OPENCODE_ENTRYPOINT_SH,
-        },
-        DockerProvider::Pi => ImageSpec {
-            repo: "fletch-agent-pi",
-            dockerfile: PI_DOCKERFILE,
-            entrypoint: PI_ENTRYPOINT_SH,
-        },
-        DockerProvider::Cursor => ImageSpec {
-            repo: "fletch-agent-cursor",
-            dockerfile: CURSOR_DOCKERFILE,
-            entrypoint: CURSOR_ENTRYPOINT_SH,
-        },
-    }
-}
 
 /// Builds are slow (base image pull + apt + npm) but bounded: past this we
 /// assume a wedged daemon or dead network and fail the spawn with a clear
@@ -274,35 +63,6 @@ const INSPECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// `docker rmi` on a superseded base: local layer deletion, I/O-bound but not
 /// network-bound. Same bound `cleanup`'s removals use.
 const REMOVE_TIMEOUT: Duration = Duration::from_secs(60);
-
-/// The content-addressed tag for a provider's embedded image.
-pub fn image_tag(provider: DockerProvider) -> String {
-    let spec = image_spec(provider);
-    tag_for(spec.repo, spec.dockerfile, spec.entrypoint)
-}
-
-/// The repo (image name without tag) of a provider's embedded image. With
-/// [`image_tag`] this is the GC's vocabulary of Fletch-owned names: the repos
-/// are chosen by this module and are not meaningful outside Fletch, so a
-/// non-current tag under one of them is attributable to us even on legacy
-/// images built before [`AGENT_IMAGE_LABEL`] existed.
-pub fn image_repo(provider: DockerProvider) -> &'static str {
-    image_spec(provider).repo
-}
-
-/// `<repo>:<sha256(dockerfile + entrypoint)[..12]>` — 12 hex chars, the same
-/// abbreviation depth docker itself uses for short ids. The hash covers only the
-/// dockerfile+entrypoint content (not the repo), so claude's tail is unchanged
-/// from before the repo argument existed as long as its content is.
-fn tag_for(repo: &str, dockerfile: &str, entrypoint: &str) -> String {
-    use sha2::Digest;
-    let mut hasher = sha2::Sha256::new();
-    hasher.update(dockerfile.as_bytes());
-    hasher.update(entrypoint.as_bytes());
-    let digest = hasher.finalize();
-    let hex: String = digest.iter().map(|b| format!("{b:02x}")).collect();
-    format!("{repo}:{}", &hex[..12])
-}
 
 /// The image to launch containers from, honoring the `docker_image` settings
 /// key: a non-empty override is returned verbatim (no build, no inspect, no
@@ -887,21 +647,7 @@ fn image_exists(tag: &str) -> Result<bool> {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Every provider image builds on [`BASE_IMAGE`]. This is the invariant
-    /// [`reap_superseded_base`] rests on: it only ever inspects and reclaims
-    /// that one tag, so a spec that quietly moved to a different base would
-    /// orphan images nothing reclaims.
-    #[test]
-    fn every_spec_builds_on_the_declared_base() {
-        let from = format!("FROM {BASE_IMAGE}\n");
-        for provider in DockerProvider::ALL {
-            assert!(
-                image_spec(provider).dockerfile.starts_with(&from),
-                "{provider:?} must build FROM {BASE_IMAGE}",
-            );
-        }
-    }
+    use crate::sandbox::container::images::{tag_for, ENTRYPOINT_SH};
 
     /// The reclamation queue's rules: only a *proven* displacement is queued
     /// (both ids known and different), never twice, and the queue is capped.
@@ -950,171 +696,6 @@ mod tests {
     }
 
     #[test]
-    fn tag_is_content_addressed() {
-        let tag = tag_for("fletch-agent", "FROM a\n", "#!/bin/sh\n");
-        let (repo, hash) = tag.split_once(':').unwrap();
-        assert_eq!(repo, "fletch-agent");
-        assert_eq!(hash.len(), 12);
-        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
-
-        // Deterministic, and any content change moves the tag.
-        assert_eq!(tag, tag_for("fletch-agent", "FROM a\n", "#!/bin/sh\n"));
-        assert_ne!(tag, tag_for("fletch-agent", "FROM b\n", "#!/bin/sh\n"));
-        assert_ne!(tag, tag_for("fletch-agent", "FROM a\n", "#!/bin/bash\n"));
-        // The repo is a prefix, not part of the hash: a different repo with the
-        // same content shares the tail (so a repo rename can't force a rebuild).
-        assert_eq!(
-            tag_for("fletch-agent", "FROM a\n", "#!/bin/sh\n")
-                .split_once(':')
-                .unwrap()
-                .1,
-            tag_for("other", "FROM a\n", "#!/bin/sh\n")
-                .split_once(':')
-                .unwrap()
-                .1,
-        );
-    }
-
-    /// Golden guard: claude's image content is pinned byte-for-byte so an
-    /// *accidental* edit can't silently move the content-addressed tag and
-    /// force every user through a cold rebuild. Deliberate changes update the
-    /// frozen bytes here and record why:
-    ///
-    /// - image-lifecycle PR: added `LABEL fletch.agent=claude` so the image GC
-    ///   can attribute Fletch's images by label instead of guessing from
-    ///   names. One planned rehash → one rebuild for every user on update,
-    ///   accepted (and the GC reaps the superseded image).
-    #[test]
-    fn claude_image_is_unchanged() {
-        // Frozen bytes (do not "fix" to match an accidentally changed constant
-        // — update the constant back instead; deliberate changes update these
-        // bytes and the doc comment above).
-        const FROZEN_DOCKERFILE: &str = "FROM node:22-slim\nRUN apt-get update && apt-get install -y --no-install-recommends \\\n    git curl ca-certificates ripgrep jq procps \\\n && rm -rf /var/lib/apt/lists/*\nLABEL fletch.agent=claude\nRUN npm install -g @anthropic-ai/claude-code\nCOPY entrypoint.sh /entrypoint.sh\nRUN chmod +x /entrypoint.sh\nENTRYPOINT [\"/entrypoint.sh\"]\n";
-        const FROZEN_ENTRYPOINT: &str = "#!/bin/sh\nset -e\nmkdir -p \"$HOME\"\nif [ ! -f \"$HOME/.claude.json\" ]; then\n  printf '{\"hasCompletedOnboarding\": true}\\n' > \"$HOME/.claude.json\"\nfi\nexec \"$@\"\n";
-        assert_eq!(DOCKERFILE, FROZEN_DOCKERFILE, "claude Dockerfile changed");
-        assert_eq!(
-            ENTRYPOINT_SH, FROZEN_ENTRYPOINT,
-            "claude entrypoint changed"
-        );
-        assert!(image_tag(DockerProvider::Claude).starts_with("fletch-agent:"));
-    }
-
-    /// Codex gets its own repo and a distinct tag, and shares claude's base
-    /// layers (identical `FROM` + apt line) so the cache is reused.
-    #[test]
-    fn codex_image_is_distinct_and_shares_base() {
-        let codex = image_tag(DockerProvider::Codex);
-        assert!(codex.starts_with("fletch-agent-codex:"), "{codex}");
-        assert_ne!(codex, image_tag(DockerProvider::Claude));
-
-        // Base layers shared: the FROM line and the apt install line are
-        // byte-identical, so Docker reuses those layers across both images.
-        // (The per-provider `LABEL fletch.agent=…` sits after the base and is
-        // deliberately excluded — it differs by construction.)
-        assert_eq!(
-            base_layers(DOCKERFILE),
-            base_layers(CODEX_DOCKERFILE),
-            "base layers must match for cache reuse"
-        );
-        // Provider-specific install step differs.
-        assert!(CODEX_DOCKERFILE.contains("@openai/codex"));
-        assert!(!CODEX_DOCKERFILE.contains("claude-code"));
-    }
-
-    /// The base layers (`FROM` + the shared apt step, through the apt-list
-    /// cleanup) that every provider image must share byte-for-byte so Docker's
-    /// layer cache is reused. Stops at the apt cleanup rather than the install
-    /// `RUN` so it's install-agnostic — npm-installed providers and cursor's
-    /// curl-installer image both compare equal on the base.
-    fn base_layers(dockerfile: &str) -> Vec<&str> {
-        let mut out = Vec::new();
-        for line in dockerfile.lines() {
-            out.push(line);
-            if line.contains("rm -rf /var/lib/apt/lists") {
-                break;
-            }
-        }
-        out
-    }
-
-    /// OpenCode and Pi each get their own repo + distinct tag, share claude's base
-    /// layers (cache reuse), and install only their own package — no other
-    /// provider's CLI leaks into either image.
-    #[test]
-    fn opencode_and_pi_images_are_distinct_and_share_base() {
-        let claude = image_tag(DockerProvider::Claude);
-        let base = base_layers(DOCKERFILE);
-
-        for (provider, prefix, pkg) in [
-            (
-                DockerProvider::Opencode,
-                "fletch-agent-opencode:",
-                "opencode-ai",
-            ),
-            (
-                DockerProvider::Pi,
-                "fletch-agent-pi:",
-                "@earendil-works/pi-coding-agent",
-            ),
-        ] {
-            let tag = image_tag(provider);
-            assert!(tag.starts_with(prefix), "{tag}");
-            assert_ne!(tag, claude);
-            let dockerfile = image_spec(provider).dockerfile;
-            assert_eq!(
-                base_layers(dockerfile),
-                base,
-                "base layers must match for cache reuse"
-            );
-            assert!(dockerfile.contains(pkg), "{provider:?} must install {pkg}");
-            // No cross-contamination with the other providers' install steps.
-            assert!(!dockerfile.contains("claude-code"));
-            assert!(!dockerfile.contains("@openai/codex"));
-        }
-
-        // The two new tags are distinct from each other, too.
-        assert_ne!(
-            image_tag(DockerProvider::Opencode),
-            image_tag(DockerProvider::Pi)
-        );
-    }
-
-    /// Cursor gets its own repo + distinct tag and shares claude's base layers
-    /// (cache reuse) even though it installs via the official curl installer
-    /// rather than npm — the base-sharing invariant is install-agnostic. No other
-    /// provider's package leaks into the image.
-    #[test]
-    fn cursor_image_is_distinct_and_shares_base() {
-        let cursor = image_tag(DockerProvider::Cursor);
-        assert!(cursor.starts_with("fletch-agent-cursor:"), "{cursor}");
-        for other in [
-            DockerProvider::Claude,
-            DockerProvider::Codex,
-            DockerProvider::Opencode,
-            DockerProvider::Pi,
-        ] {
-            assert_ne!(
-                cursor,
-                image_tag(other),
-                "cursor tag collides with {other:?}"
-            );
-        }
-        // Base (FROM + apt) byte-identical despite the curl-installer install step.
-        assert_eq!(
-            base_layers(CURSOR_DOCKERFILE),
-            base_layers(DOCKERFILE),
-            "base layers must match for cache reuse",
-        );
-        // Installs cursor-agent via its official installer; no other provider's pkg.
-        assert!(CURSOR_DOCKERFILE.contains("cursor.com/install"));
-        assert!(CURSOR_DOCKERFILE.contains("cursor-agent"));
-        assert!(!CURSOR_DOCKERFILE.contains("claude-code"));
-        assert!(!CURSOR_DOCKERFILE.contains("@openai/codex"));
-        assert!(!CURSOR_DOCKERFILE.contains("opencode-ai"));
-        assert!(!CURSOR_DOCKERFILE.contains("pi-coding-agent"));
-    }
-
-    #[test]
     fn build_argv_shape() {
         // `--pull` on every build, `--no-cache` on refresh rebuilds only: see
         // the `build_args` doc — neither a stale cached base nor a cached
@@ -1140,32 +721,6 @@ mod tests {
                 "/tmp/ctx"
             ],
         );
-    }
-
-    /// Every provider's Dockerfile carries `LABEL fletch.agent=<provider id>`
-    /// — the GC's attribution authority. The value must round-trip through
-    /// `DockerProvider::from_id` so label values and provider ids can't drift.
-    #[test]
-    fn every_dockerfile_carries_the_agent_label() {
-        for provider in DockerProvider::ALL {
-            let dockerfile = image_spec(provider).dockerfile;
-            let value = dockerfile
-                .lines()
-                .find_map(|l| l.strip_prefix(&format!("LABEL {AGENT_IMAGE_LABEL}=")))
-                .unwrap_or_else(|| {
-                    panic!("{provider:?} Dockerfile is missing the fletch.agent label")
-                });
-            assert_eq!(
-                DockerProvider::from_id(value.trim()),
-                Some(provider),
-                "{provider:?} label value must be its provider id",
-            );
-            // `id()` is `from_id`'s inverse — the version trigger keys the
-            // host probe and loop guard on it, so drift would silently
-            // disable (or cross-wire) the trigger.
-            assert_eq!(provider.id(), value.trim());
-            assert_eq!(DockerProvider::from_id(provider.id()), Some(provider));
-        }
     }
 
     /// The version-mismatch trigger's pure core: refresh only on a known,

--- a/src-tauri/src/sandbox/docker/mod.rs
+++ b/src-tauri/src/sandbox/docker/mod.rs
@@ -10,20 +10,21 @@
 //! [`sweep_orphans_at_startup`], which waits one out), an absent binary is
 //! treated as settled for the run.
 //!
-//! Layout:
-//! - [`cli`] — docker binary resolution + bounded-invocation helpers. Every
+//! Layout — the Docker *runtime*, on top of the runtime-neutral policy in
+//! [`crate::sandbox::container`]:
+//! - [`cli`] — docker binary resolution + bounded-invocation wrappers. Every
 //!   docker call in this module goes through it, so no invocation can hang
 //!   the app on a wedged daemon.
 //! - [`probe`] — cached daemon availability for UI polling.
-//! - [`image`] — the embedded agent Dockerfile and content-addressed builds.
-//! - [`cleanup`] — container labels, the dead-instance orphan sweep, and the
-//!   stale agent-image GC.
+//! - [`image`] — building, inspecting and reclaiming the agent images whose
+//!   content lives in [`container::images`](crate::sandbox::container::images).
+//! - [`cleanup`] — the dead-instance orphan sweep and the stale agent-image GC,
+//!   keyed on [`container::labels`](crate::sandbox::container::labels).
 //! - [`engine`] — `DockerEngine`, the `SandboxEngine` implementation
 //!   (one `docker run --rm --init` container per agent process).
 
 use std::time::{Duration, Instant};
 
-pub mod auth;
 mod cleanup;
 mod cli;
 mod engine;
@@ -40,90 +41,16 @@ pub use engine::{
 pub use probe::{availability, DockerAvailability};
 pub use progress::set_build_sink;
 
-/// A provider Fletch can run inside a Docker sandbox. This is the single
-/// capability gate the rest of the app consults instead of string-matching
-/// `provider == "claude"`: [`supervisor::lifecycle::ensure_engine_supports_provider`]
-/// refuses anything [`from_id`](DockerProvider::from_id) doesn't recognize, and
-/// the launch path ([`engine`]) branches on the variant for the provider-specific
-/// image ([`image`]), config-dir mount, and auth. Everything else about a
-/// container (workspace / RPC / object-store mounts, naming, teardown) is
-/// provider-agnostic.
-///
-/// Seatbelt runs six providers; Docker is being brought up one at a time as each
-/// gets its image + config-mount + auth wired here — claude, codex, opencode, pi,
-/// and cursor so far. antigravity remains gated: its CLI (`agy`) has no
-/// non-interactive credential path — auth is browser OAuth with its tokens in the
-/// host keychain and no API-key env fallback (maintainer-confirmed), so a fresh
-/// container cannot authenticate. See `ensure_engine_supports_provider`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum DockerProvider {
-    Claude,
-    Codex,
-    Opencode,
-    Pi,
-    Cursor,
-}
+/// The container auth chain, now runtime-neutral. Re-exported so the
+/// `sandbox::docker::auth::…` paths the app and its Tauri commands already use
+/// keep resolving.
+pub use crate::sandbox::container::auth;
 
-impl DockerProvider {
-    /// Every docker-supported provider. The image GC derives "the current
-    /// expected images" from this list, so a variant missing here would make
-    /// the GC treat that provider's live image as stale — when adding a
-    /// variant, extend this list (the exhaustive `match` in `image::image_spec`
-    /// will already force you into that file).
-    pub const ALL: [Self; 5] = [
-        Self::Claude,
-        Self::Codex,
-        Self::Opencode,
-        Self::Pi,
-        Self::Cursor,
-    ];
-
-    /// Map a provider id (as stamped on `AgentRecord.provider` / used by the
-    /// frontend) to its Docker support, or `None` when the provider has no
-    /// container support yet — the launch gate turns `None` into the
-    /// user-facing "isn't available in Docker sandboxes yet" refusal.
-    pub fn from_id(provider: &str) -> Option<Self> {
-        match provider {
-            "claude" => Some(Self::Claude),
-            "codex" => Some(Self::Codex),
-            "opencode" => Some(Self::Opencode),
-            "pi" => Some(Self::Pi),
-            "cursor" => Some(Self::Cursor),
-            _ => None,
-        }
-    }
-
-    /// The provider id string — [`from_id`](Self::from_id)'s inverse
-    /// (round-trip enforced by a test in [`image`]). Used where a variant must
-    /// key string-indexed state shared with the rest of the app, e.g. the host
-    /// version probe (`agent::cached_provider_version`) and the persisted
-    /// version-refresh loop guard (see `engine`).
-    pub fn id(self) -> &'static str {
-        match self {
-            Self::Claude => "claude",
-            Self::Codex => "codex",
-            Self::Opencode => "opencode",
-            Self::Pi => "pi",
-            Self::Cursor => "cursor",
-        }
-    }
-
-    /// The command name on the image's PATH — what this provider's npm package
-    /// installs as its executable. Handed to `launch_agent` as the in-image
-    /// `agent_bin` (a host-resolved absolute path would be meaningless inside
-    /// the container). Matches the provider's `bin` field for both supported
-    /// providers today, but named explicitly so it stays an image fact, not a
-    /// coincidence.
-    pub fn image_bin(self) -> &'static str {
-        match self {
-            Self::Claude => "claude",
-            Self::Codex => "codex",
-            Self::Opencode => "opencode",
-            Self::Pi => "pi",
-            Self::Cursor => "cursor-agent",
-        }
-    }
-}
+/// The set of providers a container can run, under the name the rest of the app
+/// knows it by. Docker was the first container runtime, so the type is spelled
+/// [`ContainerProvider`](crate::sandbox::container::ContainerProvider) at its new
+/// home and re-exported here.
+pub use crate::sandbox::container::ContainerProvider as DockerProvider;
 
 /// How long the startup sweep waits between probes while the daemon is still
 /// coming up. Comfortably above [`probe`]'s 5s cache TTL, so every poll is one

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod container;
 pub mod docker;
 mod engine;
 pub mod guarantees;


### PR DESCRIPTION
Groundwork for adding Podman as a third sandbox engine (PR 2 of the series; sibling of #625 — no shared files, merges independently).

`sandbox/docker/` mixed two kinds of code: Docker *runtime* plumbing (binary resolution, daemon probe, build/run/rm invocations) and container launch *policy* that any container runtime would carry out identically. This moves the policy into a new `sandbox/container/` module so a Podman engine can reuse it verbatim, while `docker/` keeps everything that shells out.

## Moved into `sandbox/container/`

- `run_args.rs` — the pure `run` argv builder (`RunSpec`, `ProviderMounts`, mount/env invariants)
- `labels.rs` — the `fletch.host-pid` / `fletch.agent-id` container labels
- `provider.rs` — `DockerProvider` → `ContainerProvider` (which providers can run in a container, ids, in-image binaries)
- `proc.rs` — bounded subprocess execution (timeouts, line forwarding) + its tests
- `images.rs` — embedded Dockerfiles/entrypoints, `ImageSpec`, content-addressed tagging. Content only: nothing here builds or inspects
- `auth.rs` / `launch_auth.rs` — the container credential chain and per-provider launch prep

## Deliberately left in `docker/`

- All exec paths: `image.rs` build/inspect/refresh/GC, `cleanup.rs` sweeps, `cli.rs` docker wrappers, `probe.rs`, `progress.rs`, the `SandboxEngine` impl
- `setup_token.rs` — host-side credential acquisition UX (drives `claude setup-token` on the host PTY; not container launch policy)
- `engine/tests.rs` stays put with updated imports — its 60 tests interleave argv, config-dir, util and auth assertions; splitting it would be a large risky diff for no coverage gain

## Zero behavior change

- Every external path keeps compiling via re-exports (`sandbox::docker::DockerProvider`, `sandbox::docker::auth::*`, …); the diff outside `src-tauri/src/sandbox/` is empty
- Moves done with `git mv` so history follows
- 1427 tests pass; test count under `sandbox/` identical before/after (163); clippy and rustfmt clean

Known follow-up for the Podman PR: `proc.rs`'s timeout message still says "is the Docker daemon responding?" — kept verbatim (a test asserts on it) to stay behavior-identical.