### PR TITLE
feat(sandbox): the Podman engine gets Docker's hardening layer

### DIFF
--- a/src-tauri/src/agent/spawn.rs
+++ b/src-tauri/src/agent/spawn.rs
@@ -700,7 +700,11 @@ fn agent_bin_for(
     if engine.kind().is_container() {
         sandbox::docker::DockerProvider::from_id(provider)
             .map(|p| p.image_bin().to_string())
-            .ok_or_else(|| Error::Other(format!("{label} isn't available in Docker sandboxes yet")))
+            .ok_or_else(|| {
+                Error::Other(format!(
+                    "{label} isn't available in container sandboxes yet"
+                ))
+            })
     } else {
         resolve_agent_bin(provider, bin, label, home)
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -978,6 +978,48 @@ async fn set_docker_launch_settings(
     Ok(())
 }
 
+/// Persist the podman launch knobs (`podman_image` override + `podman_memory` /
+/// `podman_cpus` limits) and update the in-process mirror the spawn path reads.
+/// The docker command's twin in every respect but the keys and the mirror it
+/// writes — the two runtimes keep separate knobs so a user running both can
+/// point each at its own image and limits.
+#[tauri::command]
+async fn set_podman_launch_settings(
+    image: Option<String>,
+    memory: Option<String>,
+    cpus: Option<String>,
+    state: tauri::State<'_, DbState>,
+) -> Result<(), String> {
+    // Blank → None: a cleared field must not be stored as a launch override
+    // (an empty `--memory`/`--cpus` value or `podman_image` would break `podman
+    // run`), and the mirror treats blank as "use default" anyway.
+    let norm = |v: Option<String>| v.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
+    let image = norm(image);
+    let memory = norm(memory);
+    let cpus = norm(cpus);
+    {
+        let conn = state.lock();
+        // All three must land together, for the reason the docker twin above
+        // spells out: a partial write is a config the UI never shows.
+        let tx = conn.unchecked_transaction().map_err(|e| e.to_string())?;
+        for (key, value) in [
+            (sandbox::podman::IMAGE_SETTING, &image),
+            (sandbox::podman::MEMORY_SETTING, &memory),
+            (sandbox::podman::CPUS_SETTING, &cpus),
+        ] {
+            database::set_setting(&tx, key, value.as_deref().unwrap_or(""))
+                .map_err(|e| e.to_string())?;
+        }
+        tx.commit().map_err(|e| e.to_string())?;
+    }
+    sandbox::podman::set_launch_settings(sandbox::podman::LaunchSettings {
+        image_override: image,
+        memory,
+        cpus,
+    });
+    Ok(())
+}
+
 /// Startup seed retry pacing for an unavailable secret store: start at 30s
 /// (the realistic case — a login-item launch racing the keychain unlock —
 /// resolves quickly) and back off to a slow probe that never gives up. An
@@ -1363,10 +1405,10 @@ pub fn run() {
                 }
             }
 
-            // Seed the docker launch knobs (image override + resource limits)
-            // the same way — mirrored in-process for the spawn path. Slice C2
-            // adds the settings UI whose set-commands keep this in sync
-            // mid-run; until then changes apply on next launch.
+            // Seed the per-runtime launch knobs (image override + resource
+            // limits) the same way — mirrored in-process for the spawn path,
+            // which has no DB handle. Kept in sync mid-run by
+            // `set_docker_launch_settings` / `set_podman_launch_settings`.
             {
                 let conn = db.lock();
                 sandbox::docker::set_launch_settings(sandbox::docker::LaunchSettings {
@@ -1374,30 +1416,45 @@ pub fn run() {
                     memory: database::get_setting(&conn, sandbox::docker::MEMORY_SETTING),
                     cpus: database::get_setting(&conn, sandbox::docker::CPUS_SETTING),
                 });
+                sandbox::podman::set_launch_settings(sandbox::podman::LaunchSettings {
+                    image_override: database::get_setting(&conn, sandbox::podman::IMAGE_SETTING),
+                    memory: database::get_setting(&conn, sandbox::podman::MEMORY_SETTING),
+                    cpus: database::get_setting(&conn, sandbox::podman::CPUS_SETTING),
+                });
             }
 
-            // Seed the docker version-refresh loop guard (mirror of the
-            // `docker_version_refresh_guard` setting — private bookkeeping,
-            // not user-facing) and wire its write-back, so a host CLI pinned
-            // away from the registry's latest triggers at most one
-            // version-parity rebuild ever, not one per app run. Same mirror
-            // idiom as the launch knobs above; the guard is consulted and
-            // recorded on spawn/background threads that have no DB handle.
+            // Seed each runtime's version-refresh loop guard (mirrors of the
+            // `docker_version_refresh_guard` / `podman_version_refresh_guard`
+            // settings — private bookkeeping, not user-facing) and wire their
+            // write-backs, so a host CLI pinned away from the registry's latest
+            // triggers at most one version-parity rebuild ever, not one per app
+            // run. Same mirror idiom as the launch knobs above; the guards are
+            // consulted and recorded on spawn/background threads that have no DB
+            // handle. Per runtime because the image stores are separate: a
+            // rebuild that settled docker's mismatch proves nothing about
+            // podman's store.
             {
-                let seeded: std::collections::HashMap<String, String> =
-                    database::get_setting(&db.lock(), sandbox::docker::VERSION_GUARD_SETTING)
+                let seed = |key: &'static str| -> std::collections::HashMap<String, String> {
+                    database::get_setting(&db.lock(), key)
                         .and_then(|s| serde_json::from_str(&s).ok())
-                        .unwrap_or_default();
-                let guard_db = db.clone();
-                sandbox::docker::init_version_refresh_guard(seeded, move |attempted| {
-                    if let Ok(json) = serde_json::to_string(attempted) {
-                        let _ = database::set_setting(
-                            &guard_db.lock(),
-                            sandbox::docker::VERSION_GUARD_SETTING,
-                            &json,
-                        );
+                        .unwrap_or_default()
+                };
+                let persister = |key: &'static str| {
+                    let guard_db = db.clone();
+                    move |attempted: &std::collections::HashMap<String, String>| {
+                        if let Ok(json) = serde_json::to_string(attempted) {
+                            let _ = database::set_setting(&guard_db.lock(), key, &json);
+                        }
                     }
-                });
+                };
+                sandbox::docker::init_version_refresh_guard(
+                    seed(sandbox::docker::VERSION_GUARD_SETTING),
+                    persister(sandbox::docker::VERSION_GUARD_SETTING),
+                );
+                sandbox::podman::init_version_refresh_guard(
+                    seed(sandbox::podman::VERSION_GUARD_SETTING),
+                    persister(sandbox::podman::VERSION_GUARD_SETTING),
+                );
             }
 
             // Seed the in-process container auth token (mirror of the stored
@@ -1437,11 +1494,14 @@ pub fn run() {
                 }));
             }
 
-            // Forward docker image-build progress to the UI. The
-            // build runs deep in the spawn path (no AppHandle there), so it
-            // emits through a process-wide sink installed here — mirroring the
-            // git-dist emitter above. Rare (first docker spawn per image), so a
-            // single toast fed by these events suffices.
+            // Forward container image-build progress to the UI — either
+            // runtime's, through one sink. The build runs deep in the spawn path
+            // (no AppHandle there), so it emits through a process-wide sink
+            // installed here — mirroring the git-dist emitter above. Rare (first
+            // spawn per image per runtime), so a single toast fed by these events
+            // suffices; `started` carries the runtime name so the toast can say
+            // which one is building. The `docker:build-progress` event name is
+            // the established wire contract and stays as-is.
             {
                 use tauri::Emitter;
                 let handle = app.handle().clone();
@@ -1676,6 +1736,7 @@ pub fn run() {
             submit_claude_setup_code,
             cancel_claude_container_auth,
             set_docker_launch_settings,
+            set_podman_launch_settings,
             workflow::wf_list_runs,
             workflow::wf_get_run,
             workflow::wf_events,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -699,12 +699,25 @@ async fn set_sandbox_engine(
 ) -> Result<(), String> {
     let kind = sandbox::EngineKind::from_setting(&engine)
         .ok_or_else(|| format!("unknown sandbox engine: {engine}"))?;
-    // Podman parses and probes but cannot launch (`sandbox::engine_for`), so it
-    // must not be *persistable*: a stored `podman` value would be stamped onto
-    // every new agent and fail each spawn. Rejected here rather than hidden in
-    // the UI alone — the setting is reachable over IPC.
     if kind == sandbox::EngineKind::Podman {
-        return Err("the Podman engine can't run agents yet — it isn't selectable.".into());
+        // Same gate Docker gets below: a stored engine value is stamped onto
+        // every new agent, so persisting one whose runtime can't launch would
+        // fail each spawn. Checked here rather than in the UI alone — the
+        // setting is reachable over IPC.
+        let probe = tauri::async_runtime::spawn_blocking(sandbox::podman_availability)
+            .await
+            .map_err(|e| e.to_string())?;
+        match probe {
+            sandbox::PodmanAvailability::Available { .. } => {}
+            sandbox::PodmanAvailability::NotInstalled => {
+                return Err("Podman is not installed — install Podman first.".into())
+            }
+            sandbox::PodmanAvailability::MachineDown => {
+                return Err(
+                    "The Podman machine isn't running — run `podman machine start` first.".into(),
+                )
+            }
+        }
     }
     if kind == sandbox::EngineKind::Docker {
         // `spawn_blocking`: the probe can block up to its 2s timeout.
@@ -739,13 +752,8 @@ async fn probe_docker_engine() -> Result<sandbox::DockerAvailability, String> {
         .map_err(|e| e.to_string())
 }
 
-/// Probe the local Podman installation. Async + `spawn_blocking` because the
-/// probe can block up to its 2s timeout.
-///
-/// Exposed before the engine can launch anything: the probe is what tells us
-/// whether a machine is even a candidate, and it is read-only. Selecting Podman
-/// is still refused by `set_sandbox_engine`, so a healthy answer here does not
-/// make the engine usable.
+/// Probe the local Podman installation for the settings UI. Async +
+/// `spawn_blocking` because the probe can block up to its 2s timeout.
 #[tauri::command]
 async fn probe_podman_engine() -> Result<sandbox::PodmanAvailability, String> {
     tauri::async_runtime::spawn_blocking(sandbox::podman_availability)
@@ -1583,9 +1591,12 @@ pub fn run() {
             // untouched.
             crate::sandbox::cleanup_nested_rpc_roots();
             crate::sandbox::cleanup_nested_checkouts_roots();
-            // Same reclamation for docker containers left by dead instances —
-            // probe-gated and on its own thread, so startup never waits on it.
+            // Same reclamation for containers left by dead instances, one
+            // sweep per container runtime — each probe-gated and on its own
+            // thread, so startup never waits on either, and a machine with
+            // neither runtime installed pays for no invocation at all.
             crate::sandbox::docker::sweep_orphans_at_startup();
+            crate::sandbox::podman::sweep_orphans_at_startup();
 
             // Quitting normally goes through `RunEvent::ExitRequested` (below),
             // but a SIGINT (Ctrl-C under `tauri dev`) or SIGTERM (sent by the

--- a/src-tauri/src/sandbox/container/config_dir.rs
+++ b/src-tauri/src/sandbox/container/config_dir.rs
@@ -1,6 +1,9 @@
 //! Non-default config-dir detection (does the container need a `-e CLAUDE_CONFIG_DIR`
 //! / `-e CODEX_HOME` / `-e XDG_*`?) and the borrowed git object stores a
 //! `--shared` clone reaches through alternates.
+//!
+//! Runtime-neutral: every answer here is a question about the *host* env and
+//! filesystem, so both container runtimes read the same one.
 
 use std::path::{Path, PathBuf};
 
@@ -14,7 +17,7 @@ use crate::sandbox::policy::resolve_existing_prefix;
 /// forwarding a blank value the resolver ignored would desync the two.
 ///
 /// [`codex_home_dir`]: crate::sandbox::policy::codex_home_dir
-pub(super) fn codex_home_is_nondefault(home: &Path) -> bool {
+pub(crate) fn codex_home_is_nondefault(home: &Path) -> bool {
     match std::env::var_os("CODEX_HOME") {
         Some(v) if !v.is_empty() => {
             resolve_existing_prefix(&PathBuf::from(v))
@@ -27,17 +30,17 @@ pub(super) fn codex_home_is_nondefault(home: &Path) -> bool {
 // Codex's `$CODEX_HOME` resolution (`codex_home_dir`) and opencode's data/
 // config dir resolution (`opencode_data_dir`, `opencode_config_dir`, their
 // shared `xdg_base`) now live in [`crate::sandbox::policy`] — they're class-1
-// host-persistence dirs both engines share (Docker mounts them; seatbelt
+// host-persistence dirs every engine shares (containers mount them; seatbelt
 // grants them), so the policy module is their single source of truth.
-// Imported at the top of the engine module.
+// Imported by [`super::launch`], which assembles the mounts.
 
 /// Whether `$var` points to an XDG base other than the default `home/<default_rel>`
 /// the container already resolves via `HOME`. Only a non-default base is forwarded,
 /// mirroring [`codex_home_is_nondefault`]; both sides canonicalize via
 /// [`resolve_existing_prefix`] so a symlink can't read as non-default. This stays
-/// docker-local: it's launch-time env-forwarding logic (does the container need a
-/// `-e XDG_*`?), not a write-policy question.
-pub(super) fn xdg_base_is_nondefault(var: &str, home: &Path, default_rel: &str) -> bool {
+/// out of [`crate::sandbox::policy`]: it's launch-time env-forwarding logic (does
+/// the container need a `-e XDG_*`?), not a write-policy question.
+pub(crate) fn xdg_base_is_nondefault(var: &str, home: &Path, default_rel: &str) -> bool {
     match std::env::var_os(var) {
         Some(v) if !v.is_empty() => {
             resolve_existing_prefix(&PathBuf::from(v))
@@ -61,7 +64,7 @@ pub(super) fn xdg_base_is_nondefault(var: &str, home: &Path, default_rel: &str) 
 /// symlink source, so a config dir pointing at the resolved target is still
 /// covered by that mount. The *original* path is returned for a genuinely
 /// non-default dir, so the mount/forward stay at the host path (invariant 1).
-pub(super) fn nondefault_claude_config_dir(home: &Path) -> Option<PathBuf> {
+pub(crate) fn nondefault_claude_config_dir(home: &Path) -> Option<PathBuf> {
     let dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from)?;
     (!config_dir_is_default(&dir, home)).then_some(dir)
 }
@@ -69,7 +72,7 @@ pub(super) fn nondefault_claude_config_dir(home: &Path) -> Option<PathBuf> {
 /// Whether `dir` resolves to the default `~/.claude`. Both sides go through
 /// [`resolve_existing_prefix`] — see [`nondefault_claude_config_dir`] for why.
 /// Pure over its inputs so the comparison rule is directly testable.
-pub(super) fn config_dir_is_default(dir: &Path, home: &Path) -> bool {
+pub(crate) fn config_dir_is_default(dir: &Path, home: &Path) -> bool {
     resolve_existing_prefix(dir) == resolve_existing_prefix(&home.join(".claude"))
 }
 
@@ -103,7 +106,7 @@ pub(super) fn config_dir_is_default(dir: &Path, home: &Path) -> bool {
 /// be mounted too or in-container git can't normalize the alternate. Results
 /// are deduped (repos may share a base) and cycle-guarded. A missing store is
 /// dropped, not mounted — see below.
-pub(super) fn borrowed_object_stores(source_repos: &[PathBuf]) -> Vec<PathBuf> {
+pub(crate) fn borrowed_object_stores(source_repos: &[PathBuf]) -> Vec<PathBuf> {
     /// The alternates listed in `<objects_dir>/info/alternates`, if any. Only
     /// ever called on stores reached from a trusted source repo, so the file it
     /// reads is always under user-owned (non-agent-writable) state.

--- a/src-tauri/src/sandbox/container/freshness.rs
+++ b/src-tauri/src/sandbox/container/freshness.rs
@@ -1,0 +1,153 @@
+//! The image-freshness policy both container runtimes apply: how long a built
+//! agent image may serve before a background rebuild, and whether a
+//! host/in-image CLI version pair warrants one.
+//!
+//! Pure by construction — no runtime coupling at all. The `image inspect` that
+//! reads a build date, the `run` that probes the in-image CLI, and the rebuild
+//! itself all shell out and stay in each runtime's own `image` module; what
+//! lives here is only the decision those invocations feed.
+
+use std::time::Duration;
+
+/// Dogma: **an agent image is never older than a week.** The images install
+/// "latest at build time" (npm installs, cursor's installer), so their
+/// contents freeze at build; this TTL bounds that freeze. An image past the
+/// TTL still serves the current launch — freshness is a background concern,
+/// never a launch blocker — and is rebuilt under the same tag off-thread.
+/// Deliberately not a setting.
+pub(crate) const IMAGE_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
+
+/// TTL verdict for an image's build timestamp against [`IMAGE_MAX_AGE`].
+/// `Unknown` (an unparseable timestamp) is deliberately its own state: the
+/// caller treats it as fresh, because rebuilding on unparseable metadata would
+/// rebuild on *every* resolution forever (the rebuilt image's metadata would
+/// presumably parse no better if the runtime's format changed under us).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Freshness {
+    Fresh,
+    Stale,
+    Unknown,
+}
+
+/// Classify a raw image creation timestamp (RFC3339, e.g.
+/// `2026-07-01T12:00:00.000000000Z` — what both runtimes' `image inspect`
+/// reports). Pure: `now` is injected so tests use fixed instants.
+pub(crate) fn classify_freshness(
+    created_raw: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Freshness {
+    let Ok(created) = chrono::DateTime::parse_from_rfc3339(created_raw.trim()) else {
+        return Freshness::Unknown;
+    };
+    // A negative age (clock skew, image "from the future") compares below any
+    // positive TTL and lands on Fresh — the right bias for bad clocks.
+    let max_age = chrono::Duration::from_std(IMAGE_MAX_AGE).expect("TTL fits chrono::Duration");
+    if now.signed_duration_since(created) > max_age {
+        Freshness::Stale
+    } else {
+        Freshness::Fresh
+    }
+}
+
+/// Pure core of the version-mismatch trigger: refresh only when both sides
+/// are known, differ (plain `!=` — deliberately no semver ordering: "newer"
+/// is not computable across five vendors' formats, and parity is the actual
+/// goal), and this pairing hasn't already been attempted (rebuilding can't
+/// fix a host that's simply pinned away from the registry's latest).
+pub(crate) fn version_refresh_wanted(
+    host: Option<&str>,
+    container: Option<&str>,
+    already_attempted: bool,
+) -> bool {
+    match (host, container) {
+        (Some(h), Some(c)) => !already_attempted && h != c,
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The version-mismatch trigger's pure core: refresh only on a known,
+    /// unequal, not-yet-attempted pairing. Plain `!=`, no semver ordering.
+    #[test]
+    fn version_refresh_decision() {
+        // Mismatch → refresh.
+        assert!(version_refresh_wanted(
+            Some("v2.0.1"),
+            Some("v2.0.0"),
+            false
+        ));
+        // Direction doesn't matter (no ordering): host older also fires once.
+        assert!(version_refresh_wanted(
+            Some("v1.0.0"),
+            Some("v2.0.0"),
+            false
+        ));
+        // Match → fresh.
+        assert!(!version_refresh_wanted(
+            Some("v2.0.0"),
+            Some("v2.0.0"),
+            false
+        ));
+        // No host CLI (not installed / probe failed) → inert.
+        assert!(!version_refresh_wanted(None, Some("v2.0.0"), false));
+        // Container version unknown (post-build probe failed) → inert.
+        assert!(!version_refresh_wanted(Some("v2.0.0"), None, false));
+        assert!(!version_refresh_wanted(None, None, false));
+        // Already-attempted pairing → inert (pinned host must not loop).
+        assert!(!version_refresh_wanted(
+            Some("v2.0.1"),
+            Some("v2.0.0"),
+            true
+        ));
+    }
+
+    /// The TTL decision's pure core, with fixed instants: inside the window →
+    /// fresh, past it → stale, unparseable → unknown (treated as fresh by the
+    /// caller — never rebuild-loop on bad metadata), and a future timestamp
+    /// (clock skew) → fresh.
+    #[test]
+    fn freshness_classification() {
+        use chrono::{TimeZone, Utc};
+        let now = Utc.with_ymd_and_hms(2026, 7, 8, 12, 0, 0).unwrap();
+
+        // The runtimes' actual format: RFC3339 with nanoseconds and Z.
+        assert_eq!(
+            classify_freshness("2026-07-07T12:00:00.123456789Z", now),
+            Freshness::Fresh,
+            "one day old is fresh",
+        );
+        assert_eq!(
+            classify_freshness("2026-07-01T12:00:00Z", now),
+            Freshness::Fresh,
+            "exactly the TTL boundary is still fresh (strictly-older rebuilds)",
+        );
+        assert_eq!(
+            classify_freshness("2026-07-01T11:59:59Z", now),
+            Freshness::Stale,
+            "past the TTL is stale",
+        );
+        assert_eq!(
+            classify_freshness("2026-01-01T00:00:00Z", now),
+            Freshness::Stale,
+            "months old is stale",
+        );
+        assert_eq!(
+            classify_freshness("2026-08-01T00:00:00Z", now),
+            Freshness::Fresh,
+            "a future build date (clock skew) is fresh, not stale",
+        );
+        assert_eq!(
+            classify_freshness("not-a-timestamp", now),
+            Freshness::Unknown,
+        );
+        assert_eq!(classify_freshness("", now), Freshness::Unknown);
+        // Whitespace from the CLI pipe is tolerated.
+        assert_eq!(
+            classify_freshness("  2026-07-07T12:00:00Z\n", now),
+            Freshness::Fresh,
+        );
+    }
+}

--- a/src-tauri/src/sandbox/container/image_gc.rs
+++ b/src-tauri/src/sandbox/container/image_gc.rs
@@ -1,0 +1,495 @@
+//! The stale-agent-image GC's listing format, parsing and selection rule —
+//! everything about *which* images to reclaim, with nothing about how to list or
+//! remove them.
+//!
+//! Both runtimes print their listings through the same Go-template format
+//! ([`IMAGES_FORMAT`], which we choose), so the rows parse identically and the
+//! selection rule below is shared verbatim. Each runtime's `cleanup` module
+//! supplies the listings and runs the `rmi`s.
+//!
+//! One rule: an image carrying the `fletch.agent` label
+//! ([`images::AGENT_IMAGE_LABEL`](super::images::AGENT_IMAGE_LABEL)) that is not
+//! one of the current expected tags is removed. Anything we can't attribute
+//! survives — the under-reclaim bias the container sweep takes too.
+
+use std::collections::HashSet;
+
+use super::images::{image_repo, image_tag};
+use super::ContainerProvider;
+
+/// `images` line format for the image GC listings. Untagged (dangling) images
+/// print `<none>` for repository and tag under both runtimes.
+pub(crate) const IMAGES_FORMAT: &str = "{{.ID}} {{.Repository}} {{.Tag}}";
+
+/// One `images` row: a (repo:tag, image id) pair — the same image id appears in
+/// multiple rows when it carries multiple tags, which is exactly what the GC
+/// wants: it untags Fletch's name and leaves any other name alone.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ImageRow {
+    pub(crate) id: String,
+    pub(crate) repo: String,
+    pub(crate) tag: String,
+}
+
+impl ImageRow {
+    /// Whether this row is a dangling image (`<none>:<none>`) — removable only
+    /// by id.
+    fn untagged(&self) -> bool {
+        self.repo == "<none>" || self.tag == "<none>"
+    }
+
+    /// The `repo:tag` name of a tagged row.
+    fn named(&self) -> String {
+        format!("{}:{}", self.repo, self.tag)
+    }
+
+    /// What to hand `rmi`: the name for tagged rows (untag just ours), the id
+    /// for dangling ones (the only handle they have).
+    fn removal_ref(&self) -> String {
+        if self.untagged() {
+            self.id.clone()
+        } else {
+            self.named()
+        }
+    }
+}
+
+/// One [`IMAGES_FORMAT`] line → an [`ImageRow`]; `None` on malformed lines
+/// (skipped — under-reclaim bias, same as the container sweep).
+pub(crate) fn parse_images_line(line: &str) -> Option<ImageRow> {
+    let mut parts = line.split_whitespace();
+    let row = ImageRow {
+        id: parts.next()?.to_string(),
+        repo: parts.next()?.to_string(),
+        tag: parts.next()?.to_string(),
+    };
+    Some(row)
+}
+
+/// The tags a launch could legitimately use right now — `image_tag(provider)`
+/// across every container-supported provider. Everything else Fletch built is
+/// superseded by definition.
+pub(crate) fn current_tags() -> HashSet<String> {
+    ContainerProvider::ALL
+        .iter()
+        .map(|p| image_tag(*p))
+        .collect()
+}
+
+/// The image repos Fletch owns today (one per live provider).
+pub(crate) fn known_repos() -> HashSet<&'static str> {
+    ContainerProvider::ALL
+        .iter()
+        .map(|p| image_repo(*p))
+        .collect()
+}
+
+/// The GC's selection rule, pure (inputs are pre-fetched listings, fixed in
+/// tests). `labeled` holds every image carrying the `fletch.agent` label;
+/// `legacy` holds the tagged contents of Fletch's own repos (pre-label
+/// installs). Returns deduplicated `rmi` refs.
+///
+/// The label is the authority, with one belt-and-braces exception each way:
+/// a *labeled* image tagged outside our namespace is kept (a user re-tagged
+/// our image under their own name — their tag, their call), and an *unlabeled*
+/// image is removed only on an exact `legacy_tags` match (the closed list of
+/// tags pre-label Fletch actually shipped — shape or namespace alone is never
+/// an ownership signal for unlabeled images). Current tags and the runtime's
+/// image override are always kept.
+///
+/// "Our namespace" is `known_repos` (the live providers) plus `retired_repos`
+/// ([`RETIRED_REPOS`] — providers we used to ship). Both are passed in rather
+/// than read from the constants so the rule stays testable on fixed inputs, as
+/// is `legacy_tags`: a runtime with no pre-label history (podman) passes an
+/// empty list and gets no legacy arm at all.
+///
+/// Within Fletch's repos, a labeled image is a removal candidate only under a
+/// tag Fletch itself could have written: the content-addressed shape (12
+/// lowercase hex chars — see `images::tag_for`) or no tag at all (a dangling
+/// rebuild predecessor). A human-shaped tag like `fletch-agent:backup` —
+/// a user's `docker tag` of our image — is theirs to keep: a tag a human
+/// wrote is the human's call. Retirement changes nothing about that: a
+/// retired repo buys a row into the candidate set, not past the safety rules.
+pub(crate) fn image_removal_refs(
+    labeled: &[ImageRow],
+    legacy: &[ImageRow],
+    current_tags: &HashSet<String>,
+    known_repos: &HashSet<&'static str>,
+    retired_repos: &[&str],
+    legacy_tags: &[&str],
+    override_image: Option<&str>,
+) -> Vec<String> {
+    let override_image = override_image.map(str::trim).filter(|s| !s.is_empty());
+    // A row that must survive no matter which listing produced it. The
+    // override comparison is defensive by design: match its exact `repo:tag`,
+    // its bare-repo spelling (both runtimes read `foo` as `foo:latest`), or the
+    // image id (all listings print the same short id).
+    let protected = |row: &ImageRow| {
+        if !row.untagged() && current_tags.contains(&row.named()) {
+            return true;
+        }
+        let Some(ov) = override_image else {
+            return false;
+        };
+        ov == row.id
+            || (!row.untagged() && (ov == row.named() || (row.tag == "latest" && ov == row.repo)))
+    };
+
+    // A repo Fletch owns now or used to own. Retired repos count because the
+    // `fletch.agent` label has already proven the image is ours — omitting
+    // them is exactly what stranded a retired provider's still-tagged images:
+    // the legacy arm skips them (they're labeled) and this arm skipped them
+    // (their repo was no longer known), so nothing could ever reclaim them.
+    let in_our_namespace = |row: &ImageRow| {
+        known_repos.contains(row.repo.as_str()) || retired_repos.contains(&row.repo.as_str())
+    };
+
+    let mut seen = HashSet::new();
+    let mut refs = Vec::new();
+    let mut push = |row: &ImageRow| {
+        let r = row.removal_ref();
+        if seen.insert(r.clone()) {
+            refs.push(r);
+        }
+    };
+
+    for row in labeled {
+        if !row.untagged() && !in_our_namespace(row) {
+            continue; // labeled but re-tagged under a user name: never touch
+        }
+        if !row.untagged() && !is_content_addressed_tag(&row.tag) {
+            continue; // human-written tag in our repo: their tag, their call
+        }
+        if protected(row) {
+            continue;
+        }
+        push(row);
+    }
+    for row in legacy {
+        // Exact match only: an unlabeled image carries no ownership proof, so
+        // the only safe removal signal is a tag we know Fletch shipped. A
+        // user's own image in our namespace — even under a hex/git-SHA-shaped
+        // tag like `fletch-agent:deadbeefcafe` — never matches.
+        if row.untagged() || !legacy_tags.contains(&row.named().as_str()) {
+            continue;
+        }
+        if protected(row) {
+            continue;
+        }
+        push(row);
+    }
+    refs
+}
+
+/// Whether a tag has the shape Fletch's content addressing writes — exactly
+/// 12 lowercase hex chars (`images::tag_for`'s `sha256[..12]`). Anything else
+/// in a Fletch repo was written by a human and is never a removal candidate.
+pub(crate) fn is_content_addressed_tag(tag: &str) -> bool {
+    tag.len() == 12
+        && tag
+            .bytes()
+            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
+}
+
+/// Every image repo Fletch used to own — the closed list of namespaces that
+/// are ours by history rather than by [`ContainerProvider::ALL`]. Bare repo
+/// names (`fletch-agent-x`), never `repo:tag`: these images DO carry the
+/// `fletch.agent` label, so ownership is already proven and the GC needs no
+/// per-tag allowlist to act on them — the ordinary safety rules for labeled
+/// rows (content-addressed tag shape, current tags, the image override) still
+/// apply unchanged. Runtime-neutral: a retired provider's images are stranded
+/// the same way in either store.
+///
+/// **Add an entry whenever a [`ContainerProvider`] variant is removed.**
+/// Without one, every still-tagged image under that repo is stranded on every
+/// user's disk forever, at ~0.5-1GB each: the labeled arm would skip it (repo
+/// no longer known) and the legacy arm would skip it (it's labeled). Only
+/// *untagged* rows survive a retirement today, since they never consult the
+/// repo at all.
+///
+/// Empty until the first retirement — this is forward-safety, not a live bug,
+/// and an empty list is behaviourally identical to not having one.
+pub(crate) const RETIRED_REPOS: &[&str] = &[];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(id: &str, repo: &str, tag: &str) -> ImageRow {
+        ImageRow {
+            id: id.into(),
+            repo: repo.into(),
+            tag: tag.into(),
+        }
+    }
+
+    #[test]
+    fn images_line_parsing() {
+        assert_eq!(
+            parse_images_line("abc123def456 fletch-agent 0011aabbccdd"),
+            Some(row("abc123def456", "fletch-agent", "0011aabbccdd")),
+        );
+        // Dangling images print `<none>` placeholders.
+        assert_eq!(
+            parse_images_line("abc123def456 <none> <none>"),
+            Some(row("abc123def456", "<none>", "<none>")),
+        );
+        assert_eq!(parse_images_line("abc123def456 fletch-agent"), None);
+        assert_eq!(parse_images_line(""), None);
+    }
+
+    /// The GC's one rule plus its fences, on fixed listings: labeled + stale
+    /// → remove; labeled + current → keep; labeled outside Fletch's repos
+    /// (user re-tag) → keep; unlabeled non-fletch → keep; legacy fletch-repo
+    /// stale → remove; the image override → keep in every spelling.
+    #[test]
+    fn image_gc_selection() {
+        let current_tags: HashSet<String> = ["fletch-agent:cafe00000000".to_string()].into();
+        let known_repos: HashSet<&'static str> = ["fletch-agent", "fletch-agent-codex"].into();
+        let legacy_tags: &[&str] = &["fletch-agent-codex:fa189de85caf"];
+
+        let labeled = vec![
+            // Old hash under a Fletch repo: superseded by a Dockerfile revision.
+            row("aaa", "fletch-agent", "0dab1e000000"),
+            // The current tag: what launches use today.
+            row("bbb", "fletch-agent", "cafe00000000"),
+            // Untagged leftover of a TTL rebuild: removable only by id.
+            row("ccc", "<none>", "<none>"),
+            // Labeled but re-tagged under a user's name: their tag, kept.
+            row("ddd", "mybackup", "keep"),
+            // The override, hypothetically labeled (shouldn't happen): kept.
+            row("eee", "ghcr.io/me/custom", "1"),
+            // Labeled but human-tagged inside our repo (a `tag` of our
+            // image): their tag, kept.
+            row("hhh", "fletch-agent", "backup"),
+        ];
+        let legacy = vec![
+            // Genuine pre-label image: exact legacy-list match, removable.
+            row("fff", "fletch-agent-codex", "fa189de85caf"),
+            // Current tag also shows up in the repo-scoped listing: kept.
+            row("bbb", "fletch-agent", "cafe00000000"),
+            // Selection must be safe even if a listing misbehaves: an
+            // unlabeled non-fletch row is never removed.
+            row("ggg", "someones-image", "latest"),
+            // A user's own image built into our namespace: human tag, kept.
+            row("iii", "fletch-agent", "backup"),
+            // A user's own image under a hex/git-SHA-shaped tag in our
+            // namespace: shape is not ownership — kept (exact-match only).
+            row("jjj", "fletch-agent", "deadbeefcafe"),
+        ];
+
+        let refs = image_removal_refs(
+            &labeled,
+            &legacy,
+            &current_tags,
+            &known_repos,
+            &[],
+            legacy_tags,
+            Some("ghcr.io/me/custom:1"),
+        );
+        assert_eq!(
+            refs,
+            vec![
+                "fletch-agent:0dab1e000000".to_string(),
+                "ccc".to_string(),
+                "fletch-agent-codex:fa189de85caf".to_string(),
+            ],
+        );
+
+        // An empty legacy list — what a runtime with no pre-label history
+        // passes — drops the legacy arm entirely and keeps the labeled verdict.
+        let refs = image_removal_refs(
+            &labeled,
+            &legacy,
+            &current_tags,
+            &known_repos,
+            &[],
+            &[],
+            Some("ghcr.io/me/custom:1"),
+        );
+        assert_eq!(
+            refs,
+            vec!["fletch-agent:0dab1e000000".to_string(), "ccc".to_string()],
+        );
+    }
+
+    /// Only tags Fletch's content addressing could have written count as
+    /// removal candidates — exactly 12 lowercase hex chars.
+    #[test]
+    fn content_addressed_tag_shape() {
+        assert!(is_content_addressed_tag("0123abcdef01"));
+        assert!(is_content_addressed_tag("000000000000"));
+        // Human-shaped tags, wrong length, uppercase: all kept.
+        assert!(!is_content_addressed_tag("backup"));
+        assert!(!is_content_addressed_tag("latest"));
+        assert!(!is_content_addressed_tag("0123ABCDEF01"));
+        assert!(!is_content_addressed_tag("0123abcdef0"));
+        assert!(!is_content_addressed_tag("0123abcdef012"));
+        assert!(!is_content_addressed_tag(""));
+    }
+
+    /// Override matching is defensive across spellings: exact `repo:tag`,
+    /// bare repo (the implicit `:latest`), and image id all protect.
+    #[test]
+    fn image_gc_override_spellings() {
+        let current_tags = HashSet::new();
+        let known_repos: HashSet<&'static str> = ["fletch-agent"].into();
+        // Hypothetical worst case: the user's override lives *inside* a
+        // Fletch repo under a content-addressed-looking tag (anything
+        // human-shaped is already kept by the tag-shape guard).
+        let labeled = vec![
+            row("aaa", "fletch-agent", "aaaaaaaaaaaa"),
+            row("bbb", "fletch-agent", "bbbbbbbbbbbb"),
+        ];
+
+        // Exact repo:tag override protects that row only.
+        let refs = image_removal_refs(
+            &labeled,
+            &[],
+            &current_tags,
+            &known_repos,
+            &[],
+            &[],
+            Some("fletch-agent:aaaaaaaaaaaa"),
+        );
+        assert_eq!(refs, vec!["fletch-agent:bbbbbbbbbbbb".to_string()]);
+
+        // Id override protects by id.
+        let refs = image_removal_refs(
+            &labeled,
+            &[],
+            &current_tags,
+            &known_repos,
+            &[],
+            &[],
+            Some("bbb"),
+        );
+        assert_eq!(refs, vec!["fletch-agent:aaaaaaaaaaaa".to_string()]);
+
+        // A bare-repo override reads as `:latest` — and a `:latest` row in our
+        // repo is kept by the tag-shape guard even before the override check,
+        // with or without the override present.
+        let with_latest = vec![row("lll", "fletch-agent", "latest")];
+        for ov in [Some("fletch-agent"), None] {
+            assert!(image_removal_refs(
+                &with_latest,
+                &[],
+                &current_tags,
+                &known_repos,
+                &[],
+                &[],
+                ov
+            )
+            .is_empty());
+        }
+
+        // Blank override protects nothing (same as None).
+        let refs = image_removal_refs(
+            &labeled,
+            &[],
+            &current_tags,
+            &known_repos,
+            &[],
+            &[],
+            Some("  "),
+        );
+        assert_eq!(refs.len(), 2);
+
+        // Overlapping listings dedupe to one removal ref.
+        let refs = image_removal_refs(
+            &labeled,
+            &labeled,
+            &current_tags,
+            &known_repos,
+            &[],
+            &[],
+            None,
+        );
+        assert_eq!(refs.len(), 2);
+    }
+
+    /// Retiring a provider must not strand its images. A labeled row under a
+    /// retired repo is reclaimable, but only on the same terms as a live one:
+    /// the content-addressed tag shape and the override still fence it, and a
+    /// repo that is neither live nor retired is still untouchable.
+    #[test]
+    fn image_gc_reclaims_retired_provider_repos() {
+        let current_tags: HashSet<String> = ["fletch-agent:cafe00000000".to_string()].into();
+        let known_repos: HashSet<&'static str> = ["fletch-agent"].into();
+        let retired: &[&str] = &["fletch-agent-pi"];
+
+        let labeled = vec![
+            // The stranding case: labeled, our old repo, our tag shape.
+            row("aaa", "fletch-agent-pi", "abc123def456"),
+            // Human-written tag in the retired repo: retirement is not a
+            // licence to delete a tag a human wrote.
+            row("bbb", "fletch-agent-pi", "backup"),
+            // Never ours: not a live repo, not a retired one.
+            row("ccc", "someones-image", "0dab1e000000"),
+            // Retired repo, but it's the user's image override.
+            row("ddd", "fletch-agent-pi", "0dab1e000000"),
+            // Live repo, current tag: unaffected by any of this.
+            row("eee", "fletch-agent", "cafe00000000"),
+        ];
+
+        let refs = image_removal_refs(
+            &labeled,
+            &[],
+            &current_tags,
+            &known_repos,
+            retired,
+            &[],
+            Some("fletch-agent-pi:0dab1e000000"),
+        );
+        assert_eq!(refs, vec!["fletch-agent-pi:abc123def456".to_string()]);
+
+        // The shipped list is empty, and an empty list is a strict no-op:
+        // every one of those rows is now outside our namespace but for the
+        // live-repo one, which is the current tag.
+        assert!(image_removal_refs(
+            &labeled,
+            &[],
+            &current_tags,
+            &known_repos,
+            &[],
+            &[],
+            Some("fletch-agent-pi:0dab1e000000"),
+        )
+        .is_empty());
+    }
+
+    /// [`RETIRED_REPOS`] holds bare repo names, not `repo:tag` — it widens the
+    /// namespace the labeled arm trusts, so a stray tag would silently match
+    /// nothing (a listing's repo is compared whole). Entries must also be
+    /// genuinely retired: a repo a live provider still owns belongs in
+    /// [`ContainerProvider::ALL`]'s derivation, not here.
+    #[test]
+    fn retired_repos_are_bare_fletch_repo_names() {
+        let known = known_repos();
+        for repo in RETIRED_REPOS {
+            assert!(!repo.contains(':'), "retired entry must be a repo: {repo}");
+            assert!(
+                repo.starts_with("fletch-agent"),
+                "retired repo isn't a fletch namespace: {repo}",
+            );
+            assert!(
+                !known.contains(repo),
+                "still-live repo listed as retired: {repo}",
+            );
+        }
+    }
+
+    /// The expected-tag / known-repo sets the GC derives from the provider
+    /// list: one entry per live provider, and every current tag lives in a
+    /// known repo (so a live image is never a candidate by namespace alone).
+    #[test]
+    fn expected_sets_cover_every_live_provider() {
+        let tags = current_tags();
+        let repos = known_repos();
+        assert_eq!(tags.len(), ContainerProvider::ALL.len());
+        for tag in &tags {
+            let (repo, _) = tag.split_once(':').expect("image tags are repo:tag");
+            assert!(repos.contains(repo), "current tag outside our repos: {tag}");
+        }
+    }
+}

--- a/src-tauri/src/sandbox/container/images.rs
+++ b/src-tauri/src/sandbox/container/images.rs
@@ -14,7 +14,8 @@
 //! can be garbage-collected.
 //!
 //! Content only: nothing here talks to a container runtime. Building, inspecting,
-//! the freshness TTL, and the GC all live in `sandbox::docker::image`.
+//! the freshness TTL, and the GC live in each runtime's own image module
+//! (`sandbox::docker::image`, `sandbox::podman::image`).
 
 use super::ContainerProvider;
 
@@ -243,6 +244,29 @@ pub(crate) fn image_tag(provider: ContainerProvider) -> String {
 /// images built before [`AGENT_IMAGE_LABEL`] existed.
 pub(crate) fn image_repo(provider: ContainerProvider) -> &'static str {
     image_spec(provider).repo
+}
+
+/// Write a build context holding exactly the two embedded files, so nothing
+/// from the host repo can leak into the image. Callers own the throwaway `dir`.
+///
+/// `COPY` preserves the context file's mode. The embedded Dockerfiles'
+/// `RUN chmod +x` is what actually guarantees an executable entrypoint on every
+/// host; setting the mode here too just keeps the copied layer's metadata sane
+/// where the host supports it.
+pub(crate) fn write_build_context(
+    dir: &std::path::Path,
+    dockerfile: &str,
+    entrypoint: &str,
+) -> std::io::Result<()> {
+    std::fs::write(dir.join("Dockerfile"), dockerfile)?;
+    let entrypoint_path = dir.join("entrypoint.sh");
+    std::fs::write(&entrypoint_path, entrypoint)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&entrypoint_path, std::fs::Permissions::from_mode(0o755))?;
+    }
+    Ok(())
 }
 
 /// `<repo>:<sha256(dockerfile + entrypoint)[..12]>` — 12 hex chars, the same

--- a/src-tauri/src/sandbox/container/labels.rs
+++ b/src-tauri/src/sandbox/container/labels.rs
@@ -25,3 +25,54 @@ pub(crate) fn host_pid_label() -> String {
 pub(crate) fn agent_id_label(agent_id: &str) -> String {
     format!("{AGENT_ID_LABEL}={agent_id}")
 }
+
+/// The `--filter` argument selecting one agent's containers. Built from
+/// [`agent_id_label`] so the query can never drift from what the launch
+/// stamped.
+pub(crate) fn agent_id_filter(agent_id: &str) -> String {
+    format!("label={}", agent_id_label(agent_id))
+}
+
+/// `<runtime> inspect` line format pairing each container id with its owning
+/// pid. `index` (rather than a direct field access) yields an empty string
+/// when the label is somehow absent, which parses to "no pid" and is skipped
+/// — under-reclaiming, never removing something we can't attribute. Lives here
+/// so the template and [`HOST_PID_LABEL`] can't drift (guarded by a test).
+pub(crate) const INSPECT_FORMAT: &str = r#"{{.Id}} {{index .Config.Labels "fletch.host-pid"}}"#;
+
+/// Parse [`INSPECT_FORMAT`] output and keep the ids whose owning pid is
+/// provably dead. A missing or unparsable pid means we can't attribute the
+/// container, so it is left alone (same under-reclaim bias as
+/// `cleanup_nested_state_roots_in`). Pure — the liveness probe is injected
+/// for unit tests.
+pub(crate) fn orphaned_ids(inspect_stdout: &str, alive: impl Fn(i32) -> bool) -> Vec<String> {
+    inspect_stdout
+        .lines()
+        .filter_map(parse_inspect_line)
+        .filter(|(_, pid)| pid.is_some_and(|p| !alive(p)))
+        .map(|(id, _)| id)
+        .collect()
+}
+
+/// One [`INSPECT_FORMAT`] line → `(container_id, owning_pid)`. The pid is
+/// `None` when the label was empty or not a number.
+pub(crate) fn parse_inspect_line(line: &str) -> Option<(String, Option<i32>)> {
+    let mut parts = line.split_whitespace();
+    let id = parts.next()?;
+    let pid = parts.next().and_then(|p| p.parse::<i32>().ok());
+    Some((id.to_string(), pid))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The inspect template reads the same label the launch stamps. Spelled as
+    /// a literal (Go templates can't be `const`-formatted), so a rename of
+    /// [`HOST_PID_LABEL`] would otherwise silently return empty pids for every
+    /// container and make the orphan sweep reclaim nothing.
+    #[test]
+    fn inspect_format_reads_the_host_pid_label() {
+        assert!(INSPECT_FORMAT.contains(HOST_PID_LABEL), "{INSPECT_FORMAT}");
+    }
+}

--- a/src-tauri/src/sandbox/container/launch.rs
+++ b/src-tauri/src/sandbox/container/launch.rs
@@ -1,0 +1,355 @@
+//! Per-launch container policy: the env a containerized agent gets, the mount
+//! sources that must exist before `-v` sees them, and the per-provider config /
+//! data / auth preparation.
+//!
+//! Everything a container launch decides *before* it knows which runtime will
+//! carry it out. The runtime engines ([`docker::engine`], [`podman::engine`])
+//! call [`prepare`] and then hand what comes back to
+//! [`run_args`](super::run_args) — so the two runtimes launch byte-identically
+//! and a change to launch policy cannot land on only one of them.
+//!
+//! [`docker::engine`]: crate::sandbox::docker
+//! [`podman::engine`]: crate::sandbox::podman
+
+use std::path::PathBuf;
+
+use crate::error::{Error, Result};
+use crate::sandbox::engine::AgentLaunchCtx;
+use crate::sandbox::policy::{codex_home_dir, opencode_config_dir, opencode_data_dir};
+
+use super::config_dir::{
+    borrowed_object_stores, codex_home_is_nondefault, nondefault_claude_config_dir,
+    xdg_base_is_nondefault,
+};
+use super::launch_auth::{
+    apply_container_auth, prepare_codex_launch, prepare_cursor_launch, prepare_opencode_launch,
+    prepare_pi_launch, present_api_keys,
+};
+use super::run_args::{prepare_config_mount_dir, ProviderMounts, CREDENTIALS_FILE};
+use super::ContainerProvider;
+
+/// The launch inputs [`prepare`] resolved: the CLI process env, the object
+/// stores to bind read-only, and the owned per-provider mount inputs a
+/// [`ProviderMounts`] borrows from.
+pub(crate) struct ContainerLaunch {
+    /// Env set on the runtime CLI process; forwarded into the container by the
+    /// bare `-e NAME` flags `run_args` emits (values never touch argv —
+    /// invariant 3). Config-dir vars come first, the resolved auth vars last.
+    pub env: Vec<(String, String)>,
+    /// Object stores every checkout under the agent's writable root borrows via
+    /// git alternates, each bind-mounted read-only at its identical host path.
+    pub borrowed_object_stores: Vec<PathBuf>,
+
+    provider: ContainerProvider,
+    /// Index into [`env`](Self::env) where the auth tail starts — everything
+    /// from here on is a credential name to forward. Only the resolved set is
+    /// forwarded: an ambient credential the chain didn't pick must not reach
+    /// the container and override the resolved login.
+    auth_start: usize,
+
+    claude_config_dir: Option<PathBuf>,
+    claude_credentials_rw: bool,
+    config_dir_credentials_rw: bool,
+    projects_src: Option<PathBuf>,
+    codex_config_dir: Option<PathBuf>,
+    forward_codex_home: bool,
+    oc_data: Option<PathBuf>,
+    oc_config: Option<PathBuf>,
+    forward_xdg_data_home: bool,
+    forward_xdg_config_home: bool,
+    pi_data: Option<PathBuf>,
+    cursor_data: Option<PathBuf>,
+}
+
+impl ContainerLaunch {
+    /// The auth var *names* to forward — exactly the tail [`prepare`] appended.
+    pub(crate) fn auth_vars(&self) -> Vec<&str> {
+        self.env[self.auth_start..]
+            .iter()
+            .map(|(k, _)| k.as_str())
+            .collect()
+    }
+
+    /// The launching provider's mount directives, borrowed from the owned
+    /// inputs [`prepare`] filled in. Exactly one provider arm ran, so exactly
+    /// one variant's inputs are populated.
+    pub(crate) fn mounts(&self) -> ProviderMounts<'_> {
+        match self.provider {
+            ContainerProvider::Claude => ProviderMounts::Claude {
+                config_dir: self.claude_config_dir.as_deref(),
+                credentials_rw: self.claude_credentials_rw,
+                config_dir_credentials_rw: self.config_dir_credentials_rw,
+                projects_src: self
+                    .projects_src
+                    .as_deref()
+                    .expect("claude launch must supply a projects_src"),
+            },
+            ContainerProvider::Codex => ProviderMounts::Codex {
+                config_dir: self
+                    .codex_config_dir
+                    .as_deref()
+                    .expect("codex launch must supply a config_dir"),
+                forward_home: self.forward_codex_home,
+            },
+            ContainerProvider::Opencode => ProviderMounts::Opencode {
+                data_dir: self
+                    .oc_data
+                    .as_deref()
+                    .expect("opencode launch must supply a data_dir"),
+                config_dir: self.oc_config.as_deref(),
+                forward_xdg_data_home: self.forward_xdg_data_home,
+                forward_xdg_config_home: self.forward_xdg_config_home,
+            },
+            ContainerProvider::Pi => ProviderMounts::Pi {
+                data_dir: self
+                    .pi_data
+                    .as_deref()
+                    .expect("pi launch must supply a data_dir"),
+            },
+            ContainerProvider::Cursor => ProviderMounts::Cursor {
+                data_dir: self
+                    .cursor_data
+                    .as_deref()
+                    .expect("cursor launch must supply a data_dir"),
+            },
+        }
+    }
+}
+
+/// Resolve everything a container launch of `provider` needs, creating the
+/// mount sources that must exist first. Fails the launch rather than handing a
+/// missing or unusable source to `-v`: a bare `-v` on a missing source has the
+/// runtime materialize it *root-owned*, which silently breaks the agent's
+/// access to its own auth/config/transcripts.
+pub(crate) fn prepare(
+    ctx: &AgentLaunchCtx,
+    provider: ContainerProvider,
+) -> Result<ContainerLaunch> {
+    // Object stores every checkout under the agent's writable root borrows
+    // via git alternates (a --shared clone). Derived from `ctx.source_repos`
+    // — Fletch's authoritative record of each checkout's user-owned source
+    // repo — NOT from the checkout's own `.git/objects/info/alternates`.
+    // That alternates file lives inside the agent's read-write checkout, so
+    // a container agent can overwrite it to name any host path and, on a
+    // reused-checkout relaunch (resume / switch_view), have that path
+    // bind-mounted read-only into its container — defeating ConfinedReads.
+    // Deriving from the source repos (which the agent cannot write) mounts
+    // exactly what a `--shared` clone borrows without trusting agent state.
+    // Spans every tracked repo, not just the primary: a multi-repo agent
+    // has one shared clone per repo. Mounted read-only; empty when a source
+    // is missing or has no object store. Container engines force Clone-mode
+    // workspaces for every provider, so this is provider-agnostic.
+    let borrowed_object_stores = borrowed_object_stores(ctx.source_repos);
+
+    let mut env: Vec<(String, String)> = vec![
+        ("HOME".into(), ctx.home.to_string_lossy().into_owned()),
+        (
+            "FLETCH_RPC_DIR".into(),
+            ctx.rpc_dir.to_string_lossy().into_owned(),
+        ),
+        ("TERM".into(), "xterm-256color".into()),
+        ("COLORTERM".into(), "truecolor".into()),
+    ];
+    // A workflow step agent's blackboard is bind-mounted at its identical
+    // host path (invariant 1, like the RPC mailbox), so `WF_BLACKBOARD` is
+    // the same host path under either engine. Pushed before the provider
+    // match sets `auth_start` so it forwards as a plain env var, not an
+    // auth var.
+    if let Some(board) = ctx.blackboard {
+        // Fail closed if the blackboard was not provisioned before launch:
+        // a bare `-v` on a missing source has the runtime create it *root-owned*,
+        // leaving the host-side reader unable to read the agent's verdict/
+        // handoff files. Seatbelt already fails here (its `canonicalize`
+        // errors on a missing path); match that so an ordering bug in the
+        // scheduler surfaces instead of silently corrupting the mount.
+        if !board.is_dir() {
+            return Err(Error::Other(format!(
+                "workflow blackboard not provisioned before launch: {}",
+                board.display()
+            )));
+        }
+        env.push((
+            crate::workflow::blackboard::WF_BLACKBOARD_ENV.into(),
+            board.to_string_lossy().into_owned(),
+        ));
+    }
+
+    // Owned per-provider mount inputs, borrowed into a `ProviderMounts` by
+    // `ContainerLaunch::mounts`. Defaults describe "no config surface"; the
+    // matched arm fills in what its provider needs.
+    let mut claude_config_dir: Option<PathBuf> = None;
+    let mut claude_credentials_rw = false;
+    let mut config_dir_credentials_rw = false;
+    let mut projects_src: Option<PathBuf> = None;
+    let mut codex_config_dir: Option<PathBuf> = None;
+    let mut forward_codex_home = false;
+    let mut oc_data: Option<PathBuf> = None;
+    let mut oc_config: Option<PathBuf> = None;
+    let mut forward_xdg_data_home = false;
+    let mut forward_xdg_config_home = false;
+    let mut pi_data: Option<PathBuf> = None;
+    let mut cursor_data: Option<PathBuf> = None;
+
+    // The config-dir env (CLAUDE_CONFIG_DIR / CODEX_HOME / XDG_*) is pushed
+    // before this mark so only the *auth* tail is forwarded as auth vars.
+    let auth_start;
+    match provider {
+        ContainerProvider::Claude => {
+            let cfg = nondefault_claude_config_dir(ctx.home);
+
+            // Make sure the mount sources exist before we hand them to `-v`.
+            // If a source can't be created (a file already sits at the path,
+            // a read-only or missing parent, permissions), mounting it anyway
+            // would let the runtime recreate it root-owned or fail the bind
+            // opaquely — either way claude loses access to its auth/config.
+            // Fail the launch with the path instead of a bad mount.
+            let claude_dir = ctx.home.join(".claude");
+            prepare_config_mount_dir(&claude_dir)?;
+            if let Some(dir) = &cfg {
+                prepare_config_mount_dir(dir)?;
+            }
+
+            // Per-agent host dir backing claude's `projects/` (session
+            // transcripts). Bind-mounted read-write over the read-only config
+            // dir's `projects/` (see `run_args::push_claude_config_mount`) so
+            // `--resume` survives container recreation without exposing the
+            // shared `~/.claude/projects` — other agents' transcripts and
+            // global memory stay unreachable (invariant 5). Lives under the
+            // agent's writable root, so archive teardown's `rm -rf` reclaims
+            // it with no separate cleanup. Created before the container runs so
+            // the runtime binds an existing source instead of materializing it
+            // root-owned.
+            let ps = ctx
+                .writable_root
+                .join(crate::transcripts::DOCKER_CLAUDE_PROJECTS_DIRNAME);
+            std::fs::create_dir_all(&ps).map_err(|e| {
+                Error::Other(format!(
+                    "preparing Docker sandbox projects mount {} failed: {e}",
+                    ps.display()
+                ))
+            })?;
+
+            // The read-only config mounts get a writable `.credentials.json`
+            // overlay only when the file already exists: a bare `-v` on a
+            // missing source makes the runtime create a root-owned *directory*
+            // there, which would break claude's later write of the real file.
+            claude_credentials_rw = claude_dir.join(CREDENTIALS_FILE).is_file();
+            config_dir_credentials_rw = cfg
+                .as_deref()
+                .is_some_and(|dir| dir.join(CREDENTIALS_FILE).is_file());
+            if let Some(dir) = &cfg {
+                env.push((
+                    "CLAUDE_CONFIG_DIR".into(),
+                    dir.to_string_lossy().into_owned(),
+                ));
+            }
+            claude_config_dir = cfg;
+            projects_src = Some(ps);
+
+            auth_start = env.len();
+            apply_container_auth(&mut env, super::auth::resolve())?;
+        }
+        ContainerProvider::Codex => {
+            // Codex's config dir is bind-mounted read-write: auth.json token
+            // refresh and the session rollout files it writes both need to
+            // persist, and writing rollouts at the same host path keeps the
+            // host-side transcript reader (`find_codex_rollouts`) working.
+            let dir = codex_home_dir(ctx.home);
+            // Forward CODEX_HOME only when it points somewhere other than the
+            // default `~/.codex` the container already resolves via HOME —
+            // mirrors `nondefault_claude_config_dir`.
+            forward_codex_home = codex_home_is_nondefault(ctx.home);
+            if forward_codex_home {
+                env.push(("CODEX_HOME".into(), dir.to_string_lossy().into_owned()));
+            }
+
+            auth_start = env.len();
+            prepare_codex_launch(
+                &mut env,
+                &dir,
+                std::env::var("OPENAI_API_KEY").ok().as_deref(),
+            )?;
+            codex_config_dir = Some(dir);
+        }
+        ContainerProvider::Opencode => {
+            // OpenCode's data dir carries the accounts DB / auth.json and the
+            // session storage the host transcript reader tails, so it's bound
+            // read-write at its identical host path (mirrors codex's ~/.codex).
+            let data = opencode_data_dir(ctx.home);
+            // Forward XDG_DATA_HOME only when it points somewhere other than
+            // the default `~/.local/share` the container resolves via HOME —
+            // mirrors codex's CODEX_HOME handling.
+            forward_xdg_data_home =
+                xdg_base_is_nondefault("XDG_DATA_HOME", ctx.home, ".local/share");
+            if forward_xdg_data_home {
+                if let Some(v) = std::env::var_os("XDG_DATA_HOME") {
+                    env.push(("XDG_DATA_HOME".into(), v.to_string_lossy().into_owned()));
+                }
+            }
+            // The config dir (custom providers + plugin installs opencode
+            // writes) is optional: opencode runs without it, and binding a
+            // missing source would have the runtime create it root-owned. Mount
+            // + forward it only when it already exists.
+            let config = opencode_config_dir(ctx.home);
+            if config.is_dir() {
+                forward_xdg_config_home =
+                    xdg_base_is_nondefault("XDG_CONFIG_HOME", ctx.home, ".config");
+                if forward_xdg_config_home {
+                    if let Some(v) = std::env::var_os("XDG_CONFIG_HOME") {
+                        env.push(("XDG_CONFIG_HOME".into(), v.to_string_lossy().into_owned()));
+                    }
+                }
+                oc_config = Some(config);
+            }
+
+            auth_start = env.len();
+            let api_keys = present_api_keys(|n| std::env::var(n).ok());
+            prepare_opencode_launch(&mut env, &data, api_keys)?;
+            oc_data = Some(data);
+        }
+        ContainerProvider::Pi => {
+            // Pi keeps everything under `~/.pi` (agent/auth.json,
+            // agent/settings.json, agent/sessions/), bound read-write at its
+            // identical host path so auth persists and the host transcript
+            // reader tails the sessions.
+            let data = ctx.home.join(".pi");
+            auth_start = env.len();
+            let api_keys = present_api_keys(|n| std::env::var(n).ok());
+            prepare_pi_launch(&mut env, &data, api_keys)?;
+            pi_data = Some(data);
+        }
+        ContainerProvider::Cursor => {
+            // `~/.cursor` is bound read-write at its identical host path so
+            // cursor's session transcripts land where the host reader
+            // (`agent::cursor_locate`) tails them. It carries no credential
+            // (the login token is keychain-bound); auth is CURSOR_API_KEY only.
+            let data = ctx.home.join(".cursor");
+            auth_start = env.len();
+            prepare_cursor_launch(
+                &mut env,
+                &data,
+                std::env::var("CURSOR_API_KEY").ok().as_deref(),
+            )?;
+            cursor_data = Some(data);
+        }
+    }
+
+    Ok(ContainerLaunch {
+        env,
+        borrowed_object_stores,
+        provider,
+        auth_start,
+        claude_config_dir,
+        claude_credentials_rw,
+        config_dir_credentials_rw,
+        projects_src,
+        codex_config_dir,
+        forward_codex_home,
+        oc_data,
+        oc_config,
+        forward_xdg_data_home,
+        forward_xdg_config_home,
+        pi_data,
+        cursor_data,
+    })
+}

--- a/src-tauri/src/sandbox/container/launch.rs
+++ b/src-tauri/src/sandbox/container/launch.rs
@@ -224,7 +224,7 @@ pub(crate) fn prepare(
                 .join(crate::transcripts::DOCKER_CLAUDE_PROJECTS_DIRNAME);
             std::fs::create_dir_all(&ps).map_err(|e| {
                 Error::Other(format!(
-                    "preparing Docker sandbox projects mount {} failed: {e}",
+                    "preparing container sandbox projects mount {} failed: {e}",
                     ps.display()
                 ))
             })?;

--- a/src-tauri/src/sandbox/container/mod.rs
+++ b/src-tauri/src/sandbox/container/mod.rs
@@ -20,6 +20,14 @@
 //! - [`sweep`] — the startup orphan sweep's probe-retry schedule.
 //! - [`images`] — the embedded Dockerfiles/entrypoints and their
 //!   content-addressed tags. Content only: nothing here builds or inspects.
+//! - [`freshness`] — the image TTL and the host/in-image version-parity
+//!   decision: when a built image has gone stale enough to rebuild.
+//! - [`version_guard`] — the per-runtime loop guard that caps version-parity
+//!   rebuild attempts at one per `host@tag` pairing.
+//! - [`image_gc`] — which superseded agent images to reclaim: the listing
+//!   format, its row parsing, and the selection rule.
+//! - [`progress`] — the process-wide image-build progress sink the UI toast
+//!   listens on.
 //! - [`auth`] — the Anthropic credential chain for containerized agents.
 //! - [`launch_auth`] — per-provider launch preparation: folding resolved
 //!   credentials into the CLI process env and failing fast without one.
@@ -29,14 +37,18 @@
 
 pub mod auth;
 pub(crate) mod config_dir;
+pub(crate) mod freshness;
+pub(crate) mod image_gc;
 pub(crate) mod images;
 pub(crate) mod labels;
 pub(crate) mod launch;
 pub(crate) mod launch_auth;
 pub(crate) mod proc;
+pub mod progress;
 pub(crate) mod provider;
 pub(crate) mod run_args;
 pub(crate) mod sweep;
 pub(crate) mod util;
+pub(crate) mod version_guard;
 
 pub use provider::ContainerProvider;

--- a/src-tauri/src/sandbox/container/mod.rs
+++ b/src-tauri/src/sandbox/container/mod.rs
@@ -8,10 +8,16 @@
 //!
 //! - [`provider`] — which providers can run in a container at all
 //!   ([`ContainerProvider`]), their ids and in-image binaries.
+//! - [`launch`] — per-launch policy: the container env, the mount sources it
+//!   creates, and the per-provider config/data/auth preparation. What both
+//!   runtimes' `launch_agent` calls before building any argv.
+//! - [`config_dir`] — non-default config-dir detection and borrowed object stores.
 //! - [`run_args`] — the `run` argv builder: mounts at identical host paths, the
 //!   per-provider config/data mounts, and the bare `-e NAME` auth forwards.
 //! - [`labels`] — the `fletch.host-pid` / `fletch.agent-id` labels every
-//!   container carries so orphan and per-agent sweeps can attribute it.
+//!   container carries so orphan and per-agent sweeps can attribute it, plus
+//!   the pid-liveness parsing those sweeps share.
+//! - [`sweep`] — the startup orphan sweep's probe-retry schedule.
 //! - [`images`] — the embedded Dockerfiles/entrypoints and their
 //!   content-addressed tags. Content only: nothing here builds or inspects.
 //! - [`auth`] — the Anthropic credential chain for containerized agents.
@@ -19,13 +25,18 @@
 //!   credentials into the CLI process env and failing fast without one.
 //! - [`proc`] — bounded subprocess execution (timeouts, line forwarding), the
 //!   machinery every runtime CLI invocation is funneled through.
+//! - [`util`] — container naming and the reserved-exit-code messages.
 
 pub mod auth;
+pub(crate) mod config_dir;
 pub(crate) mod images;
 pub(crate) mod labels;
+pub(crate) mod launch;
 pub(crate) mod launch_auth;
 pub(crate) mod proc;
 pub(crate) mod provider;
 pub(crate) mod run_args;
+pub(crate) mod sweep;
+pub(crate) mod util;
 
 pub use provider::ContainerProvider;

--- a/src-tauri/src/sandbox/container/proc.rs
+++ b/src-tauri/src/sandbox/container/proc.rs
@@ -6,7 +6,8 @@
 //! polling, the startup sweep): a stopped Docker Desktop, for one, leaves a
 //! socket that accepts connections and then hangs. Callers pass an explicit
 //! timeout and get a clear "timed out" error instead. Nothing here knows which
-//! runtime it is running — see `sandbox::docker::cli` for the Docker wrappers.
+//! runtime it is running — see `sandbox::docker::cli` and
+//! `sandbox::podman::cli` for the per-runtime wrappers.
 
 use std::process::{Command, Output, Stdio};
 use std::time::Duration;
@@ -87,7 +88,9 @@ pub(crate) fn run_with_timeout(mut cmd: Command, timeout: Duration, what: &str) 
 
 fn timeout_error(what: &str, timeout: Duration) -> Error {
     Error::Other(format!(
-        "{what} timed out after {:.0?} — is the Docker daemon responding?",
+        // `what` already names the runtime and subcommand ("docker build",
+        // "podman info"), so the hint stays runtime-neutral.
+        "{what} timed out after {:.0?} — is the container runtime responding?",
         timeout,
     ))
 }

--- a/src-tauri/src/sandbox/container/progress.rs
+++ b/src-tauri/src/sandbox/container/progress.rs
@@ -1,14 +1,19 @@
-//! Image-build progress broadcast to the UI.
+//! Image-build progress broadcast to the UI, shared by both container runtimes.
 //!
-//! The embedded agent image is built on the first docker spawn (see
-//! [`super::image::ensure_image`]) — a potentially minutes-long `docker build`
-//! that blocks the spawn until it finishes. That work happens deep in the
-//! engine launch path, which has no `AppHandle`, so this module offers a
-//! process-wide sink the app installs once at startup ([`set_build_sink`]) to
-//! forward build events to the UI. Until a sink is installed (or in headless
-//! tests) emitting is a no-op, so the build path stays decoupled from Tauri —
-//! matching how `engine::set_launch_settings` mirrors settings without a DB
-//! handle.
+//! The embedded agent image is built on the first spawn under a given runtime —
+//! a potentially minutes-long `build` that blocks the spawn until it finishes.
+//! That work happens deep in the engine launch path, which has no `AppHandle`,
+//! so this module offers a process-wide sink the app installs once at startup
+//! ([`set_build_sink`]) to forward build events to the UI. Until a sink is
+//! installed (or in headless tests) emitting is a no-op, so the build path stays
+//! decoupled from Tauri — matching how the engines' `set_launch_settings`
+//! mirrors settings without a DB handle.
+//!
+//! One sink for both runtimes, because there is one toast: only one foreground
+//! build can be in flight at a time under either runtime (each runtime
+//! serializes its builds on its own lock, and a launch waits for its own build),
+//! and [`BuildEvent::Started`] carries the runtime's display name so the toast
+//! can say which one the user is waiting on.
 
 use parking_lot::RwLock;
 
@@ -17,9 +22,12 @@ use parking_lot::RwLock;
 #[derive(Clone, serde::Serialize)]
 #[serde(tag = "phase", rename_all = "kebab-case")]
 pub enum BuildEvent {
-    /// A build just started (image missing, `docker build` about to run).
-    Started,
-    /// One line of `docker build` output.
+    /// A build just started (image missing, `build` about to run). `runtime` is
+    /// the runtime's display name ("Docker" / "Podman") so the toast can name
+    /// it; the frontend treats it as optional, so an event without it still
+    /// renders.
+    Started { runtime: &'static str },
+    /// One line of `build` output.
     Line { line: String },
     /// The build finished successfully.
     Finished,
@@ -57,7 +65,7 @@ mod tests {
     fn sink_receives_events_and_no_op_without_one() {
         // No sink installed at first: emitting must not panic (the build path
         // runs in headless tests with no app wired up).
-        emit(BuildEvent::Started);
+        emit(BuildEvent::Started { runtime: "Docker" });
 
         let count = Arc::new(AtomicUsize::new(0));
         let seen = count.clone();
@@ -65,7 +73,7 @@ mod tests {
             seen.fetch_add(1, Ordering::SeqCst);
         });
 
-        emit(BuildEvent::Started);
+        emit(BuildEvent::Started { runtime: "Podman" });
         emit(BuildEvent::Line {
             line: "step 1/5".into(),
         });
@@ -83,9 +91,12 @@ mod tests {
             json,
             serde_json::json!({ "phase": "line", "line": "pulling base image" })
         );
+        // `started` carries the runtime name alongside the phase the frontend
+        // switches on — an additive field, so the wire contract still holds for
+        // a consumer that only reads `phase`.
         assert_eq!(
-            serde_json::to_value(BuildEvent::Started).unwrap(),
-            serde_json::json!({ "phase": "started" })
+            serde_json::to_value(BuildEvent::Started { runtime: "Podman" }).unwrap(),
+            serde_json::json!({ "phase": "started", "runtime": "Podman" })
         );
         assert_eq!(
             serde_json::to_value(BuildEvent::Failed {

--- a/src-tauri/src/sandbox/container/progress.rs
+++ b/src-tauri/src/sandbox/container/progress.rs
@@ -9,30 +9,34 @@
 //! decoupled from Tauri — matching how the engines' `set_launch_settings`
 //! mirrors settings without a DB handle.
 //!
-//! One sink for both runtimes, because there is one toast: only one foreground
-//! build can be in flight at a time under either runtime (each runtime
-//! serializes its builds on its own lock, and a launch waits for its own build),
-//! and [`BuildEvent::Started`] carries the runtime's display name so the toast
-//! can say which one the user is waiting on.
+//! One sink for both runtimes — but NOT one build at a time: each runtime
+//! serializes builds on its own lock, so a Docker and a Podman first-build can
+//! overlap. Every event therefore carries `runtime`, its lifecycle key: the
+//! frontend keys build state on it, so interleaved lifecycles can't clear or
+//! overwrite each other's toast.
 
 use parking_lot::RwLock;
 
 /// One image-build lifecycle event. Serializes tagged (`{ "phase": "line",
-/// "line": "…" }`) so the frontend can pattern-match a single event stream.
+/// "runtime": "Docker", "line": "…" }`) so the frontend can pattern-match a
+/// single event stream. `runtime` is the runtime's display name ("Docker" /
+/// "Podman") on every variant — it is the key that separates two overlapping
+/// lifecycles, not decoration; the frontend still treats it as optional so an
+/// event without it renders under a neutral key.
 #[derive(Clone, serde::Serialize)]
 #[serde(tag = "phase", rename_all = "kebab-case")]
 pub enum BuildEvent {
-    /// A build just started (image missing, `build` about to run). `runtime` is
-    /// the runtime's display name ("Docker" / "Podman") so the toast can name
-    /// it; the frontend treats it as optional, so an event without it still
-    /// renders.
+    /// A build just started (image missing, `build` about to run).
     Started { runtime: &'static str },
     /// One line of `build` output.
-    Line { line: String },
+    Line { runtime: &'static str, line: String },
     /// The build finished successfully.
-    Finished,
+    Finished { runtime: &'static str },
     /// The build failed; `error` is the user-readable reason.
-    Failed { error: String },
+    Failed {
+        runtime: &'static str,
+        error: String,
+    },
 }
 
 type Sink = Box<dyn Fn(BuildEvent) + Send + Sync>;
@@ -75,35 +79,42 @@ mod tests {
 
         emit(BuildEvent::Started { runtime: "Podman" });
         emit(BuildEvent::Line {
+            runtime: "Podman",
             line: "step 1/5".into(),
         });
-        emit(BuildEvent::Finished);
+        emit(BuildEvent::Finished { runtime: "Podman" });
         assert_eq!(count.load(Ordering::SeqCst), 3);
     }
 
+    /// `runtime` rides every phase, not just `started`: it is the lifecycle
+    /// key that keeps two overlapping runtimes' events from clearing or
+    /// overwriting each other's toast state. Fields are additive, so a
+    /// consumer that only reads `phase` still works.
     #[test]
-    fn build_event_serializes_tagged() {
-        let json = serde_json::to_value(BuildEvent::Line {
-            line: "pulling base image".into(),
-        })
-        .unwrap();
-        assert_eq!(
-            json,
-            serde_json::json!({ "phase": "line", "line": "pulling base image" })
-        );
-        // `started` carries the runtime name alongside the phase the frontend
-        // switches on — an additive field, so the wire contract still holds for
-        // a consumer that only reads `phase`.
+    fn build_event_serializes_tagged_with_runtime_on_every_phase() {
         assert_eq!(
             serde_json::to_value(BuildEvent::Started { runtime: "Podman" }).unwrap(),
             serde_json::json!({ "phase": "started", "runtime": "Podman" })
         );
         assert_eq!(
+            serde_json::to_value(BuildEvent::Line {
+                runtime: "Docker",
+                line: "pulling base image".into(),
+            })
+            .unwrap(),
+            serde_json::json!({ "phase": "line", "runtime": "Docker", "line": "pulling base image" })
+        );
+        assert_eq!(
+            serde_json::to_value(BuildEvent::Finished { runtime: "Docker" }).unwrap(),
+            serde_json::json!({ "phase": "finished", "runtime": "Docker" })
+        );
+        assert_eq!(
             serde_json::to_value(BuildEvent::Failed {
+                runtime: "Podman",
                 error: "boom".into()
             })
             .unwrap(),
-            serde_json::json!({ "phase": "failed", "error": "boom" })
+            serde_json::json!({ "phase": "failed", "runtime": "Podman", "error": "boom" })
         );
     }
 }

--- a/src-tauri/src/sandbox/container/provider.rs
+++ b/src-tauri/src/sandbox/container/provider.rs
@@ -43,7 +43,7 @@ impl ContainerProvider {
     /// Map a provider id (as stamped on `AgentRecord.provider` / used by the
     /// frontend) to its container support, or `None` when the provider has no
     /// container support yet — the launch gate turns `None` into the
-    /// user-facing "isn't available in Docker sandboxes yet" refusal.
+    /// user-facing "isn't available in container sandboxes yet" refusal.
     pub fn from_id(provider: &str) -> Option<Self> {
         match provider {
             "claude" => Some(Self::Claude),

--- a/src-tauri/src/sandbox/container/run_args.rs
+++ b/src-tauri/src/sandbox/container/run_args.rs
@@ -353,7 +353,7 @@ pub(crate) fn prepare_config_mount_dir(dir: &Path) -> Result<()> {
     for target in std::iter::once(dir.to_path_buf()).chain(overlays.map(|s| dir.join(s))) {
         std::fs::create_dir_all(&target).map_err(|e| {
             Error::Other(format!(
-                "preparing Docker sandbox config mount {} failed: {e}",
+                "preparing container sandbox config mount {} failed: {e}",
                 target.display()
             ))
         })?;

--- a/src-tauri/src/sandbox/container/run_args.rs
+++ b/src-tauri/src/sandbox/container/run_args.rs
@@ -20,6 +20,12 @@ use super::labels;
 /// the two engines can't drift.
 pub(crate) const CREDENTIALS_FILE: &str = CLAUDE_CREDENTIALS_FILE;
 
+/// Resource caps a container launch carries when the user has set none. Shared
+/// by every runtime: the ceiling is a property of what an agent needs to build
+/// and test, not of who runs the container.
+pub(crate) const DEFAULT_MEMORY: &str = "4g";
+pub(crate) const DEFAULT_CPUS: &str = "2";
+
 /// Subdirs of a claude config dir that Claude Code creates and writes *afresh
 /// every session* — the per-session env store (`mkdir session-env/<id>` at
 /// startup) and the shell-environment snapshot the Bash tool sources. The
@@ -272,6 +278,51 @@ pub(crate) fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
     args.push(spec.image.into());
     args.push(spec.agent_bin.into());
     args
+}
+
+/// Every *host* path [`run_args`] turns into a bind mount, in argv order.
+/// Deliberately excludes the tmpfs overlays (no source) and the `projects/`
+/// target (its source is `projects_src`, which is listed).
+///
+/// Lives next to [`run_args`] so the two can't drift: a runtime that has to
+/// vet mount sources before launching (Podman's machine shares only configured
+/// host dirs — see `podman::machine`) must see exactly what will be bound, and
+/// a mount added above without an entry here would go unvetted.
+pub(crate) fn mount_sources(spec: &RunSpec<'_>) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = vec![spec.writable_root.into(), spec.rpc_dir.into()];
+    if let Some(board) = spec.blackboard {
+        out.push(board.into());
+    }
+    out.extend(spec.borrowed_object_stores.iter().cloned());
+    match &spec.mounts {
+        // The `.credentials.json` overlays are subpaths of the config dirs
+        // listed here, so a containment check over these covers them too.
+        ProviderMounts::Claude {
+            config_dir,
+            projects_src,
+            ..
+        } => {
+            out.push(spec.home.join(".claude"));
+            if let Some(dir) = config_dir {
+                out.push((*dir).into());
+            }
+            out.push((*projects_src).into());
+        }
+        ProviderMounts::Codex { config_dir, .. } => out.push((*config_dir).into()),
+        ProviderMounts::Opencode {
+            data_dir,
+            config_dir,
+            ..
+        } => {
+            out.push((*data_dir).into());
+            if let Some(dir) = config_dir {
+                out.push((*dir).into());
+            }
+        }
+        ProviderMounts::Pi { data_dir } => out.push((*data_dir).into()),
+        ProviderMounts::Cursor { data_dir } => out.push((*data_dir).into()),
+    }
+    out
 }
 
 /// Bind-mount `dir` **read-write** at its identical host path (no `:ro`). The

--- a/src-tauri/src/sandbox/container/sweep.rs
+++ b/src-tauri/src/sandbox/container/sweep.rs
@@ -1,0 +1,61 @@
+//! The startup orphan sweep's retry schedule, shared by every container
+//! runtime.
+//!
+//! A single probe at startup loses a race it usually can't win: a container
+//! runtime takes tens of seconds after login to answer (Docker Desktop's boot,
+//! a `podman machine` starting), the probe times out at 2s, and a Fletch
+//! launched from the dock or as a login item therefore reports "down" and
+//! sweeps nothing. The sweeps are the only thing that ever reclaims a dead
+//! instance's containers, so a user who loses that race every launch
+//! accumulates them forever. Retrying costs an idle thread and one probe
+//! round-trip per [`SWEEP_RETRY_INTERVAL`], bounded by [`SWEEP_RETRY_BUDGET`].
+
+use std::time::Duration;
+
+/// How long the startup sweep waits between probes while the runtime is still
+/// coming up. Comfortably above each probe's 5s cache TTL, so every poll is one
+/// genuine round-trip rather than a re-read of the same cached answer, and
+/// short enough that the sweeps start within half a minute of the runtime
+/// finishing its boot.
+pub(crate) const SWEEP_RETRY_INTERVAL: Duration = Duration::from_secs(30);
+
+/// How long the startup sweep keeps waiting for a down runtime before giving
+/// up. Ten minutes covers a cold login — Docker Desktop's own 20-60s (or a
+/// `podman machine` boot) plus a slow disk, a VPN prompt, or a user who starts
+/// it by hand a few minutes in — while staying strictly bounded: a machine
+/// where the runtime simply never runs must not keep a thread ticking for the
+/// life of the app. The budget gates when we stop *scheduling* waits, so the
+/// final probe can land up to one [`SWEEP_RETRY_INTERVAL`] past it. Giving up
+/// is cheap: the next app start sweeps again, so the cost of a miss is one
+/// run's worth of unreclaimed containers, not a permanent leak.
+pub(crate) const SWEEP_RETRY_BUDGET: Duration = Duration::from_secs(10 * 60);
+
+/// What the startup sweep thread does after one probe — see [`sweep_step`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SweepStep {
+    /// The runtime answered: run the sweeps, once, and finish.
+    Sweep,
+    /// The runtime is down but may still be booting: wait and probe again.
+    Retry,
+    /// Nothing to wait for, or the budget is spent: the thread exits having
+    /// swept nothing.
+    Stop,
+}
+
+/// The retry schedule as a pure decision over the two questions every runtime
+/// probe answers: is it usable now, and is it even installed.
+///
+/// A missing binary stops immediately rather than retrying: a runtime being
+/// *installed* mid-run is rare, the next app start covers it, and each retry
+/// would re-pay the binary-resolution stat walk for a state that essentially
+/// never flips. "Installed but down" is the state we expect to flip — that's
+/// the whole point of the retry.
+pub(crate) fn sweep_step(usable: bool, installed: bool, elapsed: Duration) -> SweepStep {
+    if usable {
+        SweepStep::Sweep
+    } else if installed && elapsed < SWEEP_RETRY_BUDGET {
+        SweepStep::Retry
+    } else {
+        SweepStep::Stop
+    }
+}

--- a/src-tauri/src/sandbox/container/util.rs
+++ b/src-tauri/src/sandbox/container/util.rs
@@ -38,6 +38,12 @@ fn nonce() -> String {
     hex[..8].to_string()
 }
 
+/// `Some(v)` only when `v` is present and non-blank — settings rows can hold
+/// empty strings, which must fall back to the launch defaults.
+pub(crate) fn non_blank(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|v| !v.is_empty())
+}
+
 /// The runtime-specific wording [`describe_exit_code`] renders around. One
 /// value per runtime, declared next to that runtime's engine.
 pub(crate) struct ExitCopy {

--- a/src-tauri/src/sandbox/container/util.rs
+++ b/src-tauri/src/sandbox/container/util.rs
@@ -1,0 +1,120 @@
+//! Container naming and the runtime-reserved exit-code messages: the pieces of
+//! the launch/teardown path that carry no runtime coupling at all.
+//!
+//! Liveness lookups stay per-runtime — they shell out — and live next to their
+//! runtime's CLI wrapper (`docker::engine::util`, `podman::engine::util`).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// `fletch-<agent_id>-<8-char nonce>`. The nonce keeps respawns (view switch,
+/// binary swap) from colliding with a predecessor container of the same agent
+/// that `--rm` hasn't finished reaping yet; hashing in the pid keeps two
+/// side-by-side Fletch instances apart even for a same-named agent.
+pub(crate) fn container_name(agent_id: &str) -> String {
+    // Container names must match [a-zA-Z0-9][a-zA-Z0-9_.-]* under both docker
+    // and podman; the `fletch-` prefix fixes the first char, sanitize the rest.
+    let sanitized: String = agent_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    format!("fletch-{sanitized}-{}", nonce())
+}
+
+/// 8 hex chars from (pid, monotonic counter): unique within a host across
+/// concurrently running instances for the lifetime of any one container.
+fn nonce() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::process::id().hash(&mut hasher);
+    COUNTER.fetch_add(1, Ordering::Relaxed).hash(&mut hasher);
+    let hex: String = format!("{:016x}", hasher.finish());
+    hex[..8].to_string()
+}
+
+/// The runtime-specific wording [`describe_exit_code`] renders around. One
+/// value per runtime, declared next to that runtime's engine.
+pub(crate) struct ExitCopy {
+    /// Display name of the runtime whose CLI reserved the code.
+    pub runtime: &'static str,
+    /// What reported a start failure: Docker has a daemon, Podman a machine.
+    pub error_source: &'static str,
+    /// One check the user can act on when the runtime couldn't start.
+    pub remedy: &'static str,
+    /// Settings key naming a user-supplied image, for runtimes that honor one.
+    /// `None` drops the custom-image clause: a runtime with no override must
+    /// not point the user at a setting it ignores.
+    pub image_setting: Option<&'static str>,
+}
+
+/// User-readable meanings for a container CLI's reserved exit codes; other
+/// codes are the contained agent's own and pass through unmapped. `run` relays
+/// the agent's own exit status, so an agent that starts fine and later exits
+/// 125/126/127 is indistinguishable from a launcher/image failure — the
+/// messages name the likely runtime-layer cause but flag the agent-exit
+/// possibility so they don't mislead when the container did launch.
+///
+/// Provider-neutral: the teardown plan carries only the container name, and the
+/// sandbox image varies per provider, so these speak of "the agent binary"
+/// rather than naming `claude`.
+pub(crate) fn describe_exit_code(code: i32, copy: &ExitCopy) -> Option<String> {
+    let ExitCopy {
+        runtime,
+        error_source,
+        remedy,
+        image_setting,
+    } = copy;
+    let msg = match code {
+        125 => format!(
+            "Exit 125: {runtime} could not start the sandbox container — {error_source} reported an error (or the agent itself exited 125). {remedy}"
+        ),
+        126 => {
+            let mut msg = "Exit 126: the agent binary in the sandbox image is present but not runnable (or the agent itself exited 126).".to_string();
+            if let Some(key) = image_setting {
+                msg.push_str(&format!(" If you set a custom {key}, check its agent CLI."));
+            }
+            msg
+        }
+        127 => {
+            let mut msg = "Exit 127: no agent binary on the sandbox image's PATH (or the agent itself exited 127).".to_string();
+            if let Some(key) = image_setting {
+                msg.push_str(&format!(
+                    " A custom {key} must include the launching agent's CLI."
+                ));
+            }
+            msg
+        }
+        _ => return None,
+    };
+    Some(msg)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A runtime with no image override must not mention one, and every message
+    /// must still hedge about the agent's own exit status.
+    #[test]
+    fn exit_copy_without_an_image_setting_omits_the_override_clause() {
+        let copy = ExitCopy {
+            runtime: "Podman",
+            error_source: "the machine",
+            remedy: "Is the Podman machine running?",
+            image_setting: None,
+        };
+        for code in [125, 126, 127] {
+            let msg = describe_exit_code(code, &copy).unwrap();
+            assert!(msg.contains("agent itself exited"), "must hedge: {msg}");
+            assert!(!msg.contains("custom"), "no override to point at: {msg}");
+        }
+        assert!(describe_exit_code(125, &copy).unwrap().contains("Podman"));
+        assert_eq!(describe_exit_code(1, &copy), None);
+    }
+}

--- a/src-tauri/src/sandbox/container/version_guard.rs
+++ b/src-tauri/src/sandbox/container/version_guard.rs
@@ -1,0 +1,81 @@
+//! The version-refresh loop guard: one per container runtime, sharing this
+//! implementation.
+//!
+//! The guard caps the version-parity rebuild trigger at one attempt per
+//! `host_version@image_tag` pairing *ever*, not one per app run. In the guarded
+//! case — a host CLI pinned away from the registry's latest, so the mismatch
+//! survives even a successful rebuild — an in-memory-only guard would decay into
+//! one full `--no-cache` rebuild on every app run.
+//!
+//! Each runtime owns a `static VersionGuard` and its own settings key (docker's
+//! `docker_version_refresh_guard`, podman's `podman_version_refresh_guard`), so
+//! the two runtimes' image stores never talk each other out of a rebuild: an
+//! image present in one store says nothing about the other's.
+
+use std::collections::HashMap;
+
+use parking_lot::RwLock;
+
+/// Writes the guard map back to its settings row (installed by
+/// [`VersionGuard::init`]).
+type Persist = Box<dyn Fn(&HashMap<String, String>) + Send + Sync>;
+
+/// provider id → `"host_version@image_tag"` last successfully rebuilt for, plus
+/// the write-back. One pair per provider suffices — any change to either side
+/// legitimately warrants one fresh attempt.
+struct State {
+    attempted: HashMap<String, String>,
+    persist: Option<Persist>,
+}
+
+/// A runtime's loop guard, mirrored in-process because the image code that
+/// consults it runs on spawn paths and background threads with no DB handle.
+/// Seeded and wired to a persister at startup by [`init`](Self::init); until
+/// then (tests, headless) it's empty and unpersisted, and recording still guards
+/// the current process run.
+pub(crate) struct VersionGuard(RwLock<Option<State>>);
+
+impl VersionGuard {
+    pub(crate) const fn new() -> Self {
+        Self(RwLock::new(None))
+    }
+
+    /// Install the guard state: `attempted` as loaded from the runtime's
+    /// settings row, `persist` writing it back.
+    pub(crate) fn init(
+        &self,
+        attempted: HashMap<String, String>,
+        persist: impl Fn(&HashMap<String, String>) + Send + Sync + 'static,
+    ) {
+        *self.0.write() = Some(State {
+            attempted,
+            persist: Some(Box::new(persist)),
+        });
+    }
+
+    /// Whether a version-mismatch rebuild already succeeded for exactly this
+    /// `pair` (`"host_version@image_tag"`). If so the trigger is inert: the
+    /// mismatch survived a rebuild, so it isn't rebuildable-away (pinned host).
+    pub(crate) fn attempted(&self, provider_id: &str, pair: &str) -> bool {
+        self.0
+            .read()
+            .as_ref()
+            .is_some_and(|g| g.attempted.get(provider_id).map(String::as_str) == Some(pair))
+    }
+
+    /// Record (and persist, when wired) that a version-mismatch rebuild
+    /// succeeded for `pair`. Called from the background rebuild thread on
+    /// success only — failures must retry on a later run, exactly like TTL
+    /// rebuild failures.
+    pub(crate) fn record(&self, provider_id: &str, pair: String) {
+        let mut guard = self.0.write();
+        let state = guard.get_or_insert_with(|| State {
+            attempted: HashMap::new(),
+            persist: None,
+        });
+        state.attempted.insert(provider_id.to_string(), pair);
+        if let Some(persist) = &state.persist {
+            persist(&state.attempted);
+        }
+    }
+}

--- a/src-tauri/src/sandbox/docker/cleanup.rs
+++ b/src-tauri/src/sandbox/docker/cleanup.rs
@@ -32,16 +32,8 @@ use super::{cli, engine, image, DockerProvider};
 /// the `cleanup::host_pid_label` / `cleanup::HOST_PID_LABEL` paths this module's
 /// callers already use keep resolving from their runtime-neutral home.
 pub(super) use crate::sandbox::container::labels::{
-    agent_id_label, host_pid_label, HOST_PID_LABEL,
+    agent_id_filter, host_pid_label, orphaned_ids, HOST_PID_LABEL, INSPECT_FORMAT,
 };
-
-/// The `--filter` argument selecting one agent's containers. Built from
-/// [`agent_id_label`] so the query can never drift from what `docker run`
-/// stamped. Split out as a pure function so its argv shape is unit-testable
-/// without a daemon.
-fn agent_id_filter(agent_id: &str) -> String {
-    format!("label={}", agent_id_label(agent_id))
-}
 
 /// Listing/inspect are metadata-only; generous next to their usual
 /// milliseconds, so tripping one means the daemon is wedged.
@@ -50,12 +42,6 @@ const QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 /// `docker rm -f` also kills a still-running container's process; give the
 /// batched removal room without letting a hung daemon pin the sweep thread.
 const REMOVE_TIMEOUT: Duration = Duration::from_secs(60);
-
-/// `docker inspect` line format pairing each container id with its owning
-/// pid. `index` (rather than a direct field access) yields an empty string
-/// when the label is somehow absent, which parses to "no pid" and is skipped
-/// — under-reclaiming, never removing something we can't attribute.
-const INSPECT_FORMAT: &str = r#"{{.Id}} {{index .Config.Labels "fletch.host-pid"}}"#;
 
 /// Remove every fletch-labeled container whose owning host instance is dead.
 /// Returns the number removed. Callers gate on the probe and run this off
@@ -107,29 +93,6 @@ pub fn sweep_orphans() -> Result<usize> {
         )));
     }
     Ok(orphans.len())
-}
-
-/// Parse [`INSPECT_FORMAT`] output and keep the ids whose owning pid is
-/// provably dead. A missing or unparsable pid means we can't attribute the
-/// container, so it is left alone (same under-reclaim bias as
-/// `cleanup_nested_state_roots_in`). Pure — the liveness probe is injected
-/// for unit tests.
-fn orphaned_ids(inspect_stdout: &str, alive: impl Fn(i32) -> bool) -> Vec<String> {
-    inspect_stdout
-        .lines()
-        .filter_map(parse_inspect_line)
-        .filter(|(_, pid)| pid.is_some_and(|p| !alive(p)))
-        .map(|(id, _)| id)
-        .collect()
-}
-
-/// One [`INSPECT_FORMAT`] line → `(container_id, owning_pid)`. The pid is
-/// `None` when the label was empty or not a number.
-fn parse_inspect_line(line: &str) -> Option<(String, Option<i32>)> {
-    let mut parts = line.split_whitespace();
-    let id = parts.next()?;
-    let pid = parts.next().and_then(|p| p.parse::<i32>().ok());
-    Some((id.to_string(), pid))
 }
 
 /// Remove every container stamped with `fletch.agent-id=<agent_id>`, running
@@ -484,6 +447,7 @@ const RETIRED_REPOS: &[&str] = &[];
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sandbox::container::labels::{agent_id_label, parse_inspect_line};
 
     #[test]
     fn label_argv_shapes() {

--- a/src-tauri/src/sandbox/docker/cleanup.rs
+++ b/src-tauri/src/sandbox/docker/cleanup.rs
@@ -21,12 +21,15 @@
 //! is removed. That covers old-hash tags left by Dockerfile revisions and
 //! untagged leftovers from TTL rebuilds. Anything we can't attribute survives.
 
-use std::collections::HashSet;
 use std::time::Duration;
 
 use crate::error::{Error, Result};
+use crate::sandbox::container::image_gc::{
+    current_tags, image_removal_refs, known_repos, parse_images_line, ImageRow, IMAGES_FORMAT,
+    RETIRED_REPOS,
+};
 
-use super::{cli, engine, image, DockerProvider};
+use super::{cli, engine, image};
 
 /// The labels `docker run` stamps and every sweep here queries. Re-exported so
 /// the `cleanup::host_pid_label` / `cleanup::HOST_PID_LABEL` paths this module's
@@ -152,55 +155,6 @@ pub fn remove_agent_containers(agent_id: &str) -> Result<usize> {
     Ok(ids.len())
 }
 
-/// `docker images` line format for the image GC listings. Untagged (dangling)
-/// images print `<none>` for repository and tag.
-const IMAGES_FORMAT: &str = "{{.ID}} {{.Repository}} {{.Tag}}";
-
-/// One `docker images` row: a (repo:tag, image id) pair — the same image id
-/// appears in multiple rows when it carries multiple tags, which is exactly
-/// what the GC wants: it untags Fletch's name and leaves any other name alone.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ImageRow {
-    id: String,
-    repo: String,
-    tag: String,
-}
-
-impl ImageRow {
-    /// Whether this row is a dangling image (`<none>:<none>`) — removable only
-    /// by id.
-    fn untagged(&self) -> bool {
-        self.repo == "<none>" || self.tag == "<none>"
-    }
-
-    /// The `repo:tag` name of a tagged row.
-    fn named(&self) -> String {
-        format!("{}:{}", self.repo, self.tag)
-    }
-
-    /// What to hand `docker rmi`: the name for tagged rows (untag just ours),
-    /// the id for dangling ones (the only handle they have).
-    fn removal_ref(&self) -> String {
-        if self.untagged() {
-            self.id.clone()
-        } else {
-            self.named()
-        }
-    }
-}
-
-/// One [`IMAGES_FORMAT`] line → an [`ImageRow`]; `None` on malformed lines
-/// (skipped — under-reclaim bias, same as the container sweep).
-fn parse_images_line(line: &str) -> Option<ImageRow> {
-    let mut parts = line.split_whitespace();
-    let row = ImageRow {
-        id: parts.next()?.to_string(),
-        repo: parts.next()?.to_string(),
-        tag: parts.next()?.to_string(),
-    };
-    Some(row)
-}
-
 /// Remove superseded Fletch agent images. One rule: an image carrying the
 /// `fletch.agent` label that is not one of the current expected tags (the set
 /// of `image_tag(provider)` across all providers) is removed — old-hash tags
@@ -222,14 +176,8 @@ fn parse_images_line(line: &str) -> Option<ImageRow> {
 /// logged at debug. Returns the number of images actually removed; callers
 /// treat all failures as non-fatal.
 pub fn sweep_stale_images() -> Result<usize> {
-    let current_tags: HashSet<String> = DockerProvider::ALL
-        .iter()
-        .map(|p| image::image_tag(*p))
-        .collect();
-    let known_repos: HashSet<&'static str> = DockerProvider::ALL
-        .iter()
-        .map(|p| image::image_repo(*p))
-        .collect();
+    let current_tags = current_tags();
+    let known_repos = known_repos();
     let override_image = engine::image_override();
 
     let labeled = list_images(&[
@@ -259,6 +207,7 @@ pub fn sweep_stale_images() -> Result<usize> {
         &current_tags,
         &known_repos,
         RETIRED_REPOS,
+        LEGACY_TAGS,
         override_image.as_deref(),
     );
     if refs.is_empty() {
@@ -304,110 +253,6 @@ fn list_images(args: &[&str]) -> Result<Vec<ImageRow>> {
         .collect())
 }
 
-/// The GC's selection rule, pure (inputs are pre-fetched listings, fixed in
-/// tests). `labeled` holds every image carrying the `fletch.agent` label;
-/// `legacy` holds the tagged contents of Fletch's own repos (pre-label
-/// installs). Returns deduplicated `docker rmi` refs.
-///
-/// The label is the authority, with one belt-and-braces exception each way:
-/// a *labeled* image tagged outside our namespace is kept (a user re-tagged
-/// our image under their own name — their tag, their call), and an *unlabeled*
-/// image is removed only on an exact [`LEGACY_TAGS`] match (the closed list of
-/// tags pre-label Fletch actually shipped — shape or namespace alone is never
-/// an ownership signal for unlabeled images). Current tags and the
-/// `docker_image` override are always kept.
-///
-/// "Our namespace" is `known_repos` (the live providers) plus `retired_repos`
-/// ([`RETIRED_REPOS`] — providers we used to ship). Both are passed in rather
-/// than read from the constants so the rule stays testable on fixed inputs.
-///
-/// Within Fletch's repos, a labeled image is a removal candidate only under a
-/// tag Fletch itself could have written: the content-addressed shape (12
-/// lowercase hex chars — see `image::tag_for`) or no tag at all (a dangling
-/// rebuild predecessor). A human-shaped tag like `fletch-agent:backup` —
-/// a user's `docker tag` of our image — is theirs to keep: a tag a human
-/// wrote is the human's call. Retirement changes nothing about that: a
-/// retired repo buys a row into the candidate set, not past the safety rules.
-fn image_removal_refs(
-    labeled: &[ImageRow],
-    legacy: &[ImageRow],
-    current_tags: &HashSet<String>,
-    known_repos: &HashSet<&'static str>,
-    retired_repos: &[&str],
-    override_image: Option<&str>,
-) -> Vec<String> {
-    let override_image = override_image.map(str::trim).filter(|s| !s.is_empty());
-    // A row that must survive no matter which listing produced it. The
-    // override comparison is defensive by design: match its exact `repo:tag`,
-    // its bare-repo spelling (docker reads `foo` as `foo:latest`), or the
-    // image id (all listings print the same short id).
-    let protected = |row: &ImageRow| {
-        if !row.untagged() && current_tags.contains(&row.named()) {
-            return true;
-        }
-        let Some(ov) = override_image else {
-            return false;
-        };
-        ov == row.id
-            || (!row.untagged() && (ov == row.named() || (row.tag == "latest" && ov == row.repo)))
-    };
-
-    // A repo Fletch owns now or used to own. Retired repos count because the
-    // `fletch.agent` label has already proven the image is ours — omitting
-    // them is exactly what stranded a retired provider's still-tagged images:
-    // the legacy arm skips them (they're labeled) and this arm skipped them
-    // (their repo was no longer known), so nothing could ever reclaim them.
-    let in_our_namespace = |row: &ImageRow| {
-        known_repos.contains(row.repo.as_str()) || retired_repos.contains(&row.repo.as_str())
-    };
-
-    let mut seen = HashSet::new();
-    let mut refs = Vec::new();
-    let mut push = |row: &ImageRow| {
-        let r = row.removal_ref();
-        if seen.insert(r.clone()) {
-            refs.push(r);
-        }
-    };
-
-    for row in labeled {
-        if !row.untagged() && !in_our_namespace(row) {
-            continue; // labeled but re-tagged under a user name: never touch
-        }
-        if !row.untagged() && !is_content_addressed_tag(&row.tag) {
-            continue; // human-written tag in our repo: their tag, their call
-        }
-        if protected(row) {
-            continue;
-        }
-        push(row);
-    }
-    for row in legacy {
-        // Exact match only: an unlabeled image carries no ownership proof, so
-        // the only safe removal signal is a tag we know Fletch shipped. A
-        // user's own image in our namespace — even under a hex/git-SHA-shaped
-        // tag like `fletch-agent:deadbeefcafe` — never matches.
-        if row.untagged() || !LEGACY_TAGS.contains(&row.named().as_str()) {
-            continue;
-        }
-        if protected(row) {
-            continue;
-        }
-        push(row);
-    }
-    refs
-}
-
-/// Whether a tag has the shape Fletch's content addressing writes — exactly
-/// 12 lowercase hex chars (`image::tag_for`'s `sha256[..12]`). Anything else
-/// in a Fletch repo was written by a human and is never a removal candidate.
-fn is_content_addressed_tag(tag: &str) -> bool {
-    tag.len() == 12
-        && tag
-            .bytes()
-            .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
-}
-
 /// Every tag pre-label Fletch ever shipped — the exact, closed set of images
 /// the legacy GC arm may remove. Each is `tag_for(repo, dockerfile,
 /// entrypoint)` recomputed from the embedded constants at the named git
@@ -425,28 +270,10 @@ const LEGACY_TAGS: &[&str] = &[
     "fletch-agent-cursor:b84044879c26", // cursor, #369 after it (b77d973..3870598)
 ];
 
-/// Every image repo Fletch used to own — the closed list of namespaces that
-/// are ours by history rather than by [`DockerProvider::ALL`]. Bare repo
-/// names (`fletch-agent-x`), never `repo:tag`: unlike [`LEGACY_TAGS`] these
-/// images DO carry the `fletch.agent` label, so ownership is already proven
-/// and the GC needs no per-tag allowlist to act on them — the ordinary
-/// safety rules for labeled rows (content-addressed tag shape, current tags,
-/// the `docker_image` override) still apply unchanged.
-///
-/// **Add an entry whenever a [`DockerProvider`] variant is removed.** Without
-/// one, every still-tagged image under that repo is stranded on every user's
-/// disk forever, at ~0.5-1GB each: the labeled arm would skip it (repo no
-/// longer known) and the legacy arm would skip it (it's labeled). Only
-/// *untagged* rows survive a retirement today, since they never consult the
-/// repo at all.
-///
-/// Empty until the first retirement — this is forward-safety, not a live bug,
-/// and an empty list is behaviourally identical to not having one.
-const RETIRED_REPOS: &[&str] = &[];
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sandbox::container::image_gc::is_content_addressed_tag;
     use crate::sandbox::container::labels::{agent_id_label, parse_inspect_line};
 
     #[test]
@@ -491,98 +318,16 @@ mod tests {
         assert_eq!(orphans, vec!["bbb".to_string()]);
     }
 
-    fn row(id: &str, repo: &str, tag: &str) -> ImageRow {
-        ImageRow {
-            id: id.into(),
-            repo: repo.into(),
-            tag: tag.into(),
-        }
-    }
-
-    #[test]
-    fn images_line_parsing() {
-        assert_eq!(
-            parse_images_line("abc123def456 fletch-agent 0011aabbccdd"),
-            Some(row("abc123def456", "fletch-agent", "0011aabbccdd")),
-        );
-        // Dangling images print `<none>` placeholders.
-        assert_eq!(
-            parse_images_line("abc123def456 <none> <none>"),
-            Some(row("abc123def456", "<none>", "<none>")),
-        );
-        assert_eq!(parse_images_line("abc123def456 fletch-agent"), None);
-        assert_eq!(parse_images_line(""), None);
-    }
-
-    /// The GC's one rule plus its fences, on fixed listings: labeled + stale
-    /// → remove; labeled + current → keep; labeled outside Fletch's repos
-    /// (user re-tag) → keep; unlabeled non-fletch → keep; legacy fletch-repo
-    /// stale → remove; the `docker_image` override → keep in every spelling.
-    #[test]
-    fn image_gc_selection() {
-        let current_tags: HashSet<String> = ["fletch-agent:cafe00000000".to_string()].into();
-        let known_repos: HashSet<&'static str> = ["fletch-agent", "fletch-agent-codex"].into();
-
-        let labeled = vec![
-            // Old hash under a Fletch repo: superseded by a Dockerfile revision.
-            row("aaa", "fletch-agent", "0dab1e000000"),
-            // The current tag: what launches use today.
-            row("bbb", "fletch-agent", "cafe00000000"),
-            // Untagged leftover of a TTL rebuild: removable only by id.
-            row("ccc", "<none>", "<none>"),
-            // Labeled but re-tagged under a user's name: their tag, kept.
-            row("ddd", "mybackup", "keep"),
-            // The override, hypothetically labeled (shouldn't happen): kept.
-            row("eee", "ghcr.io/me/custom", "1"),
-            // Labeled but human-tagged inside our repo (`docker tag` of our
-            // image): their tag, kept.
-            row("hhh", "fletch-agent", "backup"),
-        ];
-        let legacy = vec![
-            // Genuine pre-label image: exact LEGACY_TAGS match, removable.
-            row("fff", "fletch-agent-codex", "fa189de85caf"),
-            // Current tag also shows up in the repo-scoped listing: kept.
-            row("bbb", "fletch-agent", "cafe00000000"),
-            // Selection must be safe even if a listing misbehaves: an
-            // unlabeled non-fletch row is never removed.
-            row("ggg", "someones-image", "latest"),
-            // A user's own image built into our namespace: human tag, kept.
-            row("iii", "fletch-agent", "backup"),
-            // A user's own image under a hex/git-SHA-shaped tag in our
-            // namespace: shape is not ownership — kept (exact-match only).
-            row("jjj", "fletch-agent", "deadbeefcafe"),
-        ];
-
-        let refs = image_removal_refs(
-            &labeled,
-            &legacy,
-            &current_tags,
-            &known_repos,
-            &[],
-            Some("ghcr.io/me/custom:1"),
-        );
-        assert_eq!(
-            refs,
-            vec![
-                "fletch-agent:0dab1e000000".to_string(),
-                "ccc".to_string(),
-                "fletch-agent-codex:fa189de85caf".to_string(),
-            ],
-        );
-    }
-
     /// The legacy allowlist stays well-formed: every entry names a repo Fletch
     /// owns — currently or historically ([`RETIRED_REPOS`], which the legacy
     /// listing also covers) — under a content-addressed tag shape. (The hash
     /// values themselves are frozen history — recomputed from the embedded
-    /// constants at the commits named on each entry.)
+    /// constants at the commits named on each entry.) The list is docker's
+    /// alone: podman ships after the label era, so its GC passes no legacy arm.
     #[test]
     fn legacy_tags_are_fletch_shaped() {
-        let owned: HashSet<&'static str> = DockerProvider::ALL
-            .iter()
-            .map(|p| image::image_repo(*p))
-            .chain(RETIRED_REPOS.iter().copied())
-            .collect();
+        let mut owned = known_repos();
+        owned.extend(RETIRED_REPOS.iter().copied());
         for entry in LEGACY_TAGS {
             let (repo, tag) = entry
                 .split_once(':')
@@ -590,142 +335,6 @@ mod tests {
             assert!(owned.contains(repo), "unknown legacy repo: {repo}");
             assert!(is_content_addressed_tag(tag), "malformed legacy tag: {tag}");
         }
-    }
-
-    /// [`RETIRED_REPOS`] holds bare repo names, not `repo:tag` — it widens the
-    /// namespace the labeled arm trusts, so a stray tag would silently match
-    /// nothing (a `docker images` repo is compared whole). Entries must also
-    /// be genuinely retired: a repo a live provider still owns belongs in
-    /// [`DockerProvider::ALL`]'s derivation, not here.
-    #[test]
-    fn retired_repos_are_bare_fletch_repo_names() {
-        let known_repos: HashSet<&'static str> = DockerProvider::ALL
-            .iter()
-            .map(|p| image::image_repo(*p))
-            .collect();
-        for repo in RETIRED_REPOS {
-            assert!(!repo.contains(':'), "retired entry must be a repo: {repo}");
-            assert!(
-                repo.starts_with("fletch-agent"),
-                "retired repo isn't a fletch namespace: {repo}",
-            );
-            assert!(
-                !known_repos.contains(repo),
-                "still-live repo listed as retired: {repo}",
-            );
-        }
-    }
-
-    /// Only tags Fletch's content addressing could have written count as
-    /// removal candidates — exactly 12 lowercase hex chars.
-    #[test]
-    fn content_addressed_tag_shape() {
-        assert!(is_content_addressed_tag("0123abcdef01"));
-        assert!(is_content_addressed_tag("000000000000"));
-        // Human-shaped tags, wrong length, uppercase: all kept.
-        assert!(!is_content_addressed_tag("backup"));
-        assert!(!is_content_addressed_tag("latest"));
-        assert!(!is_content_addressed_tag("0123ABCDEF01"));
-        assert!(!is_content_addressed_tag("0123abcdef0"));
-        assert!(!is_content_addressed_tag("0123abcdef012"));
-        assert!(!is_content_addressed_tag(""));
-    }
-
-    /// Override matching is defensive across spellings: exact `repo:tag`,
-    /// bare repo (docker's implicit `:latest`), and image id all protect.
-    #[test]
-    fn image_gc_override_spellings() {
-        let current_tags = HashSet::new();
-        let known_repos: HashSet<&'static str> = ["fletch-agent"].into();
-        // Hypothetical worst case: the user's override lives *inside* a
-        // Fletch repo under a content-addressed-looking tag (anything
-        // human-shaped is already kept by the tag-shape guard).
-        let labeled = vec![
-            row("aaa", "fletch-agent", "aaaaaaaaaaaa"),
-            row("bbb", "fletch-agent", "bbbbbbbbbbbb"),
-        ];
-
-        // Exact repo:tag override protects that row only.
-        let refs = image_removal_refs(
-            &labeled,
-            &[],
-            &current_tags,
-            &known_repos,
-            &[],
-            Some("fletch-agent:aaaaaaaaaaaa"),
-        );
-        assert_eq!(refs, vec!["fletch-agent:bbbbbbbbbbbb".to_string()]);
-
-        // Id override protects by id.
-        let refs = image_removal_refs(&labeled, &[], &current_tags, &known_repos, &[], Some("bbb"));
-        assert_eq!(refs, vec!["fletch-agent:aaaaaaaaaaaa".to_string()]);
-
-        // A bare-repo override reads as `:latest` — and a `:latest` row in our
-        // repo is kept by the tag-shape guard even before the override check,
-        // with or without the override present.
-        let with_latest = vec![row("lll", "fletch-agent", "latest")];
-        for ov in [Some("fletch-agent"), None] {
-            assert!(
-                image_removal_refs(&with_latest, &[], &current_tags, &known_repos, &[], ov)
-                    .is_empty()
-            );
-        }
-
-        // Blank override protects nothing (same as None).
-        let refs = image_removal_refs(&labeled, &[], &current_tags, &known_repos, &[], Some("  "));
-        assert_eq!(refs.len(), 2);
-
-        // Overlapping listings dedupe to one removal ref.
-        let refs = image_removal_refs(&labeled, &labeled, &current_tags, &known_repos, &[], None);
-        assert_eq!(refs.len(), 2);
-    }
-
-    /// Retiring a provider must not strand its images. A labeled row under a
-    /// retired repo is reclaimable, but only on the same terms as a live one:
-    /// the content-addressed tag shape and the override still fence it, and a
-    /// repo that is neither live nor retired is still untouchable.
-    #[test]
-    fn image_gc_reclaims_retired_provider_repos() {
-        let current_tags: HashSet<String> = ["fletch-agent:cafe00000000".to_string()].into();
-        let known_repos: HashSet<&'static str> = ["fletch-agent"].into();
-        let retired: &[&str] = &["fletch-agent-pi"];
-
-        let labeled = vec![
-            // The stranding case: labeled, our old repo, our tag shape.
-            row("aaa", "fletch-agent-pi", "abc123def456"),
-            // Human-written tag in the retired repo: retirement is not a
-            // licence to delete a tag a human wrote.
-            row("bbb", "fletch-agent-pi", "backup"),
-            // Never ours: not a live repo, not a retired one.
-            row("ccc", "someones-image", "0dab1e000000"),
-            // Retired repo, but it's the user's `docker_image` override.
-            row("ddd", "fletch-agent-pi", "0dab1e000000"),
-            // Live repo, current tag: unaffected by any of this.
-            row("eee", "fletch-agent", "cafe00000000"),
-        ];
-
-        let refs = image_removal_refs(
-            &labeled,
-            &[],
-            &current_tags,
-            &known_repos,
-            retired,
-            Some("fletch-agent-pi:0dab1e000000"),
-        );
-        assert_eq!(refs, vec!["fletch-agent-pi:abc123def456".to_string()]);
-
-        // The shipped list is empty, and an empty list is a strict no-op:
-        // every one of those rows is now outside our namespace but for the
-        // live-repo one, which is the current tag.
-        assert!(image_removal_refs(
-            &labeled,
-            &[],
-            &current_tags,
-            &known_repos,
-            &[],
-            Some("fletch-agent-pi:0dab1e000000"),
-        )
-        .is_empty());
     }
 
     /// Integration: a labeled image under a Fletch repo with a non-current tag

--- a/src-tauri/src/sandbox/docker/engine/mod.rs
+++ b/src-tauri/src/sandbox/docker/engine/mod.rs
@@ -91,9 +91,9 @@ pub use settings::{
 pub(super) use settings::{image_override, record_version_refresh, version_refresh_attempted};
 
 use crate::sandbox::container::run_args::{run_args, RunSpec, DEFAULT_CPUS, DEFAULT_MEMORY};
-use crate::sandbox::container::util::container_name;
+use crate::sandbox::container::util::{container_name, non_blank};
 use settings::LAUNCH_SETTINGS;
-use util::{container_gone_within, describe_exit_code, non_blank};
+use util::{container_gone_within, describe_exit_code};
 
 /// Signal/removal docker calls during teardown.
 const KILL_TIMEOUT: Duration = Duration::from_secs(10);

--- a/src-tauri/src/sandbox/docker/engine/mod.rs
+++ b/src-tauri/src/sandbox/docker/engine/mod.rs
@@ -234,7 +234,11 @@ impl SandboxEngine for DockerEngine {
             env: prep.env,
             kill: KillHandle::Engine {
                 engine: DockerEngine::shared(),
-                plan: KillPlan::Container { name },
+                // One daemon endpoint: nothing to pin teardown to.
+                plan: KillPlan::Container {
+                    name,
+                    connection: None,
+                },
             },
         })
     }
@@ -245,7 +249,7 @@ impl SandboxEngine for DockerEngine {
     /// exit), and an error here would abort the caller's local process-group
     /// teardown of the docker CLI child.
     fn kill(&self, plan: &KillPlan) -> Result<()> {
-        let KillPlan::Container { name } = plan;
+        let KillPlan::Container { name, .. } = plan;
         match cli::run_docker(&["kill", "-s", "TERM", name], KILL_TIMEOUT) {
             Ok(out) if out.status.success() => {
                 if !container_gone_within(name, TERM_GRACE) {

--- a/src-tauri/src/sandbox/docker/engine/mod.rs
+++ b/src-tauri/src/sandbox/docker/engine/mod.rs
@@ -55,17 +55,17 @@
 //!
 //! Layout: this module folder splits the engine into
 //! - [`settings`] — launch knobs and the version-refresh guard
-//! - [`config_dir`] — non-default config-dir detection and borrowed object stores
-//! - [`util`] — naming, liveness, exit codes
+//! - [`util`] — docker liveness lookups and its exit-code wording
 //!
-//! Per-provider container auth
-//! ([`container::launch_auth`](crate::sandbox::container::launch_auth)) and the
-//! `run` argv builder ([`container::run_args`](crate::sandbox::container::run_args))
-//! are runtime-neutral and live outside this folder.
+//! Everything else a container launch decides is runtime-neutral and lives
+//! outside this folder: the per-launch env / mount / auth preparation
+//! ([`container::launch`](crate::sandbox::container::launch)), per-provider auth
+//! ([`container::launch_auth`](crate::sandbox::container::launch_auth)), the
+//! `run` argv builder ([`container::run_args`](crate::sandbox::container::run_args)),
+//! and container naming ([`container::util`](crate::sandbox::container::util)).
 //!
 //! The `DockerEngine` struct and its `SandboxEngine` impl stay here.
 
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
 
@@ -73,11 +73,9 @@ use crate::error::{Error, Result};
 use crate::sandbox::engine::{
     AgentLaunchCtx, EngineKind, KillHandle, KillPlan, LaunchPlan, SandboxEngine,
 };
-use crate::sandbox::policy::{codex_home_dir, opencode_config_dir, opencode_data_dir};
 
 use super::{cli, image, DockerProvider};
 
-mod config_dir;
 mod settings;
 #[cfg(test)]
 mod tests;
@@ -92,19 +90,10 @@ pub use settings::{
 // Consumed by sibling docker submodules (`image`, `cleanup`) at `engine::X`.
 pub(super) use settings::{image_override, record_version_refresh, version_refresh_attempted};
 
-use crate::sandbox::container::launch_auth::{
-    apply_container_auth, prepare_codex_launch, prepare_cursor_launch, prepare_opencode_launch,
-    prepare_pi_launch, present_api_keys,
-};
-use crate::sandbox::container::run_args::{
-    prepare_config_mount_dir, run_args, ProviderMounts, RunSpec, CREDENTIALS_FILE,
-};
-use config_dir::{
-    borrowed_object_stores, codex_home_is_nondefault, nondefault_claude_config_dir,
-    xdg_base_is_nondefault,
-};
-use settings::{DEFAULT_CPUS, DEFAULT_MEMORY, LAUNCH_SETTINGS};
-use util::{container_gone_within, container_name, describe_exit_code, non_blank};
+use crate::sandbox::container::run_args::{run_args, RunSpec, DEFAULT_CPUS, DEFAULT_MEMORY};
+use crate::sandbox::container::util::container_name;
+use settings::LAUNCH_SETTINGS;
+use util::{container_gone_within, describe_exit_code, non_blank};
 
 /// Signal/removal docker calls during teardown.
 const KILL_TIMEOUT: Duration = Duration::from_secs(10);
@@ -191,14 +180,16 @@ impl SandboxEngine for DockerEngine {
         EngineKind::Docker
     }
 
-    /// Launch a container for `ctx.provider`. The provider-agnostic scaffolding —
-    /// the writable-root and RPC mailbox mounts, borrowed git object stores, the
-    /// `--rm --init` shape, naming, and teardown — is shared; the per-provider
-    /// image, config-dir mount, and auth are selected by matching on
-    /// [`DockerProvider`]. `agent_bin` is the in-image command name the caller
-    /// already resolved for the docker boundary (`claude` / `codex`).
-    /// `ensure_engine_supports_provider` gates this to a supported provider, so
-    /// the `from_id` failure below is defensive only.
+    /// Launch a container for `ctx.provider`. Everything but the binary and the
+    /// resolved image is shared with the other container runtime: the env,
+    /// mounts and auth come from
+    /// [`container::launch::prepare`](crate::sandbox::container::launch::prepare)
+    /// and the argv from
+    /// [`container::run_args`](crate::sandbox::container::run_args). `agent_bin`
+    /// is the in-image command name the caller already resolved for the docker
+    /// boundary (`claude` / `codex`). `ensure_engine_supports_provider` gates
+    /// this to a supported provider, so the `from_id` failure below is
+    /// defensive only.
     fn launch_agent(&self, ctx: &AgentLaunchCtx, agent_bin: &str) -> Result<LaunchPlan> {
         let provider = DockerProvider::from_id(ctx.provider).ok_or_else(|| {
             Error::Other(format!(
@@ -211,261 +202,13 @@ impl SandboxEngine for DockerEngine {
         let settings = LAUNCH_SETTINGS.read().clone();
         let image = self.resolve_image_cached(provider, settings.image_override.as_deref())?;
         let name = container_name(ctx.agent_id);
+        // Everything about *what* to mount, set, and authenticate is
+        // runtime-neutral policy; this engine only decides which binary carries
+        // it out.
+        let prep = crate::sandbox::container::launch::prepare(ctx, provider)?;
 
-        // Object stores every checkout under the agent's writable root borrows
-        // via git alternates (a --shared clone). Derived from `ctx.source_repos`
-        // — Fletch's authoritative record of each checkout's user-owned source
-        // repo — NOT from the checkout's own `.git/objects/info/alternates`.
-        // That alternates file lives inside the agent's read-write checkout, so
-        // a container agent can overwrite it to name any host path and, on a
-        // reused-checkout relaunch (resume / switch_view), have that path
-        // bind-mounted read-only into its container — defeating ConfinedReads.
-        // Deriving from the source repos (which the agent cannot write) mounts
-        // exactly what a `--shared` clone borrows without trusting agent state.
-        // Spans every tracked repo, not just the primary: a multi-repo agent
-        // has one shared clone per repo. Mounted read-only; empty when a source
-        // is missing or has no object store. Docker forces Clone-mode
-        // workspaces for every provider, so this is provider-agnostic.
-        let borrowed_object_stores = borrowed_object_stores(ctx.source_repos);
-
-        // Env set on the docker CLI process; forwarded into the container by the
-        // bare `-e NAME` flags `run_args` emits (values never touch argv —
-        // invariant 3). Config-dir + auth vars are appended per provider below.
-        let mut env: Vec<(String, String)> = vec![
-            ("HOME".into(), ctx.home.to_string_lossy().into_owned()),
-            (
-                "FLETCH_RPC_DIR".into(),
-                ctx.rpc_dir.to_string_lossy().into_owned(),
-            ),
-            ("TERM".into(), "xterm-256color".into()),
-            ("COLORTERM".into(), "truecolor".into()),
-        ];
-        // A workflow step agent's blackboard is bind-mounted at its identical
-        // host path (invariant 1, like the RPC mailbox), so `WF_BLACKBOARD` is
-        // the same host path under either engine. Pushed before the provider
-        // match sets `auth_start` so it forwards as a plain env var, not an
-        // auth var.
-        if let Some(board) = ctx.blackboard {
-            // Fail closed if the blackboard was not provisioned before launch:
-            // a bare `-v` on a missing source has Docker create it *root-owned*,
-            // leaving the host-side reader unable to read the agent's verdict/
-            // handoff files. Seatbelt already fails here (its `canonicalize`
-            // errors on a missing path); match that so an ordering bug in the
-            // scheduler surfaces instead of silently corrupting the mount.
-            if !board.is_dir() {
-                return Err(Error::Other(format!(
-                    "workflow blackboard not provisioned before launch: {}",
-                    board.display()
-                )));
-            }
-            env.push((
-                crate::workflow::blackboard::WF_BLACKBOARD_ENV.into(),
-                board.to_string_lossy().into_owned(),
-            ));
-        }
-
-        // Owned per-provider mount inputs, borrowed into a `ProviderMounts` when
-        // the `RunSpec` is built below. Defaults describe "no config surface";
-        // the matched arm fills in what its provider needs.
-        let mut claude_config_dir: Option<PathBuf> = None;
-        let mut claude_credentials_rw = false;
-        let mut config_dir_credentials_rw = false;
-        let mut projects_src: Option<PathBuf> = None;
-        let mut codex_config_dir: Option<PathBuf> = None;
-        let mut forward_codex_home = false;
-        let mut oc_data: Option<PathBuf> = None;
-        let mut oc_config: Option<PathBuf> = None;
-        let mut forward_xdg_data_home = false;
-        let mut forward_xdg_config_home = false;
-        let mut pi_data: Option<PathBuf> = None;
-        let mut cursor_data: Option<PathBuf> = None;
-
-        // The config-dir env (CLAUDE_CONFIG_DIR / CODEX_HOME / XDG_*) is pushed
-        // before this mark so only the *auth* tail is forwarded as auth vars.
-        let auth_start;
-        match provider {
-            DockerProvider::Claude => {
-                let cfg = nondefault_claude_config_dir(ctx.home);
-
-                // Make sure the mount sources exist before we hand them to `-v`.
-                // If a source can't be created (a file already sits at the path,
-                // a read-only or missing parent, permissions), mounting it anyway
-                // would let Docker recreate it root-owned or fail the bind
-                // opaquely — either way claude loses access to its auth/config.
-                // Fail the launch with the path instead of a bad mount.
-                let claude_dir = ctx.home.join(".claude");
-                prepare_config_mount_dir(&claude_dir)?;
-                if let Some(dir) = &cfg {
-                    prepare_config_mount_dir(dir)?;
-                }
-
-                // Per-agent host dir backing claude's `projects/` (session
-                // transcripts). Bind-mounted read-write over the read-only config
-                // dir's `projects/` (see [`push_claude_config_mount`]) so
-                // `--resume` survives container recreation without exposing the
-                // shared `~/.claude/projects` — other agents' transcripts and
-                // global memory stay unreachable (invariant 5). Lives under the
-                // agent's writable root, so archive teardown's `rm -rf` reclaims
-                // it with no separate cleanup. Created before `docker run` so
-                // Docker binds an existing source instead of materializing it
-                // root-owned.
-                let ps = ctx
-                    .writable_root
-                    .join(crate::transcripts::DOCKER_CLAUDE_PROJECTS_DIRNAME);
-                std::fs::create_dir_all(&ps).map_err(|e| {
-                    Error::Other(format!(
-                        "preparing Docker sandbox projects mount {} failed: {e}",
-                        ps.display()
-                    ))
-                })?;
-
-                // The read-only config mounts get a writable `.credentials.json`
-                // overlay only when the file already exists: a bare `-v` on a
-                // missing source makes Docker create a root-owned *directory*
-                // there, which would break claude's later write of the real file.
-                claude_credentials_rw = claude_dir.join(CREDENTIALS_FILE).is_file();
-                config_dir_credentials_rw = cfg
-                    .as_deref()
-                    .is_some_and(|dir| dir.join(CREDENTIALS_FILE).is_file());
-                if let Some(dir) = &cfg {
-                    env.push((
-                        "CLAUDE_CONFIG_DIR".into(),
-                        dir.to_string_lossy().into_owned(),
-                    ));
-                }
-                claude_config_dir = cfg;
-                projects_src = Some(ps);
-
-                auth_start = env.len();
-                apply_container_auth(&mut env, crate::sandbox::container::auth::resolve())?;
-            }
-            DockerProvider::Codex => {
-                // Codex's config dir is bind-mounted read-write: auth.json token
-                // refresh and the session rollout files it writes both need to
-                // persist, and writing rollouts at the same host path keeps the
-                // host-side transcript reader (`find_codex_rollouts`) working.
-                let dir = codex_home_dir(ctx.home);
-                // Forward CODEX_HOME only when it points somewhere other than the
-                // default `~/.codex` the container already resolves via HOME —
-                // mirrors `nondefault_claude_config_dir`.
-                forward_codex_home = codex_home_is_nondefault(ctx.home);
-                if forward_codex_home {
-                    env.push(("CODEX_HOME".into(), dir.to_string_lossy().into_owned()));
-                }
-
-                auth_start = env.len();
-                prepare_codex_launch(
-                    &mut env,
-                    &dir,
-                    std::env::var("OPENAI_API_KEY").ok().as_deref(),
-                )?;
-                codex_config_dir = Some(dir);
-            }
-            DockerProvider::Opencode => {
-                // OpenCode's data dir carries the accounts DB / auth.json and the
-                // session storage the host transcript reader tails, so it's bound
-                // read-write at its identical host path (mirrors codex's ~/.codex).
-                let data = opencode_data_dir(ctx.home);
-                // Forward XDG_DATA_HOME only when it points somewhere other than
-                // the default `~/.local/share` the container resolves via HOME —
-                // mirrors codex's CODEX_HOME handling.
-                forward_xdg_data_home =
-                    xdg_base_is_nondefault("XDG_DATA_HOME", ctx.home, ".local/share");
-                if forward_xdg_data_home {
-                    if let Some(v) = std::env::var_os("XDG_DATA_HOME") {
-                        env.push(("XDG_DATA_HOME".into(), v.to_string_lossy().into_owned()));
-                    }
-                }
-                // The config dir (custom providers + plugin installs opencode
-                // writes) is optional: opencode runs without it, and binding a
-                // missing source would have Docker create it root-owned. Mount +
-                // forward it only when it already exists.
-                let config = opencode_config_dir(ctx.home);
-                if config.is_dir() {
-                    forward_xdg_config_home =
-                        xdg_base_is_nondefault("XDG_CONFIG_HOME", ctx.home, ".config");
-                    if forward_xdg_config_home {
-                        if let Some(v) = std::env::var_os("XDG_CONFIG_HOME") {
-                            env.push(("XDG_CONFIG_HOME".into(), v.to_string_lossy().into_owned()));
-                        }
-                    }
-                    oc_config = Some(config);
-                }
-
-                auth_start = env.len();
-                let api_keys = present_api_keys(|n| std::env::var(n).ok());
-                prepare_opencode_launch(&mut env, &data, api_keys)?;
-                oc_data = Some(data);
-            }
-            DockerProvider::Pi => {
-                // Pi keeps everything under `~/.pi` (agent/auth.json,
-                // agent/settings.json, agent/sessions/), bound read-write at its
-                // identical host path so auth persists and the host transcript
-                // reader tails the sessions.
-                let data = ctx.home.join(".pi");
-                auth_start = env.len();
-                let api_keys = present_api_keys(|n| std::env::var(n).ok());
-                prepare_pi_launch(&mut env, &data, api_keys)?;
-                pi_data = Some(data);
-            }
-            DockerProvider::Cursor => {
-                // `~/.cursor` is bound read-write at its identical host path so
-                // cursor's session transcripts land where the host reader
-                // (`agent::cursor_locate`) tails them. It carries no credential
-                // (the login token is keychain-bound); auth is CURSOR_API_KEY only.
-                let data = ctx.home.join(".cursor");
-                auth_start = env.len();
-                prepare_cursor_launch(
-                    &mut env,
-                    &data,
-                    std::env::var("CURSOR_API_KEY").ok().as_deref(),
-                )?;
-                cursor_data = Some(data);
-            }
-        }
-
-        // Forward exactly the resolved auth var names (the tail appended after
-        // `auth_start`). Scoped so the borrow of `env` ends before it moves into
-        // the plan below.
         let prefix_args = {
-            let auth_vars: Vec<&str> = env[auth_start..].iter().map(|(k, _)| k.as_str()).collect();
-            // Assemble the provider's mount directives from the owned locals the
-            // matched arm above filled in. Exactly one arm ran, so exactly one
-            // variant's locals are populated.
-            let mounts = match provider {
-                DockerProvider::Claude => ProviderMounts::Claude {
-                    config_dir: claude_config_dir.as_deref(),
-                    credentials_rw: claude_credentials_rw,
-                    config_dir_credentials_rw,
-                    projects_src: projects_src
-                        .as_deref()
-                        .expect("claude launch must supply a projects_src"),
-                },
-                DockerProvider::Codex => ProviderMounts::Codex {
-                    config_dir: codex_config_dir
-                        .as_deref()
-                        .expect("codex launch must supply a config_dir"),
-                    forward_home: forward_codex_home,
-                },
-                DockerProvider::Opencode => ProviderMounts::Opencode {
-                    data_dir: oc_data
-                        .as_deref()
-                        .expect("opencode launch must supply a data_dir"),
-                    config_dir: oc_config.as_deref(),
-                    forward_xdg_data_home,
-                    forward_xdg_config_home,
-                },
-                DockerProvider::Pi => ProviderMounts::Pi {
-                    data_dir: pi_data
-                        .as_deref()
-                        .expect("pi launch must supply a data_dir"),
-                },
-                DockerProvider::Cursor => ProviderMounts::Cursor {
-                    data_dir: cursor_data
-                        .as_deref()
-                        .expect("cursor launch must supply a data_dir"),
-                },
-            };
+            let auth_vars = prep.auth_vars();
             run_args(&RunSpec {
                 interactive: ctx.interactive,
                 name: &name,
@@ -475,8 +218,8 @@ impl SandboxEngine for DockerEngine {
                 home: ctx.home,
                 cwd: ctx.cwd,
                 blackboard: ctx.blackboard,
-                mounts,
-                borrowed_object_stores: &borrowed_object_stores,
+                mounts: prep.mounts(),
+                borrowed_object_stores: &prep.borrowed_object_stores,
                 memory: non_blank(settings.memory.as_deref()).unwrap_or(DEFAULT_MEMORY),
                 cpus: non_blank(settings.cpus.as_deref()).unwrap_or(DEFAULT_CPUS),
                 image: &image,
@@ -488,7 +231,7 @@ impl SandboxEngine for DockerEngine {
         Ok(LaunchPlan {
             program: docker,
             prefix_args,
-            env,
+            env: prep.env,
             kill: KillHandle::Engine {
                 engine: DockerEngine::shared(),
                 plan: KillPlan::Container { name },

--- a/src-tauri/src/sandbox/docker/engine/settings.rs
+++ b/src-tauri/src/sandbox/docker/engine/settings.rs
@@ -12,8 +12,8 @@ pub const MEMORY_SETTING: &str = "docker_memory";
 /// Settings key for the container CPU limit (`docker run --cpus`).
 pub const CPUS_SETTING: &str = "docker_cpus";
 
-pub(super) const DEFAULT_MEMORY: &str = "4g";
-pub(super) const DEFAULT_CPUS: &str = "2";
+// The launch defaults are container policy, not docker's: they live in
+// [`crate::sandbox::container::run_args`] so both runtimes cap the same way.
 
 /// Launch knobs read from the `settings` table, mirrored in-process (the spawn
 /// path has no DB handle — same pattern as `sandbox::set_selected_engine_kind`).
@@ -24,9 +24,11 @@ pub struct LaunchSettings {
     /// `docker_image` — a non-empty value is used verbatim, skipping the
     /// embedded image build entirely.
     pub image_override: Option<String>,
-    /// `docker_memory` — `--memory` value; `None`/blank means [`DEFAULT_MEMORY`].
+    /// `docker_memory` — `--memory` value; `None`/blank means the container
+    /// layer's `DEFAULT_MEMORY`.
     pub memory: Option<String>,
-    /// `docker_cpus` — `--cpus` value; `None`/blank means [`DEFAULT_CPUS`].
+    /// `docker_cpus` — `--cpus` value; `None`/blank means the container layer's
+    /// `DEFAULT_CPUS`.
     pub cpus: Option<String>,
 }
 

--- a/src-tauri/src/sandbox/docker/engine/settings.rs
+++ b/src-tauri/src/sandbox/docker/engine/settings.rs
@@ -5,6 +5,8 @@
 
 use parking_lot::RwLock;
 
+use crate::sandbox::container::version_guard::VersionGuard;
+
 /// Settings key overriding the container image (see [`super::image::resolve_image`]).
 pub const IMAGE_SETTING: &str = "docker_image";
 /// Settings key for the container memory limit (`docker run --memory`).
@@ -53,62 +55,37 @@ pub fn set_launch_settings(settings: LaunchSettings) {
 /// attempt.
 pub const VERSION_GUARD_SETTING: &str = "docker_version_refresh_guard";
 
-/// Writes the guard map back to its settings row (installed by
-/// [`init_version_refresh_guard`]).
-type VersionGuardPersist = Box<dyn Fn(&std::collections::HashMap<String, String>) + Send + Sync>;
-
-/// The version-refresh loop guard, mirrored in-process like
-/// [`LAUNCH_SETTINGS`] (the image code that consults it runs on spawn paths
-/// and background threads with no DB handle). Seeded and wired to a persister
-/// at startup by [`init_version_refresh_guard`]; until then (tests, headless)
-/// it's empty and unpersisted, and recording still guards the current
-/// process run.
-struct VersionGuard {
-    /// provider id → `"host_version@image_tag"` last successfully rebuilt for.
-    attempted: std::collections::HashMap<String, String>,
-    /// Writes the whole map back to the settings row.
-    persist: Option<VersionGuardPersist>,
-}
-
-static VERSION_GUARD: RwLock<Option<VersionGuard>> = RwLock::new(None);
+/// Docker's loop-guard state, mirrored in-process like [`LAUNCH_SETTINGS`] (the
+/// image code that consults it runs on spawn paths and background threads with
+/// no DB handle). The machinery is shared with podman — see
+/// [`container::version_guard`](crate::sandbox::container::version_guard) —
+/// while the static and its settings key stay per runtime: an image present in
+/// docker's store says nothing about podman's.
+static VERSION_GUARD: VersionGuard = VersionGuard::new();
 
 /// Install the loop-guard state: `attempted` as loaded from
 /// [`VERSION_GUARD_SETTING`], `persist` writing it back. The app wires this
 /// to a `database::set_setting` closure at startup — the same mirror idiom as
-/// [`set_launch_settings`] and `progress::set_build_sink`.
+/// [`set_launch_settings`] and `container::progress::set_build_sink`.
 pub fn init_version_refresh_guard(
     attempted: std::collections::HashMap<String, String>,
     persist: impl Fn(&std::collections::HashMap<String, String>) + Send + Sync + 'static,
 ) {
-    *VERSION_GUARD.write() = Some(VersionGuard {
-        attempted,
-        persist: Some(Box::new(persist)),
-    });
+    VERSION_GUARD.init(attempted, persist);
 }
 
 /// Whether a version-mismatch rebuild already succeeded for exactly this
 /// `pair` (`"host_version@image_tag"`). If so the trigger is inert: the
 /// mismatch survived a rebuild, so it isn't rebuildable-away (pinned host).
 pub(crate) fn version_refresh_attempted(provider_id: &str, pair: &str) -> bool {
-    VERSION_GUARD
-        .read()
-        .as_ref()
-        .is_some_and(|g| g.attempted.get(provider_id).map(String::as_str) == Some(pair))
+    VERSION_GUARD.attempted(provider_id, pair)
 }
 
 /// Record (and persist, when wired) that a version-mismatch rebuild succeeded
 /// for `pair`. Called from the background rebuild thread on success only —
 /// failures must retry on a later run, exactly like TTL rebuild failures.
 pub(crate) fn record_version_refresh(provider_id: &str, pair: String) {
-    let mut guard = VERSION_GUARD.write();
-    let state = guard.get_or_insert_with(|| VersionGuard {
-        attempted: std::collections::HashMap::new(),
-        persist: None,
-    });
-    state.attempted.insert(provider_id.to_string(), pair);
-    if let Some(persist) = &state.persist {
-        persist(&state.attempted);
-    }
+    VERSION_GUARD.record(provider_id, pair);
 }
 
 /// The current `docker_image` override, trimmed, `None` when unset/blank —

--- a/src-tauri/src/sandbox/docker/engine/tests.rs
+++ b/src-tauri/src/sandbox/docker/engine/tests.rs
@@ -2,13 +2,16 @@ use super::*;
 
 use std::path::{Path, PathBuf};
 
-use super::config_dir::config_dir_is_default;
 use super::util::container_running;
 use crate::sandbox::container::auth::ContainerAuth;
+use crate::sandbox::container::config_dir::{borrowed_object_stores, config_dir_is_default};
 use crate::sandbox::container::launch_auth::{
-    codex_auth_env, cursor_auth_env, multi_provider_auth_env, NO_CODEX_AUTH_MSG,
-    NO_CONTAINER_AUTH_MSG, NO_CURSOR_AUTH_MSG, NO_OPENCODE_AUTH_MSG, NO_PI_AUTH_MSG,
+    apply_container_auth, codex_auth_env, cursor_auth_env, multi_provider_auth_env,
+    prepare_codex_launch, prepare_cursor_launch, prepare_opencode_launch, prepare_pi_launch,
+    present_api_keys, NO_CODEX_AUTH_MSG, NO_CONTAINER_AUTH_MSG, NO_CURSOR_AUTH_MSG,
+    NO_OPENCODE_AUTH_MSG, NO_PI_AUTH_MSG,
 };
+use crate::sandbox::container::run_args::{prepare_config_mount_dir, ProviderMounts};
 
 /// The version-refresh loop guard: exact-pair matching, per-provider
 /// isolation, persistence callback on record, and safe recording before
@@ -908,6 +911,26 @@ fn exit_code_mapping_is_distinct_and_scoped() {
             "code {code} must pass through"
         );
     }
+}
+
+/// Golden guard on Docker's rendered exit-code messages. They now come from a
+/// template the two container runtimes share (`container::util::ExitCopy`), so
+/// pin the bytes: a well-meant edit to the shared wording must not silently
+/// change what a Docker user reads.
+#[test]
+fn exit_code_messages_are_unchanged() {
+    assert_eq!(
+        describe_exit_code(125).unwrap(),
+        "Exit 125: Docker could not start the sandbox container — the daemon reported an error (or the agent itself exited 125). Is Docker Desktop still running?",
+    );
+    assert_eq!(
+        describe_exit_code(126).unwrap(),
+        "Exit 126: the agent binary in the sandbox image is present but not runnable (or the agent itself exited 126). If you set a custom docker_image, check its agent CLI.",
+    );
+    assert_eq!(
+        describe_exit_code(127).unwrap(),
+        "Exit 127: no agent binary on the sandbox image's PATH (or the agent itself exited 127). A custom docker_image must include the launching agent's CLI.",
+    );
 }
 
 #[test]

--- a/src-tauri/src/sandbox/docker/engine/tests.rs
+++ b/src-tauri/src/sandbox/docker/engine/tests.rs
@@ -1302,7 +1302,10 @@ fn kill_and_liveness_against_live_container() {
     );
 
     let engine = DockerEngine::shared();
-    let plan = KillPlan::Container { name: name.clone() };
+    let plan = KillPlan::Container {
+        name: name.clone(),
+        connection: None,
+    };
     assert!(
         container_running(&name),
         "fresh container should be running"

--- a/src-tauri/src/sandbox/docker/engine/util.rs
+++ b/src-tauri/src/sandbox/docker/engine/util.rs
@@ -12,12 +12,6 @@ use crate::sandbox::docker::cli;
 /// Liveness lookups (`docker inspect`).
 const INSPECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// `Some(v)` only when `v` is present and non-blank — settings rows can hold
-/// empty strings, which must fall back to defaults.
-pub(super) fn non_blank(value: Option<&str>) -> Option<&str> {
-    value.map(str::trim).filter(|v| !v.is_empty())
-}
-
 /// Whether the daemon says the container is currently running. Errors
 /// (container gone, daemon down, timeout) read as not running.
 pub(super) fn container_running(name: &str) -> bool {
@@ -51,7 +45,7 @@ pub(super) fn container_gone_within(name: &str, budget: Duration) -> bool {
 /// what reports a start failure, Docker Desktop is what the user restarts, and
 /// `docker_image` is the override a 126/127 may be pointing at.
 const EXIT_COPY: ExitCopy = ExitCopy {
-    runtime: "Docker",
+    runtime: crate::sandbox::docker::RUNTIME_NAME,
     error_source: "the daemon",
     remedy: "Is Docker Desktop still running?",
     image_setting: Some(super::IMAGE_SETTING),

--- a/src-tauri/src/sandbox/docker/engine/util.rs
+++ b/src-tauri/src/sandbox/docker/engine/util.rs
@@ -1,10 +1,12 @@
-//! Container naming, liveness lookups, and the docker-reserved exit-code
-//! messages — the small provider-neutral helpers the launch/teardown paths lean
-//! on.
+//! Docker's liveness lookups and its wording for the reserved exit codes.
+//!
+//! Container naming and the exit-code message templates are runtime-neutral and
+//! live in [`container::util`](crate::sandbox::container::util); the liveness
+//! lookups stay here because they shell out to docker.
 
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
+use crate::sandbox::container::util::ExitCopy;
 use crate::sandbox::docker::cli;
 
 /// Liveness lookups (`docker inspect`).
@@ -14,38 +16,6 @@ const INSPECT_TIMEOUT: Duration = Duration::from_secs(5);
 /// empty strings, which must fall back to defaults.
 pub(super) fn non_blank(value: Option<&str>) -> Option<&str> {
     value.map(str::trim).filter(|v| !v.is_empty())
-}
-
-/// `fletch-<agent_id>-<8-char nonce>`. The nonce keeps respawns (view switch,
-/// binary swap) from colliding with a predecessor container of the same agent
-/// that `--rm` hasn't finished reaping yet; hashing in the pid keeps two
-/// side-by-side Fletch instances apart even for a same-named agent.
-pub(super) fn container_name(agent_id: &str) -> String {
-    // Docker names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*; the `fletch-`
-    // prefix fixes the first char, sanitize the rest.
-    let sanitized: String = agent_id
-        .chars()
-        .map(|c| {
-            if c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-') {
-                c
-            } else {
-                '-'
-            }
-        })
-        .collect();
-    format!("fletch-{sanitized}-{}", nonce())
-}
-
-/// 8 hex chars from (pid, monotonic counter): unique within a host across
-/// concurrently running instances for the lifetime of any one container.
-fn nonce() -> String {
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    std::process::id().hash(&mut hasher);
-    COUNTER.fetch_add(1, Ordering::Relaxed).hash(&mut hasher);
-    let hex: String = format!("{:016x}", hasher.finish());
-    hex[..8].to_string()
 }
 
 /// Whether the daemon says the container is currently running. Errors
@@ -77,22 +47,18 @@ pub(super) fn container_gone_within(name: &str, budget: Duration) -> bool {
     }
 }
 
-/// User-readable meanings for the docker CLI's reserved exit codes; other
-/// codes are the contained agent's own and pass through unmapped. `docker run`
-/// relays the agent's own exit status, so an agent that starts fine and later
-/// exits 125/126/127 is indistinguishable from a launcher/image failure — the
-/// messages name the likely Docker-layer cause but flag the agent-exit
-/// possibility so they don't mislead when the container did launch.
-///
-/// Provider-neutral: the teardown plan carries only the container name, and the
-/// sandbox image now varies per provider, so these speak of "the agent binary"
-/// rather than naming `claude`.
+/// Docker's wording for the shared reserved-exit-code messages. The daemon is
+/// what reports a start failure, Docker Desktop is what the user restarts, and
+/// `docker_image` is the override a 126/127 may be pointing at.
+const EXIT_COPY: ExitCopy = ExitCopy {
+    runtime: "Docker",
+    error_source: "the daemon",
+    remedy: "Is Docker Desktop still running?",
+    image_setting: Some(super::IMAGE_SETTING),
+};
+
+/// User-readable meanings for the docker CLI's reserved exit codes — see
+/// [`container::util::describe_exit_code`](crate::sandbox::container::util::describe_exit_code).
 pub(super) fn describe_exit_code(code: i32) -> Option<String> {
-    let msg = match code {
-        125 => "Exit 125: Docker could not start the sandbox container — the daemon reported an error (or the agent itself exited 125). Is Docker Desktop still running?",
-        126 => "Exit 126: the agent binary in the sandbox image is present but not runnable (or the agent itself exited 126). If you set a custom docker_image, check its agent CLI.",
-        127 => "Exit 127: no agent binary on the sandbox image's PATH (or the agent itself exited 127). A custom docker_image must include the launching agent's CLI.",
-        _ => return None,
-    };
-    Some(msg.to_string())
+    crate::sandbox::container::util::describe_exit_code(code, &EXIT_COPY)
 }

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -7,7 +7,9 @@
 //! Content addressing alone would freeze the *packages inside* an image
 //! forever, though: every image installs "latest at build time" (npm installs,
 //! cursor's installer), so a stable Dockerfile means a user's containerized CLI
-//! never updates while the host CLI does. [`IMAGE_MAX_AGE`] fixes that with a
+//! never updates while the host CLI does.
+//! [`IMAGE_MAX_AGE`](crate::sandbox::container::freshness::IMAGE_MAX_AGE) fixes
+//! that with a
 //! TTL: at resolution, an existing image older than the TTL is served for the
 //! current launch and rebuilt under the same tag in the background
 //! (stale-while-revalidate — see [`refresh_in_background_if_needed`]). A
@@ -29,28 +31,23 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use crate::error::Result;
+use crate::sandbox::container::freshness::{classify_freshness, version_refresh_wanted, Freshness};
 use crate::sandbox::container::images::{image_spec, write_build_context, BASE_IMAGE};
+use crate::sandbox::container::progress::{self, BuildEvent};
 
 use super::cli;
-use super::progress::{self, BuildEvent};
 use super::DockerProvider;
 
 /// The image content this module builds from, re-exported so the
-/// `image::image_tag` / `image::image_repo` / `image::AGENT_IMAGE_LABEL` paths
-/// [`super::cleanup`]'s GC uses keep resolving.
-pub(super) use crate::sandbox::container::images::{image_repo, image_tag, AGENT_IMAGE_LABEL};
+/// `image::image_tag` / `image::AGENT_IMAGE_LABEL` paths [`super::cleanup`]'s GC
+/// uses keep resolving. (The expected-tag and known-repo sets it derives from
+/// them now live in
+/// [`container::image_gc`](crate::sandbox::container::image_gc).)
+pub(super) use crate::sandbox::container::images::{image_tag, AGENT_IMAGE_LABEL};
 
 /// Progress sink for image builds: called once per docker output line. Callers
 /// pass a tracing forwarder to log build output, or `&|_| {}` to ignore it.
 pub type Progress<'a> = &'a (dyn Fn(&str) + Send + Sync);
-
-/// Dogma: **an agent image is never older than a week.** The images install
-/// "latest at build time" (npm installs, cursor's installer), so their
-/// contents freeze at build; this TTL bounds that freeze. An image past the
-/// TTL still serves the current launch — freshness is a background concern,
-/// never a launch blocker — and is rebuilt under the same tag off-thread
-/// (see [`refresh_in_background_if_stale`]). Deliberately not a setting.
-pub const IMAGE_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 
 /// Builds are slow (base image pull + apt + npm) but bounded: past this we
 /// assume a wedged daemon or dead network and fail the spawn with a clear
@@ -68,7 +65,9 @@ const REMOVE_TIMEOUT: Duration = Duration::from_secs(60);
 /// key: a non-empty override is returned verbatim (no build, no inspect, no
 /// TTL, no version check — the user owns that image's lifecycle); otherwise
 /// the embedded image is built if missing, refreshed in the background if
-/// older than [`IMAGE_MAX_AGE`] or version-divergent from the host CLI, and
+/// older than
+/// [`IMAGE_MAX_AGE`](crate::sandbox::container::freshness::IMAGE_MAX_AGE) or
+/// version-divergent from the host CLI, and
 /// its tag returned. Callers read the settings key and probe the host CLI
 /// (`host_cli_version` — see `agent::cached_provider_version`) and pass both
 /// in — this module stays DB-free and host-probe-free.
@@ -151,7 +150,9 @@ fn ensure_image_with(
     // the user is actually waiting on. Each output line is forwarded alongside
     // the caller's own sink so the tracing forwarder / test counter keep
     // working unchanged.
-    progress::emit(BuildEvent::Started);
+    progress::emit(BuildEvent::Started {
+        runtime: super::RUNTIME_NAME,
+    });
     let forward = |line: &str| {
         on_progress(line);
         progress::emit(BuildEvent::Line {
@@ -330,39 +331,11 @@ fn build_args(tag: &str, ctx: &Path, no_cache: bool) -> Vec<String> {
     args
 }
 
-/// TTL verdict for an image's `.Created` timestamp against [`IMAGE_MAX_AGE`].
-/// Pure — `now` is injected so tests use fixed instants. `Unknown` (an
-/// unparseable timestamp) is deliberately its own state: the caller treats it
-/// as fresh, because rebuilding on unparseable metadata would rebuild on
-/// *every* resolution forever (the rebuilt image's metadata would presumably
-/// parse no better if the daemon's format changed under us).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Freshness {
-    Fresh,
-    Stale,
-    Unknown,
-}
-
-/// Classify a raw `docker image inspect --format {{.Created}}` value (RFC3339,
-/// e.g. `2026-07-01T12:00:00.000000000Z`).
-fn classify_freshness(created_raw: &str, now: chrono::DateTime<chrono::Utc>) -> Freshness {
-    let Ok(created) = chrono::DateTime::parse_from_rfc3339(created_raw.trim()) else {
-        return Freshness::Unknown;
-    };
-    // A negative age (clock skew, image "from the future") compares below any
-    // positive TTL and lands on Fresh — the right bias for bad clocks.
-    let max_age = chrono::Duration::from_std(IMAGE_MAX_AGE).expect("TTL fits chrono::Duration");
-    if now.signed_duration_since(created) > max_age {
-        Freshness::Stale
-    } else {
-        Freshness::Fresh
-    }
-}
-
 /// Why a background refresh rebuild was kicked — log attribution, plus the
 /// version trigger's loop-guard bookkeeping on success.
 enum RefreshReason {
-    /// The image's build date passed [`IMAGE_MAX_AGE`].
+    /// The image's build date passed the shared TTL
+    /// ([`IMAGE_MAX_AGE`](crate::sandbox::container::freshness::IMAGE_MAX_AGE)).
     Ttl,
     /// The host CLI's probed version differs from the container image's;
     /// `guard_pair` is the `host@tag` pair recorded (persistently, on rebuild
@@ -461,22 +434,6 @@ fn refresh_in_background_if_needed(
         tag.to_string(),
         RefreshReason::VersionMismatch { guard_pair },
     );
-}
-
-/// Pure core of the version-mismatch trigger: refresh only when both sides
-/// are known, differ (plain `!=` — deliberately no semver ordering: "newer"
-/// is not computable across five vendors' formats, and parity is the actual
-/// goal), and this pairing hasn't already been attempted (rebuilding can't
-/// fix a host that's simply pinned away from the registry's latest).
-fn version_refresh_wanted(
-    host: Option<&str>,
-    container: Option<&str>,
-    already_attempted: bool,
-) -> bool {
-    match (host, container) {
-        (Some(h), Some(c)) => !already_attempted && h != c,
-        _ => false,
-    }
 }
 
 /// Kick the background stale-while-revalidate rebuild shared by both refresh
@@ -707,88 +664,6 @@ mod tests {
                 "fletch-agent:abc123def456",
                 "/tmp/ctx"
             ],
-        );
-    }
-
-    /// The version-mismatch trigger's pure core: refresh only on a known,
-    /// unequal, not-yet-attempted pairing. Plain `!=`, no semver ordering.
-    #[test]
-    fn version_refresh_decision() {
-        // Mismatch → refresh.
-        assert!(version_refresh_wanted(
-            Some("v2.0.1"),
-            Some("v2.0.0"),
-            false
-        ));
-        // Direction doesn't matter (no ordering): host older also fires once.
-        assert!(version_refresh_wanted(
-            Some("v1.0.0"),
-            Some("v2.0.0"),
-            false
-        ));
-        // Match → fresh.
-        assert!(!version_refresh_wanted(
-            Some("v2.0.0"),
-            Some("v2.0.0"),
-            false
-        ));
-        // No host CLI (not installed / probe failed) → inert.
-        assert!(!version_refresh_wanted(None, Some("v2.0.0"), false));
-        // Container version unknown (post-build probe failed) → inert.
-        assert!(!version_refresh_wanted(Some("v2.0.0"), None, false));
-        assert!(!version_refresh_wanted(None, None, false));
-        // Already-attempted pairing → inert (pinned host must not loop).
-        assert!(!version_refresh_wanted(
-            Some("v2.0.1"),
-            Some("v2.0.0"),
-            true
-        ));
-    }
-
-    /// The TTL decision's pure core, with fixed instants: inside the window →
-    /// fresh, past it → stale, unparseable → unknown (treated as fresh by the
-    /// caller — never rebuild-loop on bad metadata), and a future timestamp
-    /// (clock skew) → fresh.
-    #[test]
-    fn freshness_classification() {
-        use chrono::{TimeZone, Utc};
-        let now = Utc.with_ymd_and_hms(2026, 7, 8, 12, 0, 0).unwrap();
-
-        // Docker's actual format: RFC3339 with nanoseconds and Z.
-        assert_eq!(
-            classify_freshness("2026-07-07T12:00:00.123456789Z", now),
-            Freshness::Fresh,
-            "one day old is fresh",
-        );
-        assert_eq!(
-            classify_freshness("2026-07-01T12:00:00Z", now),
-            Freshness::Fresh,
-            "exactly the TTL boundary is still fresh (strictly-older rebuilds)",
-        );
-        assert_eq!(
-            classify_freshness("2026-07-01T11:59:59Z", now),
-            Freshness::Stale,
-            "past the TTL is stale",
-        );
-        assert_eq!(
-            classify_freshness("2026-01-01T00:00:00Z", now),
-            Freshness::Stale,
-            "months old is stale",
-        );
-        assert_eq!(
-            classify_freshness("2026-08-01T00:00:00Z", now),
-            Freshness::Fresh,
-            "a future build date (clock skew) is fresh, not stale",
-        );
-        assert_eq!(
-            classify_freshness("not-a-timestamp", now),
-            Freshness::Unknown,
-        );
-        assert_eq!(classify_freshness("", now), Freshness::Unknown);
-        // Whitespace from the CLI pipe is tolerated.
-        assert_eq!(
-            classify_freshness("  2026-07-07T12:00:00Z\n", now),
-            Freshness::Fresh,
         );
     }
 

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -156,13 +156,17 @@ fn ensure_image_with(
     let forward = |line: &str| {
         on_progress(line);
         progress::emit(BuildEvent::Line {
+            runtime: super::RUNTIME_NAME,
             line: line.to_string(),
         });
     };
     let result = run_build(dockerfile, entrypoint, tag, false, &forward);
     match &result {
-        Ok(()) => progress::emit(BuildEvent::Finished),
+        Ok(()) => progress::emit(BuildEvent::Finished {
+            runtime: super::RUNTIME_NAME,
+        }),
         Err(e) => progress::emit(BuildEvent::Failed {
+            runtime: super::RUNTIME_NAME,
             error: e.to_string(),
         }),
     }

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -29,7 +29,7 @@ use std::sync::Mutex;
 use std::time::Duration;
 
 use crate::error::Result;
-use crate::sandbox::container::images::{image_spec, BASE_IMAGE};
+use crate::sandbox::container::images::{image_spec, write_build_context, BASE_IMAGE};
 
 use super::cli;
 use super::progress::{self, BuildEvent};
@@ -170,7 +170,7 @@ fn ensure_image_with(
     Ok(false)
 }
 
-/// Write the two-file build context and run `docker build -t tag`, streaming
+/// Write the build context and run `docker build -t tag`, streaming
 /// output to `on_line`. Shared by the foreground first-build
 /// ([`ensure_image_with`], `no_cache: false`) and the background refresh
 /// rebuild ([`rebuild_image`], `no_cache: true`); callers hold [`BUILD_LOCK`]
@@ -182,21 +182,8 @@ fn run_build(
     no_cache: bool,
     on_line: Progress,
 ) -> Result<()> {
-    // Build from a throwaway context dir holding exactly the two files —
-    // nothing from the host repo can leak into the image.
     let ctx = tempfile::tempdir()?;
-    std::fs::write(ctx.path().join("Dockerfile"), dockerfile)?;
-    let entrypoint_path = ctx.path().join("entrypoint.sh");
-    std::fs::write(&entrypoint_path, entrypoint)?;
-    // COPY preserves the context file's mode. The embedded Dockerfile's
-    // `RUN chmod +x` is what actually guarantees an executable entrypoint on
-    // every host; setting the mode here too just keeps the copied layer's
-    // metadata sane where the host supports it.
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&entrypoint_path, std::fs::Permissions::from_mode(0o755))?;
-    }
+    write_build_context(ctx.path(), dockerfile, entrypoint)?;
 
     // Every build passes `--pull`, which can move [`BASE_IMAGE`] onto a newer
     // digest and orphan the image we were previously building on. Snapshot the

--- a/src-tauri/src/sandbox/docker/mod.rs
+++ b/src-tauri/src/sandbox/docker/mod.rs
@@ -32,7 +32,6 @@ mod cli;
 mod engine;
 mod image;
 mod probe;
-mod progress;
 pub mod setup_token;
 
 pub use cleanup::remove_agent_containers;
@@ -41,7 +40,13 @@ pub use engine::{
     IMAGE_SETTING, MEMORY_SETTING, VERSION_GUARD_SETTING,
 };
 pub use probe::{availability, DockerAvailability};
-pub use progress::set_build_sink;
+
+/// The image-build progress sink, now runtime-neutral and shared with podman
+/// (one sink, one toast — see
+/// [`container::progress`](crate::sandbox::container::progress)). Re-exported so
+/// the `sandbox::docker::set_build_sink` path `lib.rs` installs at startup keeps
+/// resolving.
+pub use crate::sandbox::container::progress::set_build_sink;
 
 /// The container auth chain, now runtime-neutral. Re-exported so the
 /// `sandbox::docker::auth::…` paths the app and its Tauri commands already use
@@ -53,6 +58,11 @@ pub use crate::sandbox::container::auth;
 /// [`ContainerProvider`](crate::sandbox::container::ContainerProvider) at its new
 /// home and re-exported here.
 pub use crate::sandbox::container::ContainerProvider as DockerProvider;
+
+/// This runtime's display name in user-facing copy — the build toast's
+/// [`BuildEvent::Started`](crate::sandbox::container::progress::BuildEvent) and
+/// the reserved-exit-code messages.
+pub(super) const RUNTIME_NAME: &str = "Docker";
 
 /// Map a Docker probe result onto the shared retry schedule
 /// ([`container::sweep`](crate::sandbox::container::sweep)). A missing binary

--- a/src-tauri/src/sandbox/docker/mod.rs
+++ b/src-tauri/src/sandbox/docker/mod.rs
@@ -25,6 +25,8 @@
 
 use std::time::{Duration, Instant};
 
+use crate::sandbox::container::sweep::{SweepStep, SWEEP_RETRY_INTERVAL};
+
 mod cleanup;
 mod cli;
 mod engine;
@@ -52,54 +54,13 @@ pub use crate::sandbox::container::auth;
 /// home and re-exported here.
 pub use crate::sandbox::container::ContainerProvider as DockerProvider;
 
-/// How long the startup sweep waits between probes while the daemon is still
-/// coming up. Comfortably above [`probe`]'s 5s cache TTL, so every poll is one
-/// genuine daemon round-trip rather than a re-read of the same cached answer,
-/// and short enough that the sweeps start within half a minute of Docker
-/// Desktop finishing its boot.
-const SWEEP_RETRY_INTERVAL: Duration = Duration::from_secs(30);
-
-/// How long the startup sweep keeps waiting for a down daemon before giving
-/// up. Ten minutes covers a cold login — Docker Desktop's own 20-60s plus a
-/// slow disk, a VPN prompt, or a user who starts it by hand a few minutes in —
-/// while staying strictly bounded: a machine where Docker simply never runs
-/// must not keep a thread ticking for the life of the app. The budget gates
-/// when we stop *scheduling* waits, so the final probe can land up to one
-/// [`SWEEP_RETRY_INTERVAL`] past it. Giving up is cheap: the next app start
-/// sweeps again, so the cost of a miss is one run's worth of unreclaimed
-/// images, not a permanent leak.
-const SWEEP_RETRY_BUDGET: Duration = Duration::from_secs(10 * 60);
-
-/// What the startup sweep thread does after one probe — see [`sweep_step`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum SweepStep {
-    /// Docker answered: run both sweeps, once, and finish.
-    Sweep,
-    /// The daemon is down but may still be booting: wait and probe again.
-    Retry,
-    /// Nothing to wait for, or the budget is spent: the thread exits having
-    /// swept nothing.
-    Stop,
-}
-
-/// The retry schedule as a pure decision: given the latest probe result and
-/// how long the sweep thread has been waiting, keep waiting, sweep, or stop.
-/// Split out of [`sweep_orphans_at_startup`] so the schedule is unit-testable
-/// without a daemon and without sleeping.
-///
-/// [`DockerAvailability::NotInstalled`] stops immediately rather than
-/// retrying: Docker being *installed* mid-run is rare, the next app start
-/// covers it, and each retry would re-pay `cli::docker_bin`'s
-/// binary-resolution stat walk for a state that essentially never flips.
-/// [`DockerAvailability::DaemonDown`], by contrast, is the state we expect to
-/// flip — that's the whole point of the retry.
+/// Map a Docker probe result onto the shared retry schedule
+/// ([`container::sweep`](crate::sandbox::container::sweep)). A missing binary
+/// is settled for the run; a down daemon is the state we expect to flip.
 fn sweep_step(availability: &DockerAvailability, elapsed: Duration) -> SweepStep {
-    match availability {
-        DockerAvailability::Available { .. } => SweepStep::Sweep,
-        DockerAvailability::NotInstalled => SweepStep::Stop,
-        DockerAvailability::DaemonDown if elapsed < SWEEP_RETRY_BUDGET => SweepStep::Retry,
-        DockerAvailability::DaemonDown => SweepStep::Stop,
-    }
+    let usable = matches!(availability, DockerAvailability::Available { .. });
+    let installed = !matches!(availability, DockerAvailability::NotInstalled);
+    crate::sandbox::container::sweep::sweep_step(usable, installed, elapsed)
 }
 
 /// Best-effort reclamation of containers left behind by dead Fletch
@@ -162,6 +123,7 @@ pub(crate) fn docker_tests_enabled() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::sandbox::container::sweep::SWEEP_RETRY_BUDGET;
 
     /// The startup sweep's retry schedule: an available daemon sweeps at any
     /// point in the window, a missing binary never retries, and a down daemon

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -88,7 +88,14 @@ pub struct AgentLaunchCtx<'a> {
 /// Engine-specific data describing how to tear down what was launched.
 #[derive(Clone)]
 pub enum KillPlan {
-    Container { name: String },
+    Container {
+        name: String,
+        /// The runtime endpoint that launched this container, so teardown
+        /// reaches the same machine even if the runtime's default connection
+        /// changed since (podman: the pinned `--connection`). Always `None` for
+        /// docker — one daemon endpoint, nothing to distinguish.
+        connection: Option<String>,
+    },
 }
 
 /// Teardown handle bound at launch time. Sessions call [`KillHandle::kill`]

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -68,20 +68,23 @@ pub fn engine_for(kind: EngineKind) -> Result<Arc<dyn SandboxEngine>> {
                 )))
             }
         },
-        // Podman has no launch path yet: the kind, the probe and the coverage
-        // declarations ship ahead of `SandboxEngine`, so there is nothing here to
-        // return. Refused unconditionally — *not* probe-gated like Docker above —
-        // because "the probe says Podman is healthy" must not become "so launch
-        // it somehow": the only two outcomes available would be launching
-        // unsandboxed or falling back to seatbelt, and both are the isolation
-        // downgrade this function exists to prevent. Unconditional refusal here
-        // is what makes shipping a selectable kind safe before it can run
-        // anything; the next change adds the engine and replaces this arm.
-        EngineKind::Podman => Err(Error::SandboxUnavailable(
-            "The Podman engine cannot launch agents yet — this build ships the engine's \
-             availability probe only. Switch the sandbox engine to launch."
-                .into(),
-        )),
+        EngineKind::Podman => match podman::availability() {
+            PodmanAvailability::Available { .. } => Ok(podman::PodmanEngine::shared()),
+            status => {
+                tracing::warn!(
+                    ?status,
+                    "podman engine selected but unavailable; refusing to launch outside the container boundary"
+                );
+                let remedy = match status {
+                    PodmanAvailability::MachineDown => "run `podman machine start`",
+                    _ => "install Podman",
+                };
+                Err(Error::SandboxUnavailable(format!(
+                    "Podman sandbox is selected but unavailable ({status:?}); \
+                     {remedy} or switch the sandbox engine before launching."
+                )))
+            }
+        },
     }
 }
 

--- a/src-tauri/src/sandbox/podman/cleanup.rs
+++ b/src-tauri/src/sandbox/podman/cleanup.rs
@@ -1,0 +1,169 @@
+//! The dead-instance orphan sweep and the per-agent container removal, for
+//! podman.
+//!
+//! The same two questions [`docker::cleanup`](crate::sandbox::docker) answers,
+//! against the same labels ([`container::labels`](crate::sandbox::container::labels)):
+//! "whose owning instance is dead?" (startup) and "is anything still running for
+//! *this* agent?" (archive/discard). The label parsing and the under-reclaim
+//! bias are shared with docker; only the invocations differ.
+//!
+//! No image GC here — Podman ships without one for now, so a superseded agent
+//! image stays in the local store until the user reclaims it.
+
+use std::time::Duration;
+
+use crate::error::{Error, Result};
+use crate::sandbox::container::labels::{
+    agent_id_filter, orphaned_ids, HOST_PID_LABEL, INSPECT_FORMAT,
+};
+
+use super::cli;
+
+/// Listing/inspect are metadata-only; generous next to their usual
+/// milliseconds, so tripping one means the machine connection is wedged.
+const QUERY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// `podman rm -f` also kills a still-running container's process; give the
+/// batched removal room without letting a hung machine pin the sweep thread.
+const REMOVE_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Remove every fletch-labeled container whose owning host instance is dead.
+/// Returns the number removed. Callers gate on the probe and run this off the
+/// main thread — see [`super::sweep_orphans_at_startup`].
+pub(super) fn sweep_orphans() -> Result<usize> {
+    let ids = list_ids(&format!("label={HOST_PID_LABEL}"))?;
+    if ids.is_empty() {
+        return Ok(0);
+    }
+
+    let id_refs: Vec<&str> = ids.iter().map(String::as_str).collect();
+    let mut inspect_args = vec!["inspect", "-f", INSPECT_FORMAT];
+    inspect_args.extend(&id_refs);
+    let inspected = cli::run_podman(&inspect_args, QUERY_TIMEOUT)?;
+    // Don't require a zero exit: inspect exits non-zero if ANY id vanished
+    // between ps and inspect (e.g. a `--rm` container finishing), but still
+    // prints the rows it found — those are the ones we act on.
+    let stdout = String::from_utf8_lossy(&inspected.stdout);
+    let orphans = orphaned_ids(&stdout, crate::sandbox::seatbelt::pid_alive);
+    if orphans.is_empty() {
+        return Ok(0);
+    }
+
+    tracing::info!(
+        count = orphans.len(),
+        "removing podman containers of dead fletch instances"
+    );
+    remove(&orphans.iter().map(String::as_str).collect::<Vec<_>>())?;
+    Ok(orphans.len())
+}
+
+/// Remove every container stamped with `fletch.agent-id=<agent_id>`, running or
+/// not. Returns the number removed.
+///
+/// The disposal counterpart to [`sweep_orphans`], and deliberately *without*
+/// its pid-liveness check: the caller has decided this specific agent is going
+/// away, so every container bearing its id is fair game — including one owned
+/// by this very live instance, which is the whole point (the supervisor may no
+/// longer hold a kill handle for it). Attribution is still exact: the label is
+/// stamped only by our own launches, and it names one agent.
+///
+/// Matching on the label rather than the container name is required, not a
+/// preference — names carry a random nonce
+/// ([`container::util::container_name`](crate::sandbox::container::util::container_name)),
+/// so only the launching process ever knew them.
+pub fn remove_agent_containers(agent_id: &str) -> Result<usize> {
+    let ids = list_ids(&agent_id_filter(agent_id))?;
+    if ids.is_empty() {
+        return Ok(0);
+    }
+    tracing::info!(
+        agent_id,
+        count = ids.len(),
+        "removing podman containers of a disposed agent"
+    );
+    remove(&ids.iter().map(String::as_str).collect::<Vec<_>>())?;
+    Ok(ids.len())
+}
+
+/// Container ids matching one `--filter` expression.
+fn list_ids(filter: &str) -> Result<Vec<String>> {
+    let list = cli::run_podman(&["ps", "-aq", "--filter", filter], QUERY_TIMEOUT)?;
+    if !list.status.success() {
+        return Err(Error::Other(format!(
+            "podman ps failed: {}",
+            String::from_utf8_lossy(&list.stderr).trim(),
+        )));
+    }
+    Ok(String::from_utf8_lossy(&list.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+        .collect())
+}
+
+/// `podman rm -f` over a batch of ids.
+fn remove(ids: &[&str]) -> Result<()> {
+    let mut rm_args = vec!["rm", "-f"];
+    rm_args.extend(ids);
+    let removed = cli::run_podman(&rm_args, REMOVE_TIMEOUT)?;
+    if !removed.status.success() {
+        return Err(Error::Other(format!(
+            "podman rm failed: {}",
+            String::from_utf8_lossy(&removed.stderr).trim(),
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::container::labels::host_pid_label;
+
+    /// Integration: a container labeled with a dead pid is swept; one labeled
+    /// with our own (live) pid survives.
+    /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]
+    fn sweeps_dead_instance_containers_only() {
+        if !crate::sandbox::podman::podman_tests_enabled() {
+            return;
+        }
+        let run = |label: &str, name: &str| {
+            let out = cli::run_podman(
+                &[
+                    "run", "-d", "--label", label, "--name", name, "busybox", "sleep", "60",
+                ],
+                Duration::from_secs(120),
+            )
+            .unwrap();
+            assert!(
+                out.status.success(),
+                "podman run failed: {}",
+                String::from_utf8_lossy(&out.stderr),
+            );
+        };
+        // 99999998 exceeds macOS's pid range and can't be a live process.
+        let dead_name = format!("fletch-test-dead-{}", std::process::id());
+        let live_name = format!("fletch-test-live-{}", std::process::id());
+        run(&format!("{HOST_PID_LABEL}=99999998"), &dead_name);
+        run(&host_pid_label(), &live_name);
+
+        let removed = sweep_orphans().unwrap();
+        assert!(removed >= 1, "the dead-pid container should be swept");
+
+        let exists = |name: &str| {
+            let out = cli::run_podman(
+                &["ps", "-aq", "--filter", &format!("name={name}")],
+                Duration::from_secs(10),
+            )
+            .unwrap();
+            !String::from_utf8_lossy(&out.stdout).trim().is_empty()
+        };
+        assert!(!exists(&dead_name), "dead-instance container must be gone");
+        assert!(exists(&live_name), "live-instance container must survive");
+
+        let _ = cli::run_podman(&["rm", "-f", &live_name], Duration::from_secs(30));
+    }
+}

--- a/src-tauri/src/sandbox/podman/cleanup.rs
+++ b/src-tauri/src/sandbox/podman/cleanup.rs
@@ -1,24 +1,35 @@
-//! The dead-instance orphan sweep and the per-agent container removal, for
-//! podman.
+//! The dead-instance orphan sweep, the per-agent container removal, and the
+//! stale-image GC, for podman.
 //!
-//! The same two questions [`docker::cleanup`](crate::sandbox::docker) answers,
+//! The same questions [`docker::cleanup`](crate::sandbox::docker) answers,
 //! against the same labels ([`container::labels`](crate::sandbox::container::labels)):
-//! "whose owning instance is dead?" (startup) and "is anything still running for
-//! *this* agent?" (archive/discard). The label parsing and the under-reclaim
-//! bias are shared with docker; only the invocations differ.
+//! "whose owning instance is dead?" (startup), "is anything still running for
+//! *this* agent?" (archive/discard), and "which agent images has a rebuild
+//! superseded?" ([`sweep_stale_images`]). The label parsing, the selection rule
+//! and the under-reclaim bias are shared with docker
+//! ([`container::image_gc`](crate::sandbox::container::image_gc)); only the
+//! invocations differ.
 //!
 //! One invocation shape does differ in kind: docker has a single daemon, while
-//! podman has one container store per machine and launches pin themselves to
-//! the connection they resolved at the time (see [`super::machine`]). Asking
-//! only the current default would strand containers on every other machine, so
-//! both sweeps run once per machine connection.
+//! podman has one container store *and one image store* per machine, and
+//! launches pin themselves to the connection they resolved at the time (see
+//! [`super::machine`]). Asking only the current default would strand containers —
+//! and superseded images — on every other machine, so all three sweeps run once
+//! per machine connection ([`across_machines`]).
 //!
-//! No image GC here — Podman ships without one for now, so a superseded agent
-//! image stays in the local store until the user reclaims it.
+//! One difference in the image GC: podman runs the labeled arm only. Docker's
+//! second arm exists for images built before the `fletch.agent` label shipped,
+//! and Podman support lands well after it — a Podman store can hold no
+//! pre-label Fletch image, so there is nothing for a legacy allowlist to match.
 
 use std::time::Duration;
 
 use crate::error::{Error, Result};
+use crate::sandbox::container::image_gc::{
+    current_tags, image_removal_refs, known_repos, parse_images_line, ImageRow, IMAGES_FORMAT,
+    RETIRED_REPOS,
+};
+use crate::sandbox::container::images::AGENT_IMAGE_LABEL;
 use crate::sandbox::container::labels::{
     agent_id_filter, orphaned_ids, HOST_PID_LABEL, INSPECT_FORMAT,
 };
@@ -74,7 +85,7 @@ fn sweep_orphans_on(connection: Option<&str>) -> Result<usize> {
 }
 
 /// Remove every container stamped with `fletch.agent-id=<agent_id>`, running or
-/// not. Returns the number removed.
+/// not, on every machine. Returns the number removed.
 ///
 /// The disposal counterpart to [`sweep_orphans`], and deliberately *without*
 /// its pid-liveness check: the caller has decided this specific agent is going
@@ -216,6 +227,91 @@ fn list_ids(connection: Option<&str>, filter: &str) -> Result<Vec<String>> {
         .collect())
 }
 
+/// Remove superseded Fletch agent images from every machine's store. One rule:
+/// an image carrying the `fletch.agent` label that is not one of the current
+/// expected tags is removed — old-hash tags from Dockerfile revisions and
+/// untagged leftovers from refresh rebuilds alike.
+///
+/// Fanned out like the container sweeps, and for the same reason turned up a
+/// level: image stores are per-machine too, so an unpinned pass would GC only
+/// whichever machine happens to be the default and leave every image a launch on
+/// another machine superseded sitting there forever.
+///
+/// Never touched: current tags, the user's `podman_image` override (excluded
+/// defensively even though it can't carry the label), any unlabeled image, and
+/// images in use by a container — `podman rmi` runs WITHOUT `-f`, so an in-use
+/// image fails removal, which is expected and logged at debug. Returns the number
+/// of images actually removed; callers treat all failures as non-fatal.
+pub(super) fn sweep_stale_images() -> Result<usize> {
+    across_machines("podman image sweep", sweep_stale_images_on)
+}
+
+/// One image-GC pass against a single connection's store — what
+/// [`sweep_stale_images`] fans out, and what a background refresh rebuild calls
+/// directly for the one store it just rebuilt in.
+pub(super) fn sweep_stale_images_on(connection: Option<&str>) -> Result<usize> {
+    let refs = image_removal_refs(
+        &list_images(
+            connection,
+            &[
+                "images",
+                "--filter",
+                &format!("label={AGENT_IMAGE_LABEL}"),
+                "--format",
+                IMAGES_FORMAT,
+            ],
+        )?,
+        // No legacy arm: see the module doc — a Podman store predates nothing.
+        &[],
+        &current_tags(),
+        &known_repos(),
+        RETIRED_REPOS,
+        &[],
+        super::settings::image_override().as_deref(),
+    );
+    if refs.is_empty() {
+        return Ok(0);
+    }
+
+    tracing::info!(
+        count = refs.len(),
+        "removing superseded fletch agent images from the podman store"
+    );
+    let mut removed = 0;
+    for image_ref in &refs {
+        // One rmi per image (not batched): a single in-use image must not taint
+        // the exit status the others report. No `-f` — an image backing a running
+        // container stays, by design.
+        let out = cli::run_podman_on(connection, &["rmi", image_ref], REMOVE_TIMEOUT)?;
+        if out.status.success() {
+            removed += 1;
+        } else {
+            tracing::debug!(
+                target: "fletch::podman",
+                image = %image_ref,
+                stderr = %String::from_utf8_lossy(&out.stderr).trim(),
+                "stale image not removed (expected when a container still uses it)",
+            );
+        }
+    }
+    Ok(removed)
+}
+
+/// Run one `podman images` listing on one connection and parse its rows.
+fn list_images(connection: Option<&str>, args: &[&str]) -> Result<Vec<ImageRow>> {
+    let out = cli::run_podman_on(connection, args, QUERY_TIMEOUT)?;
+    if !out.status.success() {
+        return Err(Error::Other(format!(
+            "podman images failed: {}",
+            String::from_utf8_lossy(&out.stderr).trim(),
+        )));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter_map(parse_images_line)
+        .collect())
+}
+
 /// `podman rm -f` over a batch of ids, on one connection.
 fn remove(connection: Option<&str>, ids: &[&str]) -> Result<()> {
     let mut rm_args = vec!["rm", "-f"];
@@ -307,5 +403,80 @@ mod tests {
         assert!(exists(&live_name), "live-instance container must survive");
 
         let _ = cli::run_podman(&["rm", "-f", &live_name], Duration::from_secs(30));
+    }
+
+    /// Integration: a labeled image under a Fletch repo with a non-current tag
+    /// is swept from podman's store; an unlabeled image outside Fletch's repos
+    /// survives. Also pins the one podman-side assumption the shared selection
+    /// rule rests on — that `podman images --format` prints the same three
+    /// whitespace-separated columns docker does, so [`parse_images_line`] reads
+    /// both.
+    ///
+    /// Runs against the default connection (`None`) throughout, which is where
+    /// the images it builds land; [`sweep_stale_images`]'s fan-out then covers it
+    /// as one of the connections it visits.
+    /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]
+    fn sweeps_stale_labeled_images_only() {
+        if !crate::sandbox::podman::podman_tests_enabled() {
+            return;
+        }
+        let build = |dockerfile: &str, tag: &str| {
+            let ctx = tempfile::tempdir().unwrap();
+            std::fs::write(ctx.path().join("Dockerfile"), dockerfile).unwrap();
+            let out = cli::run_podman(
+                &["build", "-t", tag, &ctx.path().to_string_lossy()],
+                Duration::from_secs(120),
+            )
+            .unwrap();
+            assert!(
+                out.status.success(),
+                "podman build failed: {}",
+                String::from_utf8_lossy(&out.stderr),
+            );
+        };
+        // A labeled image under Fletch's repo with a tag no provider owns —
+        // exactly what a superseded image looks like.
+        let stale_tag = "fletch-agent:000000000000";
+        build(
+            &format!("FROM busybox\nLABEL {AGENT_IMAGE_LABEL}=claude\n"),
+            stale_tag,
+        );
+        // An unlabeled image outside Fletch's repos: must survive.
+        let bystander = "fletch-gc-test-bystander:keep";
+        build("FROM busybox\nENV FLETCH_GC_TEST=1\n", bystander);
+
+        // The listing must parse before the sweep's verdict means anything.
+        let rows = list_images(
+            None,
+            &[
+                "images",
+                "--filter",
+                &format!("label={AGENT_IMAGE_LABEL}"),
+                "--format",
+                IMAGES_FORMAT,
+            ],
+        )
+        .unwrap();
+        assert!(
+            rows.iter()
+                .any(|r| r.repo == "fletch-agent" && r.tag == "000000000000"),
+            "podman's --format output must parse into the shared row shape: {rows:?}",
+        );
+
+        let removed = sweep_stale_images_on(None).unwrap();
+        assert!(removed >= 1, "the stale labeled image should be swept");
+
+        let exists = |tag: &str| {
+            cli::run_podman(&["image", "inspect", tag], Duration::from_secs(10))
+                .unwrap()
+                .status
+                .success()
+        };
+        assert!(!exists(stale_tag), "stale labeled image must be gone");
+        assert!(exists(bystander), "unlabeled non-fletch image must survive");
+
+        let _ = cli::run_podman(&["rmi", "-f", bystander], Duration::from_secs(30));
     }
 }

--- a/src-tauri/src/sandbox/podman/cleanup.rs
+++ b/src-tauri/src/sandbox/podman/cleanup.rs
@@ -7,6 +7,12 @@
 //! *this* agent?" (archive/discard). The label parsing and the under-reclaim
 //! bias are shared with docker; only the invocations differ.
 //!
+//! One invocation shape does differ in kind: docker has a single daemon, while
+//! podman has one container store per machine and launches pin themselves to
+//! the connection they resolved at the time (see [`super::machine`]). Asking
+//! only the current default would strand containers on every other machine, so
+//! both sweeps run once per machine connection.
+//!
 //! No image GC here — Podman ships without one for now, so a superseded agent
 //! image stays in the local store until the user reclaims it.
 
@@ -27,11 +33,18 @@ const QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 /// batched removal room without letting a hung machine pin the sweep thread.
 const REMOVE_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Remove every fletch-labeled container whose owning host instance is dead.
-/// Returns the number removed. Callers gate on the probe and run this off the
-/// main thread — see [`super::sweep_orphans_at_startup`].
+/// Remove every fletch-labeled container whose owning host instance is dead,
+/// across every machine — a launch is pinned to the connection it resolved at
+/// the time, so yesterday's containers can sit on a machine that is no longer
+/// the default. Returns the number removed. Callers gate on the probe and run
+/// this off the main thread — see [`super::sweep_orphans_at_startup`].
 pub(super) fn sweep_orphans() -> Result<usize> {
-    let ids = list_ids(&format!("label={HOST_PID_LABEL}"))?;
+    across_machines("podman orphan sweep", sweep_orphans_on)
+}
+
+/// One sweep pass against a single connection.
+fn sweep_orphans_on(connection: Option<&str>) -> Result<usize> {
+    let ids = list_ids(connection, &format!("label={HOST_PID_LABEL}"))?;
     if ids.is_empty() {
         return Ok(0);
     }
@@ -39,7 +52,7 @@ pub(super) fn sweep_orphans() -> Result<usize> {
     let id_refs: Vec<&str> = ids.iter().map(String::as_str).collect();
     let mut inspect_args = vec!["inspect", "-f", INSPECT_FORMAT];
     inspect_args.extend(&id_refs);
-    let inspected = cli::run_podman(&inspect_args, QUERY_TIMEOUT)?;
+    let inspected = cli::run_podman_on(connection, &inspect_args, QUERY_TIMEOUT)?;
     // Don't require a zero exit: inspect exits non-zero if ANY id vanished
     // between ps and inspect (e.g. a `--rm` container finishing), but still
     // prints the rows it found — those are the ones we act on.
@@ -53,7 +66,10 @@ pub(super) fn sweep_orphans() -> Result<usize> {
         count = orphans.len(),
         "removing podman containers of dead fletch instances"
     );
-    remove(&orphans.iter().map(String::as_str).collect::<Vec<_>>())?;
+    remove(
+        connection,
+        &orphans.iter().map(String::as_str).collect::<Vec<_>>(),
+    )?;
     Ok(orphans.len())
 }
 
@@ -72,7 +88,14 @@ pub(super) fn sweep_orphans() -> Result<usize> {
 /// ([`container::util::container_name`](crate::sandbox::container::util::container_name)),
 /// so only the launching process ever knew them.
 pub fn remove_agent_containers(agent_id: &str) -> Result<usize> {
-    let ids = list_ids(&agent_id_filter(agent_id))?;
+    across_machines("podman disposal removal", |connection| {
+        remove_agent_containers_on(connection, agent_id)
+    })
+}
+
+/// One removal pass against a single connection.
+fn remove_agent_containers_on(connection: Option<&str>, agent_id: &str) -> Result<usize> {
+    let ids = list_ids(connection, &agent_id_filter(agent_id))?;
     if ids.is_empty() {
         return Ok(0);
     }
@@ -81,13 +104,104 @@ pub fn remove_agent_containers(agent_id: &str) -> Result<usize> {
         count = ids.len(),
         "removing podman containers of a disposed agent"
     );
-    remove(&ids.iter().map(String::as_str).collect::<Vec<_>>())?;
+    remove(
+        connection,
+        &ids.iter().map(String::as_str).collect::<Vec<_>>(),
+    )?;
     Ok(ids.len())
 }
 
-/// Container ids matching one `--filter` expression.
-fn list_ids(filter: &str) -> Result<Vec<String>> {
-    let list = cli::run_podman(&["ps", "-aq", "--filter", filter], QUERY_TIMEOUT)?;
+/// Run `pass` once per machine connection and total what it reclaimed, or once
+/// unpinned when there are no machine connections (native Linux, where the
+/// single local endpoint is the whole story).
+///
+/// Best-effort per connection, in keeping with the under-reclaim bias: a
+/// stopped or wedged machine logs and the remaining ones still get swept —
+/// stopping at the first failure would leave reclaimable containers on
+/// machines that answer fine.
+fn across_machines(
+    what: &str,
+    mut pass: impl FnMut(Option<&str>) -> Result<usize>,
+) -> Result<usize> {
+    let connections = machine_connections();
+    if connections.is_empty() {
+        return pass(None);
+    }
+    let mut total = 0;
+    for connection in &connections {
+        match pass(Some(connection)) {
+            Ok(n) => total += n,
+            Err(e) => tracing::warn!(
+                target: "fletch::podman",
+                connection = %connection,
+                error = %e,
+                "{what} failed on this connection",
+            ),
+        }
+    }
+    Ok(total)
+}
+
+/// One connection name per Podman machine, from
+/// `podman system connection list --format json`. Anything we can't run or read
+/// yields none, which the caller reads as "just use the default".
+fn machine_connections() -> Vec<String> {
+    let Ok(out) = cli::run_podman(
+        &["system", "connection", "list", "--format", "json"],
+        QUERY_TIMEOUT,
+    ) else {
+        return Vec::new();
+    };
+    if !out.status.success() {
+        return Vec::new();
+    }
+    parse_machine_connections(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// The machine connection names in a connection listing: entries not explicitly
+/// `IsMachine: false` (older podman omits the field, and a non-machine entry is
+/// a socket or a remote host, neither of which is ours to sweep).
+///
+/// Each machine appears twice, as `<machine>` and `<machine>-root`. Both list
+/// containers of the same machine, so the pair collapses to whichever podman
+/// listed first — sweeping both would ask the same machine twice.
+fn parse_machine_connections(stdout: &str) -> Vec<String> {
+    let Ok(connections) = serde_json::from_str::<Vec<serde_json::Value>>(stdout) else {
+        return Vec::new();
+    };
+    let mut seen: Vec<&str> = Vec::new();
+    let mut out: Vec<String> = Vec::new();
+    for connection in &connections {
+        if connection.get("IsMachine").and_then(|m| m.as_bool()) == Some(false) {
+            continue;
+        }
+        let Some(name) = connection
+            .get("Name")
+            .and_then(|n| n.as_str())
+            .map(str::trim)
+        else {
+            continue;
+        };
+        if name.is_empty() {
+            continue;
+        }
+        let machine = name.strip_suffix("-root").unwrap_or(name);
+        if seen.contains(&machine) {
+            continue;
+        }
+        seen.push(machine);
+        out.push(name.to_string());
+    }
+    out
+}
+
+/// Container ids matching one `--filter` expression, on one connection.
+fn list_ids(connection: Option<&str>, filter: &str) -> Result<Vec<String>> {
+    let list = cli::run_podman_on(
+        connection,
+        &["ps", "-aq", "--filter", filter],
+        QUERY_TIMEOUT,
+    )?;
     if !list.status.success() {
         return Err(Error::Other(format!(
             "podman ps failed: {}",
@@ -102,11 +216,11 @@ fn list_ids(filter: &str) -> Result<Vec<String>> {
         .collect())
 }
 
-/// `podman rm -f` over a batch of ids.
-fn remove(ids: &[&str]) -> Result<()> {
+/// `podman rm -f` over a batch of ids, on one connection.
+fn remove(connection: Option<&str>, ids: &[&str]) -> Result<()> {
     let mut rm_args = vec!["rm", "-f"];
     rm_args.extend(ids);
-    let removed = cli::run_podman(&rm_args, REMOVE_TIMEOUT)?;
+    let removed = cli::run_podman_on(connection, &rm_args, REMOVE_TIMEOUT)?;
     if !removed.status.success() {
         return Err(Error::Other(format!(
             "podman rm failed: {}",
@@ -120,6 +234,34 @@ fn remove(ids: &[&str]) -> Result<()> {
 mod tests {
     use super::*;
     use crate::sandbox::container::labels::host_pid_label;
+
+    /// The sweep set is one connection per machine: rootful pairs collapse
+    /// (both name the same container store), non-machine entries are somebody
+    /// else's containers, and an unreadable listing leaves the caller with the
+    /// default connection alone.
+    #[test]
+    fn machine_connections_are_one_per_machine() {
+        let listing = r#"[
+          { "Name": "podman-machine-default", "IsMachine": true, "Default": true },
+          { "Name": "podman-machine-default-root", "IsMachine": true, "Default": false },
+          { "Name": "work-vm-root", "IsMachine": true, "Default": false },
+          { "Name": "work-vm", "IsMachine": true, "Default": false },
+          { "Name": "build-box", "IsMachine": false, "Default": false, "URI": "ssh://core@build.example.com:22/run/podman/podman.sock" },
+          { "Name": "local", "IsMachine": false, "Default": false, "URI": "unix:///run/podman/podman.sock" },
+          { "Name": "  ", "IsMachine": true },
+          { "IsMachine": true },
+          { "Name": "legacy-no-flag" }
+        ]"#;
+        assert_eq!(
+            parse_machine_connections(listing),
+            ["podman-machine-default", "work-vm-root", "legacy-no-flag"],
+        );
+
+        assert!(parse_machine_connections("[]").is_empty());
+        assert!(parse_machine_connections("").is_empty());
+        assert!(parse_machine_connections("Error: no such thing").is_empty());
+        assert!(parse_machine_connections(r#"{"Name":"m"}"#).is_empty());
+    }
 
     /// Integration: a container labeled with a dead pid is swept; one labeled
     /// with our own (live) pid survives.

--- a/src-tauri/src/sandbox/podman/cli.rs
+++ b/src-tauri/src/sandbox/podman/cli.rs
@@ -16,11 +16,11 @@
 //!    and lives in [`container::proc`](crate::sandbox::container::proc); what's
 //!    here is the thin Podman-specific layer over it.
 
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::time::Duration;
 
 use crate::error::{Error, Result};
-use crate::sandbox::container::proc::run_with_timeout;
+use crate::sandbox::container::proc::{forward_lines, run_with_timeout, wait_with_deadline};
 
 /// Absolute path of the podman CLI, or `None` when it isn't installed.
 /// Resolved fresh on every call (the underlying login-shell env is cached, so
@@ -43,4 +43,50 @@ pub(super) fn run_podman(args: &[&str], timeout: Duration) -> Result<Output> {
     cmd.args(args);
     let what = format!("podman {}", args.first().copied().unwrap_or_default());
     run_with_timeout(cmd, timeout, &what)
+}
+
+/// Run `podman <args>` streaming every output line (stdout and stderr) to
+/// `on_line` as it appears — the shape `podman build` needs so a minutes-long
+/// image build reaches the log while it runs. Fails on non-zero exit with the
+/// last output lines in the message, or on `timeout` expiry.
+pub(super) fn run_podman_streaming(
+    args: &[&str],
+    timeout: Duration,
+    on_line: &(dyn Fn(&str) + Send + Sync),
+) -> Result<()> {
+    let bin = podman_bin()
+        .ok_or_else(|| Error::Other("podman binary not found — is Podman installed?".into()))?;
+    let what = format!("podman {}", args.first().copied().unwrap_or_default());
+    let mut child = Command::new(bin)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+    let stdout = child.stdout.take().expect("stdout piped above");
+    let stderr = child.stderr.take().expect("stderr piped above");
+
+    // Keep a bounded tail of everything seen, so a failure message carries the
+    // actual podman error (which lands near the end of the stream) without
+    // buffering an entire multi-minute build log.
+    let tail = std::sync::Mutex::new(std::collections::VecDeque::<String>::new());
+
+    // Scoped threads: the readers borrow `on_line` and `tail`, and both pipes
+    // are drained continuously so the child can never block on a full pipe
+    // while we sit in the wait loop below.
+    let status = std::thread::scope(|scope| {
+        scope.spawn(|| forward_lines(stdout, on_line, &tail));
+        scope.spawn(|| forward_lines(stderr, on_line, &tail));
+        wait_with_deadline(&mut child, timeout, &what)
+    })?;
+
+    if !status.success() {
+        let tail = tail.lock().unwrap();
+        return Err(Error::Other(format!(
+            "{what} failed (exit {}):\n{}",
+            status.code().unwrap_or(-1),
+            tail.iter().cloned().collect::<Vec<_>>().join("\n"),
+        )));
+    }
+    Ok(())
 }

--- a/src-tauri/src/sandbox/podman/cli.rs
+++ b/src-tauri/src/sandbox/podman/cli.rs
@@ -32,24 +32,44 @@ pub(super) fn podman_bin() -> Option<std::path::PathBuf> {
     crate::bin_resolve::resolve_bin("podman", &home).map(std::path::PathBuf::from)
 }
 
-/// Run `podman <args>` capturing stdout/stderr, failing after `timeout`.
-/// Returns the raw `Output` — callers inspect the exit status themselves, since
-/// several podman commands use non-zero exits as answers (e.g. `image inspect`
-/// on a missing image), not as errors.
+/// Run `podman <args>` on whichever connection is the default. For anything
+/// belonging to one container's lifetime, use [`run_podman_on`] with that
+/// container's pinned connection instead — the default can change mid-run.
 pub(super) fn run_podman(args: &[&str], timeout: Duration) -> Result<Output> {
+    run_podman_on(None, args, timeout)
+}
+
+/// Run `podman [--connection <name>] <args>` capturing stdout/stderr, failing
+/// after `timeout`. Returns the raw `Output` — callers inspect the exit status
+/// themselves, since several podman commands use non-zero exits as answers
+/// (e.g. `image inspect` on a missing image), not as errors.
+///
+/// The pin is a *global* flag, so it goes ahead of the subcommand; the error
+/// label still names the subcommand, which is the part a user can act on.
+pub(super) fn run_podman_on(
+    connection: Option<&str>,
+    args: &[&str],
+    timeout: Duration,
+) -> Result<Output> {
     let bin = podman_bin()
         .ok_or_else(|| Error::Other("podman binary not found — is Podman installed?".into()))?;
     let mut cmd = Command::new(bin);
+    if let Some(connection) = connection {
+        cmd.args(["--connection", connection]);
+    }
     cmd.args(args);
     let what = format!("podman {}", args.first().copied().unwrap_or_default());
     run_with_timeout(cmd, timeout, &what)
 }
 
-/// Run `podman <args>` streaming every output line (stdout and stderr) to
-/// `on_line` as it appears — the shape `podman build` needs so a minutes-long
-/// image build reaches the log while it runs. Fails on non-zero exit with the
-/// last output lines in the message, or on `timeout` expiry.
+/// Run `podman [--connection <name>] <args>` streaming every output line
+/// (stdout and stderr) to `on_line` as it appears — the shape `podman build`
+/// needs so a minutes-long image build reaches the log while it runs. Fails on
+/// non-zero exit with the last output lines in the message, or on `timeout`
+/// expiry. `connection` matters here too: images live per-machine, so a build
+/// has to land on the machine the run will use.
 pub(super) fn run_podman_streaming(
+    connection: Option<&str>,
     args: &[&str],
     timeout: Duration,
     on_line: &(dyn Fn(&str) + Send + Sync),
@@ -57,7 +77,11 @@ pub(super) fn run_podman_streaming(
     let bin = podman_bin()
         .ok_or_else(|| Error::Other("podman binary not found — is Podman installed?".into()))?;
     let what = format!("podman {}", args.first().copied().unwrap_or_default());
-    let mut child = Command::new(bin)
+    let mut cmd = Command::new(bin);
+    if let Some(connection) = connection {
+        cmd.args(["--connection", connection]);
+    }
+    let mut child = cmd
         .args(args)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())

--- a/src-tauri/src/sandbox/podman/engine.rs
+++ b/src-tauri/src/sandbox/podman/engine.rs
@@ -1,0 +1,363 @@
+//! The Podman sandbox engine: one container per agent process, agent ≈ PID 1.
+//!
+//! Behaviourally the Docker engine with a different binary. Every invariant
+//! [`docker::engine`](crate::sandbox::docker) documents holds here unchanged and
+//! for the same reason, because the parts that carry them are the same code:
+//! the mounts, env and auth come from
+//! [`container::launch`](crate::sandbox::container::launch), the argv from
+//! [`container::run_args`](crate::sandbox::container::run_args), the labels from
+//! [`container::labels`](crate::sandbox::container::labels), and the image
+//! content from [`container::images`](crate::sandbox::container::images). What
+//! this file adds is the podman binary, the podman teardown commands, and one
+//! Podman-specific reliability gate.
+//!
+//! **The machine preflight.** Podman's macOS VM sees only the host directories
+//! the machine shares, and a bind mount from outside them silently yields an
+//! empty dir rather than an error (see [`super::machine`]). Docker Desktop has
+//! no equivalent failure — its VM shares the whole filesystem — so this check
+//! exists on this side only, and it runs before the launch rather than after so
+//! the user gets the path instead of a broken checkout.
+//!
+//! Containers run as root, like Docker's: the launch is shared, and podman's
+//! rootless mode is a narrowing the guarantee declarations already account for
+//! (see `sandbox::guarantees`).
+
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::Duration;
+
+use crate::error::{Error, Result};
+use crate::sandbox::container::run_args::{
+    mount_sources, run_args, RunSpec, DEFAULT_CPUS, DEFAULT_MEMORY,
+};
+use crate::sandbox::container::util::{container_name, describe_exit_code, ExitCopy};
+use crate::sandbox::container::ContainerProvider;
+use crate::sandbox::engine::{
+    AgentLaunchCtx, EngineKind, KillHandle, KillPlan, LaunchPlan, SandboxEngine,
+};
+
+use super::{cli, image, machine};
+
+/// Signal/removal podman calls during teardown.
+const KILL_TIMEOUT: Duration = Duration::from_secs(10);
+/// How long a TERM'd container gets to exit before escalating to KILL — same
+/// order as the session-side process-group escalation grace windows.
+const TERM_GRACE: Duration = Duration::from_millis(500);
+/// Liveness lookups (`podman inspect`).
+const INSPECT_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Podman's wording for the shared reserved-exit-code messages. `image_setting`
+/// is `None`: Podman honors no image override, so pointing the user at one
+/// would name a setting this engine ignores.
+const EXIT_COPY: ExitCopy = ExitCopy {
+    runtime: "Podman",
+    error_source: "the machine",
+    remedy: "Is the Podman machine running?",
+    image_setting: None,
+};
+
+/// The `SandboxEngine` implementation for Podman. Obtain it via
+/// [`PodmanEngine::shared`]: launches embed an `Arc` of the engine in their
+/// [`KillHandle`], and sharing one instance also shares the once-per-app-run
+/// image resolution cache.
+pub struct PodmanEngine {
+    /// Images resolved for this app run, keyed by provider so each provider's
+    /// image is resolved (and built) at most once. Only successes are cached —
+    /// a failed build retries on the next spawn (the user may have started the
+    /// machine or fixed their network since).
+    resolved_image: Mutex<std::collections::HashMap<ContainerProvider, String>>,
+}
+
+impl PodmanEngine {
+    /// The process-wide engine instance — the same `Arc` that `engine_for`
+    /// hands to launch paths and that every launch parks in its `KillHandle`.
+    pub fn shared() -> Arc<PodmanEngine> {
+        static ENGINE: OnceLock<Arc<PodmanEngine>> = OnceLock::new();
+        ENGINE
+            .get_or_init(|| {
+                Arc::new(PodmanEngine {
+                    resolved_image: Mutex::new(std::collections::HashMap::new()),
+                })
+            })
+            .clone()
+    }
+
+    /// The image to launch `provider` from, resolving (and building, if the
+    /// local store lacks it) at most once per app run.
+    fn resolve_image_cached(&self, provider: ContainerProvider) -> Result<String> {
+        let mut cache = self.resolved_image.lock().unwrap();
+        if let Some(tag) = cache.get(&provider) {
+            return Ok(tag.clone());
+        }
+        // Free-form build output rides in the `line` field (not the message) so
+        // the sentry scrubber drops it — see the privacy invariant in `lib.rs`.
+        let on_progress = |line: &str| tracing::info!(target: "fletch::podman_build", line = %line, "podman build output");
+        let tag = image::resolve_image(provider, &on_progress)
+            .map_err(|e| Error::Other(format!("preparing the Podman sandbox image failed: {e}")))?;
+        cache.insert(provider, tag.clone());
+        Ok(tag)
+    }
+}
+
+impl SandboxEngine for PodmanEngine {
+    fn kind(&self) -> EngineKind {
+        EngineKind::Podman
+    }
+
+    /// Launch a container for `ctx.provider`. Identical to the Docker engine's
+    /// launch but for the binary, the resolved image, and the machine
+    /// preflight. `ensure_engine_supports_provider` gates this to a supported
+    /// provider, so the `from_id` failure below is defensive only.
+    fn launch_agent(&self, ctx: &AgentLaunchCtx, agent_bin: &str) -> Result<LaunchPlan> {
+        let provider = ContainerProvider::from_id(ctx.provider).ok_or_else(|| {
+            Error::Other(format!(
+                "Podman sandbox has no support for provider `{}`",
+                ctx.provider
+            ))
+        })?;
+        let podman = cli::podman_bin()
+            .ok_or_else(|| Error::Other("podman binary not found — is Podman installed?".into()))?;
+        let image = self.resolve_image_cached(provider)?;
+        let name = container_name(ctx.agent_id);
+        let prep = crate::sandbox::container::launch::prepare(ctx, provider)?;
+
+        let prefix_args = {
+            let auth_vars = prep.auth_vars();
+            let spec = RunSpec {
+                interactive: ctx.interactive,
+                name: &name,
+                agent_id: ctx.agent_id,
+                writable_root: ctx.writable_root,
+                rpc_dir: ctx.rpc_dir,
+                home: ctx.home,
+                cwd: ctx.cwd,
+                blackboard: ctx.blackboard,
+                mounts: prep.mounts(),
+                borrowed_object_stores: &prep.borrowed_object_stores,
+                // No podman-side memory/cpus settings surface yet: the shared
+                // launch defaults apply.
+                memory: DEFAULT_MEMORY,
+                cpus: DEFAULT_CPUS,
+                image: &image,
+                agent_bin,
+                auth_vars: &auth_vars,
+            };
+            // Before the run, not after: an unshared source mounts empty rather
+            // than failing, so the launch has to be refused while we can still
+            // name the path.
+            machine::ensure_sources_are_shared(&mount_sources(&spec))?;
+            run_args(&spec)
+        };
+
+        Ok(LaunchPlan {
+            program: podman,
+            prefix_args,
+            env: prep.env,
+            kill: KillHandle::Engine {
+                engine: PodmanEngine::shared(),
+                plan: KillPlan::Container { name },
+            },
+        })
+    }
+
+    /// Tear the container down: TERM, a grace window, then KILL, then a
+    /// best-effort `rm -f`. Best-effort throughout and always `Ok` — the
+    /// container is usually already gone (`--rm`, machine stopped, normal
+    /// exit), and an error here would abort the caller's local process-group
+    /// teardown of the podman CLI child.
+    fn kill(&self, plan: &KillPlan) -> Result<()> {
+        let KillPlan::Container { name } = plan;
+        match cli::run_podman(&["kill", "-s", "TERM", name], KILL_TIMEOUT) {
+            Ok(out) if out.status.success() => {
+                if !container_gone_within(name, TERM_GRACE) {
+                    tracing::info!(container = %name, "container survived TERM grace; escalating to KILL");
+                    let _ = cli::run_podman(&["kill", name], KILL_TIMEOUT);
+                }
+            }
+            // Non-zero exit = "no such container" (already exited and
+            // auto-removed) — nothing to escalate.
+            Ok(_) => {}
+            Err(e) => tracing::warn!(container = %name, error = %e, "podman kill failed"),
+        }
+        // Usually a no-op thanks to --rm; covers a wedged auto-remove.
+        let _ = cli::run_podman(&["rm", "-f", name], KILL_TIMEOUT);
+        Ok(())
+    }
+
+    fn describe_exit(&self, _plan: &KillPlan, code: i32) -> Option<String> {
+        describe_exit_code(code, &EXIT_COPY)
+    }
+}
+
+/// Whether podman says the container is currently running. Errors (container
+/// gone, machine down, timeout) read as not running.
+fn container_running(name: &str) -> bool {
+    match cli::run_podman(
+        &["inspect", "-f", "{{.State.Running}}", name],
+        INSPECT_TIMEOUT,
+    ) {
+        Ok(out) => out.status.success() && String::from_utf8_lossy(&out.stdout).trim() == "true",
+        Err(e) => {
+            tracing::debug!(container = %name, error = %e, "podman inspect failed; treating as dead");
+            false
+        }
+    }
+}
+
+/// Poll until the container stops running or `budget` elapses.
+fn container_gone_within(name: &str, budget: Duration) -> bool {
+    let deadline = std::time::Instant::now() + budget;
+    loop {
+        if !container_running(name) {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::container::run_args::prepare_config_mount_dir;
+    use std::path::PathBuf;
+
+    /// Podman's exit-code wording names the machine (it has no daemon) and
+    /// points at `podman machine`, while still hedging that the code may be the
+    /// agent's own. No `docker_image` mention — this engine honors no override.
+    #[test]
+    fn exit_code_wording_is_podman_shaped() {
+        let daemon = describe_exit_code(125, &EXIT_COPY).unwrap();
+        assert!(daemon.contains("Podman"), "{daemon}");
+        assert!(daemon.contains("Podman machine"), "{daemon}");
+        for code in [125, 126, 127] {
+            let msg = describe_exit_code(code, &EXIT_COPY).unwrap();
+            assert!(msg.contains("agent itself exited"), "must hedge: {msg}");
+            assert!(!msg.contains("docker"), "{msg}");
+        }
+        assert_eq!(describe_exit_code(1, &EXIT_COPY), None);
+    }
+
+    /// Integration: a real `podman run` through the engine's own launch plan
+    /// round-trips a marker file the host wrote into the workspace mount, which
+    /// is the whole path-identity contract in one assertion.
+    /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]
+    fn podman_run_echo_round_trip() {
+        if !crate::sandbox::podman::podman_tests_enabled() {
+            return;
+        }
+        // Under `$HOME`, not `$TMPDIR`: the machine shares `$HOME` by default,
+        // and a mount from outside its shares would come up *empty* rather than
+        // failing — the exact confusion `machine::ensure_sources_are_shared`
+        // exists to head off, and it would make this test's failure unreadable.
+        let td = tempfile::tempdir_in(dirs::home_dir().unwrap()).unwrap();
+        let root = td.path().join("workspace");
+        let rpc = td.path().join("rpc");
+        let home = td.path().join("home");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::create_dir_all(&rpc).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::write(root.join("marker.txt"), "hello from the host\n").unwrap();
+        prepare_config_mount_dir(&home.join(".claude")).unwrap();
+        machine::ensure_sources_are_shared(&[root.clone(), rpc.clone(), home.clone()]).unwrap();
+
+        let name = container_name("podman-int-test");
+        let projects = root.join("projects-src");
+        std::fs::create_dir_all(&projects).unwrap();
+        let args = run_args(&RunSpec {
+            interactive: false,
+            name: &name,
+            agent_id: "podman-int-test",
+            writable_root: &root,
+            rpc_dir: &rpc,
+            home: &home,
+            cwd: &root,
+            blackboard: None,
+            mounts: crate::sandbox::container::run_args::ProviderMounts::Claude {
+                config_dir: None,
+                credentials_rw: false,
+                config_dir_credentials_rw: false,
+                projects_src: &projects,
+            },
+            borrowed_object_stores: &[],
+            memory: DEFAULT_MEMORY,
+            cpus: DEFAULT_CPUS,
+            image: "busybox",
+            agent_bin: "cat",
+            auth_vars: &[],
+        });
+        let mut argv: Vec<&str> = args.iter().map(String::as_str).collect();
+        let marker = root.join("marker.txt").to_string_lossy().into_owned();
+        argv.push(&marker);
+
+        let out = cli::run_podman(&argv, Duration::from_secs(120)).unwrap();
+        assert!(
+            out.status.success(),
+            "podman run failed: {}",
+            String::from_utf8_lossy(&out.stderr),
+        );
+        assert_eq!(
+            String::from_utf8_lossy(&out.stdout).trim(),
+            "hello from the host",
+            "the workspace must be readable at its identical host path",
+        );
+    }
+
+    /// Integration: the engine's kill escalation actually stops a live
+    /// container, and the liveness probe tracks it both ways.
+    /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]
+    fn kill_and_liveness_against_live_container() {
+        if !crate::sandbox::podman::podman_tests_enabled() {
+            return;
+        }
+        let name = container_name("podman-kill-test");
+        let out = cli::run_podman(
+            &[
+                "run", "-d", "--rm", "--name", &name, "busybox", "sleep", "120",
+            ],
+            Duration::from_secs(120),
+        )
+        .unwrap();
+        assert!(
+            out.status.success(),
+            "podman run failed: {}",
+            String::from_utf8_lossy(&out.stderr),
+        );
+        assert!(
+            container_running(&name),
+            "a started container reads as live"
+        );
+
+        PodmanEngine::shared()
+            .kill(&KillPlan::Container { name: name.clone() })
+            .unwrap();
+        assert!(!container_running(&name), "killed container reads as dead");
+    }
+
+    /// Integration: the preflight accepts a path under the machine's shares and
+    /// refuses one outside them, naming the offending path. Skipped on a host
+    /// with no machine (native Linux), where the check is inert by design.
+    /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]
+    fn machine_preflight_refuses_unshared_sources() {
+        if !crate::sandbox::podman::podman_tests_enabled() {
+            return;
+        }
+        let home = dirs::home_dir().unwrap();
+        if machine::ensure_sources_are_shared(std::slice::from_ref(&home)).is_err() {
+            return; // no machine, or $HOME isn't shared: nothing to assert
+        }
+        let outside = PathBuf::from("/fletch-definitely-not-shared");
+        let err = machine::ensure_sources_are_shared(std::slice::from_ref(&outside)).unwrap_err();
+        assert!(
+            err.to_string().contains(&outside.display().to_string()),
+            "the refusal must name the path: {err}",
+        );
+    }
+}

--- a/src-tauri/src/sandbox/podman/engine.rs
+++ b/src-tauri/src/sandbox/podman/engine.rs
@@ -60,11 +60,14 @@ const EXIT_COPY: ExitCopy = ExitCopy {
 /// [`KillHandle`], and sharing one instance also shares the once-per-app-run
 /// image resolution cache.
 pub struct PodmanEngine {
-    /// Images resolved for this app run, keyed by provider so each provider's
-    /// image is resolved (and built) at most once. Only successes are cached —
-    /// a failed build retries on the next spawn (the user may have started the
-    /// machine or fixed their network since).
-    resolved_image: Mutex<std::collections::HashMap<ContainerProvider, String>>,
+    /// Images resolved for this app run, keyed by provider *and* connection so
+    /// each provider's image is resolved (and built) at most once per machine.
+    /// The connection is part of the key because image stores are per-machine:
+    /// a tag present on one says nothing about another, and a launch pinned
+    /// elsewhere would run on an image that isn't there. Only successes are
+    /// cached — a failed build retries on the next spawn (the user may have
+    /// started the machine or fixed their network since).
+    resolved_image: Mutex<std::collections::HashMap<(ContainerProvider, Option<String>), String>>,
 }
 
 impl PodmanEngine {
@@ -81,21 +84,38 @@ impl PodmanEngine {
             .clone()
     }
 
-    /// The image to launch `provider` from, resolving (and building, if the
-    /// local store lacks it) at most once per app run.
-    fn resolve_image_cached(&self, provider: ContainerProvider) -> Result<String> {
+    /// The image to launch `provider` from on `connection`, resolving (and
+    /// building, if that machine's store lacks it) at most once per app run.
+    fn resolve_image_cached(
+        &self,
+        provider: ContainerProvider,
+        connection: Option<&str>,
+    ) -> Result<String> {
+        let key = (provider, connection.map(str::to_string));
         let mut cache = self.resolved_image.lock().unwrap();
-        if let Some(tag) = cache.get(&provider) {
+        if let Some(tag) = cache.get(&key) {
             return Ok(tag.clone());
         }
         // Free-form build output rides in the `line` field (not the message) so
         // the sentry scrubber drops it — see the privacy invariant in `lib.rs`.
         let on_progress = |line: &str| tracing::info!(target: "fletch::podman_build", line = %line, "podman build output");
-        let tag = image::resolve_image(provider, &on_progress)
+        let tag = image::resolve_image(provider, connection, &on_progress)
             .map_err(|e| Error::Other(format!("preparing the Podman sandbox image failed: {e}")))?;
-        cache.insert(provider, tag.clone());
+        cache.insert(key, tag.clone());
         Ok(tag)
     }
+}
+
+/// `run_argv` with this launch's connection pin ahead of it. `--connection` is a
+/// *global* flag, so it precedes the subcommand — appending it after `run` would
+/// make podman read it as a container argument. An unpinned target adds nothing.
+fn pinned_argv(connection: Option<&str>, run_argv: Vec<String>) -> Vec<String> {
+    let Some(connection) = connection else {
+        return run_argv;
+    };
+    let mut argv = vec!["--connection".to_string(), connection.to_string()];
+    argv.extend(run_argv);
+    argv
 }
 
 impl SandboxEngine for PodmanEngine {
@@ -104,9 +124,10 @@ impl SandboxEngine for PodmanEngine {
     }
 
     /// Launch a container for `ctx.provider`. Identical to the Docker engine's
-    /// launch but for the binary, the resolved image, and the machine
-    /// preflight. `ensure_engine_supports_provider` gates this to a supported
-    /// provider, so the `from_id` failure below is defensive only.
+    /// launch but for the binary, the resolved image, the machine preflight,
+    /// and the connection pin that ties those to the run.
+    /// `ensure_engine_supports_provider` gates this to a supported provider, so
+    /// the `from_id` failure below is defensive only.
     fn launch_agent(&self, ctx: &AgentLaunchCtx, agent_bin: &str) -> Result<LaunchPlan> {
         let provider = ContainerProvider::from_id(ctx.provider).ok_or_else(|| {
             Error::Other(format!(
@@ -116,7 +137,12 @@ impl SandboxEngine for PodmanEngine {
         })?;
         let podman = cli::podman_bin()
             .ok_or_else(|| Error::Other("podman binary not found — is Podman installed?".into()))?;
-        let image = self.resolve_image_cached(provider)?;
+        // Resolved before the image: everything this launch touches — the image
+        // store, the mount check, the run, the teardown — has to be the one
+        // endpoint named here, and a remote default is refused before any of it.
+        let target = machine::resolve_launch_target()?;
+        let connection = target.connection.clone();
+        let image = self.resolve_image_cached(provider, connection.as_deref())?;
         let name = container_name(ctx.agent_id);
         let prep = crate::sandbox::container::launch::prepare(ctx, provider)?;
 
@@ -144,8 +170,8 @@ impl SandboxEngine for PodmanEngine {
             // Before the run, not after: an unshared source mounts empty rather
             // than failing, so the launch has to be refused while we can still
             // name the path.
-            machine::ensure_sources_are_shared(&mount_sources(&spec))?;
-            run_args(&spec)
+            machine::ensure_sources_are_shared(&mount_sources(&spec), &target)?;
+            pinned_argv(connection.as_deref(), run_args(&spec))
         };
 
         Ok(LaunchPlan {
@@ -154,7 +180,7 @@ impl SandboxEngine for PodmanEngine {
             env: prep.env,
             kill: KillHandle::Engine {
                 engine: PodmanEngine::shared(),
-                plan: KillPlan::Container { name },
+                plan: KillPlan::Container { name, connection },
             },
         })
     }
@@ -165,12 +191,16 @@ impl SandboxEngine for PodmanEngine {
     /// exit), and an error here would abort the caller's local process-group
     /// teardown of the podman CLI child.
     fn kill(&self, plan: &KillPlan) -> Result<()> {
-        let KillPlan::Container { name } = plan;
-        match cli::run_podman(&["kill", "-s", "TERM", name], KILL_TIMEOUT) {
+        // Every call here rides the connection the launch pinned, not the
+        // current default: the container lives on one machine, and a default
+        // that moved since would leave us signalling into the wrong one.
+        let KillPlan::Container { name, connection } = plan;
+        let on = connection.as_deref();
+        match cli::run_podman_on(on, &["kill", "-s", "TERM", name], KILL_TIMEOUT) {
             Ok(out) if out.status.success() => {
-                if !container_gone_within(name, TERM_GRACE) {
+                if !container_gone_within(name, on, TERM_GRACE) {
                     tracing::info!(container = %name, "container survived TERM grace; escalating to KILL");
-                    let _ = cli::run_podman(&["kill", name], KILL_TIMEOUT);
+                    let _ = cli::run_podman_on(on, &["kill", name], KILL_TIMEOUT);
                 }
             }
             // Non-zero exit = "no such container" (already exited and
@@ -179,7 +209,7 @@ impl SandboxEngine for PodmanEngine {
             Err(e) => tracing::warn!(container = %name, error = %e, "podman kill failed"),
         }
         // Usually a no-op thanks to --rm; covers a wedged auto-remove.
-        let _ = cli::run_podman(&["rm", "-f", name], KILL_TIMEOUT);
+        let _ = cli::run_podman_on(on, &["rm", "-f", name], KILL_TIMEOUT);
         Ok(())
     }
 
@@ -188,10 +218,12 @@ impl SandboxEngine for PodmanEngine {
     }
 }
 
-/// Whether podman says the container is currently running. Errors (container
-/// gone, machine down, timeout) read as not running.
-fn container_running(name: &str) -> bool {
-    match cli::run_podman(
+/// Whether podman says the container is currently running, asked of the
+/// connection it was launched on. Errors (container gone, machine down,
+/// timeout) read as not running.
+fn container_running(name: &str, connection: Option<&str>) -> bool {
+    match cli::run_podman_on(
+        connection,
         &["inspect", "-f", "{{.State.Running}}", name],
         INSPECT_TIMEOUT,
     ) {
@@ -204,10 +236,10 @@ fn container_running(name: &str) -> bool {
 }
 
 /// Poll until the container stops running or `budget` elapses.
-fn container_gone_within(name: &str, budget: Duration) -> bool {
+fn container_gone_within(name: &str, connection: Option<&str>, budget: Duration) -> bool {
     let deadline = std::time::Instant::now() + budget;
     loop {
-        if !container_running(name) {
+        if !container_running(name, connection) {
             return true;
         }
         if std::time::Instant::now() >= deadline {
@@ -239,6 +271,31 @@ mod tests {
         assert_eq!(describe_exit_code(1, &EXIT_COPY), None);
     }
 
+    /// The pin is a global flag: it lands before `run`, verbatim (a rootful
+    /// connection keeps its `-root`), and an unpinned launch emits no flag at
+    /// all rather than an empty one.
+    #[test]
+    fn the_connection_pin_precedes_the_run_subcommand() {
+        let run_argv = vec![
+            "run".to_string(),
+            "--rm".to_string(),
+            "--name".to_string(),
+            "fletch-agent".to_string(),
+        ];
+        assert_eq!(
+            pinned_argv(Some("work-vm-root"), run_argv.clone()),
+            [
+                "--connection",
+                "work-vm-root",
+                "run",
+                "--rm",
+                "--name",
+                "fletch-agent",
+            ],
+        );
+        assert_eq!(pinned_argv(None, run_argv.clone()), run_argv);
+    }
+
     /// Integration: a real `podman run` through the engine's own launch plan
     /// round-trips a marker file the host wrote into the workspace mount, which
     /// is the whole path-identity contract in one assertion.
@@ -262,7 +319,9 @@ mod tests {
         std::fs::create_dir_all(&home).unwrap();
         std::fs::write(root.join("marker.txt"), "hello from the host\n").unwrap();
         prepare_config_mount_dir(&home.join(".claude")).unwrap();
-        machine::ensure_sources_are_shared(&[root.clone(), rpc.clone(), home.clone()]).unwrap();
+        let target = machine::resolve_launch_target().unwrap();
+        machine::ensure_sources_are_shared(&[root.clone(), rpc.clone(), home.clone()], &target)
+            .unwrap();
 
         let name = container_name("podman-int-test");
         let projects = root.join("projects-src");
@@ -293,7 +352,14 @@ mod tests {
         let marker = root.join("marker.txt").to_string_lossy().into_owned();
         argv.push(&marker);
 
-        let out = cli::run_podman(&argv, Duration::from_secs(120)).unwrap();
+        // Pinned like the engine pins it, so the run lands on the very machine
+        // whose shares were just validated.
+        let out = cli::run_podman_on(
+            target.connection.as_deref(),
+            &argv,
+            Duration::from_secs(120),
+        )
+        .unwrap();
         assert!(
             out.status.success(),
             "podman run failed: {}",
@@ -329,14 +395,20 @@ mod tests {
             String::from_utf8_lossy(&out.stderr),
         );
         assert!(
-            container_running(&name),
+            container_running(&name, None),
             "a started container reads as live"
         );
 
         PodmanEngine::shared()
-            .kill(&KillPlan::Container { name: name.clone() })
+            .kill(&KillPlan::Container {
+                name: name.clone(),
+                connection: None,
+            })
             .unwrap();
-        assert!(!container_running(&name), "killed container reads as dead");
+        assert!(
+            !container_running(&name, None),
+            "killed container reads as dead"
+        );
     }
 
     /// Integration: the preflight accepts a path under the machine's shares and
@@ -350,11 +422,15 @@ mod tests {
             return;
         }
         let home = dirs::home_dir().unwrap();
-        if machine::ensure_sources_are_shared(std::slice::from_ref(&home)).is_err() {
+        let Ok(target) = machine::resolve_launch_target() else {
+            return; // a remote default connection: refused before any mounts
+        };
+        if machine::ensure_sources_are_shared(std::slice::from_ref(&home), &target).is_err() {
             return; // no machine, or $HOME isn't shared: nothing to assert
         }
         let outside = PathBuf::from("/fletch-definitely-not-shared");
-        let err = machine::ensure_sources_are_shared(std::slice::from_ref(&outside)).unwrap_err();
+        let err = machine::ensure_sources_are_shared(std::slice::from_ref(&outside), &target)
+            .unwrap_err();
         assert!(
             err.to_string().contains(&outside.display().to_string()),
             "the refusal must name the path: {err}",

--- a/src-tauri/src/sandbox/podman/engine.rs
+++ b/src-tauri/src/sandbox/podman/engine.rs
@@ -6,9 +6,11 @@
 //! the mounts, env and auth come from
 //! [`container::launch`](crate::sandbox::container::launch), the argv from
 //! [`container::run_args`](crate::sandbox::container::run_args), the labels from
-//! [`container::labels`](crate::sandbox::container::labels), and the image
-//! content from [`container::images`](crate::sandbox::container::images). What
-//! this file adds is the podman binary, the podman teardown commands, and one
+//! [`container::labels`](crate::sandbox::container::labels), the image content
+//! from [`container::images`](crate::sandbox::container::images), and the
+//! image-freshness policy from
+//! [`container::freshness`](crate::sandbox::container::freshness). What this file
+//! adds is the podman binary, the podman teardown commands, and one
 //! Podman-specific reliability gate.
 //!
 //! **The machine preflight.** Podman's macOS VM sees only the host directories
@@ -29,12 +31,13 @@ use crate::error::{Error, Result};
 use crate::sandbox::container::run_args::{
     mount_sources, run_args, RunSpec, DEFAULT_CPUS, DEFAULT_MEMORY,
 };
-use crate::sandbox::container::util::{container_name, describe_exit_code, ExitCopy};
+use crate::sandbox::container::util::{container_name, describe_exit_code, non_blank, ExitCopy};
 use crate::sandbox::container::ContainerProvider;
 use crate::sandbox::engine::{
     AgentLaunchCtx, EngineKind, KillHandle, KillPlan, LaunchPlan, SandboxEngine,
 };
 
+use super::settings::{IMAGE_SETTING, LAUNCH_SETTINGS};
 use super::{cli, image, machine};
 
 /// Signal/removal podman calls during teardown.
@@ -45,14 +48,14 @@ const TERM_GRACE: Duration = Duration::from_millis(500);
 /// Liveness lookups (`podman inspect`).
 const INSPECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Podman's wording for the shared reserved-exit-code messages. `image_setting`
-/// is `None`: Podman honors no image override, so pointing the user at one
-/// would name a setting this engine ignores.
+/// Podman's wording for the shared reserved-exit-code messages. The machine is
+/// what reports a start failure, `podman machine` is what the user restarts, and
+/// `podman_image` is the override a 126/127 may be pointing at.
 const EXIT_COPY: ExitCopy = ExitCopy {
-    runtime: "Podman",
+    runtime: super::RUNTIME_NAME,
     error_source: "the machine",
     remedy: "Is the Podman machine running?",
-    image_setting: None,
+    image_setting: Some(IMAGE_SETTING),
 };
 
 /// The `SandboxEngine` implementation for Podman. Obtain it via
@@ -60,15 +63,20 @@ const EXIT_COPY: ExitCopy = ExitCopy {
 /// [`KillHandle`], and sharing one instance also shares the once-per-app-run
 /// image resolution cache.
 pub struct PodmanEngine {
-    /// Images resolved for this app run, keyed by provider *and* connection so
-    /// each provider's image is resolved (and built) at most once per machine.
-    /// The connection is part of the key because image stores are per-machine:
-    /// a tag present on one says nothing about another, and a launch pinned
-    /// elsewhere would run on an image that isn't there. Only successes are
-    /// cached — a failed build retries on the next spawn (the user may have
-    /// started the machine or fixed their network since).
-    resolved_image: Mutex<std::collections::HashMap<(ContainerProvider, Option<String>), String>>,
+    /// Images resolved for this app run, keyed by `(provider, override,
+    /// connection)` so each provider's image is resolved (and built) at most
+    /// once per machine, and a mid-run settings change re-resolves. The
+    /// connection is part of the key because image stores are per-machine: a tag
+    /// present on one says nothing about another, and a launch pinned elsewhere
+    /// would run on an image that isn't there. Only successes are cached — a
+    /// failed build retries on the next spawn (the user may have started the
+    /// machine or fixed their network since).
+    resolved_image: Mutex<ImageCache>,
 }
+
+/// `(provider, image override, connection)` → resolved tag.
+type ImageCache =
+    std::collections::HashMap<(ContainerProvider, Option<String>, Option<String>), String>;
 
 impl PodmanEngine {
     /// The process-wide engine instance — the same `Arc` that `engine_for`
@@ -78,29 +86,57 @@ impl PodmanEngine {
         ENGINE
             .get_or_init(|| {
                 Arc::new(PodmanEngine {
-                    resolved_image: Mutex::new(std::collections::HashMap::new()),
+                    resolved_image: Mutex::new(ImageCache::new()),
                 })
             })
             .clone()
     }
 
     /// The image to launch `provider` from on `connection`, resolving (and
-    /// building, if that machine's store lacks it) at most once per app run.
+    /// building, if that machine's store lacks it) at most once per app run per
+    /// (provider, override, connection) triple. Resolution also runs the
+    /// background freshness checks (TTL + host/container version parity — see
+    /// `image::resolve_image`), so their cadence is once per app run too. The
+    /// host version comes from the existing memoized probe
+    /// (`agent::cached_provider_version` — at most one `--version` subprocess per
+    /// provider per run, shared with ingest); a machine with no host CLI yields
+    /// `None` and the version trigger is simply inert, leaving the TTL as the
+    /// backstop.
     fn resolve_image_cached(
         &self,
         provider: ContainerProvider,
+        override_image: Option<&str>,
         connection: Option<&str>,
     ) -> Result<String> {
-        let key = (provider, connection.map(str::to_string));
+        let key = (
+            provider,
+            override_image.map(str::to_string),
+            connection.map(str::to_string),
+        );
         let mut cache = self.resolved_image.lock().unwrap();
         if let Some(tag) = cache.get(&key) {
             return Ok(tag.clone());
         }
-        // Free-form build output rides in the `line` field (not the message) so
-        // the sentry scrubber drops it — see the privacy invariant in `lib.rs`.
+        // Skip the host probe entirely on the override path: the user's image is
+        // never inspected or refreshed, so there is nothing to compare.
+        let host_cli_version = if non_blank(override_image).is_none() {
+            crate::agent::cached_provider_version(provider.id())
+        } else {
+            None
+        };
+        // Per-line build output goes to the log; the UI build toast is driven
+        // separately by the `container::progress` sink inside `image`. Free-form
+        // output rides in the `line` field (not the message) so the sentry
+        // scrubber drops it — see the privacy invariant in `lib.rs`.
         let on_progress = |line: &str| tracing::info!(target: "fletch::podman_build", line = %line, "podman build output");
-        let tag = image::resolve_image(provider, connection, &on_progress)
-            .map_err(|e| Error::Other(format!("preparing the Podman sandbox image failed: {e}")))?;
+        let tag = image::resolve_image(
+            provider,
+            connection,
+            override_image,
+            host_cli_version.as_deref(),
+            &on_progress,
+        )
+        .map_err(|e| Error::Other(format!("preparing the Podman sandbox image failed: {e}")))?;
         cache.insert(key, tag.clone());
         Ok(tag)
     }
@@ -139,10 +175,17 @@ impl SandboxEngine for PodmanEngine {
             .ok_or_else(|| Error::Other("podman binary not found — is Podman installed?".into()))?;
         // Resolved before the image: everything this launch touches — the image
         // store, the mount check, the run, the teardown — has to be the one
-        // endpoint named here, and a remote default is refused before any of it.
+        // endpoint named here, and a remote default is refused before any of it
+        // (in particular before a minutes-long build for a machine we would then
+        // refuse to launch on).
         let target = machine::resolve_launch_target()?;
         let connection = target.connection.clone();
-        let image = self.resolve_image_cached(provider, connection.as_deref())?;
+        let settings = LAUNCH_SETTINGS.read().clone();
+        let image = self.resolve_image_cached(
+            provider,
+            settings.image_override.as_deref(),
+            connection.as_deref(),
+        )?;
         let name = container_name(ctx.agent_id);
         let prep = crate::sandbox::container::launch::prepare(ctx, provider)?;
 
@@ -159,10 +202,8 @@ impl SandboxEngine for PodmanEngine {
                 blackboard: ctx.blackboard,
                 mounts: prep.mounts(),
                 borrowed_object_stores: &prep.borrowed_object_stores,
-                // No podman-side memory/cpus settings surface yet: the shared
-                // launch defaults apply.
-                memory: DEFAULT_MEMORY,
-                cpus: DEFAULT_CPUS,
+                memory: non_blank(settings.memory.as_deref()).unwrap_or(DEFAULT_MEMORY),
+                cpus: non_blank(settings.cpus.as_deref()).unwrap_or(DEFAULT_CPUS),
                 image: &image,
                 agent_bin,
                 auth_vars: &auth_vars,
@@ -257,7 +298,7 @@ mod tests {
 
     /// Podman's exit-code wording names the machine (it has no daemon) and
     /// points at `podman machine`, while still hedging that the code may be the
-    /// agent's own. No `docker_image` mention — this engine honors no override.
+    /// agent's own. The image clauses name `podman_image`, never docker's key.
     #[test]
     fn exit_code_wording_is_podman_shaped() {
         let daemon = describe_exit_code(125, &EXIT_COPY).unwrap();
@@ -267,6 +308,11 @@ mod tests {
             let msg = describe_exit_code(code, &EXIT_COPY).unwrap();
             assert!(msg.contains("agent itself exited"), "must hedge: {msg}");
             assert!(!msg.contains("docker"), "{msg}");
+        }
+        // 126/127 point at this engine's own override key.
+        for code in [126, 127] {
+            let msg = describe_exit_code(code, &EXIT_COPY).unwrap();
+            assert!(msg.contains("podman_image"), "{msg}");
         }
         assert_eq!(describe_exit_code(1, &EXIT_COPY), None);
     }

--- a/src-tauri/src/sandbox/podman/image.rs
+++ b/src-tauri/src/sandbox/podman/image.rs
@@ -36,31 +36,44 @@ const INSPECT_TIMEOUT: Duration = Duration::from_secs(10);
 /// stores, so a docker build is no reason to hold up a podman one.
 static BUILD_LOCK: Mutex<()> = Mutex::new(());
 
-/// The image to launch `provider`'s containers from, building it if the local
-/// store doesn't have it yet.
-pub(super) fn resolve_image(provider: ContainerProvider, on_progress: Progress) -> Result<String> {
+/// The image to launch `provider`'s containers from, building it if the store
+/// behind `connection` doesn't have it yet. The connection is the launch's
+/// pinned one, not the default: each machine keeps its own image store, so an
+/// image built or found elsewhere says nothing about the one the run uses.
+pub(super) fn resolve_image(
+    provider: ContainerProvider,
+    connection: Option<&str>,
+    on_progress: Progress,
+) -> Result<String> {
     let tag = image_tag(provider);
     let spec = image_spec(provider);
-    ensure_image(&tag, spec.dockerfile, spec.entrypoint, on_progress)?;
+    ensure_image(
+        connection,
+        &tag,
+        spec.dockerfile,
+        spec.entrypoint,
+        on_progress,
+    )?;
     Ok(tag)
 }
 
-/// Make sure `tag` exists in the local store, building `dockerfile` under it if
-/// it doesn't. Returns whether the image already existed. Takes the content
-/// explicitly so the integration test can exercise the build machinery with a
-/// tiny Dockerfile instead of the full agent image.
+/// Make sure `tag` exists in `connection`'s store, building `dockerfile` under
+/// it if it doesn't. Returns whether the image already existed. Takes the
+/// content explicitly so the integration test can exercise the build machinery
+/// with a tiny Dockerfile instead of the full agent image.
 fn ensure_image(
+    connection: Option<&str>,
     tag: &str,
     dockerfile: &str,
     entrypoint: &str,
     on_progress: Progress,
 ) -> Result<bool> {
-    if image_exists(tag)? {
+    if image_exists(connection, tag)? {
         return Ok(true);
     }
     let _guard = BUILD_LOCK.lock().unwrap();
     // Re-check under the lock: a concurrent spawn may have just built it.
-    if image_exists(tag)? {
+    if image_exists(connection, tag)? {
         return Ok(true);
     }
 
@@ -75,6 +88,7 @@ fn ensure_image(
     // network for its install step.
     let ctx_path = ctx.path().to_string_lossy().into_owned();
     cli::run_podman_streaming(
+        connection,
         &["build", "--pull", "-t", tag, &ctx_path],
         BUILD_TIMEOUT,
         on_progress,
@@ -83,12 +97,12 @@ fn ensure_image(
     Ok(false)
 }
 
-/// Whether `tag` exists in the local store. A non-zero `image inspect` exit is
-/// podman's "no such image" answer (it also covers an unreachable machine — the
-/// subsequent build then fails with podman's own connectivity error, which is
-/// the right message for that state).
-fn image_exists(tag: &str) -> Result<bool> {
-    let out = cli::run_podman(&["image", "inspect", tag], INSPECT_TIMEOUT)?;
+/// Whether `tag` exists in `connection`'s store. A non-zero `image inspect`
+/// exit is podman's "no such image" answer (it also covers an unreachable
+/// machine — the subsequent build then fails with podman's own connectivity
+/// error, which is the right message for that state).
+fn image_exists(connection: Option<&str>, tag: &str) -> Result<bool> {
+    let out = cli::run_podman_on(connection, &["image", "inspect", tag], INSPECT_TIMEOUT)?;
     Ok(out.status.success())
 }
 
@@ -116,10 +130,10 @@ mod tests {
         let progress = |_: &str| {
             lines.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         };
-        let existed = ensure_image(&tag, dockerfile, ENTRYPOINT_SH, &progress).unwrap();
+        let existed = ensure_image(None, &tag, dockerfile, ENTRYPOINT_SH, &progress).unwrap();
         assert!(!existed, "first call must report a fresh build");
         assert!(
-            image_exists(&tag).unwrap(),
+            image_exists(None, &tag).unwrap(),
             "image should exist after build"
         );
         assert!(
@@ -129,7 +143,7 @@ mod tests {
 
         // Second call: image present, no build, no progress.
         lines.store(0, std::sync::atomic::Ordering::SeqCst);
-        let existed = ensure_image(&tag, dockerfile, ENTRYPOINT_SH, &progress).unwrap();
+        let existed = ensure_image(None, &tag, dockerfile, ENTRYPOINT_SH, &progress).unwrap();
         assert!(existed, "second call must report the cached image");
         assert_eq!(
             lines.load(std::sync::atomic::Ordering::SeqCst),

--- a/src-tauri/src/sandbox/podman/image.rs
+++ b/src-tauri/src/sandbox/podman/image.rs
@@ -1,0 +1,142 @@
+//! Building and inspecting the embedded agent images with podman. Their
+//! *content* — the Dockerfiles, entrypoints, and content-addressed tags — is
+//! runtime-neutral and lives in
+//! [`container::images`](crate::sandbox::container::images), so a Podman agent
+//! runs the byte-identical image a Docker agent does (different local store,
+//! same recipe, same tag).
+//!
+//! Deliberately smaller than [`docker::image`](crate::sandbox::docker::image):
+//! there is no freshness TTL, no host/container version parity check, no image
+//! GC, and no user image override here yet. Missing means build; present means
+//! launch.
+
+use std::sync::Mutex;
+use std::time::Duration;
+
+use crate::error::Result;
+use crate::sandbox::container::images::{image_spec, image_tag, write_build_context};
+use crate::sandbox::container::ContainerProvider;
+
+use super::cli;
+
+/// Progress sink for image builds: called once per podman output line.
+pub type Progress<'a> = &'a (dyn Fn(&str) + Send + Sync);
+
+/// Builds are slow (base image pull + apt + npm) but bounded: past this we
+/// assume a wedged machine connection or dead network and fail the spawn with a
+/// clear error rather than letting it hang indefinitely.
+const BUILD_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Quick metadata lookups (`podman image inspect`).
+const INSPECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Serializes every image build process-wide. Concurrent spawns during a cold
+/// start would otherwise race podman into building the same image N times.
+/// Separate from docker's lock by design: the two runtimes keep separate image
+/// stores, so a docker build is no reason to hold up a podman one.
+static BUILD_LOCK: Mutex<()> = Mutex::new(());
+
+/// The image to launch `provider`'s containers from, building it if the local
+/// store doesn't have it yet.
+pub(super) fn resolve_image(provider: ContainerProvider, on_progress: Progress) -> Result<String> {
+    let tag = image_tag(provider);
+    let spec = image_spec(provider);
+    ensure_image(&tag, spec.dockerfile, spec.entrypoint, on_progress)?;
+    Ok(tag)
+}
+
+/// Make sure `tag` exists in the local store, building `dockerfile` under it if
+/// it doesn't. Returns whether the image already existed. Takes the content
+/// explicitly so the integration test can exercise the build machinery with a
+/// tiny Dockerfile instead of the full agent image.
+fn ensure_image(
+    tag: &str,
+    dockerfile: &str,
+    entrypoint: &str,
+    on_progress: Progress,
+) -> Result<bool> {
+    if image_exists(tag)? {
+        return Ok(true);
+    }
+    let _guard = BUILD_LOCK.lock().unwrap();
+    // Re-check under the lock: a concurrent spawn may have just built it.
+    if image_exists(tag)? {
+        return Ok(true);
+    }
+
+    tracing::info!(tag, "building agent podman image");
+    // Build from a throwaway context dir so nothing from the host repo can
+    // leak into the image.
+    let ctx = tempfile::tempdir()?;
+    write_build_context(ctx.path(), dockerfile, entrypoint)?;
+    // `--pull`, like docker's builds: the images exist to capture "latest at
+    // build time", and a months-old locally cached base would silently defeat
+    // that. It adds no new failure mode — every agent build already needs the
+    // network for its install step.
+    let ctx_path = ctx.path().to_string_lossy().into_owned();
+    cli::run_podman_streaming(
+        &["build", "--pull", "-t", tag, &ctx_path],
+        BUILD_TIMEOUT,
+        on_progress,
+    )?;
+    tracing::info!(tag, "agent podman image built");
+    Ok(false)
+}
+
+/// Whether `tag` exists in the local store. A non-zero `image inspect` exit is
+/// podman's "no such image" answer (it also covers an unreachable machine — the
+/// subsequent build then fails with podman's own connectivity error, which is
+/// the right message for that state).
+fn image_exists(tag: &str) -> Result<bool> {
+    let out = cli::run_podman(&["image", "inspect", tag], INSPECT_TIMEOUT)?;
+    Ok(out.status.success())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::container::images::{tag_for, ENTRYPOINT_SH};
+
+    /// Integration: builds a tiny image (busybox base) through the real
+    /// machinery, then verifies the second call is a cached no-op.
+    /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]
+    fn builds_tiny_image_and_reuses_it() {
+        if !crate::sandbox::podman::podman_tests_enabled() {
+            return;
+        }
+        let dockerfile =
+            "FROM busybox\nCOPY entrypoint.sh /entrypoint.sh\nENTRYPOINT [\"/entrypoint.sh\"]\n";
+        let tag = tag_for("fletch-agent", dockerfile, ENTRYPOINT_SH);
+        // Start clean so the build path actually runs.
+        let _ = cli::run_podman(&["rmi", "-f", &tag], Duration::from_secs(30));
+
+        let lines = std::sync::atomic::AtomicUsize::new(0);
+        let progress = |_: &str| {
+            lines.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        };
+        let existed = ensure_image(&tag, dockerfile, ENTRYPOINT_SH, &progress).unwrap();
+        assert!(!existed, "first call must report a fresh build");
+        assert!(
+            image_exists(&tag).unwrap(),
+            "image should exist after build"
+        );
+        assert!(
+            lines.load(std::sync::atomic::Ordering::SeqCst) > 0,
+            "build should have streamed progress lines",
+        );
+
+        // Second call: image present, no build, no progress.
+        lines.store(0, std::sync::atomic::Ordering::SeqCst);
+        let existed = ensure_image(&tag, dockerfile, ENTRYPOINT_SH, &progress).unwrap();
+        assert!(existed, "second call must report the cached image");
+        assert_eq!(
+            lines.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "an existing image must not rebuild",
+        );
+
+        let _ = cli::run_podman(&["rmi", "-f", &tag], Duration::from_secs(30));
+    }
+}

--- a/src-tauri/src/sandbox/podman/image.rs
+++ b/src-tauri/src/sandbox/podman/image.rs
@@ -163,13 +163,17 @@ fn ensure_image(
     let forward = |line: &str| {
         on_progress(line);
         progress::emit(BuildEvent::Line {
+            runtime: super::RUNTIME_NAME,
             line: line.to_string(),
         });
     };
     let result = run_build(connection, dockerfile, entrypoint, tag, false, &forward);
     match &result {
-        Ok(()) => progress::emit(BuildEvent::Finished),
+        Ok(()) => progress::emit(BuildEvent::Finished {
+            runtime: super::RUNTIME_NAME,
+        }),
         Err(e) => progress::emit(BuildEvent::Failed {
+            runtime: super::RUNTIME_NAME,
             error: e.to_string(),
         }),
     }

--- a/src-tauri/src/sandbox/podman/image.rs
+++ b/src-tauri/src/sandbox/podman/image.rs
@@ -1,20 +1,49 @@
-//! Building and inspecting the embedded agent images with podman. Their
-//! *content* — the Dockerfiles, entrypoints, and content-addressed tags — is
-//! runtime-neutral and lives in
+//! Building, inspecting and refreshing the embedded agent images with podman.
+//! Their *content* — the Dockerfiles, entrypoints, and content-addressed tags —
+//! is runtime-neutral and lives in
 //! [`container::images`](crate::sandbox::container::images), so a Podman agent
 //! runs the byte-identical image a Docker agent does (different local store,
-//! same recipe, same tag).
+//! same recipe, same tag). Everything here shells out to podman.
 //!
-//! Deliberately smaller than [`docker::image`](crate::sandbox::docker::image):
-//! there is no freshness TTL, no host/container version parity check, no image
-//! GC, and no user image override here yet. Missing means build; present means
-//! launch.
+//! Every invocation carries the launch's pinned connection (see
+//! [`super::machine`]). That is not a detail: podman keeps one image store per
+//! machine, so an image built or found on one connection says nothing about the
+//! one the run will use — an unpinned inspect could report "present" for a store
+//! the container never touches, and an unpinned build would land the image on the
+//! wrong machine.
+//!
+//! Content addressing alone would freeze the *packages inside* an image
+//! forever: every image installs "latest at build time" (npm installs, cursor's
+//! installer), so a stable Dockerfile means a user's containerized CLI never
+//! updates while the host CLI does. The shared TTL
+//! ([`IMAGE_MAX_AGE`](crate::sandbox::container::freshness::IMAGE_MAX_AGE))
+//! fixes that: at resolution, an existing image older than the TTL is served for
+//! the current launch and rebuilt under the same tag in the background
+//! (stale-while-revalidate — see [`refresh_in_background_if_needed`]). A
+//! host/container CLI version mismatch triggers the same background rebuild even
+//! inside the TTL window — a user who just updated their host CLI expects
+//! container parity — while the TTL remains the backstop for Podman-only users
+//! with no host CLI to compare against.
+//!
+//! Users can bypass all of this with the `podman_image` settings key (see
+//! [`resolve_image`]): a user-supplied image is used verbatim — never built,
+//! never inspected — and must have the launching provider's CLI on PATH and git
+//! installed.
+//!
+//! What Podman's freshness path does *not* mirror is docker's
+//! `reap_superseded_base`: reclaiming a base image a `--pull` displaced needs a
+//! before/after id snapshot around every build plus a retry queue, and podman's
+//! rootless store makes a stranded base cheaper to leave than to chase. The
+//! label-driven GC in [`super::cleanup`] covers everything Fletch's own builds
+//! tag.
 
 use std::sync::Mutex;
 use std::time::Duration;
 
 use crate::error::Result;
+use crate::sandbox::container::freshness::{classify_freshness, version_refresh_wanted, Freshness};
 use crate::sandbox::container::images::{image_spec, image_tag, write_build_context};
+use crate::sandbox::container::progress::{self, BuildEvent};
 use crate::sandbox::container::ContainerProvider;
 
 use super::cli;
@@ -30,30 +59,74 @@ const BUILD_TIMEOUT: Duration = Duration::from_secs(600);
 /// Quick metadata lookups (`podman image inspect`).
 const INSPECT_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Serializes every image build process-wide. Concurrent spawns during a cold
-/// start would otherwise race podman into building the same image N times.
-/// Separate from docker's lock by design: the two runtimes keep separate image
-/// stores, so a docker build is no reason to hold up a podman one.
+/// One-shot in-container version probes are a container start + a node CLI's
+/// `--version` — seconds normally, and this bound only reaps a wedged machine.
+const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Serializes every image build process-wide — foreground first-builds and
+/// background refresh rebuilds alike. Concurrent spawns during a cold start
+/// would otherwise race podman into building the same image N times, and a
+/// refresh rebuild must never interleave with a foreground build of the same
+/// tag. Separate from docker's lock by design: the two runtimes keep separate
+/// image stores, so a docker build is no reason to hold up a podman one.
 static BUILD_LOCK: Mutex<()> = Mutex::new(());
 
-/// The image to launch `provider`'s containers from, building it if the store
-/// behind `connection` doesn't have it yet. The connection is the launch's
-/// pinned one, not the default: each machine keeps its own image store, so an
-/// image built or found elsewhere says nothing about the one the run uses.
+/// The image to launch `provider`'s containers from on `connection`, honoring
+/// the `podman_image` settings key: a non-empty override is returned verbatim
+/// (no build, no inspect, no TTL, no version check — the user owns that image's
+/// lifecycle); otherwise the embedded image is built if the store behind
+/// `connection` doesn't have it, refreshed in the background if stale or
+/// version-divergent from the host CLI, and its tag returned.
+///
+/// `connection` is the launch's pinned one, not the default: each machine keeps
+/// its own image store, so an image built or found elsewhere says nothing about
+/// the one the run uses.
+///
+/// Callers read the settings key and probe the host CLI (`host_cli_version` —
+/// see `agent::cached_provider_version`) and pass both in, so this module stays
+/// DB-free and host-probe-free.
 pub(super) fn resolve_image(
     provider: ContainerProvider,
     connection: Option<&str>,
+    override_image: Option<&str>,
+    host_cli_version: Option<&str>,
     on_progress: Progress,
 ) -> Result<String> {
+    if let Some(image) = override_image.map(str::trim).filter(|s| !s.is_empty()) {
+        tracing::info!(
+            image,
+            ?provider,
+            "using user-supplied podman image (podman_image setting)"
+        );
+        return Ok(image.to_string());
+    }
     let tag = image_tag(provider);
     let spec = image_spec(provider);
-    ensure_image(
+    let already_existed = ensure_image(
         connection,
         &tag,
         spec.dockerfile,
         spec.entrypoint,
         on_progress,
     )?;
+    if already_existed {
+        // A just-built image is fresh by construction (it installed today's
+        // latest — if the host still differs, a rebuild can't fix that); a
+        // pre-existing one may have passed the TTL or drifted from the host CLI.
+        // Stale-while-revalidate: this launch still uses the existing tag, the
+        // refresh (if any) happens off-thread.
+        refresh_in_background_if_needed(provider, connection, &tag, host_cli_version);
+    } else {
+        // Post-build version probe, off-thread: warms the image-version cache
+        // for the mismatch trigger without delaying (or ever failing) the launch
+        // that just waited out the build. The spawned thread owns its connection
+        // — it outlives the borrow this call was given.
+        let tag = tag.clone();
+        let connection = connection.map(str::to_string);
+        std::thread::spawn(move || {
+            cache_image_version_post_build(provider, connection.as_deref(), &tag)
+        });
+    }
     Ok(tag)
 }
 
@@ -78,29 +151,379 @@ fn ensure_image(
     }
 
     tracing::info!(tag, "building agent podman image");
-    // Build from a throwaway context dir so nothing from the host repo can
-    // leak into the image.
-    let ctx = tempfile::tempdir()?;
-    write_build_context(ctx.path(), dockerfile, entrypoint)?;
-    // `--pull`, like docker's builds: the images exist to capture "latest at
-    // build time", and a months-old locally cached base would silently defeat
-    // that. It adds no new failure mode — every agent build already needs the
-    // network for its install step.
-    let ctx_path = ctx.path().to_string_lossy().into_owned();
-    cli::run_podman_streaming(
-        connection,
-        &["build", "--pull", "-t", tag, &ctx_path],
-        BUILD_TIMEOUT,
-        on_progress,
-    )?;
+    // Broadcast the build lifecycle to the UI. `Started`/`Finished`/`Failed`
+    // fire only here, where a foreground build actually runs (a cached image
+    // returns above without emitting), so the toast appears only for builds the
+    // user is actually waiting on. Each output line is forwarded alongside the
+    // caller's own sink so the tracing forwarder / test counter keep working
+    // unchanged.
+    progress::emit(BuildEvent::Started {
+        runtime: super::RUNTIME_NAME,
+    });
+    let forward = |line: &str| {
+        on_progress(line);
+        progress::emit(BuildEvent::Line {
+            line: line.to_string(),
+        });
+    };
+    let result = run_build(connection, dockerfile, entrypoint, tag, false, &forward);
+    match &result {
+        Ok(()) => progress::emit(BuildEvent::Finished),
+        Err(e) => progress::emit(BuildEvent::Failed {
+            error: e.to_string(),
+        }),
+    }
+    result?;
     tracing::info!(tag, "agent podman image built");
     Ok(false)
 }
 
-/// Whether `tag` exists in `connection`'s store. A non-zero `image inspect`
-/// exit is podman's "no such image" answer (it also covers an unreachable
-/// machine — the subsequent build then fails with podman's own connectivity
-/// error, which is the right message for that state).
+/// Write the build context and run `podman build -t tag` on `connection`,
+/// streaming output to `on_line`. Shared by the foreground first-build
+/// ([`ensure_image`], `no_cache: false`) and the background refresh rebuild
+/// ([`rebuild_image`], `no_cache: true`); callers hold [`BUILD_LOCK`] and own
+/// their event/progress policy.
+fn run_build(
+    connection: Option<&str>,
+    dockerfile: &str,
+    entrypoint: &str,
+    tag: &str,
+    no_cache: bool,
+    on_line: Progress,
+) -> Result<()> {
+    // A throwaway context dir, so nothing from the host repo can leak into the
+    // image.
+    let ctx = tempfile::tempdir()?;
+    write_build_context(ctx.path(), dockerfile, entrypoint)?;
+    let args = build_args(tag, ctx.path(), no_cache);
+    let args: Vec<&str> = args.iter().map(String::as_str).collect();
+    cli::run_podman_streaming(connection, &args, BUILD_TIMEOUT, on_line)
+}
+
+/// `podman build` argv for `tag` from context `ctx`. `--pull` on every build,
+/// first build and refresh rebuild alike: the images exist to capture "latest at
+/// build time", and a months-old locally cached base would silently defeat that.
+/// It adds no new failure mode — every agent build already needs the network for
+/// its install step.
+///
+/// `--no-cache` on refresh rebuilds only: `--pull` alone re-fetches the base, but
+/// the install `RUN` layer is keyed on its instruction text and would be served
+/// from cache whenever the base digest hasn't moved — a rebuild that changes
+/// nothing, silently defeating both the TTL and the version-mismatch trigger.
+/// First builds keep the cache: a brand-new image has nothing stale to bust, and
+/// cross-provider base-layer sharing on cold starts is worth keeping.
+///
+/// The connection pin is *not* here: it's a global flag that has to precede the
+/// subcommand, so [`cli::run_podman_streaming`] prepends it.
+fn build_args(tag: &str, ctx: &std::path::Path, no_cache: bool) -> Vec<String> {
+    let mut args: Vec<String> = vec!["build".into(), "--pull".into()];
+    if no_cache {
+        args.push("--no-cache".into());
+    }
+    args.extend(["-t".into(), tag.into(), ctx.to_string_lossy().into_owned()]);
+    args
+}
+
+/// Why a background refresh rebuild was kicked — log attribution, plus the
+/// version trigger's loop-guard bookkeeping on success.
+enum RefreshReason {
+    /// The image's build date passed the shared TTL.
+    Ttl,
+    /// The host CLI's probed version differs from the container image's;
+    /// `guard_pair` is the `host@tag` pair recorded (persistently, on rebuild
+    /// success) so the same combination is never retried.
+    VersionMismatch { guard_pair: String },
+}
+
+/// Decide whether the image in `connection`'s store needs a background rebuild —
+/// TTL first, then host/container version parity — and kick it if so. Returns
+/// immediately either way. Freshness is never a launch concern: inspect
+/// failures, unparseable timestamps, missing versions, and rebuild failures all
+/// leave the existing image serving launches. Logged, never propagated. The
+/// rebuild is silent for the UI (log lines only): the build toast presents a
+/// blocking first-run build, which is the wrong message for a refresh the user
+/// never waits on.
+///
+/// Everything below — inspect, probe, rebuild, post-rebuild sweep — rides the
+/// connection that triggered it, so a refresh replaces the image in the store the
+/// launch actually read from.
+///
+/// Cadence for both triggers is once per app run
+/// (`PodmanEngine::resolve_image_cached` caches resolution).
+fn refresh_in_background_if_needed(
+    provider: ContainerProvider,
+    connection: Option<&str>,
+    tag: &str,
+    host_cli_version: Option<&str>,
+) {
+    // One inspect serves both triggers: build date for the TTL, image id to key
+    // the container-version cache.
+    let Some((image_id, created_raw)) = inspect_id_and_created(connection, tag) else {
+        // The image resolved a moment ago; a metadata miss now is not worth
+        // failing a launch or rebuilding over. Next app run re-checks.
+        return;
+    };
+
+    match classify_freshness(&created_raw, chrono::Utc::now()) {
+        Freshness::Stale => {
+            tracing::info!(
+                target: "fletch::podman",
+                tag,
+                created = %created_raw,
+                "agent image is older than IMAGE_MAX_AGE; rebuilding in the background",
+            );
+            spawn_refresh_rebuild(
+                provider,
+                connection.map(str::to_string),
+                tag.to_string(),
+                RefreshReason::Ttl,
+            );
+            return;
+        }
+        Freshness::Unknown => {
+            // Once per app run in practice: resolution is cached per run
+            // (`PodmanEngine::resolve_image_cached`), so this can't spam.
+            tracing::warn!(
+                target: "fletch::podman",
+                tag,
+                created = %created_raw,
+                "unparseable image build date; treating the image as fresh",
+            );
+        }
+        Freshness::Fresh => {}
+    }
+
+    // TTL-fresh: check version parity. Ordered so the podman-run probe only
+    // happens when there's a host version to compare and the pair hasn't already
+    // been tried (the pure decision below re-validates everything).
+    let Some(host) = host_cli_version else { return };
+    let guard_pair = format!("{host}@{tag}");
+    if super::settings::version_refresh_attempted(provider.id(), &guard_pair) {
+        return;
+    }
+    let container = image_cli_version(provider, connection, tag, &image_id);
+    if !version_refresh_wanted(Some(host), container.as_deref(), false) {
+        return;
+    }
+    tracing::info!(
+        target: "fletch::podman",
+        tag,
+        host,
+        container = %container.as_deref().unwrap_or_default(),
+        "host CLI version differs from container image; rebuilding in the background",
+    );
+    spawn_refresh_rebuild(
+        provider,
+        connection.map(str::to_string),
+        tag.to_string(),
+        RefreshReason::VersionMismatch { guard_pair },
+    );
+}
+
+/// Kick the background stale-while-revalidate rebuild shared by both refresh
+/// triggers: rebuild the same tag, then (on success) record the version
+/// trigger's loop guard, re-probe the fresh image's CLI version, and sweep the
+/// just-untagged predecessor. On failure, warn and keep serving the old image.
+///
+/// The thread owns its `connection` — it outlives the launch that spawned it, and
+/// every call it makes must still reach that launch's store rather than whatever
+/// the default has become in the meantime.
+fn spawn_refresh_rebuild(
+    provider: ContainerProvider,
+    connection: Option<String>,
+    tag: String,
+    reason: RefreshReason,
+) {
+    std::thread::spawn(move || {
+        let on = connection.as_deref();
+        match rebuild_image(provider, on, &tag) {
+            Ok(()) => {
+                tracing::info!(target: "fletch::podman", tag, "agent image refreshed");
+                if let RefreshReason::VersionMismatch { guard_pair } = reason {
+                    // Recorded on success only: a transient build failure should
+                    // retry next run, but a *successful* rebuild that still
+                    // mismatches (host pinned away from latest) must never loop.
+                    super::settings::record_version_refresh(provider.id(), guard_pair);
+                }
+                cache_image_version_post_build(provider, on, &tag);
+                // Podman retagged in place; the predecessor is now untagged. Reap
+                // it (and anything else stale) right away — in this store only,
+                // since this is the only one the rebuild touched.
+                match super::cleanup::sweep_stale_images_on(on) {
+                    Ok(0) => {}
+                    Ok(n) => tracing::info!(
+                        target: "fletch::podman",
+                        removed = n,
+                        "swept superseded agent images after refresh",
+                    ),
+                    Err(e) => tracing::debug!(
+                        target: "fletch::podman",
+                        error = %e,
+                        "post-refresh image sweep failed",
+                    ),
+                }
+            }
+            Err(e) => tracing::warn!(
+                target: "fletch::podman",
+                tag,
+                error = %e,
+                "background image refresh failed; keeping the existing image",
+            ),
+        }
+    });
+}
+
+/// Rebuild `provider`'s image under the same `tag` in `connection`'s store,
+/// unconditionally (no exists-check — the point is to replace an image that
+/// exists). Serialized on [`BUILD_LOCK`] with foreground builds; `--pull
+/// --no-cache` (see [`build_args`]) so neither a stale base nor a cached install
+/// layer can defeat the refresh. On success podman retags in place and the old
+/// image becomes untagged; on failure the old tag is untouched and keeps serving
+/// launches.
+fn rebuild_image(provider: ContainerProvider, connection: Option<&str>, tag: &str) -> Result<()> {
+    let spec = image_spec(provider);
+    let _guard = BUILD_LOCK.lock().unwrap();
+    // Build output is free-form (`line` in a field, not the message) so the
+    // sentry scrubber drops it — see the privacy invariant in `lib.rs`.
+    let on_line = |line: &str| tracing::info!(target: "fletch::podman_build", line = %line, "podman build output");
+    run_build(
+        connection,
+        spec.dockerfile,
+        spec.entrypoint,
+        tag,
+        true,
+        &on_line,
+    )
+}
+
+/// The provider CLI's version inside image `tag`, memoized by `image_id` for
+/// this app run. The id is a content digest, so the memo is correct across
+/// connections: the same id names the same bytes on every machine. In-memory by
+/// choice: persistence would buy one skipped `podman run` per provider per app
+/// run — not worth a storage surface, and a restart-time re-probe also self-heals
+/// if a probe ever cached garbage. A failed probe caches nothing and returns
+/// `None` — the version trigger stays inert for that image (the TTL still covers
+/// it) and the next app run retries.
+fn image_cli_version(
+    provider: ContainerProvider,
+    connection: Option<&str>,
+    tag: &str,
+    image_id: &str,
+) -> Option<String> {
+    static CACHE: std::sync::OnceLock<Mutex<std::collections::HashMap<String, String>>> =
+        std::sync::OnceLock::new();
+    let cache = CACHE.get_or_init(|| Mutex::new(std::collections::HashMap::new()));
+    if let Some(v) = cache.lock().unwrap().get(image_id) {
+        return Some(v.clone());
+    }
+    let version = probe_image_cli_version(provider, connection, tag)?;
+    cache
+        .lock()
+        .unwrap()
+        .insert(image_id.to_string(), version.clone());
+    Some(version)
+}
+
+/// Run `podman run --rm <tag> <bin> --version` on `connection` — no mounts, no
+/// agent scaffolding; the image's entrypoint just `exec`s the argv — and extract
+/// the version with the same parser the host probe uses (`agent::parse_semver`),
+/// so the two sides compare like-for-like. The `fletch.host-pid` label is stamped
+/// on so that if the CLI probe is killed at timeout while podman keeps the
+/// container alive, the next startup's orphan sweep can still attribute and reap
+/// it — and because that sweep runs per connection, the pin is what puts the
+/// container where the sweep will look.
+fn probe_image_cli_version(
+    provider: ContainerProvider,
+    connection: Option<&str>,
+    tag: &str,
+) -> Option<String> {
+    let pid_label = crate::sandbox::container::labels::host_pid_label();
+    let out = cli::run_podman_on(
+        connection,
+        &[
+            "run",
+            "--rm",
+            "--label",
+            &pid_label,
+            tag,
+            provider.image_bin(),
+            "--version",
+        ],
+        VERSION_PROBE_TIMEOUT,
+    )
+    .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = if !out.stdout.is_empty() {
+        String::from_utf8_lossy(&out.stdout)
+    } else {
+        String::from_utf8_lossy(&out.stderr)
+    };
+    crate::agent::parse_semver(&text)
+}
+
+/// After a successful build (foreground and background): probe the fresh image's
+/// CLI version and warm the [`image_cli_version`] cache so the mismatch trigger
+/// has a container side to compare. Best-effort — a failed probe logs at debug
+/// and the trigger stays inert for this image; it never fails or delays the build
+/// that preceded it.
+fn cache_image_version_post_build(
+    provider: ContainerProvider,
+    connection: Option<&str>,
+    tag: &str,
+) {
+    let Some((image_id, _)) = inspect_id_and_created(connection, tag) else {
+        return;
+    };
+    match image_cli_version(provider, connection, tag, &image_id) {
+        Some(version) => tracing::info!(
+            target: "fletch::podman",
+            tag,
+            version,
+            "container CLI version probed after build",
+        ),
+        None => tracing::debug!(
+            target: "fletch::podman",
+            tag,
+            "post-build container CLI version probe failed; version trigger stays inert for this image",
+        ),
+    }
+}
+
+/// `(image id, creation timestamp)` for `tag` in `connection`'s store, or `None`
+/// when podman can't answer or its output doesn't parse.
+///
+/// Read from `podman image inspect`'s plain JSON rather than a `--format` Go
+/// template: podman models `Created` as a `time.Time`, which a template renders
+/// through its `String()` method (`2026-07-01 12:00:00 +0000 UTC`) while the JSON
+/// encoding is RFC3339 — the shape [`classify_freshness`] parses and docker's
+/// template happens to already produce.
+fn inspect_id_and_created(connection: Option<&str>, tag: &str) -> Option<(String, String)> {
+    let out = cli::run_podman_on(connection, &["image", "inspect", tag], INSPECT_TIMEOUT).ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    parse_inspect_json(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Pull `Id` and `Created` out of an `image inspect` JSON array (one entry per
+/// inspected image; we always inspect exactly one). Split out of
+/// [`inspect_id_and_created`] so the parsing is unit-testable without a machine.
+/// Missing or non-string fields read as "can't answer" — the caller's
+/// under-reclaim bias then leaves the image alone.
+fn parse_inspect_json(stdout: &str) -> Option<(String, String)> {
+    let parsed: serde_json::Value = serde_json::from_str(stdout).ok()?;
+    let entry = parsed.get(0)?;
+    let id = entry.get("Id")?.as_str()?;
+    let created = entry.get("Created")?.as_str()?;
+    (!id.is_empty() && !created.is_empty()).then(|| (id.to_string(), created.to_string()))
+}
+
+/// Whether `tag` exists in `connection`'s store. A non-zero `image inspect` exit
+/// is podman's "no such image" answer (it also covers an unreachable machine —
+/// the subsequent build then fails with podman's own connectivity error, which is
+/// the right message for that state).
 fn image_exists(connection: Option<&str>, tag: &str) -> Result<bool> {
     let out = cli::run_podman_on(connection, &["image", "inspect", tag], INSPECT_TIMEOUT)?;
     Ok(out.status.success())
@@ -110,6 +533,109 @@ fn image_exists(connection: Option<&str>, tag: &str) -> Result<bool> {
 mod tests {
     use super::*;
     use crate::sandbox::container::images::{tag_for, ENTRYPOINT_SH};
+
+    #[test]
+    fn build_argv_shape() {
+        // `--pull` on every build, `--no-cache` on refresh rebuilds only: see
+        // the `build_args` doc — neither a stale cached base nor a cached
+        // install layer may defeat the freshness the rebuilds exist for.
+        assert_eq!(
+            build_args(
+                "fletch-agent:abc123def456",
+                std::path::Path::new("/tmp/ctx"),
+                false
+            ),
+            vec![
+                "build",
+                "--pull",
+                "-t",
+                "fletch-agent:abc123def456",
+                "/tmp/ctx"
+            ],
+        );
+        assert_eq!(
+            build_args(
+                "fletch-agent:abc123def456",
+                std::path::Path::new("/tmp/ctx"),
+                true
+            ),
+            vec![
+                "build",
+                "--pull",
+                "--no-cache",
+                "-t",
+                "fletch-agent:abc123def456",
+                "/tmp/ctx"
+            ],
+        );
+    }
+
+    /// The inspect parse, on podman's real output shape: an RFC3339 `Created`
+    /// (which the shared TTL classifier accepts) and the short-form `Id`.
+    /// Anything malformed reads as "can't answer".
+    #[test]
+    fn inspect_json_parsing() {
+        let stdout = r#"[
+             {
+               "Id": "sha256:deadbeef",
+               "Created": "2026-07-01T12:00:00.123456789Z",
+               "Labels": { "fletch.agent": "claude" }
+             }
+        ]"#;
+        assert_eq!(
+            parse_inspect_json(stdout),
+            Some((
+                "sha256:deadbeef".to_string(),
+                "2026-07-01T12:00:00.123456789Z".to_string()
+            )),
+        );
+        // The timestamp it yields must be the shape the shared classifier reads.
+        let (_, created) = parse_inspect_json(stdout).unwrap();
+        assert_ne!(
+            classify_freshness(&created, chrono::Utc::now()),
+            Freshness::Unknown,
+            "podman's JSON timestamp must parse as RFC3339",
+        );
+
+        // Empty array (image vanished between calls), missing fields, blank
+        // values, and non-JSON all read as "no answer".
+        assert_eq!(parse_inspect_json("[]"), None);
+        assert_eq!(parse_inspect_json(r#"[{"Id": "sha256:a"}]"#), None);
+        assert_eq!(
+            parse_inspect_json(r#"[{"Id": "", "Created": "2026-07-01T12:00:00Z"}]"#),
+            None,
+        );
+        assert_eq!(parse_inspect_json("not json"), None);
+        assert_eq!(parse_inspect_json(""), None);
+    }
+
+    /// The override path must not touch podman at all — it has to work (and
+    /// return instantly) on machines where podman isn't even installed, and it
+    /// takes the connection like every other path without ever using it.
+    #[test]
+    fn override_image_skips_build_entirely() {
+        let called = std::sync::atomic::AtomicBool::new(false);
+        let progress = |_: &str| called.store(true, std::sync::atomic::Ordering::SeqCst);
+
+        // A host version is passed to prove the override path ignores it too:
+        // the user's image is never inspected, so there's nothing to compare.
+        let image = resolve_image(
+            ContainerProvider::Claude,
+            Some("no-such-connection"),
+            Some("  ghcr.io/me/custom:1  "),
+            Some("v9.9.9"),
+            &progress,
+        )
+        .unwrap();
+        assert_eq!(
+            image, "ghcr.io/me/custom:1",
+            "override is trimmed and used verbatim"
+        );
+        assert!(
+            !called.load(std::sync::atomic::Ordering::SeqCst),
+            "override path must never build",
+        );
+    }
 
     /// Integration: builds a tiny image (busybox base) through the real
     /// machinery, then verifies the second call is a cached no-op.
@@ -149,6 +675,59 @@ mod tests {
             lines.load(std::sync::atomic::Ordering::SeqCst),
             0,
             "an existing image must not rebuild",
+        );
+
+        // The freshness path's inspect must resolve against a real image: an id
+        // and an RFC3339 build date the shared classifier calls fresh.
+        let (id, created) = inspect_id_and_created(None, &tag).expect("inspect must answer");
+        assert!(!id.is_empty());
+        assert_eq!(
+            classify_freshness(&created, chrono::Utc::now()),
+            Freshness::Fresh,
+            "a just-built image must classify fresh (created = {created})",
+        );
+
+        let _ = cli::run_podman(&["rmi", "-f", &tag], Duration::from_secs(30));
+    }
+
+    /// Integration: the in-container version probe runs `<image_bin> --version`
+    /// through the image's argv path and extracts the version with the host
+    /// probe's parser — a fake `claude` script in a busybox image must come back
+    /// as `v9.9.9`, and the result must be memoized by image id.
+    /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
+    #[test]
+    #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]
+    fn probes_container_cli_version() {
+        if !crate::sandbox::podman::podman_tests_enabled() {
+            return;
+        }
+        let dockerfile = "FROM busybox\nRUN printf '#!/bin/sh\\necho 9.9.9\\n' > /bin/claude && chmod +x /bin/claude\n";
+        let tag = tag_for("fletch-agent", dockerfile, "");
+        let _ = cli::run_podman(&["rmi", "-f", &tag], Duration::from_secs(30));
+        ensure_image(None, &tag, dockerfile, "", &|_| {}).unwrap();
+
+        assert_eq!(
+            probe_image_cli_version(ContainerProvider::Claude, None, &tag).as_deref(),
+            Some("v9.9.9"),
+            "container probe must parse the CLI's --version output",
+        );
+        // The cached path returns the same answer without another podman run
+        // (indirectly observable: it works even against a bogus tag once the id
+        // is cached).
+        assert_eq!(
+            image_cli_version(ContainerProvider::Claude, None, &tag, "test-id-123").as_deref(),
+            Some("v9.9.9"),
+        );
+        assert_eq!(
+            image_cli_version(
+                ContainerProvider::Claude,
+                None,
+                "no-such-image:zzz",
+                "test-id-123"
+            )
+            .as_deref(),
+            Some("v9.9.9"),
+            "second lookup for the same image id must hit the cache",
         );
 
         let _ = cli::run_podman(&["rmi", "-f", &tag], Duration::from_secs(30));

--- a/src-tauri/src/sandbox/podman/machine.rs
+++ b/src-tauri/src/sandbox/podman/machine.rs
@@ -10,9 +10,14 @@
 //! anything but a mount problem.
 //!
 //! So the launch is refused up front, naming the path and the shared dirs. The
-//! check is skipped whenever it can't be answered (no machine at all — a native
-//! Linux host runs containers directly — or an inspect we couldn't parse):
-//! guessing "unshared" there would refuse launches that work fine.
+//! dirs come from the machine behind podman's *default connection* — the one
+//! `podman run` will use — never from any other machine, whose mounts say
+//! nothing about where this run's binds resolve. A default connection that
+//! targets a remote host is refused outright (the identical-path binds cannot
+//! exist there); the check is skipped only when it genuinely can't be answered
+//! (no machine at all — a native Linux host or a local socket runs containers
+//! directly — or a connection list / inspect we couldn't read): guessing
+//! "unshared" there would refuse launches that work fine.
 
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
@@ -28,11 +33,22 @@ use super::cli;
 const INSPECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Refuse the launch when any of `sources` lies outside the machine's shared
-/// directories. `sources` is every host path the run will bind-mount — see
+/// directories — or when podman's default connection targets a remote host,
+/// where the identical-path mounts cannot exist at all. `sources` is every
+/// host path the run will bind-mount — see
 /// [`run_args::mount_sources`](crate::sandbox::container::run_args::mount_sources).
 pub(super) fn ensure_sources_are_shared(sources: &[PathBuf]) -> Result<()> {
-    let Some(shared) = shared_dirs() else {
-        return Ok(());
+    let shared = match preflight() {
+        Preflight::Skip => return Ok(()),
+        Preflight::Remote { connection } => {
+            return Err(Error::SandboxUnavailable(format!(
+                "podman's default connection `{connection}` targets a remote host, so the \
+                 agent's mounts (workspace, RPC mailbox, credentials) would not exist inside \
+                 its containers. Make a local Podman machine the default \
+                 (`podman system connection default <machine>`) before launching.",
+            )));
+        }
+        Preflight::Dirs(dirs) => dirs,
     };
     let roots: Vec<PathBuf> = shared.iter().map(|p| resolve_existing_prefix(p)).collect();
     let Some(outside) = sources
@@ -62,83 +78,137 @@ fn is_under_any(path: &Path, roots: &[PathBuf]) -> bool {
     roots.iter().any(|root| path.starts_with(root))
 }
 
-/// The machine's shared host directories, read once per app run: the mounts
-/// don't change without a `podman machine set` + restart, and the check runs on
-/// every launch. `None` means "unanswerable" — no machine (native Linux), an
-/// inspect that failed, or one reporting no mounts at all.
-fn shared_dirs() -> Option<&'static Vec<PathBuf>> {
-    static DIRS: OnceLock<Option<Vec<PathBuf>>> = OnceLock::new();
-    DIRS.get_or_init(|| {
-        // Inspect the machine the launch will actually go through — the one
-        // behind podman's default connection — never a union across machines:
-        // a path shared only by *another* machine would pass the check and
-        // then mount empty in the container this launch starts. When the
-        // connection can't name a machine, the bare inspect (podman's default
-        // machine) is the best remaining answer.
-        let inspect_args: Vec<String> = match connection_machine() {
-            Some(name) => vec!["machine".into(), "inspect".into(), name],
-            None => vec!["machine".into(), "inspect".into()],
+/// What the preflight resolved, read once per app run: the mounts don't
+/// change without a `podman machine set` + restart, and the check runs on
+/// every launch.
+enum Preflight {
+    /// The connection's machine answered with its shared host dirs — check
+    /// every mount source against them.
+    Dirs(Vec<PathBuf>),
+    /// Unanswerable (no machine — native Linux or a local socket — an inspect
+    /// or connection list we couldn't read, or no mounts reported): guessing
+    /// "unshared" would refuse launches that work, so the check is skipped.
+    Skip,
+    /// The default connection targets a remote host. Not a mounts question:
+    /// the identical-path binds cannot exist there at all, so the launch is
+    /// refused — and never validated against some *local* machine's mounts,
+    /// which say nothing about where this run's binds resolve.
+    Remote { connection: String },
+}
+
+fn preflight() -> &'static Preflight {
+    static P: OnceLock<Preflight> = OnceLock::new();
+    P.get_or_init(|| {
+        // Resolve the machine the launch will actually go through — the one
+        // behind podman's default connection (Fletch never passes
+        // `--connection`) — never a union across machines and never a "some
+        // other machine" fallback: mounts of a machine this launch does not
+        // use can pass a path that then arrives empty in the one it does.
+        let machine = match connection_target() {
+            ConnectionTarget::Machine(name) => name,
+            ConnectionTarget::Remote { connection } => {
+                return Preflight::Remote { connection };
+            }
+            ConnectionTarget::LocalSocket | ConnectionTarget::Unknown => {
+                tracing::debug!(
+                    target: "fletch::podman",
+                    "podman default connection names no machine; skipping the shared-path preflight",
+                );
+                return Preflight::Skip;
+            }
         };
-        let args: Vec<&str> = inspect_args.iter().map(String::as_str).collect();
-        let out = cli::run_podman(&args, INSPECT_TIMEOUT).ok()?;
-        if !out.status.success() {
-            // The usual case on Linux: `podman machine` reports no such
-            // machine, because containers run on the host kernel directly and
-            // every host path is reachable.
-            tracing::debug!(
-                target: "fletch::podman",
-                "podman machine inspect reported no machine; skipping the shared-path preflight",
-            );
-            return None;
-        }
+        let inspect = cli::run_podman(&["machine", "inspect", &machine], INSPECT_TIMEOUT);
+        let out = match inspect {
+            Ok(out) if out.status.success() => out,
+            // A stale connection naming a deleted machine, or a wedged CLI:
+            // unanswerable, and `podman run` will fail on its own terms.
+            _ => {
+                tracing::debug!(
+                    target: "fletch::podman",
+                    machine = %machine,
+                    "podman machine inspect failed; skipping the shared-path preflight",
+                );
+                return Preflight::Skip;
+            }
+        };
         let dirs = parse_shared_dirs(&String::from_utf8_lossy(&out.stdout));
         if dirs.is_empty() {
             tracing::debug!(
                 target: "fletch::podman",
+                machine = %machine,
                 "podman machine inspect reported no mounts; skipping the shared-path preflight",
             );
-            return None;
+            return Preflight::Skip;
         }
-        tracing::info!(target: "fletch::podman", ?dirs, "podman machine shared directories");
-        Some(dirs)
+        tracing::info!(target: "fletch::podman", machine = %machine, ?dirs, "podman machine shared directories");
+        Preflight::Dirs(dirs)
     })
-    .as_ref()
 }
 
-/// The machine name behind podman's default connection — the connection every
-/// launch in this app uses (Fletch never passes `--connection`). `None` when
-/// the lookup fails or the default connection isn't a machine at all, and the
-/// caller falls back to inspecting podman's default machine.
-fn connection_machine() -> Option<String> {
-    let out = cli::run_podman(
+/// Where podman's default connection points.
+#[derive(Debug, PartialEq, Eq)]
+enum ConnectionTarget {
+    /// A machine, by name — the authoritative source for shared dirs.
+    Machine(String),
+    /// A local unix socket (rootful Linux, say): no VM in the path, every
+    /// host path is reachable, nothing to check.
+    LocalSocket,
+    /// A remote host: bind sources don't exist there, refuse the launch.
+    Remote { connection: String },
+    /// No default entry, or a list we couldn't run or read.
+    Unknown,
+}
+
+fn connection_target() -> ConnectionTarget {
+    let Ok(out) = cli::run_podman(
         &["system", "connection", "list", "--format", "json"],
         INSPECT_TIMEOUT,
-    )
-    .ok()?;
+    ) else {
+        return ConnectionTarget::Unknown;
+    };
     if !out.status.success() {
-        return None;
+        return ConnectionTarget::Unknown;
     }
-    default_connection_machine(&String::from_utf8_lossy(&out.stdout))
+    classify_default_connection(&String::from_utf8_lossy(&out.stdout))
 }
 
-/// The machine name named by the default entry of `podman system connection
-/// list --format json`. Machine connections come in `<machine>` / `<machine>-root`
-/// pairs, so a trailing `-root` is stripped; an entry that says it is not a
-/// machine (`IsMachine: false` — a remote host) yields `None`, because machine
-/// mounts say nothing about where a remote connection's binds resolve.
-fn default_connection_machine(stdout: &str) -> Option<String> {
-    let connections = serde_json::from_str::<Vec<serde_json::Value>>(stdout).ok()?;
-    let default = connections
+/// Classify the default entry of `podman system connection list --format json`.
+/// Machine connections come in `<machine>` / `<machine>-root` pairs, so a
+/// trailing `-root` is stripped. `IsMachine: false` splits on the URI: a
+/// `unix://` socket is this host (no VM, nothing to check), anything else —
+/// `ssh://`, `tcp://`, or a URI we can't read — is treated as remote and
+/// refused rather than guessed at. Older podman omits `IsMachine`; the name is
+/// taken as a machine name, and the inspect that follows settles whether it
+/// really is one.
+fn classify_default_connection(stdout: &str) -> ConnectionTarget {
+    let Ok(connections) = serde_json::from_str::<Vec<serde_json::Value>>(stdout) else {
+        return ConnectionTarget::Unknown;
+    };
+    let Some(default) = connections
         .iter()
-        .find(|c| c.get("Default").and_then(|d| d.as_bool()) == Some(true))?;
-    if default.get("IsMachine").and_then(|m| m.as_bool()) == Some(false) {
-        return None;
-    }
-    let name = default.get("Name")?.as_str()?.trim();
+        .find(|c| c.get("Default").and_then(|d| d.as_bool()) == Some(true))
+    else {
+        return ConnectionTarget::Unknown;
+    };
+    let name = default
+        .get("Name")
+        .and_then(|n| n.as_str())
+        .map(str::trim)
+        .unwrap_or_default();
     if name.is_empty() {
-        return None;
+        return ConnectionTarget::Unknown;
     }
-    Some(name.strip_suffix("-root").unwrap_or(name).to_string())
+    if default.get("IsMachine").and_then(|m| m.as_bool()) == Some(false) {
+        let uri = default.get("URI").and_then(|u| u.as_str()).unwrap_or("");
+        return if uri.starts_with("unix://") {
+            ConnectionTarget::LocalSocket
+        } else {
+            ConnectionTarget::Remote {
+                connection: name.to_string(),
+            }
+        };
+    }
+    ConnectionTarget::Machine(name.strip_suffix("-root").unwrap_or(name).to_string())
 }
 
 /// Host-side sources from `podman machine inspect` output: a JSON array whose
@@ -232,39 +302,67 @@ mod tests {
         );
     }
 
-    /// The default connection names the machine a launch goes through; `-root`
-    /// pairs collapse to the machine name, a non-machine default (remote host)
-    /// yields nothing, and so does an unreadable or default-less list.
+    /// The default connection decides which machine (if any) the preflight may
+    /// consult: `-root` pairs collapse to the machine name, a local unix socket
+    /// means no VM at all, and a remote default must classify as `Remote` —
+    /// never fall back to some local machine whose mounts say nothing about
+    /// where this run's binds resolve.
     #[test]
-    fn default_connection_selects_the_machine() {
+    fn default_connection_classifies_machine_socket_and_remote() {
         let rootful = r#"[
           { "Name": "podman-machine-default", "IsMachine": true, "Default": false },
           { "Name": "work-vm-root", "IsMachine": true, "Default": true },
           { "Name": "work-vm", "IsMachine": true, "Default": false }
         ]"#;
         assert_eq!(
-            default_connection_machine(rootful),
-            Some("work-vm".to_string())
+            classify_default_connection(rootful),
+            ConnectionTarget::Machine("work-vm".to_string())
         );
 
-        let remote = r#"[
-          { "Name": "build-box", "IsMachine": false, "Default": true },
+        let remote_ssh = r#"[
+          { "Name": "build-box", "IsMachine": false, "Default": true, "URI": "ssh://core@build.example.com:22/run/podman/podman.sock" },
           { "Name": "podman-machine-default", "IsMachine": true, "Default": false }
         ]"#;
-        assert_eq!(default_connection_machine(remote), None);
-
-        // Older podman omits IsMachine; the name is still the machine.
-        let legacy = r#"[ { "Name": "podman-machine-default", "Default": true } ]"#;
         assert_eq!(
-            default_connection_machine(legacy),
-            Some("podman-machine-default".to_string())
+            classify_default_connection(remote_ssh),
+            ConnectionTarget::Remote {
+                connection: "build-box".to_string()
+            }
         );
 
-        assert_eq!(default_connection_machine("[]"), None);
-        assert_eq!(default_connection_machine("Error: unknown"), None);
+        // Explicitly not a machine with no readable URI: refused, not guessed.
+        let remote_no_uri = r#"[ { "Name": "mystery", "IsMachine": false, "Default": true } ]"#;
         assert_eq!(
-            default_connection_machine(r#"[{ "Name": "m", "Default": false }]"#),
-            None
+            classify_default_connection(remote_no_uri),
+            ConnectionTarget::Remote {
+                connection: "mystery".to_string()
+            }
+        );
+
+        let local_socket = r#"[
+          { "Name": "local-root", "IsMachine": false, "Default": true, "URI": "unix:///run/podman/podman.sock" }
+        ]"#;
+        assert_eq!(
+            classify_default_connection(local_socket),
+            ConnectionTarget::LocalSocket
+        );
+
+        // Older podman omits IsMachine; the name is taken as a machine name
+        // and the inspect that follows settles it.
+        let legacy = r#"[ { "Name": "podman-machine-default", "Default": true } ]"#;
+        assert_eq!(
+            classify_default_connection(legacy),
+            ConnectionTarget::Machine("podman-machine-default".to_string())
+        );
+
+        assert_eq!(classify_default_connection("[]"), ConnectionTarget::Unknown);
+        assert_eq!(
+            classify_default_connection("Error: unknown"),
+            ConnectionTarget::Unknown
+        );
+        assert_eq!(
+            classify_default_connection(r#"[{ "Name": "m", "Default": false }]"#),
+            ConnectionTarget::Unknown
         );
     }
 

--- a/src-tauri/src/sandbox/podman/machine.rs
+++ b/src-tauri/src/sandbox/podman/machine.rs
@@ -1,0 +1,195 @@
+//! The `podman machine` shared-directory preflight.
+//!
+//! Podman on macOS runs containers inside a Linux VM, and that VM sees only the
+//! host directories the machine was configured to share (by default `$HOME`).
+//! A bind mount whose source lies outside them does not fail — the VM has
+//! nothing at that path, so the container gets an **empty directory**. Every
+//! Fletch mount is at its identical host path (invariant 1), so an agent whose
+//! workspace or RPC mailbox lands outside the shared set would start, find an
+//! empty checkout and an unreachable mailbox, and fail in ways that look like
+//! anything but a mount problem.
+//!
+//! So the launch is refused up front, naming the path and the shared dirs. The
+//! check is skipped whenever it can't be answered (no machine at all — a native
+//! Linux host runs containers directly — or an inspect we couldn't parse):
+//! guessing "unshared" there would refuse launches that work fine.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use crate::error::{Error, Result};
+use crate::sandbox::policy::resolve_existing_prefix;
+
+use super::cli;
+
+/// `podman machine inspect` is a local config read; this bound only reaps a
+/// wedged invocation.
+const INSPECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Refuse the launch when any of `sources` lies outside the machine's shared
+/// directories. `sources` is every host path the run will bind-mount — see
+/// [`run_args::mount_sources`](crate::sandbox::container::run_args::mount_sources).
+pub(super) fn ensure_sources_are_shared(sources: &[PathBuf]) -> Result<()> {
+    let Some(shared) = shared_dirs() else {
+        return Ok(());
+    };
+    let roots: Vec<PathBuf> = shared.iter().map(|p| resolve_existing_prefix(p)).collect();
+    let Some(outside) = sources
+        .iter()
+        .find(|src| !is_under_any(&resolve_existing_prefix(src), &roots))
+    else {
+        return Ok(());
+    };
+    let listed = shared
+        .iter()
+        .map(|p| p.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(Error::SandboxUnavailable(format!(
+        "{} is outside the Podman machine's shared directories ({listed}), so it would mount \
+         empty inside the container. Share it with `podman machine set --volume <dir>` and \
+         restart the machine, or keep the agent's workspace under a shared directory.",
+        outside.display(),
+    )))
+}
+
+/// Whether `path` is at or below one of `roots`. Pure over already-resolved
+/// paths — component-wise, so `/Users/ab` is not read as being under
+/// `/Users/a`. An empty `roots` covers nothing, which is why the caller treats
+/// "no shared dirs reported" as unanswerable rather than passing it through.
+fn is_under_any(path: &Path, roots: &[PathBuf]) -> bool {
+    roots.iter().any(|root| path.starts_with(root))
+}
+
+/// The machine's shared host directories, read once per app run: the mounts
+/// don't change without a `podman machine set` + restart, and the check runs on
+/// every launch. `None` means "unanswerable" — no machine (native Linux), an
+/// inspect that failed, or one reporting no mounts at all.
+fn shared_dirs() -> Option<&'static Vec<PathBuf>> {
+    static DIRS: OnceLock<Option<Vec<PathBuf>>> = OnceLock::new();
+    DIRS.get_or_init(|| {
+        let out = cli::run_podman(&["machine", "inspect"], INSPECT_TIMEOUT).ok()?;
+        if !out.status.success() {
+            // The usual case on Linux: `podman machine` reports no such
+            // machine, because containers run on the host kernel directly and
+            // every host path is reachable.
+            tracing::debug!(
+                target: "fletch::podman",
+                "podman machine inspect reported no machine; skipping the shared-path preflight",
+            );
+            return None;
+        }
+        let dirs = parse_shared_dirs(&String::from_utf8_lossy(&out.stdout));
+        if dirs.is_empty() {
+            tracing::debug!(
+                target: "fletch::podman",
+                "podman machine inspect reported no mounts; skipping the shared-path preflight",
+            );
+            return None;
+        }
+        tracing::info!(target: "fletch::podman", ?dirs, "podman machine shared directories");
+        Some(dirs)
+    })
+    .as_ref()
+}
+
+/// Host-side sources from `podman machine inspect` output: a JSON array of
+/// machines, each with a `Mounts` array whose entries carry the host path as
+/// `Source` (and the in-VM path as `Target`). Every machine's mounts are taken
+/// — the connection a launch uses is whichever is current, and a path shared by
+/// all of them is shared by that one too; taking the union only ever risks
+/// letting a launch through, which is the same bias as skipping the check.
+///
+/// Tolerant by design: a shape we don't recognize yields an empty set, which
+/// the caller reads as "unanswerable" and skips.
+fn parse_shared_dirs(stdout: &str) -> Vec<PathBuf> {
+    let Ok(machines) = serde_json::from_str::<Vec<serde_json::Value>>(stdout) else {
+        return Vec::new();
+    };
+    let mut out: Vec<PathBuf> = Vec::new();
+    for machine in machines {
+        let Some(mounts) = machine.get("Mounts").and_then(|m| m.as_array()) else {
+            continue;
+        };
+        for mount in mounts {
+            let Some(source) = mount.get("Source").and_then(|s| s.as_str()) else {
+                continue;
+            };
+            let source = source.trim();
+            if source.is_empty() {
+                continue;
+            }
+            let path = PathBuf::from(source);
+            if !out.contains(&path) {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Containment is component-wise: a sibling whose name merely starts with a
+    /// shared dir's name is not inside it.
+    #[test]
+    fn containment_is_component_wise() {
+        let roots = vec![PathBuf::from("/Users/ada"), PathBuf::from("/private/tmp")];
+
+        assert!(is_under_any(Path::new("/Users/ada"), &roots));
+        assert!(is_under_any(
+            Path::new("/Users/ada/.fletch/worktrees/orkney"),
+            &roots
+        ));
+        assert!(is_under_any(Path::new("/private/tmp/x"), &roots));
+
+        assert!(!is_under_any(Path::new("/Users/adamant/repo"), &roots));
+        assert!(!is_under_any(Path::new("/Volumes/ext/repo"), &roots));
+        assert!(!is_under_any(Path::new("/Users"), &roots));
+        // Nothing is shared when nothing is reported — which is why the caller
+        // treats an empty set as unanswerable instead of refusing every launch.
+        assert!(!is_under_any(Path::new("/Users/ada"), &[]));
+    }
+
+    /// The `podman machine inspect` shape: an array of machines, host paths in
+    /// each mount's `Source`, deduped across machines.
+    #[test]
+    fn parses_mount_sources_from_inspect_json() {
+        let stdout = r#"[
+          {
+            "Name": "podman-machine-default",
+            "State": "running",
+            "Mounts": [
+              { "ReadOnly": false, "Source": "/Users/ada", "Tag": "vol0", "Target": "/Users/ada", "Type": "virtiofs" },
+              { "ReadOnly": false, "Source": "/private/tmp", "Tag": "vol1", "Target": "/private/tmp", "Type": "virtiofs" }
+            ]
+          },
+          {
+            "Name": "second",
+            "Mounts": [
+              { "Source": "/Users/ada", "Target": "/Users/ada" },
+              { "Source": "  ", "Target": "/blank" },
+              { "Target": "/no-source" }
+            ]
+          }
+        ]"#;
+        assert_eq!(
+            parse_shared_dirs(stdout),
+            vec![PathBuf::from("/Users/ada"), PathBuf::from("/private/tmp")],
+        );
+    }
+
+    /// Anything we can't read yields an empty set, so the caller skips the
+    /// check rather than refusing launches on a shape change.
+    #[test]
+    fn unrecognized_inspect_output_yields_no_dirs() {
+        assert!(parse_shared_dirs("[]").is_empty());
+        assert!(parse_shared_dirs("").is_empty());
+        assert!(parse_shared_dirs("Error: no such machine").is_empty());
+        assert!(parse_shared_dirs(r#"[{"Name":"m"}]"#).is_empty());
+        assert!(parse_shared_dirs(r#"[{"Mounts":{}}]"#).is_empty());
+    }
+}

--- a/src-tauri/src/sandbox/podman/machine.rs
+++ b/src-tauri/src/sandbox/podman/machine.rs
@@ -69,7 +69,18 @@ fn is_under_any(path: &Path, roots: &[PathBuf]) -> bool {
 fn shared_dirs() -> Option<&'static Vec<PathBuf>> {
     static DIRS: OnceLock<Option<Vec<PathBuf>>> = OnceLock::new();
     DIRS.get_or_init(|| {
-        let out = cli::run_podman(&["machine", "inspect"], INSPECT_TIMEOUT).ok()?;
+        // Inspect the machine the launch will actually go through — the one
+        // behind podman's default connection — never a union across machines:
+        // a path shared only by *another* machine would pass the check and
+        // then mount empty in the container this launch starts. When the
+        // connection can't name a machine, the bare inspect (podman's default
+        // machine) is the best remaining answer.
+        let inspect_args: Vec<String> = match connection_machine() {
+            Some(name) => vec!["machine".into(), "inspect".into(), name],
+            None => vec!["machine".into(), "inspect".into()],
+        };
+        let args: Vec<&str> = inspect_args.iter().map(String::as_str).collect();
+        let out = cli::run_podman(&args, INSPECT_TIMEOUT).ok()?;
         if !out.status.success() {
             // The usual case on Linux: `podman machine` reports no such
             // machine, because containers run on the host kernel directly and
@@ -94,12 +105,47 @@ fn shared_dirs() -> Option<&'static Vec<PathBuf>> {
     .as_ref()
 }
 
-/// Host-side sources from `podman machine inspect` output: a JSON array of
-/// machines, each with a `Mounts` array whose entries carry the host path as
-/// `Source` (and the in-VM path as `Target`). Every machine's mounts are taken
-/// — the connection a launch uses is whichever is current, and a path shared by
-/// all of them is shared by that one too; taking the union only ever risks
-/// letting a launch through, which is the same bias as skipping the check.
+/// The machine name behind podman's default connection — the connection every
+/// launch in this app uses (Fletch never passes `--connection`). `None` when
+/// the lookup fails or the default connection isn't a machine at all, and the
+/// caller falls back to inspecting podman's default machine.
+fn connection_machine() -> Option<String> {
+    let out = cli::run_podman(
+        &["system", "connection", "list", "--format", "json"],
+        INSPECT_TIMEOUT,
+    )
+    .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    default_connection_machine(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// The machine name named by the default entry of `podman system connection
+/// list --format json`. Machine connections come in `<machine>` / `<machine>-root`
+/// pairs, so a trailing `-root` is stripped; an entry that says it is not a
+/// machine (`IsMachine: false` — a remote host) yields `None`, because machine
+/// mounts say nothing about where a remote connection's binds resolve.
+fn default_connection_machine(stdout: &str) -> Option<String> {
+    let connections = serde_json::from_str::<Vec<serde_json::Value>>(stdout).ok()?;
+    let default = connections
+        .iter()
+        .find(|c| c.get("Default").and_then(|d| d.as_bool()) == Some(true))?;
+    if default.get("IsMachine").and_then(|m| m.as_bool()) == Some(false) {
+        return None;
+    }
+    let name = default.get("Name")?.as_str()?.trim();
+    if name.is_empty() {
+        return None;
+    }
+    Some(name.strip_suffix("-root").unwrap_or(name).to_string())
+}
+
+/// Host-side sources from `podman machine inspect` output: a JSON array whose
+/// **first** machine's `Mounts` entries carry the host path as `Source` (and
+/// the in-VM path as `Target`). Only the first machine is read — the caller
+/// inspects one machine by name (or podman's default), and any further array
+/// entries would belong to machines this launch does not go through.
 ///
 /// Tolerant by design: a shape we don't recognize yields an empty set, which
 /// the caller reads as "unanswerable" and skips.
@@ -108,22 +154,23 @@ fn parse_shared_dirs(stdout: &str) -> Vec<PathBuf> {
         return Vec::new();
     };
     let mut out: Vec<PathBuf> = Vec::new();
-    for machine in machines {
-        let Some(mounts) = machine.get("Mounts").and_then(|m| m.as_array()) else {
+    let Some(machine) = machines.first() else {
+        return out;
+    };
+    let Some(mounts) = machine.get("Mounts").and_then(|m| m.as_array()) else {
+        return out;
+    };
+    for mount in mounts {
+        let Some(source) = mount.get("Source").and_then(|s| s.as_str()) else {
             continue;
         };
-        for mount in mounts {
-            let Some(source) = mount.get("Source").and_then(|s| s.as_str()) else {
-                continue;
-            };
-            let source = source.trim();
-            if source.is_empty() {
-                continue;
-            }
-            let path = PathBuf::from(source);
-            if !out.contains(&path) {
-                out.push(path);
-            }
+        let source = source.trim();
+        if source.is_empty() {
+            continue;
+        }
+        let path = PathBuf::from(source);
+        if !out.contains(&path) {
+            out.push(path);
         }
     }
     out
@@ -155,30 +202,69 @@ mod tests {
     }
 
     /// The `podman machine inspect` shape: an array of machines, host paths in
-    /// each mount's `Source`, deduped across machines.
+    /// each mount's `Source`. Only the first machine counts — a mount shared
+    /// only by a second machine must NOT pass the preflight, or the launch
+    /// would proceed and bind an empty directory in the machine it actually
+    /// runs in.
     #[test]
-    fn parses_mount_sources_from_inspect_json() {
+    fn parses_mount_sources_from_first_machine_only() {
         let stdout = r#"[
           {
             "Name": "podman-machine-default",
             "State": "running",
             "Mounts": [
               { "ReadOnly": false, "Source": "/Users/ada", "Tag": "vol0", "Target": "/Users/ada", "Type": "virtiofs" },
-              { "ReadOnly": false, "Source": "/private/tmp", "Tag": "vol1", "Target": "/private/tmp", "Type": "virtiofs" }
+              { "ReadOnly": false, "Source": "/private/tmp", "Tag": "vol1", "Target": "/private/tmp", "Type": "virtiofs" },
+              { "Source": "  ", "Target": "/blank" },
+              { "Target": "/no-source" }
             ]
           },
           {
             "Name": "second",
             "Mounts": [
-              { "Source": "/Users/ada", "Target": "/Users/ada" },
-              { "Source": "  ", "Target": "/blank" },
-              { "Target": "/no-source" }
+              { "Source": "/Volumes/only-on-second", "Target": "/Volumes/only-on-second" }
             ]
           }
         ]"#;
         assert_eq!(
             parse_shared_dirs(stdout),
             vec![PathBuf::from("/Users/ada"), PathBuf::from("/private/tmp")],
+        );
+    }
+
+    /// The default connection names the machine a launch goes through; `-root`
+    /// pairs collapse to the machine name, a non-machine default (remote host)
+    /// yields nothing, and so does an unreadable or default-less list.
+    #[test]
+    fn default_connection_selects_the_machine() {
+        let rootful = r#"[
+          { "Name": "podman-machine-default", "IsMachine": true, "Default": false },
+          { "Name": "work-vm-root", "IsMachine": true, "Default": true },
+          { "Name": "work-vm", "IsMachine": true, "Default": false }
+        ]"#;
+        assert_eq!(
+            default_connection_machine(rootful),
+            Some("work-vm".to_string())
+        );
+
+        let remote = r#"[
+          { "Name": "build-box", "IsMachine": false, "Default": true },
+          { "Name": "podman-machine-default", "IsMachine": true, "Default": false }
+        ]"#;
+        assert_eq!(default_connection_machine(remote), None);
+
+        // Older podman omits IsMachine; the name is still the machine.
+        let legacy = r#"[ { "Name": "podman-machine-default", "Default": true } ]"#;
+        assert_eq!(
+            default_connection_machine(legacy),
+            Some("podman-machine-default".to_string())
+        );
+
+        assert_eq!(default_connection_machine("[]"), None);
+        assert_eq!(default_connection_machine("Error: unknown"), None);
+        assert_eq!(
+            default_connection_machine(r#"[{ "Name": "m", "Default": false }]"#),
+            None
         );
     }
 

--- a/src-tauri/src/sandbox/podman/machine.rs
+++ b/src-tauri/src/sandbox/podman/machine.rs
@@ -18,9 +18,13 @@
 //! (no machine at all — a native Linux host or a local socket runs containers
 //! directly — or a connection list / inspect we couldn't read): guessing
 //! "unshared" there would refuse launches that work fine.
+//!
+//! The same resolution names the connection the launch is *pinned* to
+//! ([`LaunchTarget`]), which is what makes the check and the run agree: reading
+//! the state here and letting `podman run` pick its own target later is how a
+//! validated path ends up mounting empty somewhere else.
 
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
 use std::time::Duration;
 
 use crate::error::{Error, Result};
@@ -32,23 +36,112 @@ use super::cli;
 /// wedged invocation.
 const INSPECT_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// Refuse the launch when any of `sources` lies outside the machine's shared
-/// directories — or when podman's default connection targets a remote host,
-/// where the identical-path mounts cannot exist at all. `sources` is every
-/// host path the run will bind-mount — see
-/// [`run_args::mount_sources`](crate::sandbox::container::run_args::mount_sources).
-pub(super) fn ensure_sources_are_shared(sources: &[PathBuf]) -> Result<()> {
-    let shared = match preflight() {
-        Preflight::Skip => return Ok(()),
-        Preflight::Remote { connection } => {
-            return Err(Error::SandboxUnavailable(format!(
-                "podman's default connection `{connection}` targets a remote host, so the \
-                 agent's mounts (workspace, RPC mailbox, credentials) would not exist inside \
-                 its containers. Make a local Podman machine the default \
-                 (`podman system connection default <machine>`) before launching.",
-            )));
+/// Where one launch's podman invocations go, and what its mounts must live
+/// under to be visible there. Resolved once per launch and carried through the
+/// container's whole life, so validate, run, kill and reap all speak to the
+/// same endpoint.
+pub(super) struct LaunchTarget {
+    /// The connection to pin every podman invocation for this container to.
+    /// `None` = no connections configured (bare native podman), where there is
+    /// no endpoint to name and the default is the only one.
+    pub(super) connection: Option<String>,
+    /// Shared host dirs to validate mount sources against. `None` = no VM in
+    /// the path, or the question is unanswerable, so the check is skipped —
+    /// guessing "unshared" would refuse launches that work.
+    shared_dirs: Option<Vec<PathBuf>>,
+}
+
+/// Resolve the target for one launch: which connection `podman run` must be
+/// pinned to, and that connection's shared host dirs.
+///
+/// Deliberately uncached, and re-run on every launch. The two reads are local
+/// config (`podman system connection list`, `podman machine inspect`) and
+/// negligible next to a container start, while a process-wide cache retains
+/// roots from a connection or machine the next launch no longer uses — a
+/// reviewed bug, not a hypothetical. A TTL cache can come back if the cost ever
+/// shows up under a spawn storm.
+pub(super) fn resolve_launch_target() -> Result<LaunchTarget> {
+    // The machine the launch will actually go through, pinned by name from here
+    // on — never a union across machines and never a "some other machine"
+    // fallback: mounts of a machine this launch does not use can pass a path
+    // that then arrives empty in the one it does.
+    match connection_target() {
+        ConnectionTarget::Machine {
+            connection,
+            machine,
+        } => {
+            let shared_dirs = machine_shared_dirs(&machine);
+            Ok(LaunchTarget {
+                connection: Some(connection),
+                shared_dirs,
+            })
         }
-        Preflight::Dirs(dirs) => dirs,
+        // A socket endpoint still gets pinned — the default connection can
+        // change mid-run, and teardown has to reach the container's own
+        // endpoint — but there is no VM, so every host path is reachable.
+        ConnectionTarget::LocalSocket { connection } => Ok(LaunchTarget {
+            connection: Some(connection),
+            shared_dirs: None,
+        }),
+        ConnectionTarget::Unknown => {
+            tracing::debug!(
+                target: "fletch::podman",
+                "podman default connection names no machine; skipping the shared-path preflight",
+            );
+            Ok(LaunchTarget {
+                connection: None,
+                shared_dirs: None,
+            })
+        }
+        ConnectionTarget::Remote { connection } => Err(Error::SandboxUnavailable(format!(
+            "podman's default connection `{connection}` targets a remote host, so the \
+             agent's mounts (workspace, RPC mailbox, credentials) would not exist inside \
+             its containers. Make a local Podman machine the default \
+             (`podman system connection default <machine>`) before launching.",
+        ))),
+    }
+}
+
+/// The shared host dirs of `machine`, or `None` when the question can't be
+/// answered (a stale connection naming a deleted machine, a wedged CLI, or no
+/// mounts reported) — `podman run` will then fail on its own terms.
+///
+/// Unpinned by design: `machine inspect` reads local machine config by name,
+/// which is exactly the name the pin strips its `-root` suffix from.
+fn machine_shared_dirs(machine: &str) -> Option<Vec<PathBuf>> {
+    let inspect = cli::run_podman(&["machine", "inspect", machine], INSPECT_TIMEOUT);
+    let out = match inspect {
+        Ok(out) if out.status.success() => out,
+        _ => {
+            tracing::debug!(
+                target: "fletch::podman",
+                machine = %machine,
+                "podman machine inspect failed; skipping the shared-path preflight",
+            );
+            return None;
+        }
+    };
+    let dirs = parse_shared_dirs(&String::from_utf8_lossy(&out.stdout));
+    if dirs.is_empty() {
+        tracing::debug!(
+            target: "fletch::podman",
+            machine = %machine,
+            "podman machine inspect reported no mounts; skipping the shared-path preflight",
+        );
+        return None;
+    }
+    tracing::info!(target: "fletch::podman", machine = %machine, ?dirs, "podman machine shared directories");
+    Some(dirs)
+}
+
+/// Refuse the launch when any of `sources` lies outside the shared directories
+/// of `target` — the connection this launch is pinned to, so the dirs checked
+/// are the dirs the run resolves against. `sources` is every host path the run
+/// will bind-mount — see
+/// [`run_args::mount_sources`](crate::sandbox::container::run_args::mount_sources).
+pub(super) fn ensure_sources_are_shared(sources: &[PathBuf], target: &LaunchTarget) -> Result<()> {
+    let Some(shared) = target.shared_dirs.as_deref() else {
+        return Ok(());
     };
     let roots: Vec<PathBuf> = shared.iter().map(|p| resolve_existing_prefix(p)).collect();
     let Some(outside) = sources
@@ -78,81 +171,18 @@ fn is_under_any(path: &Path, roots: &[PathBuf]) -> bool {
     roots.iter().any(|root| path.starts_with(root))
 }
 
-/// What the preflight resolved, read once per app run: the mounts don't
-/// change without a `podman machine set` + restart, and the check runs on
-/// every launch.
-enum Preflight {
-    /// The connection's machine answered with its shared host dirs — check
-    /// every mount source against them.
-    Dirs(Vec<PathBuf>),
-    /// Unanswerable (no machine — native Linux or a local socket — an inspect
-    /// or connection list we couldn't read, or no mounts reported): guessing
-    /// "unshared" would refuse launches that work, so the check is skipped.
-    Skip,
-    /// The default connection targets a remote host. Not a mounts question:
-    /// the identical-path binds cannot exist there at all, so the launch is
-    /// refused — and never validated against some *local* machine's mounts,
-    /// which say nothing about where this run's binds resolve.
-    Remote { connection: String },
-}
-
-fn preflight() -> &'static Preflight {
-    static P: OnceLock<Preflight> = OnceLock::new();
-    P.get_or_init(|| {
-        // Resolve the machine the launch will actually go through — the one
-        // behind podman's default connection (Fletch never passes
-        // `--connection`) — never a union across machines and never a "some
-        // other machine" fallback: mounts of a machine this launch does not
-        // use can pass a path that then arrives empty in the one it does.
-        let machine = match connection_target() {
-            ConnectionTarget::Machine(name) => name,
-            ConnectionTarget::Remote { connection } => {
-                return Preflight::Remote { connection };
-            }
-            ConnectionTarget::LocalSocket | ConnectionTarget::Unknown => {
-                tracing::debug!(
-                    target: "fletch::podman",
-                    "podman default connection names no machine; skipping the shared-path preflight",
-                );
-                return Preflight::Skip;
-            }
-        };
-        let inspect = cli::run_podman(&["machine", "inspect", &machine], INSPECT_TIMEOUT);
-        let out = match inspect {
-            Ok(out) if out.status.success() => out,
-            // A stale connection naming a deleted machine, or a wedged CLI:
-            // unanswerable, and `podman run` will fail on its own terms.
-            _ => {
-                tracing::debug!(
-                    target: "fletch::podman",
-                    machine = %machine,
-                    "podman machine inspect failed; skipping the shared-path preflight",
-                );
-                return Preflight::Skip;
-            }
-        };
-        let dirs = parse_shared_dirs(&String::from_utf8_lossy(&out.stdout));
-        if dirs.is_empty() {
-            tracing::debug!(
-                target: "fletch::podman",
-                machine = %machine,
-                "podman machine inspect reported no mounts; skipping the shared-path preflight",
-            );
-            return Preflight::Skip;
-        }
-        tracing::info!(target: "fletch::podman", machine = %machine, ?dirs, "podman machine shared directories");
-        Preflight::Dirs(dirs)
-    })
-}
-
 /// Where podman's default connection points.
 #[derive(Debug, PartialEq, Eq)]
 enum ConnectionTarget {
-    /// A machine, by name — the authoritative source for shared dirs.
-    Machine(String),
+    /// A machine. The two names differ and are not interchangeable:
+    /// `connection` is the verbatim entry name (`work-vm-root`) that
+    /// `--connection` takes, `machine` is the `-root`-stripped name
+    /// (`work-vm`) that `podman machine inspect` takes.
+    Machine { connection: String, machine: String },
     /// A local unix socket (rootful Linux, say): no VM in the path, every
-    /// host path is reachable, nothing to check.
-    LocalSocket,
+    /// host path is reachable, nothing to check — but still an endpoint worth
+    /// pinning, hence the name.
+    LocalSocket { connection: String },
     /// A remote host: bind sources don't exist there, refuse the launch.
     Remote { connection: String },
     /// No default entry, or a list we couldn't run or read.
@@ -173,8 +203,11 @@ fn connection_target() -> ConnectionTarget {
 }
 
 /// Classify the default entry of `podman system connection list --format json`.
-/// Machine connections come in `<machine>` / `<machine>-root` pairs, so a
-/// trailing `-root` is stripped. `IsMachine: false` splits on the URI: a
+/// Machine connections come in `<machine>` / `<machine>-root` pairs, so the
+/// machine name strips a trailing `-root` while the connection name stays
+/// verbatim — pinning `--connection work-vm` when the default is
+/// `work-vm-root` would silently move the run to the rootless endpoint.
+/// `IsMachine: false` splits on the URI: a
 /// `unix://` socket is this host (no VM, nothing to check), anything else —
 /// `ssh://`, `tcp://`, or a URI we can't read — is treated as remote and
 /// refused rather than guessed at. Older podman omits `IsMachine`; the name is
@@ -201,14 +234,19 @@ fn classify_default_connection(stdout: &str) -> ConnectionTarget {
     if default.get("IsMachine").and_then(|m| m.as_bool()) == Some(false) {
         let uri = default.get("URI").and_then(|u| u.as_str()).unwrap_or("");
         return if uri.starts_with("unix://") {
-            ConnectionTarget::LocalSocket
+            ConnectionTarget::LocalSocket {
+                connection: name.to_string(),
+            }
         } else {
             ConnectionTarget::Remote {
                 connection: name.to_string(),
             }
         };
     }
-    ConnectionTarget::Machine(name.strip_suffix("-root").unwrap_or(name).to_string())
+    ConnectionTarget::Machine {
+        connection: name.to_string(),
+        machine: name.strip_suffix("-root").unwrap_or(name).to_string(),
+    }
 }
 
 /// Host-side sources from `podman machine inspect` output: a JSON array whose
@@ -316,7 +354,10 @@ mod tests {
         ]"#;
         assert_eq!(
             classify_default_connection(rootful),
-            ConnectionTarget::Machine("work-vm".to_string())
+            ConnectionTarget::Machine {
+                connection: "work-vm-root".to_string(),
+                machine: "work-vm".to_string(),
+            }
         );
 
         let remote_ssh = r#"[
@@ -344,7 +385,9 @@ mod tests {
         ]"#;
         assert_eq!(
             classify_default_connection(local_socket),
-            ConnectionTarget::LocalSocket
+            ConnectionTarget::LocalSocket {
+                connection: "local-root".to_string()
+            }
         );
 
         // Older podman omits IsMachine; the name is taken as a machine name
@@ -352,7 +395,10 @@ mod tests {
         let legacy = r#"[ { "Name": "podman-machine-default", "Default": true } ]"#;
         assert_eq!(
             classify_default_connection(legacy),
-            ConnectionTarget::Machine("podman-machine-default".to_string())
+            ConnectionTarget::Machine {
+                connection: "podman-machine-default".to_string(),
+                machine: "podman-machine-default".to_string(),
+            }
         );
 
         assert_eq!(classify_default_connection("[]"), ConnectionTarget::Unknown);
@@ -364,6 +410,48 @@ mod tests {
             classify_default_connection(r#"[{ "Name": "m", "Default": false }]"#),
             ConnectionTarget::Unknown
         );
+    }
+
+    /// The two names a machine connection carries are not interchangeable: the
+    /// pin needs the verbatim entry name, the inspect needs the stripped one.
+    /// Conflating them sends the run to the other endpoint of a rootful pair.
+    #[test]
+    fn rootful_default_keeps_the_connection_and_machine_names_apart() {
+        let listing =
+            r#"[ { "Name": "podman-machine-default-root", "IsMachine": true, "Default": true } ]"#;
+        let ConnectionTarget::Machine {
+            connection,
+            machine,
+        } = classify_default_connection(listing)
+        else {
+            panic!("a rootful machine entry must classify as a machine");
+        };
+        assert_eq!(connection, "podman-machine-default-root");
+        assert_eq!(machine, "podman-machine-default");
+    }
+
+    /// The check reads the target's own dirs, and a target with none (no VM, or
+    /// an unanswerable inspect) passes everything through.
+    #[test]
+    fn the_check_follows_the_targets_shared_dirs() {
+        let home = dirs::home_dir().unwrap();
+        let shared = LaunchTarget {
+            connection: Some("podman-machine-default-root".to_string()),
+            shared_dirs: Some(vec![home.clone()]),
+        };
+        ensure_sources_are_shared(std::slice::from_ref(&home), &shared).unwrap();
+        let outside = PathBuf::from("/fletch-definitely-not-shared");
+        let err = ensure_sources_are_shared(std::slice::from_ref(&outside), &shared).unwrap_err();
+        assert!(
+            err.to_string().contains(&outside.display().to_string()),
+            "the refusal must name the path: {err}",
+        );
+
+        let unanswerable = LaunchTarget {
+            connection: None,
+            shared_dirs: None,
+        };
+        ensure_sources_are_shared(&[outside], &unanswerable).unwrap();
     }
 
     /// Anything we can't read yields an empty set, so the caller skips the

--- a/src-tauri/src/sandbox/podman/mod.rs
+++ b/src-tauri/src/sandbox/podman/mod.rs
@@ -17,10 +17,13 @@
 //!   podman call in this module goes through it, so no invocation can hang the
 //!   app on a wedged machine connection.
 //! - [`probe`] — cached availability for UI polling.
-//! - [`image`] — building and inspecting the agent images.
+//! - [`image`] — building, inspecting and refreshing the agent images.
 //! - [`machine`] — the shared-directory preflight, Podman's one behavioural
 //!   difference from Docker at launch time.
-//! - [`cleanup`] — the dead-instance orphan sweep and per-agent removal.
+//! - [`cleanup`] — the dead-instance orphan sweep, per-agent removal, and the
+//!   stale agent-image GC.
+//! - [`settings`] — the launch knobs (`podman_image` / `podman_memory` /
+//!   `podman_cpus`) and the version-refresh loop guard.
 //! - [`engine`] — `PodmanEngine`, the `SandboxEngine` implementation (one
 //!   `podman run --rm --init` container per agent process).
 
@@ -34,10 +37,20 @@ mod engine;
 mod image;
 mod machine;
 mod probe;
+mod settings;
 
 pub use cleanup::remove_agent_containers;
 pub use engine::PodmanEngine;
 pub use probe::{availability, PodmanAvailability};
+pub use settings::{
+    init_version_refresh_guard, set_launch_settings, LaunchSettings, CPUS_SETTING, IMAGE_SETTING,
+    MEMORY_SETTING, VERSION_GUARD_SETTING,
+};
+
+/// This runtime's display name in user-facing copy — the build toast's
+/// [`BuildEvent::Started`](crate::sandbox::container::progress::BuildEvent) and
+/// the reserved-exit-code messages.
+pub(super) const RUNTIME_NAME: &str = "Podman";
 
 /// Map a Podman probe result onto the shared retry schedule
 /// ([`container::sweep`](crate::sandbox::container::sweep)). A missing binary is
@@ -50,13 +63,18 @@ fn sweep_step(availability: &PodmanAvailability, elapsed: std::time::Duration) -
     crate::sandbox::container::sweep::sweep_step(usable, installed, elapsed)
 }
 
-/// Best-effort reclamation of containers left behind by dead Fletch instances,
-/// for app startup (`lib.rs`, next to the docker sweep). Runs on its own thread,
-/// so startup never waits on Podman — not even for the 2s probe timeout — and a
-/// machine without Podman skips the sweep entirely. Non-fatal by construction.
+/// Best-effort reclamation of containers left behind by dead Fletch instances —
+/// and of superseded agent images — for app startup (`lib.rs`, next to the docker
+/// sweep). Runs on its own thread, so startup never waits on Podman — not even
+/// for the 2s probe timeout — and a machine without Podman skips both sweeps
+/// entirely. The image sweep runs second: a removed orphan container can unpin
+/// the stale image it was running. Both sweeps are non-fatal by construction.
 ///
-/// No image sweep: this runtime ships no image GC yet, so there is nothing to
-/// run as a second pass.
+/// These two sweeps and the post-refresh one are the *only* thing that ever
+/// reclaims superseded agent images from podman's store, which is why the probe
+/// retries on the [`sweep_step`] schedule rather than giving up on the first
+/// answer — a user who loses the `podman machine start` race every launch would
+/// otherwise accumulate dangling images forever.
 pub fn sweep_orphans_at_startup() {
     std::thread::spawn(|| {
         let waiting_since = Instant::now();
@@ -78,6 +96,11 @@ pub fn sweep_orphans_at_startup() {
             Ok(0) => {}
             Ok(n) => tracing::info!(removed = n, "swept orphaned fletch podman containers"),
             Err(e) => tracing::warn!(error = %e, "podman orphan sweep failed"),
+        }
+        match cleanup::sweep_stale_images() {
+            Ok(0) => {}
+            Ok(n) => tracing::info!(removed = n, "swept stale fletch agent podman images"),
+            Err(e) => tracing::warn!(error = %e, "podman image sweep failed"),
         }
     });
 }

--- a/src-tauri/src/sandbox/podman/mod.rs
+++ b/src-tauri/src/sandbox/podman/mod.rs
@@ -1,28 +1,129 @@
-//! The Podman sandbox engine's primitives. A skeleton: this module can say
-//! whether Podman is usable, and nothing more.
-//!
-//! [`EngineKind::Podman`](crate::sandbox::EngineKind::Podman) exists and probes,
-//! but `sandbox::engine_for` refuses it unconditionally — there is no
-//! `SandboxEngine` implementation here yet, and no image build or cleanup.
-//! Shipping the kind ahead of the launch path is only safe because that refusal
-//! is unconditional rather than probe-gated: a Podman-stamped agent cannot
-//! launch even on a machine where the probe reports the runtime healthy, so
-//! there is no path on which a launch silently escapes the container boundary
-//! the user picked.
+//! The Podman sandbox engine and its primitives: availability probing, the
+//! agent image, orphaned-container cleanup, and the launch path.
 //!
 //! Everything here must work when Podman is absent or its machine is down:
-//! probing reports that state instead of erroring.
+//! probing reports that state instead of erroring, the startup sweep is
+//! probe-gated so an install-less machine never pays for a podman invocation,
+//! and `sandbox::engine_for` only routes launches here when the probe says the
+//! machine answers. "Down" and "absent" are distinguished throughout: a down
+//! machine is a state that flips (see [`sweep_orphans_at_startup`], which waits
+//! one out), an absent binary is treated as settled for the run.
 //!
 //! Layout mirrors [`docker`](crate::sandbox::docker) — the Podman *runtime* on
-//! top of the runtime-neutral policy in [`crate::sandbox::container`], which
-//! Podman will reuse unchanged (identical-path binds, the same labels, the same
-//! image content):
+//! top of the runtime-neutral policy in [`crate::sandbox::container`], which it
+//! reuses unchanged (identical-path binds, the same labels, the same image
+//! content, the same per-provider auth):
 //! - [`cli`] — podman binary resolution + bounded-invocation wrappers. Every
 //!   podman call in this module goes through it, so no invocation can hang the
 //!   app on a wedged machine connection.
 //! - [`probe`] — cached availability for UI polling.
+//! - [`image`] — building and inspecting the agent images.
+//! - [`machine`] — the shared-directory preflight, Podman's one behavioural
+//!   difference from Docker at launch time.
+//! - [`cleanup`] — the dead-instance orphan sweep and per-agent removal.
+//! - [`engine`] — `PodmanEngine`, the `SandboxEngine` implementation (one
+//!   `podman run --rm --init` container per agent process).
 
+use std::time::Instant;
+
+use crate::sandbox::container::sweep::{SweepStep, SWEEP_RETRY_INTERVAL};
+
+mod cleanup;
 mod cli;
+mod engine;
+mod image;
+mod machine;
 mod probe;
 
+pub use cleanup::remove_agent_containers;
+pub use engine::PodmanEngine;
 pub use probe::{availability, PodmanAvailability};
+
+/// Map a Podman probe result onto the shared retry schedule
+/// ([`container::sweep`](crate::sandbox::container::sweep)). A missing binary is
+/// settled for the run; a down machine is the state we expect to flip — a user
+/// who runs `podman machine start` a minute after login is the case this exists
+/// for.
+fn sweep_step(availability: &PodmanAvailability, elapsed: std::time::Duration) -> SweepStep {
+    let usable = matches!(availability, PodmanAvailability::Available { .. });
+    let installed = !matches!(availability, PodmanAvailability::NotInstalled);
+    crate::sandbox::container::sweep::sweep_step(usable, installed, elapsed)
+}
+
+/// Best-effort reclamation of containers left behind by dead Fletch instances,
+/// for app startup (`lib.rs`, next to the docker sweep). Runs on its own thread,
+/// so startup never waits on Podman — not even for the 2s probe timeout — and a
+/// machine without Podman skips the sweep entirely. Non-fatal by construction.
+///
+/// No image sweep: this runtime ships no image GC yet, so there is nothing to
+/// run as a second pass.
+pub fn sweep_orphans_at_startup() {
+    std::thread::spawn(|| {
+        let waiting_since = Instant::now();
+        loop {
+            match sweep_step(&probe::availability(), waiting_since.elapsed()) {
+                SweepStep::Sweep => break,
+                SweepStep::Retry => std::thread::sleep(SWEEP_RETRY_INTERVAL),
+                SweepStep::Stop => {
+                    tracing::debug!(
+                        target: "fletch::podman",
+                        waited_secs = waiting_since.elapsed().as_secs(),
+                        "podman unavailable; skipping the startup sweep this run",
+                    );
+                    return;
+                }
+            }
+        }
+        match cleanup::sweep_orphans() {
+            Ok(0) => {}
+            Ok(n) => tracing::info!(removed = n, "swept orphaned fletch podman containers"),
+            Err(e) => tracing::warn!(error = %e, "podman orphan sweep failed"),
+        }
+    });
+}
+
+/// Gate for the `#[ignore]`d integration tests: they touch a real Podman
+/// machine, so they run only when explicitly opted in via
+/// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`.
+#[cfg(test)]
+pub(crate) fn podman_tests_enabled() -> bool {
+    std::env::var("FLETCH_PODMAN_TESTS").as_deref() == Ok("1")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sandbox::container::sweep::SWEEP_RETRY_BUDGET;
+    use std::time::Duration;
+
+    /// The Podman probe's mapping onto the shared schedule: an answering
+    /// machine sweeps, a missing binary never retries, and a down machine
+    /// retries until — and only until — the budget is spent.
+    #[test]
+    fn sweep_retry_schedule() {
+        let available = PodmanAvailability::Available {
+            server_version: "5.3.1".into(),
+        };
+        assert_eq!(sweep_step(&available, Duration::ZERO), SweepStep::Sweep);
+        assert_eq!(
+            sweep_step(&available, SWEEP_RETRY_BUDGET * 2),
+            SweepStep::Sweep,
+            "a late machine is still worth sweeping for on the probe that catches it",
+        );
+        assert_eq!(
+            sweep_step(&PodmanAvailability::NotInstalled, Duration::ZERO),
+            SweepStep::Stop,
+            "podman being installed mid-run isn't worth polling for",
+        );
+        assert_eq!(
+            sweep_step(&PodmanAvailability::MachineDown, Duration::ZERO),
+            SweepStep::Retry,
+            "the first probe usually loses the `podman machine start` race",
+        );
+        // The budget is a deadline, not a suggestion: the loop is bounded.
+        assert_eq!(
+            sweep_step(&PodmanAvailability::MachineDown, SWEEP_RETRY_BUDGET),
+            SweepStep::Stop,
+        );
+    }
+}

--- a/src-tauri/src/sandbox/podman/settings.rs
+++ b/src-tauri/src/sandbox/podman/settings.rs
@@ -1,0 +1,164 @@
+//! Launch knobs and the version-refresh loop guard, both mirrored in-process
+//! (the spawn path and background threads have no DB handle). Seeded at startup
+//! and kept in sync by the settings set-commands — see [`set_launch_settings`]
+//! and [`init_version_refresh_guard`].
+//!
+//! Deliberately a sibling of `docker::engine::settings` rather than a shared
+//! module: the keys are per runtime (`podman_image` next to `docker_image`) so a
+//! user running both engines can point each at its own image and limits, and
+//! the version guard must stay per runtime because the two keep separate image
+//! stores — an image present in one says nothing about the other.
+
+use parking_lot::RwLock;
+
+use crate::sandbox::container::version_guard::VersionGuard;
+
+/// Settings key overriding the container image (see [`super::image::resolve_image`]).
+pub const IMAGE_SETTING: &str = "podman_image";
+/// Settings key for the container memory limit (`podman run --memory`).
+pub const MEMORY_SETTING: &str = "podman_memory";
+/// Settings key for the container CPU limit (`podman run --cpus`).
+pub const CPUS_SETTING: &str = "podman_cpus";
+
+// The launch defaults are container policy, not podman's: they live in
+// [`crate::sandbox::container::run_args`] so both runtimes cap the same way.
+
+/// Launch knobs read from the `settings` table, mirrored in-process (the spawn
+/// path has no DB handle — same pattern as `sandbox::set_selected_engine_kind`).
+/// Seeded at startup in `lib.rs setup` and kept in sync by the settings
+/// set-commands.
+#[derive(Clone, Default)]
+pub struct LaunchSettings {
+    /// `podman_image` — a non-empty value is used verbatim, skipping the
+    /// embedded image build entirely.
+    pub image_override: Option<String>,
+    /// `podman_memory` — `--memory` value; `None`/blank means the container
+    /// layer's `DEFAULT_MEMORY`.
+    pub memory: Option<String>,
+    /// `podman_cpus` — `--cpus` value; `None`/blank means the container layer's
+    /// `DEFAULT_CPUS`.
+    pub cpus: Option<String>,
+}
+
+pub(super) static LAUNCH_SETTINGS: RwLock<LaunchSettings> = RwLock::new(LaunchSettings {
+    image_override: None,
+    memory: None,
+    cpus: None,
+});
+
+pub fn set_launch_settings(settings: LaunchSettings) {
+    *LAUNCH_SETTINGS.write() = settings;
+}
+
+/// Settings key persisting the version-refresh loop guard: a JSON object of
+/// `provider id → "host_version@image_tag"`, recording the last host/image
+/// pairing a version-mismatch rebuild *succeeded* for. Not a user-facing
+/// setting — private bookkeeping that must survive restarts, for the reason
+/// [`container::version_guard`](crate::sandbox::container::version_guard)
+/// documents.
+pub const VERSION_GUARD_SETTING: &str = "podman_version_refresh_guard";
+
+/// Podman's loop-guard state, mirrored in-process like [`LAUNCH_SETTINGS`].
+static VERSION_GUARD: VersionGuard = VersionGuard::new();
+
+/// Install the loop-guard state: `attempted` as loaded from
+/// [`VERSION_GUARD_SETTING`], `persist` writing it back. The app wires this to a
+/// `database::set_setting` closure at startup.
+pub fn init_version_refresh_guard(
+    attempted: std::collections::HashMap<String, String>,
+    persist: impl Fn(&std::collections::HashMap<String, String>) + Send + Sync + 'static,
+) {
+    VERSION_GUARD.init(attempted, persist);
+}
+
+/// Whether a version-mismatch rebuild already succeeded for exactly this `pair`
+/// (`"host_version@image_tag"`).
+pub(super) fn version_refresh_attempted(provider_id: &str, pair: &str) -> bool {
+    VERSION_GUARD.attempted(provider_id, pair)
+}
+
+/// Record (and persist, when wired) that a version-mismatch rebuild succeeded
+/// for `pair`. Called from the background rebuild thread on success only.
+pub(super) fn record_version_refresh(provider_id: &str, pair: String) {
+    VERSION_GUARD.record(provider_id, pair);
+}
+
+/// The current `podman_image` override, trimmed, `None` when unset/blank — read
+/// by the image GC ([`super::cleanup::sweep_stale_images`]) to defensively
+/// exclude the user's image from removal. Structurally it should never be a
+/// candidate (Fletch never builds it, so it carries no `fletch.agent` label and
+/// lives outside Fletch's repos), but a lifecycle we don't own gets a second
+/// fence.
+pub(super) fn image_override() -> Option<String> {
+    LAUNCH_SETTINGS
+        .read()
+        .image_override
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The keys mirror docker's shape one-for-one under a `podman_` prefix, so
+    /// the settings table stays readable and neither runtime can clobber the
+    /// other's knobs.
+    #[test]
+    fn keys_mirror_dockers_shape_under_a_podman_prefix() {
+        use crate::sandbox::docker;
+        for (podman, docker) in [
+            (IMAGE_SETTING, docker::IMAGE_SETTING),
+            (MEMORY_SETTING, docker::MEMORY_SETTING),
+            (CPUS_SETTING, docker::CPUS_SETTING),
+            (VERSION_GUARD_SETTING, docker::VERSION_GUARD_SETTING),
+        ] {
+            assert_ne!(podman, docker, "keys must not collide");
+            assert_eq!(
+                podman.strip_prefix("podman_"),
+                docker.strip_prefix("docker_"),
+                "{podman} should mirror {docker}",
+            );
+        }
+    }
+
+    /// The override reader treats blank as unset — the same
+    /// blank-falls-back-to-default semantics the launch path applies.
+    #[test]
+    fn blank_override_reads_as_unset() {
+        set_launch_settings(LaunchSettings {
+            image_override: Some("   ".into()),
+            memory: None,
+            cpus: None,
+        });
+        assert_eq!(image_override(), None);
+        set_launch_settings(LaunchSettings {
+            image_override: Some("  ghcr.io/me/custom:1  ".into()),
+            memory: None,
+            cpus: None,
+        });
+        assert_eq!(image_override().as_deref(), Some("ghcr.io/me/custom:1"));
+        set_launch_settings(LaunchSettings::default());
+        assert_eq!(image_override(), None);
+    }
+
+    /// Podman's guard is its own static: exact-pair matching and per-provider
+    /// isolation hold here independently of docker's (the shared machinery is
+    /// covered in `docker::engine::tests`), and recording works before `init` so
+    /// a headless run still guards its own process.
+    #[test]
+    fn version_guard_records_before_init() {
+        let pair = "v1@fletch-agent:podmanonly";
+        assert!(!version_refresh_attempted("claude", pair));
+        record_version_refresh("claude", pair.into());
+        assert!(version_refresh_attempted("claude", pair));
+        // Exact pair only, and one provider's verdict never answers another's.
+        assert!(!version_refresh_attempted(
+            "claude",
+            "v2@fletch-agent:podmanonly"
+        ));
+        assert!(!version_refresh_attempted("codex", pair));
+    }
+}

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -434,10 +434,11 @@ async fn choose_restore_branch_name(repo_path: &Path, desired: &str) -> String {
 /// 1. The stamped engine, which also picks the runtime: an agent is reaped by
 ///    the runtime that launched it, never by whichever is selected now. A
 ///    seatbelt agent never had a container, so it never pays for a probe.
-///    `record: None` (discard tolerates a missing row) can't prove either, so
-///    it falls back to Docker — the label match is exact, so looking costs
-///    nothing but the query, and a rowless podman agent's container is left to
-///    the startup sweep.
+///    `record: None` (discard tolerates a missing row) can't prove which
+///    runtime launched it, so it asks both — the label match is exact, so
+///    looking costs nothing but the queries, and nothing else would reclaim
+///    the container this app run: the startup sweep keys on a *dead* owner
+///    pid, and a rowless agent's owner is this still-running process.
 /// 2. The runtime's own availability probe — a machine without that runtime
 ///    installed must never see one of its invocations, the same precedent the
 ///    startup sweeps set.
@@ -453,34 +454,34 @@ fn reap_agent_containers(agent_id: &str, record: Option<&AgentRecord>, op: &'sta
     if engine.is_some_and(|k| !k.is_container()) {
         return;
     }
-    let podman = engine == Some(EngineKind::Podman);
     let agent_id = agent_id.to_string();
     tokio::task::spawn_blocking(move || {
-        let removed = if podman {
-            if !matches!(
-                podman::availability(),
-                podman::PodmanAvailability::Available { .. }
-            ) {
-                return;
-            }
-            podman::remove_agent_containers(&agent_id)
-        } else {
-            if !matches!(
-                docker::availability(),
-                docker::DockerAvailability::Available { .. }
-            ) {
-                return;
-            }
-            docker::remove_agent_containers(&agent_id)
-        };
-        match removed {
+        let report = |runtime: &'static str, removed: crate::error::Result<usize>| match removed {
             Ok(0) => {}
             Ok(n) => {
-                tracing::info!(agent_id = %agent_id, op, removed = n, "removed agent containers")
+                tracing::info!(agent_id = %agent_id, op, runtime, removed = n, "removed agent containers")
             }
             Err(e) => {
-                tracing::warn!(agent_id = %agent_id, op, error = %e, "agent container removal failed")
+                tracing::warn!(agent_id = %agent_id, op, runtime, error = %e, "agent container removal failed")
             }
+        };
+        // A stamped engine narrows this to one runtime; a missing record asks
+        // both, each behind its own availability gate.
+        if engine != Some(EngineKind::Podman)
+            && matches!(
+                docker::availability(),
+                docker::DockerAvailability::Available { .. }
+            )
+        {
+            report("docker", docker::remove_agent_containers(&agent_id));
+        }
+        if engine.map_or(true, |k| k == EngineKind::Podman)
+            && matches!(
+                podman::availability(),
+                podman::PodmanAvailability::Available { .. }
+            )
+        {
+            report("podman", podman::remove_agent_containers(&agent_id));
         }
     });
 }

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -7,8 +7,8 @@ use tauri::AppHandle;
 
 use crate::error::{Error, Result};
 use crate::git;
-use crate::sandbox::docker;
 use crate::sandbox::provision::{self, CheckoutSpec};
+use crate::sandbox::{docker, podman, EngineKind};
 use crate::workspace::{
     agent_parent_dir, repo_checkout_path, AgentRecord, AgentStatus, ArchiveMetadata,
     ArchivedRepoSnapshot, DiffStats, TrackedRepo,
@@ -423,41 +423,57 @@ async fn choose_restore_branch_name(repo_path: &Path, desired: &str) -> String {
 ///
 /// Why it exists: `Supervisor::detach_runtime` reaches the container only
 /// *indirectly*, through the in-memory `agents` entry — no entry, no
-/// `KillHandle`, no docker command at all. `docker run --rm` covers the
-/// ordinary exit and the startup pid-liveness sweep covers a crashed instance,
-/// but neither makes disposal itself self-sufficient. The label sweep does:
-/// it needs nothing but the agent id. (Container names can't serve here —
-/// they carry a launch-time nonce, see `docker::engine::util::container_name`
-/// — which is why the id label exists.)
+/// `KillHandle`, no runtime command at all. `run --rm` covers the ordinary exit
+/// and the startup pid-liveness sweep covers a crashed instance, but neither
+/// makes disposal itself self-sufficient. The label sweep does: it needs nothing
+/// but the agent id. (Container names can't serve here — they carry a
+/// launch-time nonce, see `container::util::container_name` — which is why the
+/// id label exists.)
 ///
 /// Three gates, cheapest first:
-/// 1. The stamped engine. A seatbelt agent never had a container, so it never
-///    pays for a probe. `record: None` (discard tolerates a missing row)
-///    can't prove that, so it looks — the label match is exact, so looking
-///    costs nothing but the query.
-/// 2. [`docker::availability`] — a machine with no Docker installed must
-///    never see a docker invocation, the same precedent
-///    `docker::sweep_orphans_at_startup` sets.
+/// 1. The stamped engine, which also picks the runtime: an agent is reaped by
+///    the runtime that launched it, never by whichever is selected now. A
+///    seatbelt agent never had a container, so it never pays for a probe.
+///    `record: None` (discard tolerates a missing row) can't prove either, so
+///    it falls back to Docker — the label match is exact, so looking costs
+///    nothing but the query, and a rowless podman agent's container is left to
+///    the startup sweep.
+/// 2. The runtime's own availability probe — a machine without that runtime
+///    installed must never see one of its invocations, the same precedent the
+///    startup sweeps set.
 /// 3. Off the caller's path entirely. `spawn_blocking` rather than a bare
-///    thread: `cli::run_docker` is a blocking process wait (up to the probe's
-///    2s plus the sweep's own timeouts) issued from inside the tokio runtime,
+///    thread: the CLI call is a blocking process wait (up to the probe's 2s
+///    plus the sweep's own timeouts) issued from inside the tokio runtime,
 ///    which is precisely the blocking pool's job — and unlike the startup
 ///    sweep, which runs before any runtime is a given, we always have one
-///    here. Detached on purpose: archive must not wait on a Docker
+///    here. Detached on purpose: archive must not wait on a container
 ///    round-trip to report success to the user.
 fn reap_agent_containers(agent_id: &str, record: Option<&AgentRecord>, op: &'static str) {
-    if record.is_some_and(|r| !stamped_engine(r).is_container()) {
+    let engine = record.map(stamped_engine);
+    if engine.is_some_and(|k| !k.is_container()) {
         return;
     }
+    let podman = engine == Some(EngineKind::Podman);
     let agent_id = agent_id.to_string();
     tokio::task::spawn_blocking(move || {
-        if !matches!(
-            docker::availability(),
-            docker::DockerAvailability::Available { .. }
-        ) {
-            return;
-        }
-        match docker::remove_agent_containers(&agent_id) {
+        let removed = if podman {
+            if !matches!(
+                podman::availability(),
+                podman::PodmanAvailability::Available { .. }
+            ) {
+                return;
+            }
+            podman::remove_agent_containers(&agent_id)
+        } else {
+            if !matches!(
+                docker::availability(),
+                docker::DockerAvailability::Available { .. }
+            ) {
+                return;
+            }
+            docker::remove_agent_containers(&agent_id)
+        };
+        match removed {
             Ok(0) => {}
             Ok(n) => {
                 tracing::info!(agent_id = %agent_id, op, removed = n, "removed agent containers")

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -43,7 +43,7 @@ pub(super) fn stamped_engine(record: &AgentRecord) -> EngineKind {
         .unwrap_or(EngineKind::SandboxExec)
 }
 
-/// Which providers run in Docker sandboxes: those with a wired-up container
+/// Which providers run in container sandboxes: those with a wired-up container
 /// image + config-mount + auth (see [`sandbox::docker::DockerProvider`]) — claude,
 /// codex, opencode, pi, and cursor so far. antigravity stays gated: its CLI has no
 /// non-interactive credential path (browser-OAuth only, tokens in the host
@@ -58,7 +58,7 @@ fn ensure_engine_supports_provider(engine: EngineKind, provider: &str) -> Result
             .map(|d| d.label())
             .unwrap_or(provider);
         return Err(Error::Other(format!(
-            "{label} isn't available in Docker sandboxes yet"
+            "{label} isn't available in container sandboxes yet"
         )));
     }
     Ok(())
@@ -1817,7 +1817,7 @@ mod tests {
             .expect_err("antigravity must refuse under docker");
         assert!(
             err.to_string()
-                .ends_with("isn't available in Docker sandboxes yet"),
+                .ends_with("isn't available in container sandboxes yet"),
             "unexpected refusal copy: {err}",
         );
         // The copy uses the human-facing product name, not the provider id.

--- a/src/api/domains/sandbox.ts
+++ b/src/api/domains/sandbox.ts
@@ -1,14 +1,21 @@
 import type { SandboxEngine } from "@/storage/preferences";
 import { invoke } from "../invoke";
-import type { ContainerAuthStatus, DockerProbe, IsolationReport } from "../types/sandbox";
+import type {
+  ContainerAuthStatus,
+  DockerProbe,
+  IsolationReport,
+  PodmanProbe,
+} from "../types/sandbox";
 
 export const sandboxApi = {
   // Sandbox engine selection. The setting is backend-owned (snake_case
-  // `sandbox_engine`, written by `set_sandbox_engine` — which validates docker
-  // against a live daemon probe and refuses when it's unreachable).
+  // `sandbox_engine`, written by `set_sandbox_engine` — which validates each
+  // container engine against a live probe and refuses when its runtime is
+  // unreachable).
   getSandboxEngine: () => invoke<SandboxEngine>("get_sandbox_engine"),
   setSandboxEngine: (engine: SandboxEngine) => invoke<void>("set_sandbox_engine", { engine }),
   probeDockerEngine: () => invoke<DockerProbe>("probe_docker_engine"),
+  probePodmanEngine: () => invoke<PodmanProbe>("probe_podman_engine"),
   // What each engine actually guarantees, for the picker (`sandbox::guarantees`).
   describeSandboxIsolation: () => invoke<IsolationReport[]>("describe_sandbox_isolation"),
   // Whether an agent must get the user's approval before publishing. Backend-owned

--- a/src/api/domains/sandbox.ts
+++ b/src/api/domains/sandbox.ts
@@ -49,6 +49,11 @@ export const sandboxApi = {
   // frontend `setSetting`.
   setDockerLaunchSettings: (image: string | null, memory: string | null, cpus: string | null) =>
     invoke<void>("set_docker_launch_settings", { image, memory, cpus }),
+  // The podman twin, over its own `podman_image` / `podman_memory` /
+  // `podman_cpus` settings. Same contract, separate keys: a user running both
+  // engines points each at its own image and limits.
+  setPodmanLaunchSettings: (image: string | null, memory: string | null, cpus: string | null) =>
+    invoke<void>("set_podman_launch_settings", { image, memory, cpus }),
   /** Launch Docker Desktop (the daemon-down error state's action). macOS-only;
    *  rejects elsewhere. */
   startDockerDesktop: () => invoke<void>("start_docker_desktop"),

--- a/src/api/types/sandbox.ts
+++ b/src/api/types/sandbox.ts
@@ -24,10 +24,11 @@ export interface ContainerAuthStatus {
 /** One image-build lifecycle event from the `docker:build-progress` stream —
  *  both container runtimes emit on it (the event name predates Podman and is
  *  kept as the wire contract). The embedded agent image is built on the first
- *  spawn under a runtime (a slow `build`); these feed the build toast. `line` is
- *  set only on `"line"`, `error` only on `"failed"`, and `runtime` (the display
- *  name, e.g. `"Podman"`) only on `"started"` — optional so an event without it
- *  still renders. */
+ *  spawn under a runtime (a slow `build`); these feed the build toast. `line`
+ *  is set only on `"line"`, `error` only on `"failed"`. `runtime` (the display
+ *  name, e.g. `"Podman"`) rides every phase: it keys the build state, so two
+ *  runtimes' overlapping lifecycles can't clear or overwrite each other —
+ *  optional so an event without it still renders, under a neutral key. */
 export interface DockerBuildEvent {
   phase: "started" | "line" | "finished" | "failed";
   line?: string;

--- a/src/api/types/sandbox.ts
+++ b/src/api/types/sandbox.ts
@@ -21,14 +21,18 @@ export interface ContainerAuthStatus {
   status: "keychain" | "stored-token" | "shell-env" | "credentials-file" | "none";
 }
 
-/** One image-build lifecycle event from the `docker:build-progress` stream.
- *  The embedded agent image is built on the first docker spawn (a slow
- *  `docker build`); these feed the build toast. `line` is set only on `"line"`,
- *  `error` only on `"failed"`. */
+/** One image-build lifecycle event from the `docker:build-progress` stream —
+ *  both container runtimes emit on it (the event name predates Podman and is
+ *  kept as the wire contract). The embedded agent image is built on the first
+ *  spawn under a runtime (a slow `build`); these feed the build toast. `line` is
+ *  set only on `"line"`, `error` only on `"failed"`, and `runtime` (the display
+ *  name, e.g. `"Podman"`) only on `"started"` — optional so an event without it
+ *  still renders. */
 export interface DockerBuildEvent {
   phase: "started" | "line" | "finished" | "failed";
   line?: string;
   error?: string;
+  runtime?: string;
 }
 
 /** One isolation claim and how completely the selected engine delivers it.

--- a/src/api/types/sandbox.ts
+++ b/src/api/types/sandbox.ts
@@ -5,6 +5,15 @@ export interface DockerProbe {
   version?: string;
 }
 
+/** Result of probing the local Podman installation (Settings › General).
+ *  `version` is the machine's podman version, present only when available.
+ *  `machine-down` is Podman's analogue of Docker's `daemon-down`, named for
+ *  what the user fixes: Podman needs a running `podman machine` on macOS. */
+export interface PodmanProbe {
+  status: "available" | "not-installed" | "machine-down";
+  version?: string;
+}
+
 /** Which step of the container auth chain (pasted token → shell env →
  *  claude credentials file) would supply Anthropic credentials to a docker
  *  agent right now (Settings › General › Sandbox status row). */

--- a/src/components/Composer/availability.ts
+++ b/src/components/Composer/availability.ts
@@ -1,4 +1,5 @@
 import { isDockerSupported, providerLabel } from "@/data/providers";
+import { isContainerEngine, sandboxEngineLabel } from "@/storage/preferences";
 import { useAppStore } from "@/store";
 
 export interface Availability {
@@ -14,9 +15,11 @@ export interface Availability {
  *
  *  Two gates, both mirroring the backend so the picker and the spawn path can't
  *  disagree: the provider CLI must actually be installed (`providerPaths`, from
- *  the startup probe), and under the Docker engine it must be one of the
- *  container-ready providers (`isDockerSupported`, mirroring
- *  `ensure_engine_supports_provider`).
+ *  the startup probe), and under a container engine (Docker or Podman) it must
+ *  be one of the container-ready providers (`isDockerSupported`, mirroring
+ *  `ensure_engine_supports_provider` — which gates on `is_container()`, not on
+ *  one runtime, since container support is a property of the image set both
+ *  runtimes build).
  *
  *  Shared by every surface that offers an agent — the composer's picker and the
  *  Roadmap's new-chat screen — because a rule that decides what the user is
@@ -29,16 +32,18 @@ export function useAgentAvailability(): (providerId: string) => Availability {
   const providerPaths = useAppStore((s) => s.providerPaths);
   const providersProbed = useAppStore((s) => s.providersProbed);
   // New agents get the currently selected sandbox engine, so a provider without
-  // container support is unspawnable while Docker is on.
-  const dockerOnly = useAppStore((s) => s.sandboxEngine) === "docker";
+  // container support is unspawnable while a container engine is on.
+  const engine = useAppStore((s) => s.sandboxEngine);
+  const containerOnly = isContainerEngine(engine);
 
   return (providerId: string) => {
-    // dockerBlocked is checked first: a non-container provider under Docker is
-    // blocked regardless of install state, and that's the more useful reason.
-    if (dockerOnly && !isDockerSupported(providerId)) {
+    // The container gate is checked first: a non-container provider is blocked
+    // regardless of install state, and that's the more useful reason.
+    if (containerOnly && !isDockerSupported(providerId)) {
+      const label = sandboxEngineLabel(engine);
       return {
-        reason: `${providerLabel(providerId)} isn't available in Docker sandboxes yet`,
-        note: "Not in Docker yet",
+        reason: `${providerLabel(providerId)} isn't available in ${label} sandboxes yet`,
+        note: `Not in ${label} yet`,
       };
     }
     // Fail open on the install gate: only enforce it once a probe has actually

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/data/providerDetail";
 import { DEFAULT_PROVIDER_ID, isDockerSupported, providerLabel } from "@/data/providers";
 import type { LocalCommandAction } from "@/data/slashCommands";
+import { isContainerEngine, sandboxEngineLabel } from "@/storage/preferences";
 import type { UsageSnapshot } from "@/store";
 import { useAppStore } from "@/store";
 import { ComposerFrame } from "./ComposerFrame";
@@ -227,14 +228,14 @@ export function Composer({
     return modelLevels.length > 0 ? modelLevels : (providerLevels ?? []);
   }, [modelReasoningLevels, providerLevels]);
 
-  // A new-agent draft can still hold a docker-unsupported provider chosen
-  // before the sandbox engine was switched to Docker. Block the send here —
-  // otherwise the stale selection reaches spawnAgent and fails in the backend.
-  // `provider` mirrors a custom agent's base, so this covers custom agents too.
-  // Existing sessions already spawned with their engine and keep a locked
-  // picker, so they're exempt.
+  // A new-agent draft can still hold a container-unsupported provider chosen
+  // before the sandbox engine was switched to Docker or Podman. Block the send
+  // here — otherwise the stale selection reaches spawnAgent and fails in the
+  // backend. `provider` mirrors a custom agent's base, so this covers custom
+  // agents too. Existing sessions already spawned with their engine and keep a
+  // locked picker, so they're exempt.
   const dockerBlocked =
-    !existingSession && sandboxEngine === "docker" && !isDockerSupported(provider);
+    !existingSession && isContainerEngine(sandboxEngine) && !isDockerSupported(provider);
 
   const [thinkingValue, setThinkingValue] = useState<string | undefined>(() =>
     resolveThinking(
@@ -407,7 +408,7 @@ export function Composer({
             className={dockerBlocked ? "tip" : undefined}
             data-tip={
               dockerBlocked
-                ? `${providerLabel(provider)} isn't available in Docker sandboxes yet — switch to Claude to send`
+                ? `${providerLabel(provider)} isn't available in ${sandboxEngineLabel(sandboxEngine)} sandboxes yet — switch to Claude to send`
                 : undefined
             }
           >

--- a/src/components/DockerBuildToast.tsx
+++ b/src/components/DockerBuildToast.tsx
@@ -3,11 +3,14 @@ import { Icon } from "./Icon";
 import { Button } from "./ui/Button";
 
 /**
- * Bottom-left toast for the embedded docker agent image build. The first docker
- * spawn triggers a (potentially minutes-long) `docker build`; this surfaces its
- * progress so the wait is legible, then clears itself when the build finishes.
- * A failed build stays up with the reason and a dismiss. Renders nothing when no
- * build is in flight. Fed by the `docker:build-progress` event (see store/app).
+ * Bottom-left toast for the embedded agent image build, under either container
+ * runtime. The first spawn under a runtime triggers a (potentially
+ * minutes-long) image build; this surfaces its progress so the wait is legible,
+ * then clears itself when the build finishes. A failed build stays up with the
+ * reason and a dismiss. Renders nothing when no build is in flight. Fed by the
+ * `docker:build-progress` event (see store/eventListeners), whose `started`
+ * payload names the runtime — absent, the copy stays runtime-neutral rather
+ * than guessing.
  */
 export function DockerBuildToast() {
   const build = useAppStore((s) => s.dockerBuild);
@@ -16,15 +19,14 @@ export function DockerBuildToast() {
   if (!build) return null;
 
   const failed = build.status === "failed";
+  const what = build.runtime ? `${build.runtime} sandbox image` : "container sandbox image";
 
   return (
     <div className="update-toast docker-build-toast" role={failed ? "alert" : "status"}>
       <Icon name={failed ? "close" : "cube"} />
       <div className="update-toast-body">
         <div className="update-toast-text">
-          <strong>
-            {failed ? "Sandbox image build failed" : "Building Docker sandbox image…"}
-          </strong>
+          <strong>{failed ? "Sandbox image build failed" : `Building ${what}…`}</strong>
           <span>
             {failed
               ? (build.error ?? "The build did not complete.")

--- a/src/components/DockerBuildToast.tsx
+++ b/src/components/DockerBuildToast.tsx
@@ -1,49 +1,68 @@
 import { useAppStore } from "@/store";
+import { NEUTRAL_BUILD_RUNTIME } from "@/store/sandbox";
 import { Icon } from "./Icon";
 import { Button } from "./ui/Button";
 
 /**
- * Bottom-left toast for the embedded agent image build, under either container
+ * Bottom-left toasts for the embedded agent image builds, one per container
  * runtime. The first spawn under a runtime triggers a (potentially
  * minutes-long) image build; this surfaces its progress so the wait is legible,
  * then clears itself when the build finishes. A failed build stays up with the
  * reason and a dismiss. Renders nothing when no build is in flight. Fed by the
- * `docker:build-progress` event (see store/eventListeners), whose `started`
- * payload names the runtime — absent, the copy stays runtime-neutral rather
- * than guessing.
+ * `docker:build-progress` event (see store/eventListeners), keyed by the
+ * runtime each event names — the runtimes build on independent locks, so a
+ * Docker and a Podman build can be in flight (and rendered) at once. An event
+ * without a runtime renders under neutral copy rather than guessing.
  */
 export function DockerBuildToast() {
-  const build = useAppStore((s) => s.dockerBuild);
+  const builds = useAppStore((s) => s.containerBuilds);
   const dismiss = useAppStore((s) => s.dismissDockerBuild);
 
-  if (!build) return null;
-
-  const failed = build.status === "failed";
-  const what = build.runtime ? `${build.runtime} sandbox image` : "container sandbox image";
+  const entries = Object.entries(builds);
+  if (entries.length === 0) return null;
 
   return (
-    <div className="update-toast docker-build-toast" role={failed ? "alert" : "status"}>
-      <Icon name={failed ? "close" : "cube"} />
-      <div className="update-toast-body">
-        <div className="update-toast-text">
-          <strong>{failed ? "Sandbox image build failed" : `Building ${what}…`}</strong>
-          <span>
-            {failed
-              ? (build.error ?? "The build did not complete.")
-              : "First container run — this can take a few minutes."}
-          </span>
-        </div>
-        {!failed && build.lastLine && (
-          <p className="update-toast-notes docker-build-line mono">{build.lastLine}</p>
-        )}
-        {failed && (
-          <div className="update-toast-actions">
-            <Button variant="ghost" onClick={dismiss}>
-              Dismiss
-            </Button>
+    <div className="docker-build-stack">
+      {entries.map(([runtime, build]) => {
+        const failed = build.status === "failed";
+        const what =
+          runtime === NEUTRAL_BUILD_RUNTIME
+            ? "container sandbox image"
+            : `${runtime} sandbox image`;
+        const heading =
+          runtime === NEUTRAL_BUILD_RUNTIME
+            ? "Sandbox image build failed"
+            : `${runtime} sandbox image build failed`;
+        return (
+          <div
+            key={runtime}
+            className="update-toast docker-build-toast"
+            role={failed ? "alert" : "status"}
+          >
+            <Icon name={failed ? "close" : "cube"} />
+            <div className="update-toast-body">
+              <div className="update-toast-text">
+                <strong>{failed ? heading : `Building ${what}…`}</strong>
+                <span>
+                  {failed
+                    ? (build.error ?? "The build did not complete.")
+                    : "First container run — this can take a few minutes."}
+                </span>
+              </div>
+              {!failed && build.lastLine && (
+                <p className="update-toast-notes docker-build-line mono">{build.lastLine}</p>
+              )}
+              {failed && (
+                <div className="update-toast-actions">
+                  <Button variant="ghost" onClick={() => dismiss(runtime)}>
+                    Dismiss
+                  </Button>
+                </div>
+              )}
+            </div>
           </div>
-        )}
-      </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/SettingsScreen/ExperimentalPane.tsx
+++ b/src/components/SettingsScreen/ExperimentalPane.tsx
@@ -36,61 +36,78 @@ export function ExperimentalPane() {
         ))}
       </SetGroup>
 
-      <DockerAdvanced />
+      <ContainerLaunchKnobs runtime="docker" />
+      <ContainerLaunchKnobs runtime="podman" last />
     </div>
   );
 }
 
-/** The three Docker launch knobs, in display order. Each maps to a
- *  backend-owned `docker_*` setting; `key` also indexes the draft/store state. */
-const DOCKER_FIELDS = [
+/** The two container runtimes that carry launch knobs, and the copy that differs
+ *  between them: the group heading and the `run` command the limits are passed
+ *  to. Everything else about the three fields is identical, which is why one
+ *  component serves both. */
+const RUNTIMES = {
+  docker: { label: "Docker", bin: "docker" },
+  podman: { label: "Podman", bin: "podman" },
+} as const;
+
+type Runtime = keyof typeof RUNTIMES;
+
+/** The three launch knobs, in display order. Each maps to a backend-owned
+ *  `<runtime>_*` setting; `key` also indexes the draft/store state. */
+const LAUNCH_FIELDS = [
   {
     key: "image",
     title: "Container image",
-    sub: "Override the built-in agent image. It must have Claude Code (`claude`) and git on PATH. Blank uses Fletch's image.",
+    sub: (_: Runtime) =>
+      "Override the built-in agent image. It must have Claude Code (`claude`) and git on PATH. Blank uses Fletch's image.",
     placeholder: "fletch-agent (built-in)",
   },
   {
     key: "memory",
     title: "Memory limit",
-    sub: "Passed to `docker run --memory`. Blank uses the default (4g).",
+    sub: (r: Runtime) =>
+      `Passed to \`${RUNTIMES[r].bin} run --memory\`. Blank uses the default (4g).`,
     placeholder: "4g",
   },
   {
     key: "cpus",
     title: "CPU limit",
-    sub: "Passed to `docker run --cpus`. Blank uses the default (2).",
+    sub: (r: Runtime) => `Passed to \`${RUNTIMES[r].bin} run --cpus\`. Blank uses the default (2).`,
     placeholder: "2",
   },
 ] as const;
 
-/** Advanced Docker-sandbox launch knobs. These persist to the backend-owned
- *  `docker_image` / `docker_memory` / `docker_cpus` settings AND update the
- *  in-process spawn-path mirror, so a change applies to the next docker spawn
- *  without a restart. Only relevant when the Docker engine is selected
+/** Advanced container-sandbox launch knobs for one runtime. These persist to the
+ *  backend-owned `<runtime>_image` / `_memory` / `_cpus` settings AND update the
+ *  in-process spawn-path mirror, so a change applies to the next spawn under
+ *  that runtime without a restart. Only relevant when that engine is selected
  *  (Settings › General › Sandbox); harmless otherwise. */
-function DockerAdvanced() {
-  const dockerImage = useAppStore((s) => s.dockerImage);
-  const dockerMemory = useAppStore((s) => s.dockerMemory);
-  const dockerCpus = useAppStore((s) => s.dockerCpus);
-  const save = useAppStore((s) => s.saveDockerLaunchSettings);
+function ContainerLaunchKnobs({ runtime, last }: { runtime: Runtime; last?: boolean }) {
+  // One selector per value: a selector returning a fresh object would hand
+  // `useSyncExternalStore` a new snapshot on every render.
+  const image = useAppStore((s) => (runtime === "docker" ? s.dockerImage : s.podmanImage));
+  const memory = useAppStore((s) => (runtime === "docker" ? s.dockerMemory : s.podmanMemory));
+  const cpus = useAppStore((s) => (runtime === "docker" ? s.dockerCpus : s.podmanCpus));
+  const save = useAppStore((s) =>
+    runtime === "docker" ? s.saveDockerLaunchSettings : s.savePodmanLaunchSettings,
+  );
 
-  const stored = { image: dockerImage, memory: dockerMemory, cpus: dockerCpus };
   // Local edit state, committed on blur/Enter so we don't persist per keystroke.
-  const [draft, setDraft] = useState(stored);
+  const [draft, setDraft] = useState({ image, memory, cpus });
 
   // Reflect external changes (e.g. a revert on a failed save) back into the
   // fields so they never drift from the store's source of truth. The three
   // values only ever move together (via `save`), so one effect covers them.
   useEffect(() => {
-    setDraft({ image: dockerImage, memory: dockerMemory, cpus: dockerCpus });
-  }, [dockerImage, dockerMemory, dockerCpus]);
+    setDraft({ image, memory, cpus });
+  }, [image, memory, cpus]);
 
   const commit = () => {
     const i = draft.image.trim();
     const m = draft.memory.trim();
     const c = draft.cpus.trim();
-    if (i === dockerImage && m === dockerMemory && c === dockerCpus) return;
+    if (i === image && m === memory && c === cpus) return;
     void save(i, m, c);
   };
 
@@ -99,9 +116,9 @@ function DockerAdvanced() {
   };
 
   return (
-    <SetGroup label="Docker sandbox" last>
-      {DOCKER_FIELDS.map((f) => (
-        <SetRow key={f.key} title={f.title} sub={f.sub}>
+    <SetGroup label={`${RUNTIMES[runtime].label} sandbox`} last={last}>
+      {LAUNCH_FIELDS.map((f) => (
+        <SetRow key={f.key} title={f.title} sub={f.sub(runtime)}>
           <TextInput
             mono
             value={draft[f.key]}

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -8,13 +8,13 @@ import { useAppStore } from "@/store";
 import { ContainerAuth } from "./ContainerAuth";
 import { type FeatureItem, SetGroup, SetHead, SetRow, SetSeg, SetToggle } from "./primitives";
 
-// Docker Desktop can start or stop while this pane stays open, so we re-probe
-// on a steady interval (plus immediately on mount and on window focus) rather
-// than once. Polling both ways keeps the engine option AND the "selected but
-// unavailable" warning tracking the live daemon: a one-shot or stop-when-
-// available probe would latch a stale state and, e.g., leave the warning
-// hidden after the daemon stops. The backend caches each probe for a few
-// seconds, so a tight interval mostly hits that cache.
+// A container runtime can start or stop while this pane stays open, so we
+// re-probe on a steady interval (plus immediately on mount and on window focus)
+// rather than once. Polling both ways keeps each engine option AND the
+// "selected but unavailable" warning tracking the live runtime: a one-shot or
+// stop-when-available probe would latch a stale state and, e.g., leave the
+// warning hidden after the daemon stops. The backend caches each probe for a
+// few seconds, so a tight interval mostly hits that cache.
 const PROBE_INTERVAL_MS = 3_000;
 
 const SIDE_PANELS: FeatureItem[] = [
@@ -63,11 +63,15 @@ export function GeneralPane() {
   const setSandboxEngine = useAppStore((s) => s.setSandboxEngine);
   const dockerProbe = useAppStore((s) => s.dockerProbe);
   const refreshDockerProbe = useAppStore((s) => s.refreshDockerProbe);
+  const podmanProbe = useAppStore((s) => s.podmanProbe);
+  const refreshPodmanProbe = useAppStore((s) => s.refreshPodmanProbe);
 
   useEffect(() => {
     let cancelled = false;
     const probe = () => {
-      if (!cancelled) void refreshDockerProbe();
+      if (cancelled) return;
+      void refreshDockerProbe();
+      void refreshPodmanProbe();
     };
     probe(); // immediately on mount
     const timer = setInterval(probe, PROBE_INTERVAL_MS);
@@ -80,17 +84,24 @@ export function GeneralPane() {
       clearInterval(timer);
       window.removeEventListener("focus", onFocus);
     };
-  }, [refreshDockerProbe]);
+  }, [refreshDockerProbe, refreshPodmanProbe]);
 
-  // Three states for the docker option: enabled when the daemon answered the
-  // probe; otherwise disabled with a hint saying how to fix it. `null` (probe
-  // still in flight) gates off too — never offer an engine we can't confirm.
+  // Three states for each container option: enabled when the runtime answered
+  // the probe; otherwise disabled with a hint saying how to fix it. `null`
+  // (probe still in flight) gates off too — never offer an engine we can't
+  // confirm.
   const dockerAvailable = dockerProbe?.status === "available";
   const dockerHint = dockerAvailable
     ? dockerProbe?.version && `v${dockerProbe.version}`
     : dockerProbe?.status === "daemon-down"
       ? "Start Docker Desktop"
       : "Install Docker Desktop";
+  const podmanAvailable = podmanProbe?.status === "available";
+  const podmanHint = podmanAvailable
+    ? podmanProbe?.version && `v${podmanProbe.version}`
+    : podmanProbe?.status === "machine-down"
+      ? "Run podman machine start"
+      : "Install Podman";
 
   const FeatureRow = ({ item }: { item: FeatureItem }) => (
     <SetRow title={item.title} sub={item.sub}>
@@ -187,7 +198,7 @@ export function GeneralPane() {
         </SetRow>
         <SetRow
           title="Engine"
-          sub="Applies to new agents; existing ones keep their engine. Docker runs agents in a Linux container, so builds and tests run on Linux."
+          sub="Applies to new agents; existing ones keep their engine. Docker and Podman both run agents in a Linux container, so builds and tests run on Linux."
         >
           <Select<SandboxEngine>
             value={sandboxEngine}
@@ -200,6 +211,12 @@ export function GeneralPane() {
                 hint: dockerHint || undefined,
                 disabled: !dockerAvailable,
               },
+              {
+                value: "podman",
+                label: "Podman",
+                hint: podmanHint || undefined,
+                disabled: !podmanAvailable,
+              },
             ]}
             onChange={(v) => void setSandboxEngine(v)}
           />
@@ -211,6 +228,17 @@ export function GeneralPane() {
             New agents won't launch until it's available.{" "}
             {dockerProbe.status === "daemon-down" ? "Start" : "Install"} Docker Desktop, or switch
             back to Seatbelt.
+          </div>
+        )}
+        {sandboxEngine === "podman" && podmanProbe && !podmanAvailable && (
+          <div className="set-sandbox-warn">
+            Podman is selected but{" "}
+            {podmanProbe.status === "machine-down"
+              ? "its machine isn't running"
+              : "isn't installed"}
+            . New agents won't launch until it's available.{" "}
+            {podmanProbe.status === "machine-down" ? "Run podman machine start" : "Install Podman"},
+            or switch back to Seatbelt.
           </div>
         )}
         <ContainerAuth />

--- a/src/components/ui/SandboxBadge.tsx
+++ b/src/components/ui/SandboxBadge.tsx
@@ -1,25 +1,31 @@
 import { Icon } from "@/components/Icon";
 import { Badge } from "./Badge";
 
-const NAME = "Docker sandbox";
-
-/** Why the path looks like the host: docker agents bind-mount the workspace at
- *  its exact host path ("path identity"), so `find`/diff output shows
+/** Why the path looks like the host: container agents bind-mount the workspace
+ *  at its exact host path ("path identity"), so `find`/diff output shows
  *  `/Users/.../workspaces/…` even though the process is confined to the
  *  container. This explanation makes that non-obvious design legible. It rides
  *  on the native `title` tooltip (via Badge's `hint`) so the OS positions it and
  *  it can't clip at a window edge like a hand-placed CSS tooltip would. */
-const HINT =
-  "Runs inside a Docker container. Paths mirror your host exactly by design, but the agent is confined to its mounted workspace — it can't reach the rest of your machine.";
+function hint(runtime: string) {
+  return `Runs inside a ${runtime} container. Paths mirror your host exactly by design, but the agent is confined to its mounted workspace — it can't reach the rest of your machine.`;
+}
 
 /** A subtle container chip shown next to the workspace path on containerized
  *  agents. Renders nothing for the default seatbelt engine, so it only appears
- *  when the sandbox engine is the non-default one. `engine` is the agent's
- *  stamped `sandbox_engine` value. */
+ *  when the sandbox engine is a container one. `engine` is the agent's stamped
+ *  `sandbox_engine` value; both container runtimes share the chip's tone,
+ *  because what it tells the user about their paths is the same either way. */
 export function SandboxBadge({ engine }: { engine?: string | null }) {
-  if (engine !== "docker") return null;
+  const runtime = engine === "docker" ? "Docker" : engine === "podman" ? "Podman" : null;
+  if (!runtime) return null;
   return (
-    <Badge variant="docker" label={NAME} hint={HINT} className="sandbox-badge">
+    <Badge
+      variant="docker"
+      label={`${runtime} sandbox`}
+      hint={hint(runtime)}
+      className="sandbox-badge"
+    >
       <Icon name="cube" size={10} />
     </Badge>
   );

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -209,7 +209,7 @@ export function parseRoadmapBoardWidth(raw: string | undefined): number | null {
 /** Isolation engine new agents are stamped with. Mirrors the backend's
  *  `EngineKind::as_setting` spellings (`sandbox/engine.rs`), so both sides
  *  agree on the wire strings. */
-export type SandboxEngine = "sandbox-exec" | "docker";
+export type SandboxEngine = "sandbox-exec" | "docker" | "podman";
 
 export const DEFAULT_SANDBOX_ENGINE: SandboxEngine = "sandbox-exec";
 
@@ -218,7 +218,27 @@ export const DEFAULT_SANDBOX_ENGINE: SandboxEngine = "sandbox-exec";
  *  `setSetting`, same posture as `telemetry_enabled`). Unknown/missing values
  *  fall back to the seatbelt default, matching the backend's parser. */
 export function parseSandboxEngine(raw: string | undefined): SandboxEngine {
-  return raw === "docker" ? "docker" : DEFAULT_SANDBOX_ENGINE;
+  return raw === "docker" || raw === "podman" ? raw : DEFAULT_SANDBOX_ENGINE;
+}
+
+/** Whether an engine runs the agent inside a container — mirrors the backend's
+ *  `EngineKind::is_container`. Every surface that gates on "containerized"
+ *  (provider support, the workspace badge) asks this instead of comparing
+ *  against `"docker"`, so a third container runtime lands in one place. */
+export function isContainerEngine(engine: SandboxEngine): boolean {
+  return engine === "docker" || engine === "podman";
+}
+
+/** The engine's name in prose ("Docker isn't available…"). */
+export function sandboxEngineLabel(engine: SandboxEngine): string {
+  switch (engine) {
+    case "docker":
+      return "Docker";
+    case "podman":
+      return "Podman";
+    default:
+      return "Seatbelt";
+  }
 }
 
 // ---- Provider binary path overrides ------------------------------------------

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -66,6 +66,7 @@ import { AUTOPILOT_SETTING, parseAutopilotEnrollment } from "./autopilot";
 import { interruptedAgents } from "./interrupted";
 import { stampPrWrite } from "./prWriteOrder";
 import { refreshWorkspace } from "./refreshWorkspace";
+import { NEUTRAL_BUILD_RUNTIME } from "./sandbox";
 import type { AppSlice, SliceCreator } from "./types";
 
 type AppSet = Parameters<SliceCreator<AppSlice>>[0];
@@ -490,36 +491,42 @@ export const registerEventListeners = async (set: AppSet, get: AppGet) => {
   });
 
   // Container image-build progress (first spawn under a runtime). Drives the
-  // build toast: started opens it — carrying the runtime name so the copy can
-  // say which one — lines update the tail, finished clears it, failed keeps it
-  // up (with the reason) until the user dismisses.
+  // build toast: started opens it, lines update the tail, finished clears it,
+  // failed keeps it up (with the reason) until the user dismisses. Every phase
+  // is routed by the event's runtime — Docker and Podman build on independent
+  // locks, so their lifecycles can interleave and one runtime's finished/failed
+  // must never touch the other's entry.
   await onDockerBuildProgress((e) => {
+    const key = e.runtime ?? NEUTRAL_BUILD_RUNTIME;
     if (e.phase === "started") {
-      set({
-        dockerBuild: {
-          status: "building",
-          lastLine: null,
-          error: null,
-          runtime: e.runtime ?? null,
-        },
-      });
-    } else if (e.phase === "line") {
-      set((s) =>
-        s.dockerBuild
-          ? { dockerBuild: { ...s.dockerBuild, lastLine: e.line ?? s.dockerBuild.lastLine } }
-          : {},
-      );
-    } else if (e.phase === "finished") {
-      set({ dockerBuild: null });
-    } else if (e.phase === "failed") {
-      // Keep whichever runtime `started` named: the failure event carries only
-      // the reason, and dropping the name would flip the toast's copy mid-build.
       set((s) => ({
-        dockerBuild: {
-          status: "failed",
-          lastLine: null,
-          error: e.error ?? "Image build failed",
-          runtime: s.dockerBuild?.runtime ?? null,
+        containerBuilds: {
+          ...s.containerBuilds,
+          [key]: { status: "building", lastLine: null, error: null },
+        },
+      }));
+    } else if (e.phase === "line") {
+      set((s) => {
+        const build = s.containerBuilds[key];
+        return build
+          ? {
+              containerBuilds: {
+                ...s.containerBuilds,
+                [key]: { ...build, lastLine: e.line ?? build.lastLine },
+              },
+            }
+          : {};
+      });
+    } else if (e.phase === "finished") {
+      set((s) => {
+        const { [key]: _, ...rest } = s.containerBuilds;
+        return { containerBuilds: rest };
+      });
+    } else if (e.phase === "failed") {
+      set((s) => ({
+        containerBuilds: {
+          ...s.containerBuilds,
+          [key]: { status: "failed", lastLine: null, error: e.error ?? "Image build failed" },
         },
       }));
     }

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -155,12 +155,15 @@ export const hydrateSettings = async (set: AppSet) => {
       // the decision timeout. Backend-owned (`set_publish_confirmation`), so only
       // an explicit "true" enables — matching `rpc::approval::parse_enabled`.
       publishConfirmation: s.publish_confirmation === "true",
-      // Advanced docker launch knobs — backend-owned (snake_case, written by
-      // `set_docker_launch_settings`), so read them here and never setSetting.
-      // Blank = unset (launch defaults apply).
+      // Advanced per-runtime launch knobs — backend-owned (snake_case, written
+      // by `set_docker_launch_settings` / `set_podman_launch_settings`), so read
+      // them here and never setSetting. Blank = unset (launch defaults apply).
       dockerImage: s.docker_image || "",
       dockerMemory: s.docker_memory || "",
       dockerCpus: s.docker_cpus || "",
+      podmanImage: s.podman_image || "",
+      podmanMemory: s.podman_memory || "",
+      podmanCpus: s.podman_cpus || "",
       // Auto-open the welcome tour for new users (no completion flag yet).
       onboardingOpen: s.onboardingComplete !== "true",
       // Panel layout — restore the user's last splitter widths and collapse state.
@@ -486,12 +489,20 @@ export const registerEventListeners = async (set: AppSet, get: AppGet) => {
     set((s) => ({ runPorts: { ...s.runPorts, [e.agent_id]: String(e.port) } }));
   });
 
-  // Docker image-build progress (first docker spawn). Drives the build toast:
-  // started opens it, lines update the tail, finished clears it, failed keeps
-  // it up (with the reason) until the user dismisses.
+  // Container image-build progress (first spawn under a runtime). Drives the
+  // build toast: started opens it — carrying the runtime name so the copy can
+  // say which one — lines update the tail, finished clears it, failed keeps it
+  // up (with the reason) until the user dismisses.
   await onDockerBuildProgress((e) => {
     if (e.phase === "started") {
-      set({ dockerBuild: { status: "building", lastLine: null, error: null } });
+      set({
+        dockerBuild: {
+          status: "building",
+          lastLine: null,
+          error: null,
+          runtime: e.runtime ?? null,
+        },
+      });
     } else if (e.phase === "line") {
       set((s) =>
         s.dockerBuild
@@ -501,9 +512,16 @@ export const registerEventListeners = async (set: AppSet, get: AppGet) => {
     } else if (e.phase === "finished") {
       set({ dockerBuild: null });
     } else if (e.phase === "failed") {
-      set({
-        dockerBuild: { status: "failed", lastLine: null, error: e.error ?? "Image build failed" },
-      });
+      // Keep whichever runtime `started` named: the failure event carries only
+      // the reason, and dropping the name would flip the toast's copy mid-build.
+      set((s) => ({
+        dockerBuild: {
+          status: "failed",
+          lastLine: null,
+          error: e.error ?? "Image build failed",
+          runtime: s.dockerBuild?.runtime ?? null,
+        },
+      }));
     }
   });
 };

--- a/src/store/sandbox.ts
+++ b/src/store/sandbox.ts
@@ -10,15 +10,20 @@ import { checkoutKey } from "./git";
 import { autopilotIsDriving, publishPreAuthorized } from "./publishApproval";
 import type { SliceCreator } from "./types";
 
-/** Live state of the embedded docker image build (first docker spawn). `null`
- *  when no build is in progress. `building` streams the latest output line;
- *  `failed` stays up (with `error`) until dismissed. Success clears to `null`. */
+/** Live state of the embedded container image build (first spawn under a
+ *  runtime). `null` when no build is in progress. `building` streams the latest
+ *  output line; `failed` stays up (with `error`) until dismissed. Success clears
+ *  to `null`. */
 export interface DockerBuildProgress {
   status: "building" | "failed";
-  /** Most recent `docker build` output line (building only). */
+  /** Most recent `build` output line (building only). */
   lastLine: string | null;
   /** Failure reason (failed only). */
   error: string | null;
+  /** Display name of the runtime doing the building ("Docker" / "Podman"), from
+   *  the `started` event. `null` when the event didn't name one — the toast then
+   *  falls back to neutral copy rather than guessing a runtime. */
+  runtime: string | null;
 }
 
 export interface SandboxSlice {
@@ -41,6 +46,12 @@ export interface SandboxSlice {
   dockerImage: string;
   dockerMemory: string;
   dockerCpus: string;
+  /** The same three knobs for podman (`podman_image` / `podman_memory` /
+   *  `podman_cpus`), with the same defaults and the same blank-is-unset rule.
+   *  Separate keys so a user running both engines configures each. */
+  podmanImage: string;
+  podmanMemory: string;
+  podmanCpus: string;
   /** Whether an agent must get the user's approval before publishing. Mirrors
    *  the backend-owned `publish_confirmation` setting. Off by default: autopilot
    *  publishes unattended, and a prompt would hang it until the decision
@@ -85,6 +96,8 @@ export interface SandboxSlice {
    *  backend, which writes the settings AND updates the spawn-path mirror.
    *  Reverts the store on failure. */
   saveDockerLaunchSettings: (image: string, memory: string, cpus: string) => Promise<void>;
+  /** The podman twin of `saveDockerLaunchSettings`. */
+  savePodmanLaunchSettings: (image: string, memory: string, cpus: string) => Promise<void>;
   /** Launch Docker Desktop (daemon-down error action); surfaces failures via
    *  `lastError`. */
   startDockerDesktop: () => Promise<void>;
@@ -118,6 +131,9 @@ export const createSandboxSlice: SliceCreator<SandboxSlice> = (set, get) => ({
   dockerImage: "",
   dockerMemory: "",
   dockerCpus: "",
+  podmanImage: "",
+  podmanMemory: "",
+  podmanCpus: "",
   publishConfirmation: false,
   pendingPublishApprovals: [],
 
@@ -225,6 +241,18 @@ export const createSandboxSlice: SliceCreator<SandboxSlice> = (set, get) => ({
         dockerCpus: get().dockerCpus,
       },
       () => api.setDockerLaunchSettings(image || null, memory || null, cpus || null),
+    ),
+
+  savePodmanLaunchSettings: (image, memory, cpus) =>
+    optimistic(
+      set,
+      { podmanImage: image, podmanMemory: memory, podmanCpus: cpus },
+      {
+        podmanImage: get().podmanImage,
+        podmanMemory: get().podmanMemory,
+        podmanCpus: get().podmanCpus,
+      },
+      () => api.setPodmanLaunchSettings(image || null, memory || null, cpus || null),
     ),
 
   startDockerDesktop: async () => {

--- a/src/store/sandbox.ts
+++ b/src/store/sandbox.ts
@@ -10,21 +10,23 @@ import { checkoutKey } from "./git";
 import { autopilotIsDriving, publishPreAuthorized } from "./publishApproval";
 import type { SliceCreator } from "./types";
 
-/** Live state of the embedded container image build (first spawn under a
- *  runtime). `null` when no build is in progress. `building` streams the latest
- *  output line; `failed` stays up (with `error`) until dismissed. Success clears
- *  to `null`. */
+/** Live state of one embedded container image build (first spawn under a
+ *  runtime). `building` streams the latest output line; `failed` stays up
+ *  (with `error`) until dismissed; success removes the entry. The runtime is
+ *  the map key in `containerBuilds`, not a field here — each runtime's build
+ *  serializes on its own lock, so Docker and Podman builds can overlap and
+ *  must not share one state slot. */
 export interface DockerBuildProgress {
   status: "building" | "failed";
   /** Most recent `build` output line (building only). */
   lastLine: string | null;
   /** Failure reason (failed only). */
   error: string | null;
-  /** Display name of the runtime doing the building ("Docker" / "Podman"), from
-   *  the `started` event. `null` when the event didn't name one — the toast then
-   *  falls back to neutral copy rather than guessing a runtime. */
-  runtime: string | null;
 }
+
+/** `containerBuilds` key for events that didn't name a runtime — the toast
+ *  shows neutral copy for it instead of guessing. */
+export const NEUTRAL_BUILD_RUNTIME = "container";
 
 export interface SandboxSlice {
   /** Engine new agents are stamped with. Mirrors the backend-owned
@@ -37,8 +39,12 @@ export interface SandboxSlice {
   /** Which container auth chain step is active (Anthropic credentials for
    *  docker agents); `null` until the first refresh lands. */
   containerAuth: ContainerAuthStatus | null;
-  /** Live image-build progress for the build toast; `null` = no build. */
-  dockerBuild: DockerBuildProgress | null;
+  /** Live image-build progress for the build toast, keyed by the runtime
+   *  display name from the event stream ("Docker" / "Podman", or
+   *  [`NEUTRAL_BUILD_RUNTIME`]). Keyed because the runtimes build
+   *  independently: one runtime's `finished` must not clear the other's
+   *  still-running toast. Empty = no build in flight. */
+  containerBuilds: Record<string, DockerBuildProgress>;
   /** Advanced docker launch knobs, mirrored from the backend-owned
    *  `docker_image` / `docker_memory` / `docker_cpus` settings. Empty string =
    *  unset (the launch path uses its defaults: 4g memory, 2 cpus, embedded
@@ -90,8 +96,10 @@ export interface SandboxSlice {
   /** Drop the stored container token, then refresh the status (a later chain
    *  step — shell env / credentials file — may take over). */
   clearContainerAuthToken: () => Promise<void>;
-  /** Dismiss the build toast (used after a failed build). */
-  dismissDockerBuild: () => void;
+  /** Dismiss one runtime's build toast (used after a failed build). Takes the
+   *  `containerBuilds` key so dismissing one runtime's failure leaves the
+   *  other's live toast alone. */
+  dismissDockerBuild: (runtime: string) => void;
   /** Persist the advanced docker launch knobs (image / memory / cpus) via the
    *  backend, which writes the settings AND updates the spawn-path mirror.
    *  Reverts the store on failure. */
@@ -127,7 +135,7 @@ export const createSandboxSlice: SliceCreator<SandboxSlice> = (set, get) => ({
   sandboxEngine: DEFAULT_SANDBOX_ENGINE,
   dockerProbe: null,
   podmanProbe: null,
-  dockerBuild: null,
+  containerBuilds: {},
   dockerImage: "",
   dockerMemory: "",
   dockerCpus: "",
@@ -229,7 +237,11 @@ export const createSandboxSlice: SliceCreator<SandboxSlice> = (set, get) => ({
     await get().refreshContainerAuth();
   },
 
-  dismissDockerBuild: () => set({ dockerBuild: null }),
+  dismissDockerBuild: (runtime) =>
+    set((s) => {
+      const { [runtime]: _, ...rest } = s.containerBuilds;
+      return { containerBuilds: rest };
+    }),
 
   saveDockerLaunchSettings: (image, memory, cpus) =>
     optimistic(

--- a/src/store/sandbox.ts
+++ b/src/store/sandbox.ts
@@ -1,4 +1,10 @@
-import { api, type ContainerAuthStatus, type DockerProbe, type PublishApproval } from "@/api";
+import {
+  api,
+  type ContainerAuthStatus,
+  type DockerProbe,
+  type PodmanProbe,
+  type PublishApproval,
+} from "@/api";
 import { DEFAULT_SANDBOX_ENGINE, type SandboxEngine } from "@/storage/preferences";
 import { checkoutKey } from "./git";
 import { autopilotIsDriving, publishPreAuthorized } from "./publishApproval";
@@ -21,6 +27,8 @@ export interface SandboxSlice {
   sandboxEngine: SandboxEngine;
   /** Latest Docker availability probe; `null` until the first probe lands. */
   dockerProbe: DockerProbe | null;
+  /** Latest Podman availability probe; `null` until the first probe lands. */
+  podmanProbe: PodmanProbe | null;
   /** Which container auth chain step is active (Anthropic credentials for
    *  docker agents); `null` until the first refresh lands. */
   containerAuth: ContainerAuthStatus | null;
@@ -59,6 +67,9 @@ export interface SandboxSlice {
   /** Re-probe Docker availability into `dockerProbe` (settings pane open).
    *  Returns the probe result so callers can poll until the daemon answers. */
   refreshDockerProbe: () => Promise<DockerProbe>;
+  /** Re-probe Podman availability into `podmanProbe`; sibling of
+   *  `refreshDockerProbe`, polled by the same settings-pane loop. */
+  refreshPodmanProbe: () => Promise<PodmanProbe>;
   /** Re-resolve the container auth chain into `containerAuth`. */
   refreshContainerAuth: () => Promise<void>;
   /** Persist a pasted `claude setup-token` for containers, then refresh the
@@ -102,6 +113,7 @@ async function optimistic(
 export const createSandboxSlice: SliceCreator<SandboxSlice> = (set, get) => ({
   sandboxEngine: DEFAULT_SANDBOX_ENGINE,
   dockerProbe: null,
+  podmanProbe: null,
   dockerBuild: null,
   dockerImage: "",
   dockerMemory: "",
@@ -161,6 +173,18 @@ export const createSandboxSlice: SliceCreator<SandboxSlice> = (set, get) => ({
       probe = { status: "not-installed" };
     }
     set({ dockerProbe: probe });
+    return probe;
+  },
+  refreshPodmanProbe: async () => {
+    let probe: PodmanProbe;
+    try {
+      probe = await api.probePodmanEngine();
+    } catch {
+      // A failed probe means we can't confirm podman — treat as not installed
+      // so the option gates off rather than dangling enabled.
+      probe = { status: "not-installed" };
+    }
+    set({ podmanProbe: probe });
     return probe;
   },
 

--- a/src/styles/shared/banners.css
+++ b/src/styles/shared/banners.css
@@ -184,11 +184,22 @@
   justify-content: flex-end;
 }
 
-/* Docker image-build toast — reuses the update-toast chrome but anchors
-   bottom-left so it never overlaps a concurrent update toast (bottom-right). */
-.docker-build-toast {
-  right: auto;
+/* Container image-build toasts — reuse the update-toast chrome but anchor
+   bottom-left so they never overlap a concurrent update toast (bottom-right).
+   The stack holds one toast per runtime: Docker and Podman build on
+   independent locks, so both can be live at once and must not overlap each
+   other either. */
+.docker-build-stack {
+  position: fixed;
   left: 16px;
+  bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: var(--z-toast);
+}
+.docker-build-toast {
+  position: static;
   transform-origin: bottom left;
 }
 .docker-build-toast > svg {


### PR DESCRIPTION
PR 5, the final slice of the Podman-engine series (stacked on #628; review with that as the base). Podman reaches operational parity with Docker: image freshness, image GC, per-engine launch settings, the build-progress toast, and the user-facing copy that previously said "Docker" on shared paths.

## Image freshness parity

- Pure policy extracted to `container/freshness.rs` (TTL, `classify_freshness`, version-refresh decision) and `container/version_guard.rs` (once-per-run refresh guard) — Docker refactored onto them, tests moved verbatim.
- Podman gets the full stale-while-revalidate treatment: TTL + host/container CLI version-parity triggers, background rebuild under its own build lock (separate image stores), in-image `--version` probe, post-build version caching.
- One deliberate divergence, unit-tested: Podman's image inspect reads **JSON**, not a Go template — podman renders `Created` via Go's `time.Time String()` under `text/template` (not RFC3339), which would have silently classified every image `Unknown` and killed the TTL.

## Image GC parity

The ~250 lines of GC safety rules (namespace fences, content-addressed-tag guard, override spellings, under-reclaim bias) extracted to `container/image_gc.rs` and shared; Docker keeps its `LEGACY_TAGS` arm, Podman correctly has none (it postdates the `fletch.agent` label). Podman's stale-image sweep wired next to its orphan sweep; a gated integration test also pins the `--format` column assumption against a real store.

## Per-engine launch settings

`podman_image` / `podman_memory` / `podman_cpus` / `podman_version_refresh_guard`, mirroring Docker's keys one-for-one (a test asserts the shapes stay parallel and never collide). `set_podman_launch_settings` command, startup seeding, and the settings UI's Docker knobs generalized to a shared `ContainerLaunchKnobs` component rendered per runtime. Docker's keys and behavior untouched. An override image skips refresh/GC/version checks exactly like Docker's, and Podman's 126/127 exit copy now names `podman_image`.

## Build toast

`docker/progress.rs` promoted to `container/progress.rs`; the wire event name (`docker:build-progress`) and `phase` values are unchanged, `Started` gains an additive `runtime` field (`runtime?: string` frontend-side), so a first Podman build now shows "Building Podman sandbox image…" instead of minutes of silence.

## Copy fixes (flagged in #628)

"preparing Docker sandbox config/projects mount … failed" → "container sandbox …"; "{label} isn't available in Docker sandboxes yet" → "container sandboxes". Genuinely Docker-only copy (docker/ internals, Docker Desktop hints, settings labels) left alone.

## Deferred, documented in-code

`reap_superseded_base` for Podman (needs the superseded-base queue; noted in `podman/image.rs` module doc); `docker*`-named frontend identifiers (wire event name is frozen, so renaming only the component would be less coherent); a Podman-specific crash-banner arm (a podman-down failure falls through to the generic banner today — a "start podman machine" recovery action is the natural follow-up).

## Verification

`cargo test`: 1446 passed, 0 failed (new unit tests for freshness/GC/settings/inspect-JSON; 3 new `FLETCH_PODMAN_TESTS=1` integration tests). clippy/rustfmt clean. Frontend: tsc clean, 999 vitest tests pass, biome clean on changed files.