### PR TITLE
feat(sandbox): add the Podman engine kind, availability probe, and coverage declarations

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -686,8 +686,9 @@ fn answer_publish_approval(id: String, approved: bool) {
 }
 
 /// Change the sandbox engine stamped onto *new* agents. Docker is validated
-/// against a live daemon probe before being accepted, so a success here means
-/// the choice is actionable. Persists to `settings` and updates the in-memory
+/// against a live daemon probe before being accepted and Podman is refused
+/// outright, so a success here means the choice is actionable. Persists to
+/// `settings` and updates the in-memory
 /// mirror — like `set_agent_bin_override` keeps the DB and process state in
 /// sync. Existing agents are unaffected: each keeps the engine stamped on its
 /// record at creation.
@@ -698,6 +699,13 @@ async fn set_sandbox_engine(
 ) -> Result<(), String> {
     let kind = sandbox::EngineKind::from_setting(&engine)
         .ok_or_else(|| format!("unknown sandbox engine: {engine}"))?;
+    // Podman parses and probes but cannot launch (`sandbox::engine_for`), so it
+    // must not be *persistable*: a stored `podman` value would be stamped onto
+    // every new agent and fail each spawn. Rejected here rather than hidden in
+    // the UI alone — the setting is reachable over IPC.
+    if kind == sandbox::EngineKind::Podman {
+        return Err("the Podman engine can't run agents yet — it isn't selectable.".into());
+    }
     if kind == sandbox::EngineKind::Docker {
         // `spawn_blocking`: the probe can block up to its 2s timeout.
         let probe = tauri::async_runtime::spawn_blocking(sandbox::docker_availability)
@@ -727,6 +735,20 @@ async fn set_sandbox_engine(
 #[tauri::command]
 async fn probe_docker_engine() -> Result<sandbox::DockerAvailability, String> {
     tauri::async_runtime::spawn_blocking(sandbox::docker_availability)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Probe the local Podman installation. Async + `spawn_blocking` because the
+/// probe can block up to its 2s timeout.
+///
+/// Exposed before the engine can launch anything: the probe is what tells us
+/// whether a machine is even a candidate, and it is read-only. Selecting Podman
+/// is still refused by `set_sandbox_engine`, so a healthy answer here does not
+/// make the engine usable.
+#[tauri::command]
+async fn probe_podman_engine() -> Result<sandbox::PodmanAvailability, String> {
+    tauri::async_runtime::spawn_blocking(sandbox::podman_availability)
         .await
         .map_err(|e| e.to_string())
 }
@@ -1635,6 +1657,7 @@ pub fn run() {
             set_publish_confirmation,
             answer_publish_approval,
             probe_docker_engine,
+            probe_podman_engine,
             get_container_auth_status,
             set_container_auth_token,
             clear_container_auth_token,

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -7,6 +7,7 @@ use crate::error::Result;
 pub enum EngineKind {
     SandboxExec,
     Docker,
+    Podman,
 }
 
 impl EngineKind {
@@ -14,7 +15,7 @@ impl EngineKind {
     /// notably [`super::guarantees`], which must state each engine's coverage of
     /// each guarantee, so an engine added here without a coverage declaration
     /// fails to compile.
-    pub const ALL: &'static [Self] = &[Self::SandboxExec, Self::Docker];
+    pub const ALL: &'static [Self] = &[Self::SandboxExec, Self::Docker, Self::Podman];
 
     /// The `sandbox_engine` settings-value spelling for this kind. Shared with
     /// the frontend's `SandboxEngine` type, so both sides agree on the wire
@@ -23,6 +24,7 @@ impl EngineKind {
         match self {
             Self::SandboxExec => "sandbox-exec",
             Self::Docker => "docker",
+            Self::Podman => "podman",
         }
     }
 
@@ -33,7 +35,7 @@ impl EngineKind {
     /// default.
     pub fn is_container(self) -> bool {
         match self {
-            Self::Docker => true,
+            Self::Docker | Self::Podman => true,
             Self::SandboxExec => false,
         }
     }
@@ -44,6 +46,7 @@ impl EngineKind {
         match value {
             "sandbox-exec" => Some(Self::SandboxExec),
             "docker" => Some(Self::Docker),
+            "podman" => Some(Self::Podman),
             _ => None,
         }
     }
@@ -178,14 +181,15 @@ mod tests {
     }
 
     #[test]
-    fn only_docker_is_a_container_engine() {
+    fn only_the_container_runtimes_are_container_engines() {
         assert!(EngineKind::Docker.is_container());
+        assert!(EngineKind::Podman.is_container());
         assert!(!EngineKind::SandboxExec.is_container());
     }
 
     #[test]
     fn engine_kind_rejects_unknown_setting_values() {
-        assert_eq!(EngineKind::from_setting("podman"), None);
+        assert_eq!(EngineKind::from_setting("containerd"), None);
         assert_eq!(EngineKind::from_setting(""), None);
     }
 }

--- a/src-tauri/src/sandbox/guarantees.rs
+++ b/src-tauri/src/sandbox/guarantees.rs
@@ -22,6 +22,29 @@ use serde::Serialize;
 
 use super::EngineKind;
 
+/// The engine-independent half of [`Guarantee::WithheldGitConfig`]'s shortfall,
+/// shared by every container runtime: each one hands the agent a read-write
+/// checkout, so each one leans on the same host-side refusal.
+///
+/// A macro rather than a `const` because [`Coverage::Partial`] carries a
+/// `&'static str` and only `concat!` of literals can prepend a runtime-specific
+/// lead-in to it. Shared rather than duplicated per runtime because this text is
+/// what the isolation panel shows the user: two copies would drift, and the
+/// drift would be silent — a copy that no longer matches the hardening it
+/// describes still compiles and still renders.
+macro_rules! git_config_host_backstop {
+    () => {
+        "Instead host-side git refuses to run in a checkout whose config would execute a program \
+         (crate::git::hardening), which is engine-independent. It reads every scope the agent can \
+         write (local and worktree, via --show-scope), so a key smuggled into .git/config.worktree \
+         is caught too. That refusal covers every command that can trigger one: the git::cmd \
+         helper seam plus the read, pull and push/fetch paths that build a command directly. \
+         push/fetch run no filter or merge driver but do run the transport-executing keys \
+         core.sshCommand, core.gitProxy and remote.<name>.uploadpack/receivepack, which the -c \
+         overrides omit, so the refusal covers them there too"
+    };
+}
+
 /// A security property Fletch's isolation claims.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Guarantee {
@@ -78,45 +101,55 @@ impl Guarantee {
     /// memory, is what forces a new guarantee or a new engine to declare its
     /// coverage. That is this module's whole job.
     pub fn coverage(self, engine: EngineKind) -> Coverage {
-        use EngineKind::{Docker, SandboxExec};
+        use EngineKind::{Docker, Podman, SandboxExec};
         match (self, engine) {
-            // Both engines' primary job: seatbelt by SBPL deny-then-allow,
-            // Docker by mounting nothing else writable.
+            // Every engine's primary job: seatbelt by SBPL deny-then-allow, the
+            // container runtimes by mounting nothing else writable.
             (Self::ConfinedWrites, _) => Coverage::Enforced,
 
             // Policy invariant 3 (`super::policy::GIT_EXEC_CONFIG_FILES`).
             (Self::WithheldGitConfig, SandboxExec) => Coverage::Enforced,
-            (Self::WithheldGitConfig, Docker) => Coverage::Partial(
+            (Self::WithheldGitConfig, Docker) => Coverage::Partial(concat!(
                 "the checkout is bind-mounted read-write, so an agent can still write its own \
                  .git/config — nested read-only binds would stop a direct write but not a \
                  rename, because Docker mounts follow the inode where seatbelt's path rules do \
-                 not. Instead host-side git refuses to run in a checkout whose config would \
-                 execute a program (crate::git::hardening), which is engine-independent. It \
-                 reads every scope the agent can write (local and worktree, via --show-scope), \
-                 so a key smuggled into .git/config.worktree is caught too. That refusal covers \
-                 every command that can trigger one: the git::cmd helper seam plus the read, \
-                 pull and push/fetch paths that build a command directly. push/fetch run no \
-                 filter or merge driver but do run the transport-executing keys core.sshCommand, \
-                 core.gitProxy and remote.<name>.uploadpack/receivepack, which the -c overrides \
-                 omit, so the refusal covers them there too",
-            ),
+                 not. ",
+                git_config_host_backstop!(),
+            )),
+            // Same mount model as Docker (`container::run_args`): identical-path
+            // binds, the checkout read-write. Rootless is worth stating because
+            // it is the difference a Podman user expects to matter — and worth
+            // bounding, because it does not matter here.
+            (Self::WithheldGitConfig, Podman) => Coverage::Partial(concat!(
+                "the checkout is bind-mounted read-write, so an agent can still write its own \
+                 .git/config — nested read-only binds would stop a direct write but not a \
+                 rename, because a Podman bind mount follows the inode just as Docker's does, \
+                 where seatbelt's path rules do not. Podman running rootless narrows what a \
+                 container escape would own on the host, but it does not narrow this: the agent \
+                 is handed that checkout read-write by design. ",
+                git_config_host_backstop!(),
+            )),
 
-            // Seatbelt denies the app-data dir explicitly; Docker never mounts it.
+            // Seatbelt denies the app-data dir explicitly; a container runtime
+            // never mounts it.
             (Self::OpaqueAppData, _) => Coverage::Enforced,
 
-            // Agents work in a clone with its own .git; under Docker the source
-            // .git is never mounted, only its object store and only read-only.
+            // Agents work in a clone with its own .git; under a container runtime
+            // the source .git is never mounted, only its object store and only
+            // read-only.
             (Self::UntouchableSourceGit, _) => Coverage::Enforced,
 
             (Self::ConfinedReads, SandboxExec) => Coverage::Unenforced(
                 "the profile starts from (allow default) and confines writes only — the agent \
                  runs as you and can read anything you can",
             ),
-            (Self::ConfinedReads, Docker) => Coverage::Enforced,
+            // Both container runtimes mount only the paths `container::run_args`
+            // lists, so nothing else on the disk is reachable to read.
+            (Self::ConfinedReads, Docker | Podman) => Coverage::Enforced,
 
             (Self::ConfinedNetwork, _) => Coverage::Unenforced(
-                "neither engine restricts egress: seatbelt's (allow default) leaves it open and \
-                 the container launch sets no --network. Treat every agent as network-capable",
+                "no engine restricts egress: seatbelt's (allow default) leaves it open and the \
+                 container launches set no --network. Treat every agent as network-capable",
             ),
 
             // Push/PR never run in the sandbox — they are brokered host-side

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod container;
 pub mod docker;
 mod engine;
 pub mod guarantees;
+pub mod podman;
 pub mod policy;
 pub mod provision;
 mod seatbelt;
@@ -15,6 +16,7 @@ use crate::error::{Error, Result};
 pub use docker::{availability as docker_availability, DockerAvailability};
 pub use engine::{AgentLaunchCtx, EngineKind, KillHandle, LaunchPlan, SandboxEngine};
 pub use guarantees::{describe as describe_isolation, IsolationReport};
+pub use podman::{availability as podman_availability, PodmanAvailability};
 pub use policy::{toolchain_cache_env, toolchain_cache_root};
 pub use seatbelt::{
     build_run_profile, cleanup_nested_checkouts_roots, cleanup_nested_rpc_roots,
@@ -66,6 +68,20 @@ pub fn engine_for(kind: EngineKind) -> Result<Arc<dyn SandboxEngine>> {
                 )))
             }
         },
+        // Podman has no launch path yet: the kind, the probe and the coverage
+        // declarations ship ahead of `SandboxEngine`, so there is nothing here to
+        // return. Refused unconditionally — *not* probe-gated like Docker above —
+        // because "the probe says Podman is healthy" must not become "so launch
+        // it somehow": the only two outcomes available would be launching
+        // unsandboxed or falling back to seatbelt, and both are the isolation
+        // downgrade this function exists to prevent. Unconditional refusal here
+        // is what makes shipping a selectable kind safe before it can run
+        // anything; the next change adds the engine and replaces this arm.
+        EngineKind::Podman => Err(Error::SandboxUnavailable(
+            "The Podman engine cannot launch agents yet — this build ships the engine's \
+             availability probe only. Switch the sandbox engine to launch."
+                .into(),
+        )),
     }
 }
 

--- a/src-tauri/src/sandbox/podman/cli.rs
+++ b/src-tauri/src/sandbox/podman/cli.rs
@@ -1,0 +1,46 @@
+//! Locate the podman binary and run it with hard timeouts.
+//!
+//! The same two rules as [`docker::cli`](crate::sandbox::docker::cli), enforced
+//! by funneling every podman invocation through this module:
+//!
+//! 1. **Resolve the binary like a GUI app.** Podman installs the CLI into
+//!    `/opt/homebrew/bin` or `/usr/local/bin`, neither of which a
+//!    Finder-launched Tauri app's PATH reliably includes —
+//!    `bin_resolve::resolve_bin` handles that (its common-dirs fallback already
+//!    covers both).
+//! 2. **Bound every call.** Podman has no daemon on macOS, but it does talk to a
+//!    `podman machine` VM over a socket, and a VM that is suspended or
+//!    mid-shutdown leaves a socket that accepts and then stalls — the same hazard
+//!    a stopped Docker Desktop poses. Callers pass an explicit timeout and get a
+//!    clear "timed out" error instead. The bounding machinery is runtime-neutral
+//!    and lives in [`container::proc`](crate::sandbox::container::proc); what's
+//!    here is the thin Podman-specific layer over it.
+
+use std::process::{Command, Output};
+use std::time::Duration;
+
+use crate::error::{Error, Result};
+use crate::sandbox::container::proc::run_with_timeout;
+
+/// Absolute path of the podman CLI, or `None` when it isn't installed.
+/// Resolved fresh on every call (the underlying login-shell env is cached, so
+/// this is just a stat walk): caching a `None` here would pin the probe to
+/// `NotInstalled` for the whole app run even after the user installs Podman,
+/// and the probe's own 5s cache already bounds the frequency.
+pub(super) fn podman_bin() -> Option<std::path::PathBuf> {
+    let home = dirs::home_dir()?;
+    crate::bin_resolve::resolve_bin("podman", &home).map(std::path::PathBuf::from)
+}
+
+/// Run `podman <args>` capturing stdout/stderr, failing after `timeout`.
+/// Returns the raw `Output` — callers inspect the exit status themselves, since
+/// several podman commands use non-zero exits as answers (e.g. `image inspect`
+/// on a missing image), not as errors.
+pub(super) fn run_podman(args: &[&str], timeout: Duration) -> Result<Output> {
+    let bin = podman_bin()
+        .ok_or_else(|| Error::Other("podman binary not found — is Podman installed?".into()))?;
+    let mut cmd = Command::new(bin);
+    cmd.args(args);
+    let what = format!("podman {}", args.first().copied().unwrap_or_default());
+    run_with_timeout(cmd, timeout, &what)
+}

--- a/src-tauri/src/sandbox/podman/mod.rs
+++ b/src-tauri/src/sandbox/podman/mod.rs
@@ -1,0 +1,28 @@
+//! The Podman sandbox engine's primitives. A skeleton: this module can say
+//! whether Podman is usable, and nothing more.
+//!
+//! [`EngineKind::Podman`](crate::sandbox::EngineKind::Podman) exists and probes,
+//! but `sandbox::engine_for` refuses it unconditionally — there is no
+//! `SandboxEngine` implementation here yet, and no image build or cleanup.
+//! Shipping the kind ahead of the launch path is only safe because that refusal
+//! is unconditional rather than probe-gated: a Podman-stamped agent cannot
+//! launch even on a machine where the probe reports the runtime healthy, so
+//! there is no path on which a launch silently escapes the container boundary
+//! the user picked.
+//!
+//! Everything here must work when Podman is absent or its machine is down:
+//! probing reports that state instead of erroring.
+//!
+//! Layout mirrors [`docker`](crate::sandbox::docker) — the Podman *runtime* on
+//! top of the runtime-neutral policy in [`crate::sandbox::container`], which
+//! Podman will reuse unchanged (identical-path binds, the same labels, the same
+//! image content):
+//! - [`cli`] — podman binary resolution + bounded-invocation wrappers. Every
+//!   podman call in this module goes through it, so no invocation can hang the
+//!   app on a wedged machine connection.
+//! - [`probe`] — cached availability for UI polling.
+
+mod cli;
+mod probe;
+
+pub use probe::{availability, PodmanAvailability};

--- a/src-tauri/src/sandbox/podman/probe.rs
+++ b/src-tauri/src/sandbox/podman/probe.rs
@@ -1,0 +1,138 @@
+//! Podman availability probe, cached for UI polling.
+//!
+//! Same contract as [`docker::probe`](crate::sandbox::docker::probe): the
+//! settings pane polls this to enable/disable the Podman engine option, and
+//! spawn paths gate on it — so it must be cheap to call repeatedly and must
+//! never hang. The underlying `podman info` call is bounded at 2s and results
+//! are cached for 5s, so a polling UI costs at most one round-trip per window.
+
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use super::cli;
+
+/// How long a probe result stays fresh. UI polling is expected at ~1s
+/// intervals; 5s keeps the traffic negligible while still flipping the UI within
+/// a beat of `podman machine start` finishing.
+const CACHE_TTL: Duration = Duration::from_secs(5);
+
+/// Hard cap on the `podman info` round-trip. A running machine answers in
+/// milliseconds; anything slower is indistinguishable from down for our
+/// purposes, and 2s keeps a first uncached call from stalling its caller.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The three states the UI distinguishes: usable now, fixable by starting the
+/// `podman machine`, or fixable only by installing Podman.
+///
+/// [`MachineDown`](Self::MachineDown) is the Podman analogue of Docker's
+/// `DaemonDown`, named for what the user actually fixes: Podman runs the
+/// containers itself with no daemon in the picture, but on macOS it needs a
+/// Linux VM, and a stopped or suspended `podman machine` is the common
+/// recoverable state. The same variant covers a Linux install whose user socket
+/// is unreachable — one remedy the user can act on either way.
+///
+/// Serializes to the wire shape the settings UI consumes:
+/// `{ "status": "...", "version"?: "..." }` (the `probe_podman_engine` command
+/// in `lib.rs` returns it directly).
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "status", rename_all = "kebab-case")]
+pub enum PodmanAvailability {
+    Available {
+        #[serde(rename = "version")]
+        server_version: String,
+    },
+    NotInstalled,
+    MachineDown,
+}
+
+/// Current Podman availability, at most [`CACHE_TTL`] stale.
+///
+/// The cache lock is held across the probe itself — deliberate: concurrent
+/// callers while the machine is down would otherwise each burn their own 2s
+/// timeout, and serializing them means followers get the fresh cached answer
+/// immediately.
+pub fn availability() -> PodmanAvailability {
+    static CACHE: Mutex<Option<(Instant, PodmanAvailability)>> = Mutex::new(None);
+    let mut cache = CACHE.lock().unwrap();
+    if let Some((at, cached)) = cache.as_ref() {
+        if at.elapsed() < CACHE_TTL {
+            return cached.clone();
+        }
+    }
+    let fresh = probe();
+    *cache = Some((Instant::now(), fresh.clone()));
+    fresh
+}
+
+/// One uncached probe: binary present? machine connection answering?
+fn probe() -> PodmanAvailability {
+    if cli::podman_bin().is_none() {
+        return PodmanAvailability::NotInstalled;
+    }
+    // `podman info` — not `podman version`, which reports the client build from
+    // the binary alone and so answers happily with the machine stopped. `info`
+    // round-trips the machine connection, which is the thing that has to work
+    // before a launch can, and exits non-zero when it can't be reached. A
+    // timeout means a socket that accepts but never answers — same user remedy,
+    // same classification.
+    match cli::run_podman(&["info", "--format", "{{.Version.Version}}"], PROBE_TIMEOUT) {
+        Ok(out) if out.status.success() => {
+            classify_version_stdout(&String::from_utf8_lossy(&out.stdout))
+        }
+        _ => PodmanAvailability::MachineDown,
+    }
+}
+
+/// Map a successful `podman info` stdout to availability. Split out of [`probe`]
+/// so the parsing is unit-testable without a machine.
+fn classify_version_stdout(stdout: &str) -> PodmanAvailability {
+    let version = stdout.trim();
+    if version.is_empty() {
+        // Zero exit but no version — treat as down rather than inventing an
+        // "unknown" state the UI would have to render.
+        PodmanAvailability::MachineDown
+    } else {
+        PodmanAvailability::Available {
+            server_version: version.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn availability_serializes_to_the_wire_shape() {
+        let available = PodmanAvailability::Available {
+            server_version: "5.3.1".into(),
+        };
+        assert_eq!(
+            serde_json::to_value(available).unwrap(),
+            serde_json::json!({ "status": "available", "version": "5.3.1" })
+        );
+        assert_eq!(
+            serde_json::to_value(PodmanAvailability::NotInstalled).unwrap(),
+            serde_json::json!({ "status": "not-installed" })
+        );
+        assert_eq!(
+            serde_json::to_value(PodmanAvailability::MachineDown).unwrap(),
+            serde_json::json!({ "status": "machine-down" })
+        );
+    }
+
+    #[test]
+    fn version_stdout_classification() {
+        assert_eq!(
+            classify_version_stdout("5.3.1\n"),
+            PodmanAvailability::Available {
+                server_version: "5.3.1".into()
+            },
+        );
+        assert_eq!(
+            classify_version_stdout("  \n"),
+            PodmanAvailability::MachineDown,
+            "a zero exit without a version is not a usable machine",
+        );
+    }
+}


### PR DESCRIPTION
PR 3 of the Podman-engine series (builds on #625 and #626): the `EngineKind::Podman` backend skeleton — the kind exists, its security coverage is declared, and its availability is probed over IPC — while everything that could actually run an agent fails closed until the launch path lands in the next PR.

## What's in

- **`EngineKind::Podman`**: wire spelling `"podman"`, added to `ALL`, `is_container() == true`. The former "rejects podman" test now uses `containerd` as its unknown value.
- **Guarantees coverage** (`sandbox/guarantees.rs`): the two arms the compiler demanded. `ConfinedReads` is `Enforced` (same mount model as Docker — only the paths `container::run_args` lists are mounted). `WithheldGitConfig` is `Partial` with a Podman-specific lead-in (bind mounts follow the inode; rootless narrows an escape's blast radius but not this) sharing the engine-independent host-side-git-hardening rationale with Docker via a literal macro, so the two runtimes' isolation-panel text can't silently drift. Docker's rendered note is byte-identical to before.
- **`sandbox/podman/`**: `podman_bin()` resolution and `run_podman()` over the shared `container::proc` helpers; an availability probe mirroring Docker's (5s cache, 2s timeout) with a three-state wire enum `available` / `not-installed` / `machine-down`. It probes `podman info --format {{.Version.Version}}` rather than `podman version`, because on macOS `version` answers client-side with the machine VM stopped — `info` round-trips the connection.
- **IPC**: new `probe_podman_engine` command.

## What deliberately fails closed

- `engine_for(Podman)` returns `SandboxUnavailable` **unconditionally** (not probe-gated): a healthy probe must not become "launch it somehow" — the only alternatives are launching unsandboxed or silently degrading to seatbelt.
- `set_sandbox_engine` **rejects** `"podman"` before any probe or DB write: a persisted value would be stamped onto every new agent and fail each spawn, and the setting is reachable over IPC, so hiding it in the UI alone wouldn't be enough. No frontend changes in this PR.

## Verification

1430 tests pass (0 failed, Docker-gated tests stay ignored); clippy and rustfmt clean. New unit tests cover the container-engine predicate, probe stdout classification, and the probe wire shape.

Known follow-up for the launch PR: `container/proc.rs::timeout_error` still says "is the Docker daemon responding?" — a Podman timeout currently surfaces Docker wording; parameterizing it belongs with the launch path.