### PR TITLE
fix(sandbox): close the podman review findings and trim the comments

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -704,11 +704,24 @@ async fn set_sandbox_engine(
         // every new agent, so persisting one whose runtime can't launch would
         // fail each spawn. Checked here rather than in the UI alone — the
         // setting is reachable over IPC.
-        let probe = tauri::async_runtime::spawn_blocking(sandbox::podman_availability)
-            .await
-            .map_err(|e| e.to_string())?;
+        // The launch blocker rides the same `spawn_blocking`: `podman info`
+        // answers over a remote default connection that every launch then
+        // refuses, so "available" alone is not "launchable".
+        let (probe, blocker) = tauri::async_runtime::spawn_blocking(|| {
+            let probe = sandbox::podman_availability();
+            let blocker = matches!(probe, sandbox::PodmanAvailability::Available { .. })
+                .then(sandbox::podman_launch_blocker)
+                .flatten();
+            (probe, blocker)
+        })
+        .await
+        .map_err(|e| e.to_string())?;
         match probe {
-            sandbox::PodmanAvailability::Available { .. } => {}
+            sandbox::PodmanAvailability::Available { .. } => {
+                if let Some(blocker) = blocker {
+                    return Err(blocker);
+                }
+            }
             sandbox::PodmanAvailability::NotInstalled => {
                 return Err("Podman is not installed — install Podman first.".into())
             }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -629,7 +629,8 @@ fn track_event(event: String, props: Option<serde_json::Value>) {
     telemetry::track(&event, props.unwrap_or_else(|| json!({})));
 }
 
-/// The persisted sandbox engine selection (`"sandbox-exec"` | `"docker"`).
+/// The persisted sandbox engine selection (`"sandbox-exec"` | `"docker"` |
+/// `"podman"`).
 /// Reads the in-memory mirror seeded at startup and kept in sync by
 /// `set_sandbox_engine`, so no DB handle is needed.
 #[tauri::command]
@@ -685,13 +686,14 @@ fn answer_publish_approval(id: String, approved: bool) {
     rpc::approval::answer(&id, approved);
 }
 
-/// Change the sandbox engine stamped onto *new* agents. Docker is validated
-/// against a live daemon probe before being accepted and Podman is refused
-/// outright, so a success here means the choice is actionable. Persists to
-/// `settings` and updates the in-memory
-/// mirror — like `set_agent_bin_override` keeps the DB and process state in
-/// sync. Existing agents are unaffected: each keeps the engine stamped on its
-/// record at creation.
+/// Change the sandbox engine stamped onto *new* agents. Container engines are
+/// validated live before being accepted — Docker against a daemon probe, Podman
+/// against `sandbox::podman::availability` plus
+/// `sandbox::podman::launch_blocker` — so a success here means the choice is
+/// actionable. Persists to `settings` and updates the in-memory mirror — like
+/// `set_agent_bin_override` keeps the DB and process state in sync. Existing
+/// agents are unaffected: each keeps the engine stamped on its record at
+/// creation.
 #[tauri::command]
 async fn set_sandbox_engine(
     engine: String,
@@ -700,13 +702,12 @@ async fn set_sandbox_engine(
     let kind = sandbox::EngineKind::from_setting(&engine)
         .ok_or_else(|| format!("unknown sandbox engine: {engine}"))?;
     if kind == sandbox::EngineKind::Podman {
-        // Same gate Docker gets below: a stored engine value is stamped onto
-        // every new agent, so persisting one whose runtime can't launch would
-        // fail each spawn. Checked here rather than in the UI alone — the
-        // setting is reachable over IPC.
-        // The launch blocker rides the same `spawn_blocking`: `podman info`
-        // answers over a remote default connection that every launch then
-        // refuses, so "available" alone is not "launchable".
+        // Same gate Docker gets below — a stored engine is stamped onto every
+        // new agent, so one whose runtime can't launch fails every spawn — and
+        // here rather than in the UI alone because the setting is reachable over
+        // IPC. "Available" isn't "launchable": `podman info` can answer over a
+        // remote default connection that every launch then refuses, hence the
+        // blocker check on the same `spawn_blocking`.
         let (probe, blocker) = tauri::async_runtime::spawn_blocking(|| {
             let probe = sandbox::podman_availability();
             let blocker = matches!(probe, sandbox::PodmanAvailability::Available { .. })
@@ -1003,9 +1004,8 @@ async fn set_podman_launch_settings(
     cpus: Option<String>,
     state: tauri::State<'_, DbState>,
 ) -> Result<(), String> {
-    // Blank → None: a cleared field must not be stored as a launch override
-    // (an empty `--memory`/`--cpus` value or `podman_image` would break `podman
-    // run`), and the mirror treats blank as "use default" anyway.
+    // Blank → None, as in the docker twin above: a cleared field must not be
+    // stored as a launch override.
     let norm = |v: Option<String>| v.map(|s| s.trim().to_string()).filter(|s| !s.is_empty());
     let image = norm(image);
     let memory = norm(memory);
@@ -1510,11 +1510,11 @@ pub fn run() {
             // Forward container image-build progress to the UI — either
             // runtime's, through one sink. The build runs deep in the spawn path
             // (no AppHandle there), so it emits through a process-wide sink
-            // installed here — mirroring the git-dist emitter above. Rare (first
-            // spawn per image per runtime), so a single toast fed by these events
-            // suffices; `started` carries the runtime name so the toast can say
-            // which one is building. The `docker:build-progress` event name is
-            // the established wire contract and stays as-is.
+            // installed here — mirroring the git-dist emitter above. Every phase
+            // carries its `runtime` and the frontend routes on it: with two
+            // runtimes sharing this stream it's the lifecycle key, not
+            // decoration. The `docker:build-progress` event name is the
+            // established wire contract and stays as-is.
             {
                 use tauri::Emitter;
                 let handle = app.handle().clone();
@@ -1664,10 +1664,9 @@ pub fn run() {
             // untouched.
             crate::sandbox::cleanup_nested_rpc_roots();
             crate::sandbox::cleanup_nested_checkouts_roots();
-            // Same reclamation for containers left by dead instances, one
-            // sweep per container runtime — each probe-gated and on its own
-            // thread, so startup never waits on either, and a machine with
-            // neither runtime installed pays for no invocation at all.
+            // Same reclamation for containers left by dead instances, one sweep
+            // per container runtime — each probe-gated and on its own thread, so
+            // startup never waits on either.
             crate::sandbox::docker::sweep_orphans_at_startup();
             crate::sandbox::podman::sweep_orphans_at_startup();
 

--- a/src-tauri/src/sandbox/container/auth.rs
+++ b/src-tauri/src/sandbox/container/auth.rs
@@ -1,48 +1,10 @@
-//! Anthropic auth for containerized agents.
-//!
-//! Host claude logins usually live in the macOS Keychain, which doesn't exist
-//! inside a container, and Fletch itself injects no credentials — so docker
-//! agents need auth resolved explicitly. [`resolve`] walks a first-hit-wins
-//! chain and returns the env vars to set on the *docker CLI process*; the
-//! launch path forwards them with bare `-e VAR` flags, so token values
-//! never appear in argv (invariant 3). They must never appear in logs either:
-//! [`ContainerAuth`] redacts values in its `Debug` output, and nothing in this
-//! module traces a token.
-//!
-//! The chain (first hit wins), re-evaluated on every spawn:
-//! 1. The **macOS Keychain** login (`security find-generic-password -s
-//!    "Claude Code-credentials"`) → its `claudeAiOauth.accessToken` forwarded as
-//!    `CLAUDE_CODE_OAUTH_TOKEN`. This is where an interactive `claude` login
-//!    stores the live credential on macOS, so reading it fresh each spawn tracks
-//!    the *currently authenticated account* — the same one a seatbelt agent
-//!    would use — with no pasting and no staleness when the user switches
-//!    accounts. Keychain-primary: it sits ahead of the stored token so a
-//!    re-login (e.g. after hitting a rate limit) takes effect immediately. Only
-//!    a usable token counts (see [`usable_oauth_token`]); no Keychain / no login
-//!    (Linux, CI) falls through. See [`keychain_token`].
-//! 2. A `claude setup-token` value captured into the app's secret store
-//!    ([`TOKEN_SETTING`], auto-populated by [`crate::sandbox::docker::setup_token`]) →
-//!    `CLAUDE_CODE_OAUTH_TOKEN`. The fallback for hosts without a readable
-//!    Keychain login.
-//! 3. The app's process env or the login-shell probe exports a credential —
-//!    `ANTHROPIC_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`, or `ANTHROPIC_AUTH_TOKEN`
-//!    (a custom-gateway bearer) → forward it plus `ANTHROPIC_BASE_URL` (the
-//!    gateway/proxy endpoint). `ANTHROPIC_BASE_URL` alone is not a credential.
-//!    This step sits below Keychain/stored, so an ambient credential here never
-//!    overrides a resolved login — but it means a gateway-only host (no
-//!    Keychain, no stored token) authenticates on docker just as it does under
-//!    seatbelt. Both sources are consulted (login-shell wins on collision) so a
-//!    token in the launching terminal's env works even when the `/bin/zsh -lc`
-//!    probe can't see it — see [`merge_auth_env`].
-//! 4. `<home>/.claude/.credentials.json` holds a usable OAuth token (non-empty
-//!    access token, non-placeholder `expiresAt`) → nothing to inject: the
-//!    `~/.claude` bind mount carries it, and refresh writes land on the host. A
-//!    stale placeholder (macOS Keychain logins leave `"expiresAt": 0` on disk)
-//!    does *not* count — see [`credentials_file_usable`].
-//! 5. Nothing → [`ContainerAuth::Unavailable`]; the spawn path fails fast and
-//!    the UI shows the "Connect Claude for containers" call-to-action.
-//!
-//! Seatbelt agents never see any of this — they keep the user's own login.
+//! Anthropic auth for containerized agents. [`resolve`] walks a first-hit-wins
+//! chain — Keychain login, stored setup-token, shell/process env, a usable
+//! `~/.claude/.credentials.json`, else [`ContainerAuth::Unavailable`] — and is
+//! re-evaluated on every spawn, so a `claude` re-login lands immediately. It
+//! returns env for the *container CLI process*, which bare `-e VAR` flags
+//! forward, so token values never appear in argv (invariant 3); nor in logs,
+//! since [`ContainerAuth`]'s `Debug` prints var names only.
 
 use std::collections::HashMap;
 use std::ffi::OsStr;
@@ -53,33 +15,26 @@ use parking_lot::RwLock;
 
 use crate::bin_resolve;
 
-/// `crate::secrets` key holding the user-pasted `claude setup-token` value —
-/// the OS keychain on release macOS builds, the same posture as
-/// `github::TOKEN_SETTING`.
+/// `crate::secrets` key holding the user-pasted `claude setup-token` value.
 pub const TOKEN_SETTING: &str = "claude_container_token";
 
 /// Env var claude reads a setup-token (OAuth) credential from.
 const OAUTH_TOKEN_VAR: &str = "CLAUDE_CODE_OAUTH_TOKEN";
 
-/// macOS Keychain generic-password service name Claude Code stores its login
-/// credential under. The password payload is the same `{"claudeAiOauth":{…}}`
-/// JSON as `~/.claude/.credentials.json`, so [`usable_oauth_token`] parses both.
+/// macOS Keychain service Claude Code stores its login under; the password
+/// payload is the same JSON as `~/.claude/.credentials.json`.
 #[cfg(target_os = "macos")]
 const KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
 
-/// Shell vars that constitute a chain hit on their own. `ANTHROPIC_AUTH_TOKEN`
-/// (a custom-gateway bearer credential) counts too, so a host that authenticates
-/// *only* via a gateway isn't refused on docker while it works under seatbelt —
-/// but it sits in the `ShellEnv` step (below Keychain/stored), so it never
-/// overrides a resolved login, matching how `ANTHROPIC_API_KEY` is treated.
+/// Shell vars that constitute a chain hit on their own — the gateway bearer
+/// `ANTHROPIC_AUTH_TOKEN` included, so a gateway-only host isn't refused.
 const SHELL_KEY_VARS: [&str; 3] = [
     "ANTHROPIC_API_KEY",
     "CLAUDE_CODE_OAUTH_TOKEN",
     "ANTHROPIC_AUTH_TOKEN",
 ];
 
-/// Everything forwarded from the login shell once one of [`SHELL_KEY_VARS`]
-/// is present; `ANTHROPIC_BASE_URL` is the endpoint for the proxy/gateway.
+/// Everything forwarded once one of [`SHELL_KEY_VARS`] is present.
 const SHELL_AUTH_VARS: [&str; 4] = [
     "ANTHROPIC_API_KEY",
     "CLAUDE_CODE_OAUTH_TOKEN",
@@ -87,34 +42,24 @@ const SHELL_AUTH_VARS: [&str; 4] = [
     "ANTHROPIC_AUTH_TOKEN",
 ];
 
-/// Endpoint var forwarded alongside a credential resolved from a *higher* chain
-/// step (Keychain/stored/credentials-file). It's an endpoint, not a credential —
-/// it points the resolved login at a custom `ANTHROPIC_BASE_URL` (e.g. a proxy
-/// in front of Anthropic that accepts that login) — so it always rides along.
-/// `ANTHROPIC_AUTH_TOKEN` is a credential, not an endpoint, so it is NOT here: an
-/// ambient one must never ride along and override the resolved login (it's only
-/// forwarded when the shell env is itself the resolved credential — the
-/// `ShellEnv` step, via [`SHELL_AUTH_VARS`]).
+/// Endpoint vars forwarded alongside a credential resolved from a *higher* chain
+/// step, to point that login at a custom proxy. Credential vars must never be
+/// listed here: an ambient one would override the resolved login.
 const PROXY_RIDE_ALONG: [&str; 1] = ["ANTHROPIC_BASE_URL"];
 
 /// Expected prefix of a `claude setup-token` credential. Other shapes are
 /// accepted with a warning — the format isn't a contract we own.
 const SETUP_TOKEN_PREFIX: &str = "sk-ant-oat";
 
-/// The stored token, cached in-process. Seeded from the DB at startup and
-/// updated by the `set_container_auth_token` / `clear_container_auth_token`
-/// commands, so [`resolve`] — called deep in spawn paths with no DB handle —
-/// never touches the DB. Same pattern as `github::set_token`.
+/// The stored token, mirrored in-process so [`resolve`] — called deep in spawn
+/// paths with no DB handle — never touches the DB.
 static STORED_TOKEN: RwLock<Option<String>> = RwLock::new(None);
 
-/// True once an explicit [`set_stored_token`] (paste/clear command) has run.
-/// Guards [`seed_stored_token`]: the startup seed retries in the background
-/// while the keychain is locked, and a delayed retry must never overwrite
-/// newer user action with the stale value it read.
+/// True once an explicit [`set_stored_token`] has run, so a delayed startup-seed
+/// retry can't overwrite newer user action with the stale value it read.
 static SEALED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
 
-/// Replace the in-process stored token. Callers that change the *persisted*
-/// token write the DB and then call this; blank counts as none. Seals the
+/// Replace the in-process stored token (blank counts as none) and seal the
 /// mirror against any still-pending startup seed.
 pub fn set_stored_token(token: Option<String>) {
     let mut w = STORED_TOKEN.write();
@@ -122,11 +67,9 @@ pub fn set_stored_token(token: Option<String>) {
     *w = sanitize(token);
 }
 
-/// Startup-seed variant of [`set_stored_token`]: applies only while no
-/// explicit set has run. The seal is checked under the mirror's write lock,
-/// so a racing paste/clear either lands after this (and overwrites the seed)
-/// or before it (and the seed no-ops) — the fresher value wins in both
-/// orders.
+/// Startup-seed variant of [`set_stored_token`]: applies only while no explicit
+/// set has run. The seal is read under the mirror's write lock, so a racing
+/// paste/clear wins in either order.
 pub fn seed_stored_token(token: Option<String>) {
     let mut w = STORED_TOKEN.write();
     if SEALED.load(std::sync::atomic::Ordering::SeqCst) {
@@ -139,8 +82,8 @@ fn stored_token() -> Option<String> {
     STORED_TOKEN.read().clone()
 }
 
-/// Blank-to-none normalization for the mirror: a cleared setting is stored as
-/// `""` (like `github_disconnect`), which must not count as a token.
+/// Blank-to-none: a cleared setting is persisted as `""`, which must not count
+/// as a token.
 fn sanitize(token: Option<String>) -> Option<String> {
     token
         .map(|t| t.trim().to_string())
@@ -150,20 +93,18 @@ fn sanitize(token: Option<String>) -> Option<String> {
 /// Which chain step supplied the credentials.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthSource {
-    /// The live macOS Keychain login (`claude`'s own credential), read fresh
-    /// each spawn and forwarded — tracks the currently authenticated account.
+    /// The live macOS Keychain login, read fresh each spawn.
     Keychain,
     /// The pasted/captured setup-token from settings.
     StoredToken,
     /// Auth vars from the app's process env or the user's login shell.
     ShellEnv,
-    /// `~/.claude/.credentials.json` — carried by the `~/.claude` mount, so
-    /// there is nothing to inject.
+    /// `~/.claude/.credentials.json` — carried by the mount, nothing to inject.
     CredentialsFile,
 }
 
-/// Outcome of the resolution chain: the env to set on the docker CLI process
-/// (forwarded into the container via bare `-e VAR`), or nothing usable.
+/// Outcome of the chain: the env to set on the container CLI process (forwarded
+/// via bare `-e VAR`), or nothing usable.
 pub enum ContainerAuth {
     Resolved {
         env: Vec<(String, String)>,
@@ -172,8 +113,8 @@ pub enum ContainerAuth {
     Unavailable,
 }
 
-/// Manual impl so a stray `{:?}` in a log line can never leak a token: env
-/// entries print their var *names* only.
+/// Manual impl so a stray `{:?}` can never leak a token: env entries print their
+/// var *names* only.
 impl fmt::Debug for ContainerAuth {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -190,26 +131,21 @@ impl fmt::Debug for ContainerAuth {
     }
 }
 
-/// The config dir whose `.credentials.json` claude reads: the explicit
-/// `CLAUDE_CONFIG_DIR` if set, else `~/.claude`. Pure over its inputs so the
-/// resolution is unit-testable without touching process env or `$HOME`.
+/// The config dir whose `.credentials.json` claude reads: `CLAUDE_CONFIG_DIR`
+/// if set, else `~/.claude`.
 fn credentials_config_dir(config_dir_env: Option<&OsStr>, home: Option<&Path>) -> Option<PathBuf> {
     config_dir_env
         .map(PathBuf::from)
         .or_else(|| home.map(|h| h.join(".claude")))
 }
 
-/// Walk the auth chain (first hit wins). Called by the docker launch path at
-/// spawn time and, via [`status`], by the settings UI. May block on the first
-/// call: the login-shell env is loaded (a shell runs) if nothing earlier
-/// populated `bin_resolve`'s cache.
+/// Walk the auth chain (first hit wins). May block on the first call: loading
+/// the login-shell env runs a shell if nothing populated `bin_resolve`'s cache.
 pub fn resolve() -> ContainerAuth {
     let keychain = keychain_token();
-    // Check the config dir claude will actually read from — the explicit
-    // `CLAUDE_CONFIG_DIR` if set, else `~/.claude` — which is also the dir the
-    // engine mounts (see `nondefault_claude_config_dir`). Hardcoding `~/.claude`
-    // would refuse a container whose only credential is a `.credentials.json`
-    // living in a custom config dir.
+    // The dir claude will actually read — and the one the engine mounts (see
+    // `nondefault_claude_config_dir`); hardcoding `~/.claude` would refuse a
+    // container whose only credential lives in a custom config dir.
     let credentials_file = credentials_config_dir(
         std::env::var_os("CLAUDE_CONFIG_DIR").as_deref(),
         dirs::home_dir().as_deref(),
@@ -225,13 +161,9 @@ pub fn resolve() -> ContainerAuth {
     resolve_from(keychain, stored_token(), env.as_ref(), credentials_file)
 }
 
-/// The live host login token from the macOS Keychain, or `None` when there's no
-/// readable/usable login (Keychain locked or empty, non-macOS host). Shells out
-/// to `security find-generic-password -s <service> -w`, which prints the stored
-/// password — the `{"claudeAiOauth":{…}}` JSON — to stdout. Read fresh on every
-/// [`resolve`] so a `claude` re-login is reflected in the very next spawn. The
-/// process may surface a one-time Keychain access prompt the first time a new
-/// Fletch build reads the item; "Always Allow" persists it.
+/// The live host login token from the macOS Keychain, read fresh on every
+/// [`resolve`] so a `claude` re-login lands on the next spawn. `None` when
+/// there's no readable/usable login (Keychain locked or empty, non-macOS host).
 #[cfg(target_os = "macos")]
 fn keychain_token() -> Option<String> {
     let out = std::process::Command::new("security")
@@ -250,17 +182,11 @@ fn keychain_token() -> Option<String> {
 }
 
 /// Fold the app's own process environment together with the login-shell probe
-/// into one auth view for the env chain step (login-shell wins on collision).
-///
-/// The docker CLI child inherits the app's process env, so a token exported in
-/// the terminal that launched Fletch — or on a bash-only host, where the
-/// `/bin/zsh -lc` probe in [`bin_resolve::login_shell_env`] can't see it — was
-/// always forwarded into the container by the bare `-e VAR` flags. Consulting
-/// only the login-shell probe here would make [`resolve`] report `Unavailable`
-/// for exactly that setup, and the fail-fast launch path would then abort a
-/// container that would otherwise have authenticated fine. Reading the process
-/// env too keeps that path working. `None` when neither source carries an auth
-/// var.
+/// into one auth view for the env chain step (login-shell wins on collision);
+/// `None` when neither carries an auth var. Both are consulted because the
+/// container CLI child inherits the process env: a token visible only there —
+/// e.g. on a bash-only host the `/bin/zsh -lc` probe can't read — would
+/// otherwise resolve `Unavailable` and abort a launch that would have worked.
 fn merge_auth_env(
     process_env: &HashMap<String, String>,
     shell_env: Option<&HashMap<String, String>>,
@@ -281,30 +207,18 @@ fn merge_auth_env(
     (!merged.is_empty()).then_some(merged)
 }
 
-/// Whether `~/.claude/.credentials.json` carries an OAuth credential the
-/// container can actually authenticate with. Mere existence is *not* enough:
-/// on a macOS host the live token lives in the Keychain and the on-disk file is
-/// commonly a stale placeholder (`"expiresAt": 0`) — counting that as a hit
-/// boots the container straight into "Not logged in · Please run /login", which
-/// it can't recover from (no interactive login inside the sandbox).
-///
-/// A file counts only when it holds a non-empty `claudeAiOauth.accessToken` and
-/// a positive `expiresAt`. We deliberately do *not* require `expiresAt` to be
-/// in the future: an expired-but-refreshable token is the documented refresh
-/// flow (the container refreshes and the write lands on the mounted file), so
-/// rejecting it would break working Linux-host setups. The `expiresAt <= 0`
-/// (or missing/empty-token) placeholder is the only shape we reject.
+/// Whether `.credentials.json` carries a credential the container can
+/// authenticate with — see [`usable_oauth_token`] for the usability bar.
 fn credentials_file_usable(contents: Option<&[u8]>) -> bool {
     usable_oauth_token(contents).is_some()
 }
 
 /// Extract a container-usable OAuth access token from a credentials JSON blob —
-/// the `~/.claude/.credentials.json` file *or* the macOS Keychain password,
-/// which share the `{"claudeAiOauth":{accessToken,expiresAt}}` shape. Returns
-/// the trimmed access token only when it's non-empty and `expiresAt > 0`, the
-/// same usability bar [`credentials_file_usable`] documents: the `expiresAt <= 0`
-/// (or empty-token / wrong-shape / unparseable) placeholder is rejected, while
-/// an expired-but-refreshable positive `expiresAt` is accepted.
+/// the `.credentials.json` file *or* the macOS Keychain password, which share
+/// the shape. Requires a non-empty token and `expiresAt > 0`: a macOS Keychain
+/// login leaves an `expiresAt: 0` placeholder on disk, and treating it as a hit
+/// boots the container into a login prompt it can't answer. Expired-but-positive
+/// is accepted — the container refreshes and the write lands on the mount.
 fn usable_oauth_token(contents: Option<&[u8]>) -> Option<String> {
     let json: serde_json::Value = serde_json::from_slice(contents?).ok()?;
     let oauth = &json["claudeAiOauth"];
@@ -316,22 +230,15 @@ fn usable_oauth_token(contents: Option<&[u8]>) -> Option<String> {
     expires_ok.then(|| token.to_string())
 }
 
-/// The chain itself, pure over its inputs so tests can exercise the ordering
-/// without touching process globals or the filesystem.
+/// The chain itself, pure over its inputs so tests can exercise the ordering.
 fn resolve_from(
     keychain: Option<String>,
     stored: Option<String>,
     shell_env: Option<&HashMap<String, String>>,
     credentials_file: bool,
 ) -> ContainerAuth {
-    // Append the endpoint ride-along (see [`PROXY_RIDE_ALONG`]) to a credential
-    // the chain picked from a *higher* step than the shell env, so a custom
-    // `ANTHROPIC_BASE_URL` still points the resolved login at its proxy. Only the
-    // endpoint rides along — never a credential var — so an ambient
-    // `ANTHROPIC_AUTH_TOKEN`/`ANTHROPIC_API_KEY` can't override the resolved
-    // login. (The endpoint is forwarded regardless of whether a gateway token is
-    // also set: the user set `BASE_URL` deliberately, often for network egress,
-    // so honoring it beats silently falling back to the default endpoint.)
+    // Only `PROXY_RIDE_ALONG` endpoints follow a credential taken from a higher
+    // step; forwarding an ambient credential var would override that login.
     let with_proxy = |mut env: Vec<(String, String)>| -> Vec<(String, String)> {
         if let Some(shell) = shell_env {
             for var in PROXY_RIDE_ALONG {
@@ -387,8 +294,7 @@ fn resolve_from(
     ContainerAuth::Unavailable
 }
 
-/// Wire shape of the `get_container_auth_status` command — [`resolve`]'s
-/// outcome for the settings status row. Serializes like `DockerAvailability`:
+/// Wire shape of the `get_container_auth_status` command:
 /// `{ "status": "keychain" | "stored-token" | "shell-env" | "credentials-file" | "none" }`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(tag = "status", rename_all = "kebab-case")]
@@ -413,9 +319,8 @@ pub fn status() -> ContainerAuthStatus {
     }
 }
 
-/// Normalize a pasted token for storage: trimmed, non-empty, plus whether it
-/// matches the expected setup-token shape (callers warn-but-accept on a
-/// mismatch). The error string never contains the input.
+/// Normalize a pasted token for storage: trimmed and non-empty, plus whether it
+/// matches the expected shape (callers warn-but-accept). Errors never echo input.
 pub fn normalize_token(raw: &str) -> Result<(String, bool), String> {
     let token = raw.trim();
     if token.is_empty() {
@@ -448,7 +353,6 @@ mod tests {
             ("ANTHROPIC_API_KEY", "proc-key"),
             ("ANTHROPIC_BASE_URL", "https://proc-proxy"),
         ]);
-        // Process env alone is honored.
         let m = merge_auth_env(&process, None).unwrap();
         assert_eq!(m.get("ANTHROPIC_API_KEY").unwrap(), "proc-key");
         // Login-shell wins on collision; process-only vars still survive.
@@ -461,16 +365,13 @@ mod tests {
     #[test]
     fn merge_auth_env_none_when_no_auth_vars() {
         assert!(merge_auth_env(&HashMap::new(), None).is_none());
-        // Non-auth vars are ignored, so a shell with only PATH is not a source.
         let junk = shell_env(&[("PATH", "/usr/bin")]);
         assert!(merge_auth_env(&junk, Some(&junk)).is_none());
     }
 
     #[test]
     fn process_env_token_resolves_instead_of_aborting() {
-        // The regression: a token in the app's process env but not the
-        // login-shell probe must resolve (not fall through to Unavailable and
-        // abort the launch). merge_auth_env feeds it into the env chain step.
+        // A token only the process env carries must resolve, not abort the launch.
         let process = shell_env(&[("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-oat-proc")]);
         let merged = merge_auth_env(&process, None);
         let (env, source) = resolved(resolve_from(None, None, merged.as_ref(), false));
@@ -486,9 +387,6 @@ mod tests {
 
     #[test]
     fn keychain_beats_stored_shell_and_credentials_file() {
-        // Keychain-primary: the live host login wins over a (possibly stale)
-        // stored setup-token, shell env, and the mounted credentials file — so a
-        // `claude` re-login is reflected on the very next spawn.
         let shell = shell_env(&[("ANTHROPIC_API_KEY", "sk-ant-api-key")]);
         let auth = resolve_from(
             Some("sk-ant-oat-keychain".into()),
@@ -509,10 +407,8 @@ mod tests {
 
     #[test]
     fn proxy_config_rides_along_but_ambient_credentials_do_not() {
-        // Keychain wins, but the shell also exports a proxy base URL and a
-        // competing API key. The base URL rides along (endpoint config); the
-        // API key must NOT — forwarding it would let claude prefer it over the
-        // Keychain login the chain actually resolved.
+        // Forwarding the ambient key would let claude prefer it over the
+        // Keychain login the chain resolved.
         let shell = shell_env(&[
             ("ANTHROPIC_API_KEY", "sk-ant-ambient-key"),
             ("ANTHROPIC_BASE_URL", "https://proxy.example.com"),
@@ -534,10 +430,7 @@ mod tests {
 
     #[test]
     fn gateway_token_alone_resolves_via_shell_env() {
-        // A host whose only credential is a custom-gateway bearer (+ its
-        // endpoint) — no Keychain, no stored token, no credentials file — still
-        // authenticates on docker, matching seatbelt. It resolves in the
-        // shell-env step, forwarding both the token and the endpoint.
+        // A gateway-only host still authenticates, matching seatbelt.
         let shell = shell_env(&[
             ("ANTHROPIC_AUTH_TOKEN", "gw-secret"),
             ("ANTHROPIC_BASE_URL", "https://gateway.example.com"),
@@ -551,11 +444,8 @@ mod tests {
 
     #[test]
     fn endpoint_rides_along_but_ambient_gateway_token_does_not() {
-        // Keychain wins. A custom BASE_URL still rides along — it's an endpoint,
-        // so it just points the resolved OAuth login at its proxy (honoring an
-        // explicit endpoint beats falling back to the default). But the ambient
-        // gateway AUTH_TOKEN must NOT ride along — forwarding it would let it
-        // override the Keychain login.
+        // The endpoint points the resolved login at its proxy; the ambient
+        // gateway token would override that login, so it must not ride along.
         let shell = shell_env(&[
             ("ANTHROPIC_AUTH_TOKEN", "gw-secret"),
             ("ANTHROPIC_BASE_URL", "https://proxy.example.com"),
@@ -574,8 +464,6 @@ mod tests {
 
     #[test]
     fn usable_oauth_token_extracts_or_rejects() {
-        // Same shape for the file and the Keychain password: extract the token
-        // when usable, reject the macOS placeholder and malformed blobs.
         assert_eq!(
             usable_oauth_token(Some(
                 br#"{"claudeAiOauth":{"accessToken":"  sk-ant-oat-x \n","expiresAt":1893456000000}}"#
@@ -583,8 +471,7 @@ mod tests {
             Some("sk-ant-oat-x".to_string()),
             "trimmed token extracted from a usable blob"
         );
-        // expiresAt:0 placeholder (Keychain login on disk), empty token, wrong
-        // shape, unparseable, absent — all reject.
+        // Placeholder, empty token, wrong shape, unparseable, absent — all reject.
         for blob in [
             &br#"{"claudeAiOauth":{"accessToken":"sk-ant-oat-x","expiresAt":0}}"#[..],
             &br#"{"claudeAiOauth":{"accessToken":"","expiresAt":1893456000000}}"#[..],
@@ -632,9 +519,8 @@ mod tests {
 
     #[test]
     fn shell_values_are_trimmed_before_forwarding() {
-        // A profile that exports a padded credential must reach the container
-        // trimmed — the status check trims when deciding it's a hit, so the
-        // forwarded value has to match or Claude auth fails in-container.
+        // The hit check trims, so the forwarded value must trim too or auth
+        // fails in-container.
         let shell = shell_env(&[("ANTHROPIC_API_KEY", "  sk-ant-api-key\n")]);
         let (env, source) = resolved(resolve_from(None, None, Some(&shell), false));
         assert_eq!(source, AuthSource::ShellEnv);
@@ -649,10 +535,7 @@ mod tests {
 
     #[test]
     fn proxy_vars_alone_are_not_a_hit_but_ride_along() {
-        // BASE_URL without a key var can't authenticate, so it doesn't make the
-        // shell env a credential hit — resolution falls through to the
-        // credentials file. The proxy endpoint still rides along so the
-        // container honors it.
+        // BASE_URL alone can't authenticate, so resolution falls through.
         let shell = shell_env(&[("ANTHROPIC_BASE_URL", "https://proxy.example.com")]);
         let (env, source) = resolved(resolve_from(None, None, Some(&shell), true));
         assert_eq!(source, AuthSource::CredentialsFile);
@@ -682,8 +565,7 @@ mod tests {
             credentials_config_dir(None, Some(home)),
             Some(PathBuf::from("/Users/u/.claude"))
         );
-        // A custom `CLAUDE_CONFIG_DIR` is used verbatim — this is the dir claude
-        // reads its `.credentials.json` from and the one the engine mounts.
+        // A custom `CLAUDE_CONFIG_DIR` is used verbatim.
         assert_eq!(
             credentials_config_dir(Some(OsStr::new("/cfg/eve")), Some(home)),
             Some(PathBuf::from("/cfg/eve"))
@@ -705,8 +587,7 @@ mod tests {
         assert!(credentials_file_usable(Some(
             br#"{"claudeAiOauth":{"accessToken":"sk-ant-oat-x","refreshToken":"r","expiresAt":1893456000000}}"#
         )));
-        // Expired-but-nonzero is still usable: the container can refresh via the
-        // mounted file (the documented refresh flow), so we must not reject it.
+        // Expired-but-nonzero stays usable: the container refreshes via the mount.
         assert!(credentials_file_usable(Some(
             br#"{"claudeAiOauth":{"accessToken":"sk-ant-oat-x","refreshToken":"r","expiresAt":1}}"#
         )));
@@ -714,7 +595,7 @@ mod tests {
 
     #[test]
     fn credentials_file_usable_rejects_stale_and_malformed() {
-        // The reported macOS bug: a Keychain login leaves a placeholder on disk.
+        // A macOS Keychain login leaves a placeholder on disk.
         assert!(!credentials_file_usable(Some(
             br#"{"claudeAiOauth":{"accessToken":"sk-ant-oat-x","refreshToken":"r","expiresAt":0}}"#
         )));

--- a/src-tauri/src/sandbox/container/config_dir.rs
+++ b/src-tauri/src/sandbox/container/config_dir.rs
@@ -1,22 +1,15 @@
 //! Non-default config-dir detection (does the container need a `-e CLAUDE_CONFIG_DIR`
 //! / `-e CODEX_HOME` / `-e XDG_*`?) and the borrowed git object stores a
-//! `--shared` clone reaches through alternates.
-//!
-//! Runtime-neutral: every answer here is a question about the *host* env and
-//! filesystem, so both container runtimes read the same one.
+//! `--shared` clone reaches through alternates. Runtime-neutral: every answer
+//! here is a question about the *host* env and filesystem.
 
 use std::path::{Path, PathBuf};
 
 use crate::sandbox::policy::resolve_existing_prefix;
 
-/// Whether `$CODEX_HOME` is set to a dir other than the default `~/.codex`
-/// (which the container already resolves via `HOME`). Only a non-default value
-/// is forwarded, mirroring [`nondefault_claude_config_dir`]; both sides go
-/// through [`resolve_existing_prefix`] so a symlink can't read as non-default.
-/// Blank counts as unset, matching [`codex_home_dir`]'s resolution —
-/// forwarding a blank value the resolver ignored would desync the two.
-///
-/// [`codex_home_dir`]: crate::sandbox::policy::codex_home_dir
+/// Whether `$CODEX_HOME` names a dir other than the default `~/.codex`. Both
+/// sides resolve through [`resolve_existing_prefix`] so a symlink can't read as
+/// non-default; blank counts as unset.
 pub(crate) fn codex_home_is_nondefault(home: &Path) -> bool {
     match std::env::var_os("CODEX_HOME") {
         Some(v) if !v.is_empty() => {
@@ -27,19 +20,12 @@ pub(crate) fn codex_home_is_nondefault(home: &Path) -> bool {
     }
 }
 
-// Codex's `$CODEX_HOME` resolution (`codex_home_dir`) and opencode's data/
-// config dir resolution (`opencode_data_dir`, `opencode_config_dir`, their
-// shared `xdg_base`) now live in [`crate::sandbox::policy`] — they're class-1
-// host-persistence dirs every engine shares (containers mount them; seatbelt
-// grants them), so the policy module is their single source of truth.
-// Imported by [`super::launch`], which assembles the mounts.
+// The dirs themselves (`codex_home_dir`, `opencode_*_dir`, `xdg_base`) live in
+// `crate::sandbox::policy` — every engine shares them.
 
-/// Whether `$var` points to an XDG base other than the default `home/<default_rel>`
-/// the container already resolves via `HOME`. Only a non-default base is forwarded,
-/// mirroring [`codex_home_is_nondefault`]; both sides canonicalize via
-/// [`resolve_existing_prefix`] so a symlink can't read as non-default. This stays
-/// out of [`crate::sandbox::policy`]: it's launch-time env-forwarding logic (does
-/// the container need a `-e XDG_*`?), not a write-policy question.
+/// Whether `$var` points to an XDG base other than the default
+/// `home/<default_rel>`, resolved on both sides so a symlink can't read as
+/// non-default.
 pub(crate) fn xdg_base_is_nondefault(var: &str, home: &Path, default_rel: &str) -> bool {
     match std::env::var_os(var) {
         Some(v) if !v.is_empty() => {
@@ -50,66 +36,29 @@ pub(crate) fn xdg_base_is_nondefault(var: &str, home: &Path, default_rel: &str) 
     }
 }
 
-/// A non-default `CLAUDE_CONFIG_DIR` from the app environment, mounted and
-/// forwarded so claude writes its config/transcripts/auth where the host
-/// expects them. `None` when unset or when it resolves to the default
-/// `~/.claude` (already mounted).
-///
-/// The default check canonicalizes *both* sides via [`resolve_existing_prefix`],
-/// so a symlink or trailing-slash in the config dir or the home path can't make
-/// a dir that really points at `~/.claude` read as non-default (a redundant
-/// mount + `CLAUDE_CONFIG_DIR` forward). Canonicalizing both sides is safe here
-/// — unlike seatbelt's literal-path SBPL allow-list, which compares against the
-/// *raw* default — because the default `~/.claude` bind mount follows its
-/// symlink source, so a config dir pointing at the resolved target is still
-/// covered by that mount. The *original* path is returned for a genuinely
-/// non-default dir, so the mount/forward stay at the host path (invariant 1).
+/// A non-default `CLAUDE_CONFIG_DIR`, or `None` when unset or resolving to the
+/// already-mounted `~/.claude`. Returns the *original* path, not the resolved
+/// one, so mount and forwarded value stay at the host path (invariant 1).
 pub(crate) fn nondefault_claude_config_dir(home: &Path) -> Option<PathBuf> {
     let dir = std::env::var_os("CLAUDE_CONFIG_DIR").map(PathBuf::from)?;
     (!config_dir_is_default(&dir, home)).then_some(dir)
 }
 
-/// Whether `dir` resolves to the default `~/.claude`. Both sides go through
-/// [`resolve_existing_prefix`] — see [`nondefault_claude_config_dir`] for why.
-/// Pure over its inputs so the comparison rule is directly testable.
+/// Whether `dir` resolves to the default `~/.claude` — resolved on both sides,
+/// so a symlink or trailing slash can't read as non-default.
 pub(crate) fn config_dir_is_default(dir: &Path, home: &Path) -> bool {
     resolve_existing_prefix(dir) == resolve_existing_prefix(&home.join(".claude"))
 }
 
 /// Every object store an agent's `--shared` checkouts borrow via git
-/// alternates — each an absolute path to mount read-only.
+/// alternates, to mount read-only. Walks all source repos (a multi-repo agent's
+/// secondary checkouts break otherwise) and follows chains transitively, deduped
+/// and cycle-guarded.
 ///
-/// SECURITY: the mount set is derived from `source_repos`, Fletch's
-/// authoritative record of each checkout's source repo
-/// (`AgentRecord.repos[].repo_path` — the user's own repos, which the agent
-/// cannot write). It is deliberately NOT derived from the checkout's own
-/// `<subdir>/.git/objects/info/alternates`. Under Docker the whole checkout is
-/// bind-mounted read-write, so a container agent can overwrite that alternates
-/// file to name any absolute host path (`~/.ssh`, `~/.aws`, Fletch's own DB);
-/// were the mount set read from it, a later relaunch that reuses the on-disk
-/// checkout without re-provisioning (`resume_agent` / `switch_view`) would
-/// bind-mount the attacker's path read-only into the container and expose it
-/// over the always-open network — defeating the Docker ConfinedReads /
-/// OpaqueAppData guarantees. Reading only the user-owned source repos keeps
-/// that agent-writable file out of the trust boundary entirely.
-///
-/// This reproduces exactly what a `--shared` clone borrows: `git clone
-/// --shared <source>` records `<source>/.git/objects` in the checkout's
-/// alternates, so that store is what must be mounted. A multi-repo agent has
-/// one source per repo, so every entry is walked, not just the primary — else
-/// secondary checkouts' borrowed objects stay unmounted and git breaks
-/// (log/diff/checkout/commit) there.
-///
-/// The chain is followed transitively from each SOURCE (safe — the source is
-/// user-owned): a source may itself borrow (B from A), leaving the checkout
-/// pointing at `<B>/.git/objects` while git resolves B→A at runtime, so A must
-/// be mounted too or in-container git can't normalize the alternate. Results
-/// are deduped (repos may share a base) and cycle-guarded. A missing store is
-/// dropped, not mounted — see below.
+/// SECURITY: derived from `source_repos`, never from the checkout's own
+/// `.git/objects/info/alternates` — that file is agent-writable, so trusting it
+/// would let an agent name any host path and have a later launch mount it.
 pub(crate) fn borrowed_object_stores(source_repos: &[PathBuf]) -> Vec<PathBuf> {
-    /// The alternates listed in `<objects_dir>/info/alternates`, if any. Only
-    /// ever called on stores reached from a trusted source repo, so the file it
-    /// reads is always under user-owned (non-agent-writable) state.
     fn read_alternates(objects_dir: &Path) -> Vec<PathBuf> {
         let Ok(contents) = std::fs::read_to_string(objects_dir.join("info/alternates")) else {
             return Vec::new();
@@ -124,9 +73,8 @@ pub(crate) fn borrowed_object_stores(source_repos: &[PathBuf]) -> Vec<PathBuf> {
 
     let mut out: Vec<PathBuf> = Vec::new();
     let mut seen = std::collections::HashSet::new();
-    // Seed the walk from each tracked SOURCE repo's own object store — the exact
-    // store a `--shared` clone of that source records in the checkout. Order
-    // follows the record's repo order (primary first), which is deterministic.
+    // The exact store a `--shared` clone of each source records in the checkout;
+    // repo order (primary first) makes the result deterministic.
     let mut queue: std::collections::VecDeque<PathBuf> = source_repos
         .iter()
         .map(|repo| repo.join(".git/objects"))
@@ -135,15 +83,11 @@ pub(crate) fn borrowed_object_stores(source_repos: &[PathBuf]) -> Vec<PathBuf> {
         if !seen.insert(store.clone()) {
             continue;
         }
-        // Follow the source's own alternates chain before emitting the store,
-        // so a chained base (A behind B) is discovered and mounted too.
         for next in read_alternates(&store) {
             queue.push_back(next);
         }
-        // Only mount a store that exists on disk: a bare `-v <path>:<path>:ro`
-        // on a missing source has Docker create it *root-owned*, and a
-        // `--shared` clone can only resolve objects that actually exist, so a
-        // missing store is never one in-container git needs.
+        // A missing store is never one in-container git needs, and mounting it
+        // would have the runtime create the path *root-owned*.
         if store.is_dir() {
             out.push(store);
         }

--- a/src-tauri/src/sandbox/container/freshness.rs
+++ b/src-tauri/src/sandbox/container/freshness.rs
@@ -2,26 +2,20 @@
 //! agent image may serve before a background rebuild, and whether a
 //! host/in-image CLI version pair warrants one.
 //!
-//! Pure by construction — no runtime coupling at all. The `image inspect` that
-//! reads a build date, the `run` that probes the in-image CLI, and the rebuild
-//! itself all shell out and stay in each runtime's own `image` module; what
-//! lives here is only the decision those invocations feed.
+//! Decisions only — every invocation they feed (the `image inspect`, the version
+//! probe, the rebuild) lives in each runtime's own `image` module.
 
 use std::time::Duration;
 
 /// Dogma: **an agent image is never older than a week.** The images install
-/// "latest at build time" (npm installs, cursor's installer), so their
-/// contents freeze at build; this TTL bounds that freeze. An image past the
-/// TTL still serves the current launch — freshness is a background concern,
-/// never a launch blocker — and is rebuilt under the same tag off-thread.
-/// Deliberately not a setting.
+/// "latest at build time", so this bounds how long their contents stay frozen.
+/// A stale image still serves the current launch and is rebuilt off-thread —
+/// freshness is never a launch blocker. Deliberately not a setting.
 pub(crate) const IMAGE_MAX_AGE: Duration = Duration::from_secs(7 * 24 * 60 * 60);
 
-/// TTL verdict for an image's build timestamp against [`IMAGE_MAX_AGE`].
-/// `Unknown` (an unparseable timestamp) is deliberately its own state: the
-/// caller treats it as fresh, because rebuilding on unparseable metadata would
-/// rebuild on *every* resolution forever (the rebuilt image's metadata would
-/// presumably parse no better if the runtime's format changed under us).
+/// TTL verdict against [`IMAGE_MAX_AGE`]. `Unknown` is its own state because
+/// callers treat it as fresh: rebuilding on unparseable metadata would rebuild
+/// on every resolution forever, the replacement parsing no better.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum Freshness {
     Fresh,
@@ -29,9 +23,8 @@ pub(crate) enum Freshness {
     Unknown,
 }
 
-/// Classify a raw image creation timestamp (RFC3339, e.g.
-/// `2026-07-01T12:00:00.000000000Z` — what both runtimes' `image inspect`
-/// reports). Pure: `now` is injected so tests use fixed instants.
+/// Classify a raw image creation timestamp (RFC3339, as both runtimes' `image
+/// inspect` reports it). `now` is injected so tests use fixed instants.
 pub(crate) fn classify_freshness(
     created_raw: &str,
     now: chrono::DateTime<chrono::Utc>,
@@ -39,8 +32,8 @@ pub(crate) fn classify_freshness(
     let Ok(created) = chrono::DateTime::parse_from_rfc3339(created_raw.trim()) else {
         return Freshness::Unknown;
     };
-    // A negative age (clock skew, image "from the future") compares below any
-    // positive TTL and lands on Fresh — the right bias for bad clocks.
+    // A negative age (clock skew) compares below any positive TTL and lands on
+    // Fresh — the right bias for bad clocks.
     let max_age = chrono::Duration::from_std(IMAGE_MAX_AGE).expect("TTL fits chrono::Duration");
     if now.signed_duration_since(created) > max_age {
         Freshness::Stale
@@ -49,11 +42,10 @@ pub(crate) fn classify_freshness(
     }
 }
 
-/// Pure core of the version-mismatch trigger: refresh only when both sides
-/// are known, differ (plain `!=` — deliberately no semver ordering: "newer"
-/// is not computable across five vendors' formats, and parity is the actual
-/// goal), and this pairing hasn't already been attempted (rebuilding can't
-/// fix a host that's simply pinned away from the registry's latest).
+/// Pure core of the version-mismatch trigger: refresh only when both sides are
+/// known, differ, and haven't already been attempted (rebuilding can't fix a
+/// host pinned away from the registry's latest). Plain `!=` — "newer" isn't
+/// computable across five vendors' version formats, and parity is the goal.
 pub(crate) fn version_refresh_wanted(
     host: Option<&str>,
     container: Option<&str>,
@@ -69,8 +61,6 @@ pub(crate) fn version_refresh_wanted(
 mod tests {
     use super::*;
 
-    /// The version-mismatch trigger's pure core: refresh only on a known,
-    /// unequal, not-yet-attempted pairing. Plain `!=`, no semver ordering.
     #[test]
     fn version_refresh_decision() {
         // Mismatch → refresh.
@@ -79,7 +69,7 @@ mod tests {
             Some("v2.0.0"),
             false
         ));
-        // Direction doesn't matter (no ordering): host older also fires once.
+        // No ordering, so host-older fires too.
         assert!(version_refresh_wanted(
             Some("v1.0.0"),
             Some("v2.0.0"),
@@ -91,12 +81,11 @@ mod tests {
             Some("v2.0.0"),
             false
         ));
-        // No host CLI (not installed / probe failed) → inert.
+        // Either side unknown → inert.
         assert!(!version_refresh_wanted(None, Some("v2.0.0"), false));
-        // Container version unknown (post-build probe failed) → inert.
         assert!(!version_refresh_wanted(Some("v2.0.0"), None, false));
         assert!(!version_refresh_wanted(None, None, false));
-        // Already-attempted pairing → inert (pinned host must not loop).
+        // Already attempted → inert (a pinned host must not loop).
         assert!(!version_refresh_wanted(
             Some("v2.0.1"),
             Some("v2.0.0"),
@@ -104,10 +93,6 @@ mod tests {
         ));
     }
 
-    /// The TTL decision's pure core, with fixed instants: inside the window →
-    /// fresh, past it → stale, unparseable → unknown (treated as fresh by the
-    /// caller — never rebuild-loop on bad metadata), and a future timestamp
-    /// (clock skew) → fresh.
     #[test]
     fn freshness_classification() {
         use chrono::{TimeZone, Utc};

--- a/src-tauri/src/sandbox/container/image_gc.rs
+++ b/src-tauri/src/sandbox/container/image_gc.rs
@@ -1,11 +1,6 @@
 //! The stale-agent-image GC's listing format, parsing and selection rule —
-//! everything about *which* images to reclaim, with nothing about how to list or
-//! remove them.
-//!
-//! Both runtimes print their listings through the same Go-template format
-//! ([`IMAGES_FORMAT`], which we choose), so the rows parse identically and the
-//! selection rule below is shared verbatim. Each runtime's `cleanup` module
-//! supplies the listings and runs the `rmi`s.
+//! *which* images to reclaim, never how to list or remove them (each runtime's
+//! `cleanup` module supplies the listings and runs the `rmi`s).
 //!
 //! One rule: an image carrying the `fletch.agent` label
 //! ([`images::AGENT_IMAGE_LABEL`](super::images::AGENT_IMAGE_LABEL)) that is not
@@ -17,13 +12,12 @@ use std::collections::HashSet;
 use super::images::{image_repo, image_tag};
 use super::ContainerProvider;
 
-/// `images` line format for the image GC listings. Untagged (dangling) images
-/// print `<none>` for repository and tag under both runtimes.
+/// `images` line format for the GC listings. Both runtimes print `<none>` for a
+/// dangling image's repository and tag.
 pub(crate) const IMAGES_FORMAT: &str = "{{.ID}} {{.Repository}} {{.Tag}}";
 
-/// One `images` row: a (repo:tag, image id) pair — the same image id appears in
-/// multiple rows when it carries multiple tags, which is exactly what the GC
-/// wants: it untags Fletch's name and leaves any other name alone.
+/// One `images` row. A multi-tagged image yields one row per tag, which is what
+/// the GC wants: it untags Fletch's name and leaves any other name alone.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ImageRow {
     pub(crate) id: String,
@@ -32,33 +26,30 @@ pub(crate) struct ImageRow {
 }
 
 impl ImageRow {
-    /// Whether this row is a dangling image (`<none>:<none>`) — removable only
-    /// by id.
     fn untagged(&self) -> bool {
         self.repo == "<none>" || self.tag == "<none>"
     }
 
-    /// The `repo:tag` name of a tagged row, spelled exactly as the listing
-    /// printed it — this is what `rmi` has to resolve.
+    /// Spelled exactly as the listing printed it — this is what `rmi` resolves.
     fn named(&self) -> String {
         format!("{}:{}", self.repo, self.tag)
     }
 
-    /// The repo without podman's implicit `localhost/` prefix for locally built
+    /// The repo without podman's implicit `localhost/` prefix on locally built
     /// images. Identity under docker, which never prints one.
     pub(crate) fn compare_repo(&self) -> &str {
         self.repo.strip_prefix("localhost/").unwrap_or(&self.repo)
     }
 
-    /// [`Self::named`] under [`Self::compare_repo`] — the spelling every
-    /// namespace/tag comparison uses, so `localhost/fletch-agent` is recognized
-    /// as ours while removal still names it verbatim.
+    /// The spelling every namespace/tag comparison uses, so
+    /// `localhost/fletch-agent` is recognized as ours while [`Self::named`]
+    /// still names it verbatim for removal.
     fn compare_name(&self) -> String {
         format!("{}:{}", self.compare_repo(), self.tag)
     }
 
-    /// What to hand `rmi`: the name for tagged rows (untag just ours), the id
-    /// for dangling ones (the only handle they have).
+    /// The name for tagged rows (untag just ours), the id for dangling ones
+    /// (their only handle).
     fn removal_ref(&self) -> String {
         if self.untagged() {
             self.id.clone()
@@ -80,9 +71,8 @@ pub(crate) fn parse_images_line(line: &str) -> Option<ImageRow> {
     Some(row)
 }
 
-/// The tags a launch could legitimately use right now — `image_tag(provider)`
-/// across every container-supported provider. Everything else Fletch built is
-/// superseded by definition.
+/// The tags a launch could legitimately use right now; everything else Fletch
+/// built is superseded by definition.
 pub(crate) fn current_tags() -> HashSet<String> {
     ContainerProvider::ALL
         .iter()
@@ -98,32 +88,19 @@ pub(crate) fn known_repos() -> HashSet<&'static str> {
         .collect()
 }
 
-/// The GC's selection rule, pure (inputs are pre-fetched listings, fixed in
-/// tests). `labeled` holds every image carrying the `fletch.agent` label;
-/// `legacy` holds the tagged contents of Fletch's own repos (pre-label
-/// installs). Returns deduplicated `rmi` refs.
+/// The GC's selection rule, pure: `labeled` holds every image carrying the
+/// `fletch.agent` label, `legacy` the tagged contents of Fletch's own repos
+/// (pre-label installs). Returns deduplicated `rmi` refs. Every set is passed in
+/// rather than read from the constants so the rule is testable on fixed inputs
+/// — and so a runtime with no pre-label history (podman) can pass an empty
+/// `legacy_tags` and get no legacy arm at all.
 ///
-/// The label is the authority, with one belt-and-braces exception each way:
-/// a *labeled* image tagged outside our namespace is kept (a user re-tagged
-/// our image under their own name — their tag, their call), and an *unlabeled*
-/// image is removed only on an exact `legacy_tags` match (the closed list of
-/// tags pre-label Fletch actually shipped — shape or namespace alone is never
-/// an ownership signal for unlabeled images). Current tags and the runtime's
-/// image override are always kept.
-///
-/// "Our namespace" is `known_repos` (the live providers) plus `retired_repos`
-/// ([`RETIRED_REPOS`] — providers we used to ship). Both are passed in rather
-/// than read from the constants so the rule stays testable on fixed inputs, as
-/// is `legacy_tags`: a runtime with no pre-label history (podman) passes an
-/// empty list and gets no legacy arm at all.
-///
-/// Within Fletch's repos, a labeled image is a removal candidate only under a
-/// tag Fletch itself could have written: the content-addressed shape (12
-/// lowercase hex chars — see `images::tag_for`) or no tag at all (a dangling
-/// rebuild predecessor). A human-shaped tag like `fletch-agent:backup` —
-/// a user's `docker tag` of our image — is theirs to keep: a tag a human
-/// wrote is the human's call. Retirement changes nothing about that: a
-/// retired repo buys a row into the candidate set, not past the safety rules.
+/// The label is the authority, fenced both ways: a *labeled* image is a
+/// candidate only inside our namespace (`known_repos` + `retired_repos`) and
+/// only under a tag Fletch itself could have written — the content-addressed
+/// shape or none at all — because a human-written tag is the human's call. An
+/// *unlabeled* image carries no ownership proof, so it goes only on an exact
+/// `legacy_tags` match. Current tags and the image override are always kept.
 pub(crate) fn image_removal_refs(
     labeled: &[ImageRow],
     legacy: &[ImageRow],
@@ -134,10 +111,9 @@ pub(crate) fn image_removal_refs(
     override_image: Option<&str>,
 ) -> Vec<String> {
     let override_image = override_image.map(str::trim).filter(|s| !s.is_empty());
-    // A row that must survive no matter which listing produced it. The
-    // override comparison is defensive by design: match its exact `repo:tag`,
-    // its bare-repo spelling (both runtimes read `foo` as `foo:latest`), or the
-    // image id (all listings print the same short id).
+    // Survives no matter which listing produced it. The override is matched in
+    // every spelling a user might have typed it: exact `repo:tag`, bare repo
+    // (both runtimes read `foo` as `foo:latest`), or image id.
     let protected = |row: &ImageRow| {
         if !row.untagged() && current_tags.contains(&row.compare_name()) {
             return true;
@@ -145,8 +121,8 @@ pub(crate) fn image_removal_refs(
         let Some(ov) = override_image else {
             return false;
         };
-        // An override may be spelled as an id (`sha256:`-prefixed on docker) or
-        // as a `repo@sha256:…` digest ref; normalize each before its comparison.
+        // An override may be spelled as a `sha256:`-prefixed id or a
+        // `repo@sha256:…` digest ref; normalize each before comparing.
         let ov_id = ov.strip_prefix("sha256:").unwrap_or(ov);
         let ov_name = ov.split_once("@sha256:").map_or(ov, |(repo, _)| repo);
         id_matches(ov_id, &row.id)
@@ -157,11 +133,9 @@ pub(crate) fn image_removal_refs(
                         && (ov_name == row.repo || ov_name == row.compare_repo()))))
     };
 
-    // A repo Fletch owns now or used to own. Retired repos count because the
-    // `fletch.agent` label has already proven the image is ours — omitting
-    // them is exactly what stranded a retired provider's still-tagged images:
-    // the legacy arm skips them (they're labeled) and this arm skipped them
-    // (their repo was no longer known), so nothing could ever reclaim them.
+    // Retired repos count: the label has already proven the image is ours, and
+    // without them a retired provider's still-tagged images are unreclaimable
+    // (the legacy arm skips them as labeled, this arm as unknown).
     let in_our_namespace = |row: &ImageRow| {
         let repo = row.compare_repo();
         known_repos.contains(repo) || retired_repos.contains(&repo)
@@ -189,10 +163,8 @@ pub(crate) fn image_removal_refs(
         push(row);
     }
     for row in legacy {
-        // Exact match only: an unlabeled image carries no ownership proof, so
-        // the only safe removal signal is a tag we know Fletch shipped. A
-        // user's own image in our namespace — even under a hex/git-SHA-shaped
-        // tag like `fletch-agent:deadbeefcafe` — never matches.
+        // Exact match only: tag *shape* is never an ownership signal for an
+        // unlabeled image, so a user's own `fletch-agent:deadbeefcafe` survives.
         if row.untagged() || !legacy_tags.contains(&row.compare_name().as_str()) {
             continue;
         }
@@ -205,9 +177,8 @@ pub(crate) fn image_removal_refs(
 }
 
 /// Prefix-tolerant image-id equality: `{{.ID}}` prints a 12-char truncation
-/// while a user pastes the full 64-char id, so either side may be the prefix.
-/// The shorter side must be at least 12 chars, or a stray short string would
-/// match half the store.
+/// while a user pastes the full 64, so either side may be the prefix. The
+/// 12-char floor stops a stray short string from matching half the store.
 fn id_matches(a: &str, b: &str) -> bool {
     if a == b {
         return true;
@@ -226,24 +197,13 @@ pub(crate) fn is_content_addressed_tag(tag: &str) -> bool {
             .all(|b| b.is_ascii_hexdigit() && !b.is_ascii_uppercase())
 }
 
-/// Every image repo Fletch used to own — the closed list of namespaces that
-/// are ours by history rather than by [`ContainerProvider::ALL`]. Bare repo
-/// names (`fletch-agent-x`), never `repo:tag`: these images DO carry the
-/// `fletch.agent` label, so ownership is already proven and the GC needs no
-/// per-tag allowlist to act on them — the ordinary safety rules for labeled
-/// rows (content-addressed tag shape, current tags, the image override) still
-/// apply unchanged. Runtime-neutral: a retired provider's images are stranded
-/// the same way in either store.
+/// Image repos Fletch used to own — bare repo names, never `repo:tag`, since
+/// these images are labeled and the labeled arm's safety rules still apply.
 ///
-/// **Add an entry whenever a [`ContainerProvider`] variant is removed.**
-/// Without one, every still-tagged image under that repo is stranded on every
-/// user's disk forever, at ~0.5-1GB each: the labeled arm would skip it (repo
-/// no longer known) and the legacy arm would skip it (it's labeled). Only
-/// *untagged* rows survive a retirement today, since they never consult the
-/// repo at all.
-///
-/// Empty until the first retirement — this is forward-safety, not a live bug,
-/// and an empty list is behaviourally identical to not having one.
+/// **Add an entry whenever a [`ContainerProvider`] variant is removed.** Without
+/// one, every still-tagged image under that repo is stranded on every user's
+/// disk forever at ~0.5-1GB each: the labeled arm skips it (repo unknown) and
+/// the legacy arm skips it (it's labeled). Empty until the first retirement.
 pub(crate) const RETIRED_REPOS: &[&str] = &[];
 
 #[cfg(test)]
@@ -264,7 +224,6 @@ mod tests {
             parse_images_line("abc123def456 fletch-agent 0011aabbccdd"),
             Some(row("abc123def456", "fletch-agent", "0011aabbccdd")),
         );
-        // Dangling images print `<none>` placeholders.
         assert_eq!(
             parse_images_line("abc123def456 <none> <none>"),
             Some(row("abc123def456", "<none>", "<none>")),
@@ -273,10 +232,6 @@ mod tests {
         assert_eq!(parse_images_line(""), None);
     }
 
-    /// The GC's one rule plus its fences, on fixed listings: labeled + stale
-    /// → remove; labeled + current → keep; labeled outside Fletch's repos
-    /// (user re-tag) → keep; unlabeled non-fletch → keep; legacy fletch-repo
-    /// stale → remove; the image override → keep in every spelling.
     #[test]
     fn image_gc_selection() {
         let current_tags: HashSet<String> = ["fletch-agent:cafe00000000".to_string()].into();
@@ -284,32 +239,29 @@ mod tests {
         let legacy_tags: &[&str] = &["fletch-agent-codex:fa189de85caf"];
 
         let labeled = vec![
-            // Old hash under a Fletch repo: superseded by a Dockerfile revision.
+            // Superseded hash: removed.
             row("aaa", "fletch-agent", "0dab1e000000"),
-            // The current tag: what launches use today.
+            // Current tag: kept.
             row("bbb", "fletch-agent", "cafe00000000"),
-            // Untagged leftover of a TTL rebuild: removable only by id.
+            // Dangling rebuild leftover: removed by id.
             row("ccc", "<none>", "<none>"),
-            // Labeled but re-tagged under a user's name: their tag, kept.
+            // Re-tagged under a user's name: kept.
             row("ddd", "mybackup", "keep"),
-            // The override, hypothetically labeled (shouldn't happen): kept.
+            // The override, hypothetically labeled: kept.
             row("eee", "ghcr.io/me/custom", "1"),
-            // Labeled but human-tagged inside our repo (a `tag` of our
-            // image): their tag, kept.
+            // Human-written tag inside our repo: kept.
             row("hhh", "fletch-agent", "backup"),
         ];
         let legacy = vec![
-            // Genuine pre-label image: exact legacy-list match, removable.
+            // Genuine pre-label image, exact legacy-list match: removed.
             row("fff", "fletch-agent-codex", "fa189de85caf"),
-            // Current tag also shows up in the repo-scoped listing: kept.
+            // Current tag, also in the repo-scoped listing: kept.
             row("bbb", "fletch-agent", "cafe00000000"),
-            // Selection must be safe even if a listing misbehaves: an
-            // unlabeled non-fletch row is never removed.
+            // Unlabeled non-fletch row, in case a listing misbehaves: kept.
             row("ggg", "someones-image", "latest"),
-            // A user's own image built into our namespace: human tag, kept.
+            // A user's own image in our namespace, human tag: kept.
             row("iii", "fletch-agent", "backup"),
-            // A user's own image under a hex/git-SHA-shaped tag in our
-            // namespace: shape is not ownership — kept (exact-match only).
+            // Same, under a hex-shaped tag — shape is not ownership: kept.
             row("jjj", "fletch-agent", "deadbeefcafe"),
         ];
 
@@ -331,8 +283,7 @@ mod tests {
             ],
         );
 
-        // An empty legacy list — what a runtime with no pre-label history
-        // passes — drops the legacy arm entirely and keeps the labeled verdict.
+        // An empty legacy list (what podman passes) drops the legacy arm.
         let refs = image_removal_refs(
             &labeled,
             &legacy,
@@ -348,13 +299,11 @@ mod tests {
         );
     }
 
-    /// Only tags Fletch's content addressing could have written count as
-    /// removal candidates — exactly 12 lowercase hex chars.
     #[test]
     fn content_addressed_tag_shape() {
         assert!(is_content_addressed_tag("0123abcdef01"));
         assert!(is_content_addressed_tag("000000000000"));
-        // Human-shaped tags, wrong length, uppercase: all kept.
+        // Human-shaped, wrong length, uppercase: all kept.
         assert!(!is_content_addressed_tag("backup"));
         assert!(!is_content_addressed_tag("latest"));
         assert!(!is_content_addressed_tag("0123ABCDEF01"));
@@ -363,21 +312,18 @@ mod tests {
         assert!(!is_content_addressed_tag(""));
     }
 
-    /// Override matching is defensive across spellings: exact `repo:tag`,
-    /// bare repo (the implicit `:latest`), and image id all protect.
     #[test]
     fn image_gc_override_spellings() {
         let current_tags = HashSet::new();
         let known_repos: HashSet<&'static str> = ["fletch-agent"].into();
-        // Hypothetical worst case: the user's override lives *inside* a
-        // Fletch repo under a content-addressed-looking tag (anything
-        // human-shaped is already kept by the tag-shape guard).
+        // Worst case: the override lives inside a Fletch repo under a
+        // content-addressed-looking tag, past the tag-shape guard.
         let labeled = vec![
             row("aaa", "fletch-agent", "aaaaaaaaaaaa"),
             row("bbb", "fletch-agent", "bbbbbbbbbbbb"),
         ];
 
-        // Exact repo:tag override protects that row only.
+        // Exact repo:tag protects that row only.
         let refs = image_removal_refs(
             &labeled,
             &[],
@@ -389,7 +335,7 @@ mod tests {
         );
         assert_eq!(refs, vec!["fletch-agent:bbbbbbbbbbbb".to_string()]);
 
-        // Id override protects by id.
+        // An id protects by id.
         let refs = image_removal_refs(
             &labeled,
             &[],
@@ -401,9 +347,8 @@ mod tests {
         );
         assert_eq!(refs, vec!["fletch-agent:aaaaaaaaaaaa".to_string()]);
 
-        // A bare-repo override reads as `:latest` — and a `:latest` row in our
-        // repo is kept by the tag-shape guard even before the override check,
-        // with or without the override present.
+        // A bare repo reads as `:latest`, which the tag-shape guard already
+        // keeps — with or without the override present.
         let with_latest = vec![row("lll", "fletch-agent", "latest")];
         for ov in [Some("fletch-agent"), None] {
             assert!(image_removal_refs(
@@ -443,20 +388,19 @@ mod tests {
         assert_eq!(refs.len(), 2);
     }
 
-    /// Podman prints locally built images as `localhost/<repo>`, so every
-    /// namespace and tag comparison has to see through that prefix while the
-    /// removal ref keeps it (that is the name `podman rmi` resolves).
+    /// Comparisons see through podman's `localhost/` prefix; the removal ref
+    /// keeps it, since that is the name `podman rmi` resolves.
     #[test]
     fn image_gc_sees_through_podmans_localhost_prefix() {
         let current_tags: HashSet<String> = ["fletch-agent:cafe00000000".to_string()].into();
         let known_repos: HashSet<&'static str> = ["fletch-agent"].into();
 
         let labeled = vec![
-            // Superseded, under podman's spelling: selected, named verbatim.
+            // Superseded: selected, named verbatim.
             row("aaa", "localhost/fletch-agent", "0dab1e000000"),
-            // The current tag under the same spelling: protected.
+            // Current tag: protected.
             row("bbb", "localhost/fletch-agent", "cafe00000000"),
-            // A user's own `localhost/` image outside our repos: untouched.
+            // Outside our repos: untouched.
             row("ccc", "localhost/my-image", "0dab1e000000"),
         ];
 
@@ -467,8 +411,6 @@ mod tests {
         );
     }
 
-    /// An override the user pasted as a full id, a `sha256:`-prefixed id, or a
-    /// `repo@sha256:…` digest ref must still protect its image.
     #[test]
     fn image_gc_override_id_and_digest_spellings() {
         let current_tags = HashSet::new();
@@ -493,7 +435,7 @@ mod tests {
             assert_eq!(refs, kept_bbb, "id override spelling {ov} must protect");
         }
 
-        // A digest ref: the `@sha256:…` half is stripped before the name match.
+        // A digest ref: the `@sha256:…` half is stripped before matching.
         let refs = image_removal_refs(
             &labeled,
             &[],
@@ -513,10 +455,8 @@ mod tests {
         assert!(!id_matches("bbb", "bbbbbbbbbbbb"));
     }
 
-    /// Retiring a provider must not strand its images. A labeled row under a
-    /// retired repo is reclaimable, but only on the same terms as a live one:
-    /// the content-addressed tag shape and the override still fence it, and a
-    /// repo that is neither live nor retired is still untouchable.
+    /// A retired repo buys a row into the candidate set, not past the safety
+    /// rules: the tag shape and the override still fence it.
     #[test]
     fn image_gc_reclaims_retired_provider_repos() {
         let current_tags: HashSet<String> = ["fletch-agent:cafe00000000".to_string()].into();
@@ -526,14 +466,13 @@ mod tests {
         let labeled = vec![
             // The stranding case: labeled, our old repo, our tag shape.
             row("aaa", "fletch-agent-pi", "abc123def456"),
-            // Human-written tag in the retired repo: retirement is not a
-            // licence to delete a tag a human wrote.
+            // Human-written tag in the retired repo: kept.
             row("bbb", "fletch-agent-pi", "backup"),
-            // Never ours: not a live repo, not a retired one.
+            // Neither live nor retired: never ours.
             row("ccc", "someones-image", "0dab1e000000"),
-            // Retired repo, but it's the user's image override.
+            // Retired repo, but it's the image override.
             row("ddd", "fletch-agent-pi", "0dab1e000000"),
-            // Live repo, current tag: unaffected by any of this.
+            // Live repo, current tag.
             row("eee", "fletch-agent", "cafe00000000"),
         ];
 
@@ -548,9 +487,7 @@ mod tests {
         );
         assert_eq!(refs, vec!["fletch-agent-pi:abc123def456".to_string()]);
 
-        // The shipped list is empty, and an empty list is a strict no-op:
-        // every one of those rows is now outside our namespace but for the
-        // live-repo one, which is the current tag.
+        // An empty retired list is a strict no-op.
         assert!(image_removal_refs(
             &labeled,
             &[],
@@ -563,11 +500,8 @@ mod tests {
         .is_empty());
     }
 
-    /// [`RETIRED_REPOS`] holds bare repo names, not `repo:tag` — it widens the
-    /// namespace the labeled arm trusts, so a stray tag would silently match
-    /// nothing (a listing's repo is compared whole). Entries must also be
-    /// genuinely retired: a repo a live provider still owns belongs in
-    /// [`ContainerProvider::ALL`]'s derivation, not here.
+    /// A listing's repo is compared whole, so a stray `repo:tag` entry in
+    /// [`RETIRED_REPOS`] would silently match nothing.
     #[test]
     fn retired_repos_are_bare_fletch_repo_names() {
         let known = known_repos();
@@ -584,9 +518,8 @@ mod tests {
         }
     }
 
-    /// The expected-tag / known-repo sets the GC derives from the provider
-    /// list: one entry per live provider, and every current tag lives in a
-    /// known repo (so a live image is never a candidate by namespace alone).
+    /// Every current tag lives in a known repo, so a live image is never a
+    /// candidate by namespace alone.
     #[test]
     fn expected_sets_cover_every_live_provider() {
         let tags = current_tags();

--- a/src-tauri/src/sandbox/container/image_gc.rs
+++ b/src-tauri/src/sandbox/container/image_gc.rs
@@ -38,9 +38,23 @@ impl ImageRow {
         self.repo == "<none>" || self.tag == "<none>"
     }
 
-    /// The `repo:tag` name of a tagged row.
+    /// The `repo:tag` name of a tagged row, spelled exactly as the listing
+    /// printed it — this is what `rmi` has to resolve.
     fn named(&self) -> String {
         format!("{}:{}", self.repo, self.tag)
+    }
+
+    /// The repo without podman's implicit `localhost/` prefix for locally built
+    /// images. Identity under docker, which never prints one.
+    pub(crate) fn compare_repo(&self) -> &str {
+        self.repo.strip_prefix("localhost/").unwrap_or(&self.repo)
+    }
+
+    /// [`Self::named`] under [`Self::compare_repo`] — the spelling every
+    /// namespace/tag comparison uses, so `localhost/fletch-agent` is recognized
+    /// as ours while removal still names it verbatim.
+    fn compare_name(&self) -> String {
+        format!("{}:{}", self.compare_repo(), self.tag)
     }
 
     /// What to hand `rmi`: the name for tagged rows (untag just ours), the id
@@ -125,14 +139,22 @@ pub(crate) fn image_removal_refs(
     // its bare-repo spelling (both runtimes read `foo` as `foo:latest`), or the
     // image id (all listings print the same short id).
     let protected = |row: &ImageRow| {
-        if !row.untagged() && current_tags.contains(&row.named()) {
+        if !row.untagged() && current_tags.contains(&row.compare_name()) {
             return true;
         }
         let Some(ov) = override_image else {
             return false;
         };
-        ov == row.id
-            || (!row.untagged() && (ov == row.named() || (row.tag == "latest" && ov == row.repo)))
+        // An override may be spelled as an id (`sha256:`-prefixed on docker) or
+        // as a `repo@sha256:…` digest ref; normalize each before its comparison.
+        let ov_id = ov.strip_prefix("sha256:").unwrap_or(ov);
+        let ov_name = ov.split_once("@sha256:").map_or(ov, |(repo, _)| repo);
+        id_matches(ov_id, &row.id)
+            || (!row.untagged()
+                && (ov_name == row.named()
+                    || ov_name == row.compare_name()
+                    || (row.tag == "latest"
+                        && (ov_name == row.repo || ov_name == row.compare_repo()))))
     };
 
     // A repo Fletch owns now or used to own. Retired repos count because the
@@ -141,7 +163,8 @@ pub(crate) fn image_removal_refs(
     // the legacy arm skips them (they're labeled) and this arm skipped them
     // (their repo was no longer known), so nothing could ever reclaim them.
     let in_our_namespace = |row: &ImageRow| {
-        known_repos.contains(row.repo.as_str()) || retired_repos.contains(&row.repo.as_str())
+        let repo = row.compare_repo();
+        known_repos.contains(repo) || retired_repos.contains(&repo)
     };
 
     let mut seen = HashSet::new();
@@ -170,7 +193,7 @@ pub(crate) fn image_removal_refs(
         // the only safe removal signal is a tag we know Fletch shipped. A
         // user's own image in our namespace — even under a hex/git-SHA-shaped
         // tag like `fletch-agent:deadbeefcafe` — never matches.
-        if row.untagged() || !legacy_tags.contains(&row.named().as_str()) {
+        if row.untagged() || !legacy_tags.contains(&row.compare_name().as_str()) {
             continue;
         }
         if protected(row) {
@@ -179,6 +202,18 @@ pub(crate) fn image_removal_refs(
         push(row);
     }
     refs
+}
+
+/// Prefix-tolerant image-id equality: `{{.ID}}` prints a 12-char truncation
+/// while a user pastes the full 64-char id, so either side may be the prefix.
+/// The shorter side must be at least 12 chars, or a stray short string would
+/// match half the store.
+fn id_matches(a: &str, b: &str) -> bool {
+    if a == b {
+        return true;
+    }
+    let (short, long) = if a.len() < b.len() { (a, b) } else { (b, a) };
+    short.len() >= 12 && long.starts_with(short)
 }
 
 /// Whether a tag has the shape Fletch's content addressing writes — exactly
@@ -406,6 +441,76 @@ mod tests {
             None,
         );
         assert_eq!(refs.len(), 2);
+    }
+
+    /// Podman prints locally built images as `localhost/<repo>`, so every
+    /// namespace and tag comparison has to see through that prefix while the
+    /// removal ref keeps it (that is the name `podman rmi` resolves).
+    #[test]
+    fn image_gc_sees_through_podmans_localhost_prefix() {
+        let current_tags: HashSet<String> = ["fletch-agent:cafe00000000".to_string()].into();
+        let known_repos: HashSet<&'static str> = ["fletch-agent"].into();
+
+        let labeled = vec![
+            // Superseded, under podman's spelling: selected, named verbatim.
+            row("aaa", "localhost/fletch-agent", "0dab1e000000"),
+            // The current tag under the same spelling: protected.
+            row("bbb", "localhost/fletch-agent", "cafe00000000"),
+            // A user's own `localhost/` image outside our repos: untouched.
+            row("ccc", "localhost/my-image", "0dab1e000000"),
+        ];
+
+        let refs = image_removal_refs(&labeled, &[], &current_tags, &known_repos, &[], &[], None);
+        assert_eq!(
+            refs,
+            vec!["localhost/fletch-agent:0dab1e000000".to_string()],
+        );
+    }
+
+    /// An override the user pasted as a full id, a `sha256:`-prefixed id, or a
+    /// `repo@sha256:…` digest ref must still protect its image.
+    #[test]
+    fn image_gc_override_id_and_digest_spellings() {
+        let current_tags = HashSet::new();
+        let known_repos: HashSet<&'static str> = ["fletch-agent"].into();
+        let full_id = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        let labeled = vec![
+            row("0123456789ab", "fletch-agent", "aaaaaaaaaaaa"),
+            row("bbbbbbbbbbbb", "fletch-agent", "bbbbbbbbbbbb"),
+        ];
+        let kept_bbb = vec!["fletch-agent:bbbbbbbbbbbb".to_string()];
+
+        for ov in [full_id.to_string(), format!("sha256:{full_id}")] {
+            let refs = image_removal_refs(
+                &labeled,
+                &[],
+                &current_tags,
+                &known_repos,
+                &[],
+                &[],
+                Some(&ov),
+            );
+            assert_eq!(refs, kept_bbb, "id override spelling {ov} must protect");
+        }
+
+        // A digest ref: the `@sha256:…` half is stripped before the name match.
+        let refs = image_removal_refs(
+            &labeled,
+            &[],
+            &current_tags,
+            &known_repos,
+            &[],
+            &[],
+            Some("fletch-agent:aaaaaaaaaaaa@sha256:0123456789abcdef"),
+        );
+        assert_eq!(refs, kept_bbb);
+
+        // A short string is never an id prefix — 12 chars is the floor.
+        assert!(id_matches("0123456789ab", full_id));
+        assert!(id_matches(full_id, "0123456789ab"));
+        assert!(!id_matches("0123456789a", full_id));
+        assert!(id_matches("bbb", "bbb"), "exact equality still holds");
+        assert!(!id_matches("bbb", "bbbbbbbbbbbb"));
     }
 
     /// Retiring a provider must not strand its images. A labeled row under a

--- a/src-tauri/src/sandbox/container/images.rs
+++ b/src-tauri/src/sandbox/container/images.rs
@@ -1,36 +1,24 @@
 //! The embedded agent images' *content*: what a container runs, one image per
-//! supported provider (see [`ContainerProvider`]).
+//! [`ContainerProvider`].
 //!
-//! The Dockerfile and entrypoint are compiled into the binary and each image's
-//! tag is derived from its content (`<repo>:<sha256[..12]>`, e.g.
-//! `fletch-agent:…` for claude, `fletch-agent-codex:…` for codex), so shipping a
-//! change to either automatically produces a new tag — the stale image is
-//! never referenced again and the next spawn rebuilds. No version bookkeeping,
-//! no manual invalidation. Provider images share their base layers (identical
-//! `FROM` + apt step), so a second provider costs only its own install layer.
+//! Each tag is content-addressed (`<repo>:<sha256(dockerfile+entrypoint)[..12]>`),
+//! so editing either file produces a new tag and the next spawn rebuilds — no
+//! version bookkeeping. Provider images share base layers byte-for-byte for
+//! cache reuse, and all carry [`AGENT_IMAGE_LABEL`] so the GC can attribute them.
 //!
-//! Every embedded image also carries [`AGENT_IMAGE_LABEL`] so superseded images
-//! (old hashes after a Dockerfile revision, untagged leftovers after a rebuild)
-//! can be garbage-collected.
-//!
-//! Content only: nothing here talks to a container runtime. Building, inspecting,
-//! the freshness TTL, and the GC live in each runtime's own image module
-//! (`sandbox::docker::image`, `sandbox::podman::image`).
+//! Content only: nothing here talks to a runtime. Building, inspecting and the
+//! GC live in `sandbox::docker::image` / `sandbox::podman::image`.
 
 use super::ContainerProvider;
 
 /// The base every provider image builds on (enforced by a test over
-/// [`image_spec`]). Named as a constant rather than left implicit in the five
-/// Dockerfile literals because the reclamation path needs to know which tag a
-/// `--pull` is able to move under us — see `image::reap_superseded_base`.
+/// [`image_spec`]). A constant because `image::reap_superseded_base` reclaims
+/// exactly this one tag — the only tag a `--pull` can move under us.
 pub(crate) const BASE_IMAGE: &str = "node:22-slim";
 
-/// The agent container image. Debian-slim keeps apt available for the tools
-/// claude needs at runtime (`git`, `rg`, `jq`, `procps` for /proc-based
-/// process introspection) while staying small; node 22 is claude-code's
-/// supported runtime. The `chmod` guarantees the entrypoint is executable
-/// regardless of the mode `COPY` picked up from the build context (context
-/// files are written at build time on the host — see `image::ensure_image`).
+/// Claude's image. `procps` is there for /proc-based process introspection; the
+/// `chmod` makes the entrypoint executable whatever mode `COPY` picked up from
+/// the host-written build context.
 pub(crate) const DOCKERFILE: &str = r#"FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates ripgrep jq procps \
@@ -42,11 +30,10 @@ RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 "#;
 
-/// PID-1 shim. The container gets `HOME=<host home>` (a path that does not
-/// exist in the image), so the entrypoint creates it and seeds the minimal
-/// `~/.claude.json` claude needs to skip interactive onboarding. Seeding is
-/// conditional and the file is container-ephemeral by design: bind-mounting the
-/// real `~/.claude.json` would break on claude's atomic rename-replace writes.
+/// Claude's PID-1 shim. `HOME=<host home>` doesn't exist in the image, so it is
+/// created here along with the onboarding seed. The seed stays
+/// container-ephemeral: bind-mounting the real `~/.claude.json` would break on
+/// claude's atomic rename-replace writes.
 pub(crate) const ENTRYPOINT_SH: &str = r#"#!/bin/sh
 set -e
 mkdir -p "$HOME"
@@ -56,12 +43,9 @@ fi
 exec "$@"
 "#;
 
-/// Codex's image. Shares [`DOCKERFILE`]'s base byte-for-byte — same `FROM
-/// node:22-slim` and the same apt line — so Docker's layer cache is reused
-/// across the two images; only the provider install step differs
-/// (`@openai/codex` instead of `@anthropic-ai/claude-code`). Codex authenticates
-/// from the read-write `~/.codex` mount (auth.json) and/or `OPENAI_API_KEY`, so
-/// the image carries no provider config of its own.
+/// Codex's image. Base is byte-identical to [`DOCKERFILE`]'s for layer-cache
+/// reuse; only the install step differs. Auth comes from the read-write
+/// `~/.codex` mount and/or `OPENAI_API_KEY`, so no provider config is baked in.
 pub(crate) const CODEX_DOCKERFILE: &str = r#"FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates ripgrep jq procps \
@@ -73,23 +57,18 @@ RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 "#;
 
-/// Codex's PID-1 shim: create `HOME` and exec, nothing more. Unlike claude,
-/// codex needs no onboarding seed — `codex exec` runs non-interactively with
-/// `--skip-git-repo-check` and `approval_policy="never"` (see
-/// `agent::codex_build_args`), and its credentials come from the mounted
-/// `~/.codex/auth.json` rather than a config file we'd seed here.
+/// Codex's PID-1 shim: create `HOME` and exec. No onboarding seed — `codex exec`
+/// (see `agent::codex_build_args`) is already non-interactive.
 pub(crate) const CODEX_ENTRYPOINT_SH: &str = r#"#!/bin/sh
 set -e
 mkdir -p "$HOME"
 exec "$@"
 "#;
 
-/// OpenCode's image. Shares [`DOCKERFILE`]'s base byte-for-byte (same `FROM
-/// node:22-slim` and apt line) for layer-cache reuse; only the install step
-/// differs (`opencode-ai`, whose `bin` resolves to a per-arch native binary via
-/// npm optional deps — arm64 and x86-64 both publish one). OpenCode authenticates
-/// from the read-write data-dir mount (its accounts DB / `auth.json`) and/or a
-/// provider API-key env var, so the image carries no provider config.
+/// OpenCode's image. Base byte-identical to [`DOCKERFILE`]'s for cache reuse.
+/// `opencode-ai`'s bin resolves to a per-arch native binary via npm optional
+/// deps (arm64 and x86-64 both publish one). Auth comes from the read-write
+/// data-dir mount and/or an API-key env var, so no provider config is baked in.
 pub(crate) const OPENCODE_DOCKERFILE: &str = r#"FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates ripgrep jq procps \
@@ -101,21 +80,17 @@ RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 "#;
 
-/// OpenCode's PID-1 shim: create `HOME` and exec. `opencode run --format json
-/// --dangerously-skip-permissions` (see `agent::opencode_build_args`) is fully
-/// non-interactive, and credentials arrive on the read-write data-dir mount or as
-/// a forwarded API-key env var, so nothing is seeded here.
+/// OpenCode's PID-1 shim: create `HOME` and exec. Nothing to seed — see
+/// `agent::opencode_build_args`.
 pub(crate) const OPENCODE_ENTRYPOINT_SH: &str = r#"#!/bin/sh
 set -e
 mkdir -p "$HOME"
 exec "$@"
 "#;
 
-/// Pi's image. Shares [`DOCKERFILE`]'s base byte-for-byte for cache reuse; only
-/// the install step differs. Pi ships as a pure-node CLI (`@earendil-works/
-/// pi-coding-agent`, bin `pi` → a `dist/cli.js` launcher), so the same package
-/// runs on every arch node:22-slim supports. Pi authenticates from the read-write
-/// `~/.pi` mount (`~/.pi/agent/auth.json`) and/or a provider API-key env var.
+/// Pi's image. Base byte-identical to [`DOCKERFILE`]'s for cache reuse. Pi is a
+/// pure-node CLI, so one package covers every arch node:22-slim supports. Auth
+/// comes from the read-write `~/.pi` mount and/or an API-key env var.
 pub(crate) const PI_DOCKERFILE: &str = r#"FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates ripgrep jq procps \
@@ -127,34 +102,21 @@ RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 "#;
 
-/// Pi's PID-1 shim: create `HOME` and exec. `pi -p --mode json` (see
-/// `agent::pi_build_args`) runs one turn non-interactively and auto-runs tools;
-/// credentials come from the mounted `~/.pi/agent/auth.json` or a forwarded
-/// API-key env var, so nothing is seeded here.
+/// Pi's PID-1 shim: create `HOME` and exec. Nothing to seed — see
+/// `agent::pi_build_args`.
 pub(crate) const PI_ENTRYPOINT_SH: &str = r#"#!/bin/sh
 set -e
 mkdir -p "$HOME"
 exec "$@"
 "#;
 
-/// Cursor's image. Shares [`DOCKERFILE`]'s base byte-for-byte (same `FROM
-/// node:22-slim` and apt line) for layer-cache reuse; only the install step
-/// differs. Unlike the other providers, cursor-agent ships not as an npm package
-/// but via its official installer (`https://cursor.com/install`), which detects
-/// `linux/arm64` and downloads a self-contained bundle (its own node runtime +
-/// per-arch native modules) into `~/.local`; we symlink its `cursor-agent`
-/// launcher onto PATH so the in-image `agent_bin` resolves, then run
-/// `--version` so a build fails loudly if the installer ever relocates the
-/// binary — `ln -s` happily creates a dangling link, and without the check
-/// that drift would only surface as exit-127 launches. The installer pins
-/// whatever version its script currently references — no worse than the `latest`
-/// npm installs the other images use: the Dockerfile *text* is constant so the
-/// content-addressed tag is stable, while a re-pull may fetch a newer bundle
-/// (contents drift under a stable tag — an accepted, documented tradeoff shared
-/// with every `npm install -g <pkg>` here). Cursor authenticates in-container from
-/// a forwarded `CURSOR_API_KEY` (see [`launch_auth`](super::launch_auth)):
-/// `cursor-agent login` stores its tokens in the host OS keychain, which a
-/// container can't read, so the image carries no provider config of its own.
+/// Cursor's image. Base byte-identical to [`DOCKERFILE`]'s for cache reuse;
+/// cursor-agent installs via its official installer into `~/.local`, so the
+/// symlink puts it on PATH for the in-image `agent_bin`. The trailing
+/// `--version` is load-bearing: `ln -s` creates dangling links happily, so
+/// without it an installer relocation would only surface as exit-127 launches.
+/// Auth is the forwarded `CURSOR_API_KEY` (see [`launch_auth`](super::launch_auth))
+/// — `cursor-agent login` writes the host keychain, which a container can't read.
 pub(crate) const CURSOR_DOCKERFILE: &str = r#"FROM node:22-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates ripgrep jq procps \
@@ -168,39 +130,29 @@ RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 "#;
 
-/// Cursor's PID-1 shim: create `HOME` and exec. `cursor-agent -p --output-format
-/// stream-json --force --trust` (see `agent::cursor_build_args`) runs one turn
-/// non-interactively; credentials arrive as the forwarded `CURSOR_API_KEY` env
-/// var and its transcripts land on the read-write `~/.cursor` mount, so nothing is
-/// seeded here.
+/// Cursor's PID-1 shim: create `HOME` and exec. Nothing to seed — see
+/// `agent::cursor_build_args`.
 pub(crate) const CURSOR_ENTRYPOINT_SH: &str = r#"#!/bin/sh
 set -e
 mkdir -p "$HOME"
 exec "$@"
 "#;
 
-/// Label key baked into every embedded agent image (`LABEL
-/// fletch.agent=<provider>` in the Dockerfiles above). It is the image GC's
-/// authority: only images carrying it — or, transitionally, pre-label images
-/// in a Fletch-owned repo — are ever candidates for removal (see
-/// `cleanup::sweep_stale_images`). The user's `docker_image` override never
-/// gets the label (it is never built by us), so it can't be attributed to
-/// Fletch and is structurally safe from the GC.
+/// Label key baked into every embedded agent image — the image GC's ownership
+/// authority: only labeled images (or, transitionally, pre-label images in a
+/// Fletch-owned repo) are removal candidates. A user's image override never
+/// carries it, so it is structurally safe from the GC.
 pub(crate) const AGENT_IMAGE_LABEL: &str = "fletch.agent";
 
-/// The image build inputs for a provider: repo name plus the Dockerfile and
-/// entrypoint whose combined content addresses the tag. Every spec's Dockerfile
-/// carries `LABEL fletch.agent=<provider>` so the image GC can attribute it
-/// (enforced by a test); each provider gets its own repo.
+/// A provider's image build inputs: its own repo, plus the Dockerfile and
+/// entrypoint whose combined content addresses the tag.
 pub(crate) struct ImageSpec {
     pub(crate) repo: &'static str,
     pub(crate) dockerfile: &'static str,
     pub(crate) entrypoint: &'static str,
 }
 
-/// Per-provider image inputs. Claude's spec is the pre-existing embedded image
-/// verbatim (see the byte-identity guard in tests); codex gets its own repo and
-/// install step, sharing claude's base layers.
+/// Per-provider image inputs.
 pub(crate) fn image_spec(provider: ContainerProvider) -> ImageSpec {
     match provider {
         ContainerProvider::Claude => ImageSpec {
@@ -237,10 +189,8 @@ pub(crate) fn image_tag(provider: ContainerProvider) -> String {
     tag_for(spec.repo, spec.dockerfile, spec.entrypoint)
 }
 
-/// The repo (image name without tag) of a provider's embedded image. With
-/// [`image_tag`] this is the GC's vocabulary of Fletch-owned names: the repos
-/// are chosen by this module and are not meaningful outside Fletch, so a
-/// non-current tag under one of them is attributable to us even on legacy
+/// The repo (image name without tag) of a provider's embedded image. These
+/// names are meaningless outside Fletch, which is what lets the GC attribute
 /// images built before [`AGENT_IMAGE_LABEL`] existed.
 pub(crate) fn image_repo(provider: ContainerProvider) -> &'static str {
     image_spec(provider).repo
@@ -248,11 +198,8 @@ pub(crate) fn image_repo(provider: ContainerProvider) -> &'static str {
 
 /// Write a build context holding exactly the two embedded files, so nothing
 /// from the host repo can leak into the image. Callers own the throwaway `dir`.
-///
-/// `COPY` preserves the context file's mode. The embedded Dockerfiles'
-/// `RUN chmod +x` is what actually guarantees an executable entrypoint on every
-/// host; setting the mode here too just keeps the copied layer's metadata sane
-/// where the host supports it.
+/// The mode set here is cosmetic — the Dockerfiles' `RUN chmod +x` is what
+/// actually guarantees an executable entrypoint on every host.
 pub(crate) fn write_build_context(
     dir: &std::path::Path,
     dockerfile: &str,
@@ -269,10 +216,8 @@ pub(crate) fn write_build_context(
     Ok(())
 }
 
-/// `<repo>:<sha256(dockerfile + entrypoint)[..12]>` — 12 hex chars, the same
-/// abbreviation depth docker itself uses for short ids. The hash covers only the
-/// dockerfile+entrypoint content (not the repo), so claude's tail is unchanged
-/// from before the repo argument existed as long as its content is.
+/// `<repo>:<sha256(dockerfile + entrypoint)[..12]>`. The repo is deliberately
+/// outside the hash, so renaming a repo never forces a rebuild.
 pub(crate) fn tag_for(repo: &str, dockerfile: &str, entrypoint: &str) -> String {
     use sha2::Digest;
     let mut hasher = sha2::Sha256::new();
@@ -287,10 +232,8 @@ pub(crate) fn tag_for(repo: &str, dockerfile: &str, entrypoint: &str) -> String 
 mod tests {
     use super::*;
 
-    /// Every provider image builds on [`BASE_IMAGE`]. This is the invariant
-    /// `image::reap_superseded_base` rests on: it only ever inspects and
-    /// reclaims that one tag, so a spec that quietly moved to a different base
-    /// would orphan images nothing reclaims.
+    /// `image::reap_superseded_base` reclaims only [`BASE_IMAGE`], so a spec on
+    /// a different base would orphan images nothing reclaims.
     #[test]
     fn every_spec_builds_on_the_declared_base() {
         let from = format!("FROM {BASE_IMAGE}\n");
@@ -310,12 +253,10 @@ mod tests {
         assert_eq!(hash.len(), 12);
         assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
 
-        // Deterministic, and any content change moves the tag.
         assert_eq!(tag, tag_for("fletch-agent", "FROM a\n", "#!/bin/sh\n"));
         assert_ne!(tag, tag_for("fletch-agent", "FROM b\n", "#!/bin/sh\n"));
         assert_ne!(tag, tag_for("fletch-agent", "FROM a\n", "#!/bin/bash\n"));
-        // The repo is a prefix, not part of the hash: a different repo with the
-        // same content shares the tail (so a repo rename can't force a rebuild).
+        // The repo is a prefix, not part of the hash: a rename can't force a rebuild.
         assert_eq!(
             tag_for("fletch-agent", "FROM a\n", "#!/bin/sh\n")
                 .split_once(':')
@@ -328,20 +269,11 @@ mod tests {
         );
     }
 
-    /// Golden guard: claude's image content is pinned byte-for-byte so an
-    /// *accidental* edit can't silently move the content-addressed tag and
-    /// force every user through a cold rebuild. Deliberate changes update the
-    /// frozen bytes here and record why:
-    ///
-    /// - image-lifecycle PR: added `LABEL fletch.agent=claude` so the image GC
-    ///   can attribute Fletch's images by label instead of guessing from
-    ///   names. One planned rehash → one rebuild for every user on update,
-    ///   accepted (and the GC reaps the superseded image).
+    /// Golden guard: an accidental edit here moves the content-addressed tag
+    /// and puts every user through a cold rebuild. Deliberate changes update
+    /// the frozen bytes below; accidental ones revert the constant instead.
     #[test]
     fn claude_image_is_unchanged() {
-        // Frozen bytes (do not "fix" to match an accidentally changed constant
-        // — update the constant back instead; deliberate changes update these
-        // bytes and the doc comment above).
         const FROZEN_DOCKERFILE: &str = "FROM node:22-slim\nRUN apt-get update && apt-get install -y --no-install-recommends \\\n    git curl ca-certificates ripgrep jq procps \\\n && rm -rf /var/lib/apt/lists/*\nLABEL fletch.agent=claude\nRUN npm install -g @anthropic-ai/claude-code\nCOPY entrypoint.sh /entrypoint.sh\nRUN chmod +x /entrypoint.sh\nENTRYPOINT [\"/entrypoint.sh\"]\n";
         const FROZEN_ENTRYPOINT: &str = "#!/bin/sh\nset -e\nmkdir -p \"$HOME\"\nif [ ! -f \"$HOME/.claude.json\" ]; then\n  printf '{\"hasCompletedOnboarding\": true}\\n' > \"$HOME/.claude.json\"\nfi\nexec \"$@\"\n";
         assert_eq!(DOCKERFILE, FROZEN_DOCKERFILE, "claude Dockerfile changed");
@@ -352,33 +284,24 @@ mod tests {
         assert!(image_tag(ContainerProvider::Claude).starts_with("fletch-agent:"));
     }
 
-    /// Codex gets its own repo and a distinct tag, and shares claude's base
-    /// layers (identical `FROM` + apt line) so the cache is reused.
     #[test]
     fn codex_image_is_distinct_and_shares_base() {
         let codex = image_tag(ContainerProvider::Codex);
         assert!(codex.starts_with("fletch-agent-codex:"), "{codex}");
         assert_ne!(codex, image_tag(ContainerProvider::Claude));
 
-        // Base layers shared: the FROM line and the apt install line are
-        // byte-identical, so Docker reuses those layers across both images.
-        // (The per-provider `LABEL fletch.agent=…` sits after the base and is
-        // deliberately excluded — it differs by construction.)
         assert_eq!(
             base_layers(DOCKERFILE),
             base_layers(CODEX_DOCKERFILE),
             "base layers must match for cache reuse"
         );
-        // Provider-specific install step differs.
         assert!(CODEX_DOCKERFILE.contains("@openai/codex"));
         assert!(!CODEX_DOCKERFILE.contains("claude-code"));
     }
 
-    /// The base layers (`FROM` + the shared apt step, through the apt-list
-    /// cleanup) that every provider image must share byte-for-byte so Docker's
-    /// layer cache is reused. Stops at the apt cleanup rather than the install
-    /// `RUN` so it's install-agnostic — npm-installed providers and cursor's
-    /// curl-installer image both compare equal on the base.
+    /// The lines every provider image must share byte-for-byte for layer-cache
+    /// reuse. Stops at the apt cleanup, not the install `RUN`, so it stays
+    /// install-agnostic (cursor installs via curl, the rest via npm).
     fn base_layers(dockerfile: &str) -> Vec<&str> {
         let mut out = Vec::new();
         for line in dockerfile.lines() {
@@ -390,9 +313,6 @@ mod tests {
         out
     }
 
-    /// OpenCode and Pi each get their own repo + distinct tag, share claude's base
-    /// layers (cache reuse), and install only their own package — no other
-    /// provider's CLI leaks into either image.
     #[test]
     fn opencode_and_pi_images_are_distinct_and_share_base() {
         let claude = image_tag(ContainerProvider::Claude);
@@ -420,22 +340,17 @@ mod tests {
                 "base layers must match for cache reuse"
             );
             assert!(dockerfile.contains(pkg), "{provider:?} must install {pkg}");
-            // No cross-contamination with the other providers' install steps.
             assert!(!dockerfile.contains("claude-code"));
             assert!(!dockerfile.contains("@openai/codex"));
         }
 
-        // The two new tags are distinct from each other, too.
         assert_ne!(
             image_tag(ContainerProvider::Opencode),
             image_tag(ContainerProvider::Pi)
         );
     }
 
-    /// Cursor gets its own repo + distinct tag and shares claude's base layers
-    /// (cache reuse) even though it installs via the official curl installer
-    /// rather than npm — the base-sharing invariant is install-agnostic. No other
-    /// provider's package leaks into the image.
+    /// Base sharing holds even though cursor installs via curl, not npm.
     #[test]
     fn cursor_image_is_distinct_and_shares_base() {
         let cursor = image_tag(ContainerProvider::Cursor);
@@ -452,13 +367,11 @@ mod tests {
                 "cursor tag collides with {other:?}"
             );
         }
-        // Base (FROM + apt) byte-identical despite the curl-installer install step.
         assert_eq!(
             base_layers(CURSOR_DOCKERFILE),
             base_layers(DOCKERFILE),
             "base layers must match for cache reuse",
         );
-        // Installs cursor-agent via its official installer; no other provider's pkg.
         assert!(CURSOR_DOCKERFILE.contains("cursor.com/install"));
         assert!(CURSOR_DOCKERFILE.contains("cursor-agent"));
         assert!(!CURSOR_DOCKERFILE.contains("claude-code"));
@@ -467,9 +380,8 @@ mod tests {
         assert!(!CURSOR_DOCKERFILE.contains("pi-coding-agent"));
     }
 
-    /// Every provider's Dockerfile carries `LABEL fletch.agent=<provider id>`
-    /// — the GC's attribution authority. The value must round-trip through
-    /// `ContainerProvider::from_id` so label values and provider ids can't drift.
+    /// The label value must round-trip through `ContainerProvider::from_id`, so
+    /// label values and provider ids can't drift apart.
     #[test]
     fn every_dockerfile_carries_the_agent_label() {
         for provider in ContainerProvider::ALL {
@@ -485,9 +397,8 @@ mod tests {
                 Some(provider),
                 "{provider:?} label value must be its provider id",
             );
-            // `id()` is `from_id`'s inverse — the version trigger keys the
-            // host probe and loop guard on it, so drift would silently
-            // disable (or cross-wire) the trigger.
+            // The version trigger keys its host probe and loop guard on `id()`,
+            // so drift would silently disable or cross-wire the trigger.
             assert_eq!(provider.id(), value.trim());
             assert_eq!(ContainerProvider::from_id(provider.id()), Some(provider));
         }

--- a/src-tauri/src/sandbox/container/labels.rs
+++ b/src-tauri/src/sandbox/container/labels.rs
@@ -1,19 +1,14 @@
-//! The labels every Fletch container carries, so a later sweep can attribute
-//! it: `fletch.host-pid=<pid>` (which app instance owns it) and
-//! `fletch.agent-id=<id>` (which agent it runs). Stamped at launch by
-//! [`run_args`](super::run_args) and consumed by the runtime's sweeps (see
-//! `sandbox::docker::cleanup`).
+//! The labels every Fletch container carries so a later sweep can attribute it.
+//! Stamped at launch by [`run_args`](super::run_args), consumed by the runtimes'
+//! sweeps (see `sandbox::docker::cleanup`).
 
 /// Label carrying the owning Fletch instance's pid.
 pub(crate) const HOST_PID_LABEL: &str = "fletch.host-pid";
 
-/// Label carrying the agent id a container runs. The startup orphan sweep
-/// keys on [`HOST_PID_LABEL`] alone (it asks "whose instance is dead?", not
-/// "which agent?"); this label is the handle for the other question —
-/// `cleanup::remove_agent_containers` uses it to tear down one named agent's
-/// containers on archive/discard. It is also the only stable handle there is:
-/// container *names* carry a random nonce (`engine::util::container_name`),
-/// so nothing outside the launching process can reconstruct them.
+/// Label carrying the agent id a container runs — the only stable handle for
+/// per-agent teardown, since container *names* carry a random nonce
+/// ([`util::container_name`](super::util::container_name)) no other process can
+/// reconstruct.
 pub(crate) const AGENT_ID_LABEL: &str = "fletch.agent-id";
 
 /// `fletch.host-pid=<our pid>` — the `--label` value stamped on a container run.
@@ -26,25 +21,19 @@ pub(crate) fn agent_id_label(agent_id: &str) -> String {
     format!("{AGENT_ID_LABEL}={agent_id}")
 }
 
-/// The `--filter` argument selecting one agent's containers. Built from
-/// [`agent_id_label`] so the query can never drift from what the launch
-/// stamped.
+/// The `--filter` argument selecting one agent's containers, built from
+/// [`agent_id_label`] so the query can't drift from what the launch stamped.
 pub(crate) fn agent_id_filter(agent_id: &str) -> String {
     format!("label={}", agent_id_label(agent_id))
 }
 
 /// `<runtime> inspect` line format pairing each container id with its owning
-/// pid. `index` (rather than a direct field access) yields an empty string
-/// when the label is somehow absent, which parses to "no pid" and is skipped
-/// — under-reclaiming, never removing something we can't attribute. Lives here
-/// so the template and [`HOST_PID_LABEL`] can't drift (guarded by a test).
+/// pid. `index` yields an empty string for a missing label, which parses to "no
+/// pid" and is skipped — the under-reclaim bias.
 pub(crate) const INSPECT_FORMAT: &str = r#"{{.Id}} {{index .Config.Labels "fletch.host-pid"}}"#;
 
 /// Parse [`INSPECT_FORMAT`] output and keep the ids whose owning pid is
-/// provably dead. A missing or unparsable pid means we can't attribute the
-/// container, so it is left alone (same under-reclaim bias as
-/// `cleanup_nested_state_roots_in`). Pure — the liveness probe is injected
-/// for unit tests.
+/// *provably* dead — an unattributable container is left alone.
 pub(crate) fn orphaned_ids(inspect_stdout: &str, alive: impl Fn(i32) -> bool) -> Vec<String> {
     inspect_stdout
         .lines()
@@ -54,7 +43,7 @@ pub(crate) fn orphaned_ids(inspect_stdout: &str, alive: impl Fn(i32) -> bool) ->
         .collect()
 }
 
-/// One [`INSPECT_FORMAT`] line → `(container_id, owning_pid)`. The pid is
+/// One [`INSPECT_FORMAT`] line → `(container_id, owning_pid)`; the pid is
 /// `None` when the label was empty or not a number.
 pub(crate) fn parse_inspect_line(line: &str) -> Option<(String, Option<i32>)> {
     let mut parts = line.split_whitespace();
@@ -67,10 +56,8 @@ pub(crate) fn parse_inspect_line(line: &str) -> Option<(String, Option<i32>)> {
 mod tests {
     use super::*;
 
-    /// The inspect template reads the same label the launch stamps. Spelled as
-    /// a literal (Go templates can't be `const`-formatted), so a rename of
-    /// [`HOST_PID_LABEL`] would otherwise silently return empty pids for every
-    /// container and make the orphan sweep reclaim nothing.
+    /// The template spells the label as a literal (Go templates can't be
+    /// `const`-formatted), so a rename would silently empty every pid.
     #[test]
     fn inspect_format_reads_the_host_pid_label() {
         assert!(INSPECT_FORMAT.contains(HOST_PID_LABEL), "{INSPECT_FORMAT}");

--- a/src-tauri/src/sandbox/container/launch.rs
+++ b/src-tauri/src/sandbox/container/launch.rs
@@ -1,15 +1,8 @@
 //! Per-launch container policy: the env a containerized agent gets, the mount
 //! sources that must exist before `-v` sees them, and the per-provider config /
-//! data / auth preparation.
-//!
-//! Everything a container launch decides *before* it knows which runtime will
-//! carry it out. The runtime engines ([`docker::engine`], [`podman::engine`])
-//! call [`prepare`] and then hand what comes back to
-//! [`run_args`](super::run_args) — so the two runtimes launch byte-identically
-//! and a change to launch policy cannot land on only one of them.
-//!
-//! [`docker::engine`]: crate::sandbox::docker
-//! [`podman::engine`]: crate::sandbox::podman
+//! data / auth preparation — everything decided *before* the runtime is known.
+//! Both runtime engines call [`prepare`] and hand the result to
+//! [`run_args`](super::run_args), so they launch byte-identically.
 
 use std::path::PathBuf;
 
@@ -32,19 +25,19 @@ use super::ContainerProvider;
 /// stores to bind read-only, and the owned per-provider mount inputs a
 /// [`ProviderMounts`] borrows from.
 pub(crate) struct ContainerLaunch {
-    /// Env set on the runtime CLI process; forwarded into the container by the
+    /// Env set on the runtime CLI process, forwarded into the container by the
     /// bare `-e NAME` flags `run_args` emits (values never touch argv —
     /// invariant 3). Config-dir vars come first, the resolved auth vars last.
     pub env: Vec<(String, String)>,
     /// Object stores every checkout under the agent's writable root borrows via
-    /// git alternates, each bind-mounted read-only at its identical host path.
+    /// git alternates, each bound read-only at its identical host path.
     pub borrowed_object_stores: Vec<PathBuf>,
 
     provider: ContainerProvider,
-    /// Index into [`env`](Self::env) where the auth tail starts — everything
-    /// from here on is a credential name to forward. Only the resolved set is
-    /// forwarded: an ambient credential the chain didn't pick must not reach
-    /// the container and override the resolved login.
+    /// Index into [`env`](Self::env) where the credential names to forward
+    /// begin. Only the resolved set is forwarded: an ambient credential the
+    /// chain didn't pick must not reach the container and override the
+    /// resolved login.
     auth_start: usize,
 
     claude_config_dir: Option<PathBuf>,
@@ -70,9 +63,8 @@ impl ContainerLaunch {
             .collect()
     }
 
-    /// The launching provider's mount directives, borrowed from the owned
-    /// inputs [`prepare`] filled in. Exactly one provider arm ran, so exactly
-    /// one variant's inputs are populated.
+    /// The launching provider's mount directives. Exactly one provider arm of
+    /// [`prepare`] ran, so exactly one variant's inputs are populated.
     pub(crate) fn mounts(&self) -> ProviderMounts<'_> {
         match self.provider {
             ContainerProvider::Claude => ProviderMounts::Claude {
@@ -117,28 +109,18 @@ impl ContainerLaunch {
 }
 
 /// Resolve everything a container launch of `provider` needs, creating the
-/// mount sources that must exist first. Fails the launch rather than handing a
-/// missing or unusable source to `-v`: a bare `-v` on a missing source has the
-/// runtime materialize it *root-owned*, which silently breaks the agent's
-/// access to its own auth/config/transcripts.
+/// mount sources first and failing the launch rather than handing `-v` a
+/// missing one — the runtime would materialize it root-owned, silently cutting
+/// the agent off from its own auth/config/transcripts.
 pub(crate) fn prepare(
     ctx: &AgentLaunchCtx,
     provider: ContainerProvider,
 ) -> Result<ContainerLaunch> {
-    // Object stores every checkout under the agent's writable root borrows
-    // via git alternates (a --shared clone). Derived from `ctx.source_repos`
-    // — Fletch's authoritative record of each checkout's user-owned source
-    // repo — NOT from the checkout's own `.git/objects/info/alternates`.
-    // That alternates file lives inside the agent's read-write checkout, so
-    // a container agent can overwrite it to name any host path and, on a
-    // reused-checkout relaunch (resume / switch_view), have that path
-    // bind-mounted read-only into its container — defeating ConfinedReads.
-    // Deriving from the source repos (which the agent cannot write) mounts
-    // exactly what a `--shared` clone borrows without trusting agent state.
-    // Spans every tracked repo, not just the primary: a multi-repo agent
-    // has one shared clone per repo. Mounted read-only; empty when a source
-    // is missing or has no object store. Container engines force Clone-mode
-    // workspaces for every provider, so this is provider-agnostic.
+    // Derived from `ctx.source_repos` (every tracked repo, not just the
+    // primary), never from the checkout's own `.git/objects/info/alternates`:
+    // that file is agent-writable, so a container agent could name any host
+    // path there and have it bind-mounted on a reused-checkout relaunch,
+    // defeating ConfinedReads.
     let borrowed_object_stores = borrowed_object_stores(ctx.source_repos);
 
     let mut env: Vec<(String, String)> = vec![
@@ -150,18 +132,13 @@ pub(crate) fn prepare(
         ("TERM".into(), "xterm-256color".into()),
         ("COLORTERM".into(), "truecolor".into()),
     ];
-    // A workflow step agent's blackboard is bind-mounted at its identical
-    // host path (invariant 1, like the RPC mailbox), so `WF_BLACKBOARD` is
-    // the same host path under either engine. Pushed before the provider
-    // match sets `auth_start` so it forwards as a plain env var, not an
-    // auth var.
+    // Pushed before the provider match sets `auth_start`, so it forwards as a
+    // plain env var rather than an auth var.
     if let Some(board) = ctx.blackboard {
-        // Fail closed if the blackboard was not provisioned before launch:
-        // a bare `-v` on a missing source has the runtime create it *root-owned*,
-        // leaving the host-side reader unable to read the agent's verdict/
-        // handoff files. Seatbelt already fails here (its `canonicalize`
-        // errors on a missing path); match that so an ordering bug in the
-        // scheduler surfaces instead of silently corrupting the mount.
+        // Fail closed rather than let the runtime materialize a missing source
+        // root-owned, which would leave the host-side reader unable to read the
+        // agent's verdict/handoff files. Matches seatbelt, whose `canonicalize`
+        // already errors here.
         if !board.is_dir() {
             return Err(Error::Other(format!(
                 "workflow blackboard not provisioned before launch: {}",
@@ -175,8 +152,7 @@ pub(crate) fn prepare(
     }
 
     // Owned per-provider mount inputs, borrowed into a `ProviderMounts` by
-    // `ContainerLaunch::mounts`. Defaults describe "no config surface"; the
-    // matched arm fills in what its provider needs.
+    // `ContainerLaunch::mounts`. Only the matched arm fills any of these in.
     let mut claude_config_dir: Option<PathBuf> = None;
     let mut claude_credentials_rw = false;
     let mut config_dir_credentials_rw = false;
@@ -197,28 +173,18 @@ pub(crate) fn prepare(
         ContainerProvider::Claude => {
             let cfg = nondefault_claude_config_dir(ctx.home);
 
-            // Make sure the mount sources exist before we hand them to `-v`.
-            // If a source can't be created (a file already sits at the path,
-            // a read-only or missing parent, permissions), mounting it anyway
-            // would let the runtime recreate it root-owned or fail the bind
-            // opaquely — either way claude loses access to its auth/config.
-            // Fail the launch with the path instead of a bad mount.
+            // Fail the launch with the path rather than hand `-v` a source we
+            // couldn't create: the bind would either be recreated root-owned or
+            // fail opaquely, and claude loses access to its auth/config.
             let claude_dir = ctx.home.join(".claude");
             prepare_config_mount_dir(&claude_dir)?;
             if let Some(dir) = &cfg {
                 prepare_config_mount_dir(dir)?;
             }
 
-            // Per-agent host dir backing claude's `projects/` (session
-            // transcripts). Bind-mounted read-write over the read-only config
-            // dir's `projects/` (see `run_args::push_claude_config_mount`) so
-            // `--resume` survives container recreation without exposing the
-            // shared `~/.claude/projects` — other agents' transcripts and
-            // global memory stay unreachable (invariant 5). Lives under the
-            // agent's writable root, so archive teardown's `rm -rf` reclaims
-            // it with no separate cleanup. Created before the container runs so
-            // the runtime binds an existing source instead of materializing it
-            // root-owned.
+            // Per-agent host dir backing claude's `projects/` — see
+            // `run_args::push_claude_config_mount`. Under the agent's writable
+            // root, so archive teardown's `rm -rf` reclaims it.
             let ps = ctx
                 .writable_root
                 .join(crate::transcripts::DOCKER_CLAUDE_PROJECTS_DIRNAME);
@@ -229,10 +195,9 @@ pub(crate) fn prepare(
                 ))
             })?;
 
-            // The read-only config mounts get a writable `.credentials.json`
-            // overlay only when the file already exists: a bare `-v` on a
-            // missing source makes the runtime create a root-owned *directory*
-            // there, which would break claude's later write of the real file.
+            // Overlay `.credentials.json` only when the file already exists: on
+            // a missing source the runtime creates a root-owned *directory*
+            // there, breaking claude's later write of the real file.
             claude_credentials_rw = claude_dir.join(CREDENTIALS_FILE).is_file();
             config_dir_credentials_rw = cfg
                 .as_deref()
@@ -250,14 +215,9 @@ pub(crate) fn prepare(
             apply_container_auth(&mut env, super::auth::resolve())?;
         }
         ContainerProvider::Codex => {
-            // Codex's config dir is bind-mounted read-write: auth.json token
-            // refresh and the session rollout files it writes both need to
-            // persist, and writing rollouts at the same host path keeps the
-            // host-side transcript reader (`find_codex_rollouts`) working.
             let dir = codex_home_dir(ctx.home);
-            // Forward CODEX_HOME only when it points somewhere other than the
-            // default `~/.codex` the container already resolves via HOME —
-            // mirrors `nondefault_claude_config_dir`.
+            // Forwarded only when non-default: the container already resolves
+            // `~/.codex` via HOME.
             forward_codex_home = codex_home_is_nondefault(ctx.home);
             if forward_codex_home {
                 env.push(("CODEX_HOME".into(), dir.to_string_lossy().into_owned()));
@@ -272,13 +232,8 @@ pub(crate) fn prepare(
             codex_config_dir = Some(dir);
         }
         ContainerProvider::Opencode => {
-            // OpenCode's data dir carries the accounts DB / auth.json and the
-            // session storage the host transcript reader tails, so it's bound
-            // read-write at its identical host path (mirrors codex's ~/.codex).
             let data = opencode_data_dir(ctx.home);
-            // Forward XDG_DATA_HOME only when it points somewhere other than
-            // the default `~/.local/share` the container resolves via HOME —
-            // mirrors codex's CODEX_HOME handling.
+            // Forwarded only when non-default, as with CODEX_HOME above.
             forward_xdg_data_home =
                 xdg_base_is_nondefault("XDG_DATA_HOME", ctx.home, ".local/share");
             if forward_xdg_data_home {
@@ -286,10 +241,8 @@ pub(crate) fn prepare(
                     env.push(("XDG_DATA_HOME".into(), v.to_string_lossy().into_owned()));
                 }
             }
-            // The config dir (custom providers + plugin installs opencode
-            // writes) is optional: opencode runs without it, and binding a
-            // missing source would have the runtime create it root-owned. Mount
-            // + forward it only when it already exists.
+            // Optional — opencode runs without it, and binding a missing source
+            // would have the runtime create it root-owned.
             let config = opencode_config_dir(ctx.home);
             if config.is_dir() {
                 forward_xdg_config_home =
@@ -308,10 +261,7 @@ pub(crate) fn prepare(
             oc_data = Some(data);
         }
         ContainerProvider::Pi => {
-            // Pi keeps everything under `~/.pi` (agent/auth.json,
-            // agent/settings.json, agent/sessions/), bound read-write at its
-            // identical host path so auth persists and the host transcript
-            // reader tails the sessions.
+            // Pi keeps auth, settings and sessions all under `~/.pi`.
             let data = ctx.home.join(".pi");
             auth_start = env.len();
             let api_keys = present_api_keys(|n| std::env::var(n).ok());
@@ -319,10 +269,8 @@ pub(crate) fn prepare(
             pi_data = Some(data);
         }
         ContainerProvider::Cursor => {
-            // `~/.cursor` is bound read-write at its identical host path so
-            // cursor's session transcripts land where the host reader
-            // (`agent::cursor_locate`) tails them. It carries no credential
-            // (the login token is keychain-bound); auth is CURSOR_API_KEY only.
+            // No credential lives here (the login token is keychain-bound);
+            // auth is CURSOR_API_KEY only.
             let data = ctx.home.join(".cursor");
             auth_start = env.len();
             prepare_cursor_launch(

--- a/src-tauri/src/sandbox/container/launch_auth.rs
+++ b/src-tauri/src/sandbox/container/launch_auth.rs
@@ -1,27 +1,22 @@
 //! Per-provider container auth: folding the resolved credential(s) into the
-//! docker CLI's process env (from which [`super::run_args::run_args`]' bare
-//! `-e NAME` flags forward them — invariant 3, values never touch argv) and the
-//! fail-fast messages when a provider has no usable credential.
+//! container CLI's process env, from which [`super::run_args::run_args`]' bare
+//! `-e NAME` flags forward them (invariant 3 — values never touch argv), plus
+//! the fail-fast messages when a provider has no usable credential.
 
 use std::path::Path;
 
 use super::auth::ContainerAuth;
 use crate::error::{Error, Result};
 
-/// Launch-blocking message when the container auth chain resolves nothing.
-/// Kept as one stable, matchable string the frontend keys its Settings
-/// call-to-action on; the wording tells the user exactly what to do.
+/// Launch-blocking message when the container auth chain resolves nothing. One
+/// stable string — the frontend keys its Settings call-to-action on it.
 pub(crate) const NO_CONTAINER_AUTH_MSG: &str = "No Anthropic credentials for containers — open Settings → General → Sandbox and connect Claude for containers (claude setup-token).";
 
-/// Fold the D1 auth-chain outcome ([`resolve`]) into the docker CLI's
-/// process env, from which [`run_args`]' bare `-e NAME` flags forward it into
-/// the container (invariant 3 — values never touch argv). An [`AuthSource`] is
-/// logged (the enum variant only, never a token value); [`ContainerAuth`]'s
-/// `Debug` redacts values so even `?source` cannot leak one. When the chain
-/// yields nothing the launch fails fast with [`NO_CONTAINER_AUTH_MSG`].
+/// Fold the claude auth-chain outcome ([`resolve`]) into the container CLI's
+/// process env. Only the [`AuthSource`] variant is logged, never a value.
+/// Nothing resolved → fail fast with [`NO_CONTAINER_AUTH_MSG`].
 ///
 /// [`resolve`]: crate::sandbox::container::auth::resolve
-/// [`run_args`]: super::run_args::run_args
 /// [`AuthSource`]: crate::sandbox::container::auth::AuthSource
 pub(crate) fn apply_container_auth(
     env: &mut Vec<(String, String)>,
@@ -40,40 +35,33 @@ pub(crate) fn apply_container_auth(
     }
 }
 
-/// Launch-blocking message when codex has no usable credential: no
-/// `auth.json` in its config dir and `OPENAI_API_KEY` unset. Mirrors
-/// [`NO_CONTAINER_AUTH_MSG`]'s fail-fast: an unauthenticated container boots
-/// straight into a login prompt it can't answer inside the sandbox.
+/// Launch-blocking message when codex has no credential: no `auth.json` in its
+/// config dir, no `OPENAI_API_KEY`. Fail fast like [`NO_CONTAINER_AUTH_MSG`] —
+/// an unauthenticated container boots into a login prompt it can't answer.
 pub(crate) const NO_CODEX_AUTH_MSG: &str =
     "No Codex credentials for containers — sign in with `codex` on the host (writes ~/.codex/auth.json) or set OPENAI_API_KEY.";
 
-/// Launch-blocking message when opencode has no usable credential: no accounts DB
-/// / auth.json on its data-dir mount and no known provider API key set. Same
-/// fail-fast rationale as [`NO_CODEX_AUTH_MSG`].
+/// Launch-blocking message when opencode has no credential: no accounts DB /
+/// auth.json on its data-dir mount and no provider API key set.
 pub(crate) const NO_OPENCODE_AUTH_MSG: &str =
     "No OpenCode credentials for containers — sign in with `opencode auth login` on the host or set a provider API key (e.g. ANTHROPIC_API_KEY or OPENAI_API_KEY).";
 
-/// Launch-blocking message when pi has no usable credential: no
-/// `~/.pi/agent/auth.json` on its mount and no known provider API key set.
+/// Launch-blocking message when pi has no credential: no
+/// `~/.pi/agent/auth.json` on its mount and no provider API key set.
 pub(crate) const NO_PI_AUTH_MSG: &str =
     "No Pi credentials for containers — sign in with `pi` on the host (writes ~/.pi/agent/auth.json) or set a provider API key (e.g. ANTHROPIC_API_KEY or OPENAI_API_KEY).";
 
-/// Launch-blocking message when cursor has no usable credential. Unlike the other
-/// providers there is no mount-based fallback: `cursor-agent login` stores its
-/// access/refresh tokens in the host OS keychain (macOS "Cursor Safe Storage"),
-/// which a Linux container can't read, and `~/.cursor` carries only identity
-/// metadata — not a bearer token. So `CURSOR_API_KEY` is the sole container
-/// credential; fail fast (before touching the filesystem) when it's unset.
+/// Launch-blocking message when cursor has no credential. There is no
+/// mount-based fallback: `cursor-agent login` stores its tokens in the host OS
+/// keychain, which a Linux container can't read, and `~/.cursor` carries only
+/// identity metadata — so `CURSOR_API_KEY` is the sole container credential.
 pub(crate) const NO_CURSOR_AUTH_MSG: &str =
     "No Cursor credentials for containers — set CURSOR_API_KEY (create one at cursor.com/dashboard). `cursor-agent login` stores its token in the host keychain, which containers can't read.";
 
 /// Provider API-key env vars the multi-provider CLIs (opencode, pi) read to
-/// authenticate. Whichever are set in the app's process env are forwarded by bare
-/// `-e NAME` (invariant 3) so the in-container CLI can use them, and a set key
-/// satisfies the auth requirement on its own. Curated to the mainstream providers
-/// both CLIs honor (verified against each CLI's binary) — not exhaustive, but
-/// enough that a user with any common key set can launch. Codex is excluded: it's
-/// single-provider (OpenAI) and resolved separately.
+/// authenticate; any one set in the app's process env satisfies auth on its own.
+/// Curated to the mainstream providers both CLIs honor, not exhaustive. Codex is
+/// excluded — it's single-provider and resolved separately.
 const MULTI_PROVIDER_API_KEY_ENV: &[&str] = &[
     "ANTHROPIC_API_KEY",
     "OPENAI_API_KEY",
@@ -85,20 +73,11 @@ const MULTI_PROVIDER_API_KEY_ENV: &[&str] = &[
     "MISTRAL_API_KEY",
 ];
 
-/// Fold codex's container auth into the docker CLI's process env, then make
-/// sure the config dir exists so the read-write bind has a host source. Codex's
-/// primary credential is the mounted `~/.codex/auth.json` (the read-write mount
-/// carries it and token refresh persists to the host); an `OPENAI_API_KEY` in
-/// the app's process env is forwarded when set (by bare `-e`, so its value never
-/// touches argv — invariant 3). Either alone suffices: a key-only user may
-/// never have run codex on the host, so the dir is created rather than
-/// required — mounting a fresh dir keeps session rollouts landing where
-/// `find_codex_rollouts` reads them. Fails the launch when neither credential
-/// is present (before touching the filesystem), so an unauthenticated
-/// container never boots into an unanswerable login prompt.
-///
-/// Unlike claude, no ANTHROPIC_*/CLAUDE_* var is injected: codex authenticates
-/// against OpenAI, and forwarding those would be dead weight at best.
+/// Fold codex's container auth into the container CLI's process env, then make
+/// sure the config dir exists so the read-write bind has a host source. Either
+/// the mounted `auth.json` or an `OPENAI_API_KEY` suffices, so a key-only user
+/// who never ran codex gets the dir created rather than required; neither
+/// present fails the launch before any filesystem work.
 pub(crate) fn prepare_codex_launch(
     env: &mut Vec<(String, String)>,
     config_dir: &Path,
@@ -123,10 +102,8 @@ pub(crate) fn prepare_codex_launch(
     Ok(())
 }
 
-/// Pure core of [`prepare_codex_launch`]: the auth env to forward given the process
-/// `OPENAI_API_KEY` (if any) and whether `auth.json` exists on the mount. A
-/// non-blank key is forwarded (trimmed); the mounted `auth.json` carries auth on
-/// its own with nothing to inject. Neither present → the launch-blocking error.
+/// Pure core of [`prepare_codex_launch`]: a non-blank key is forwarded trimmed,
+/// a mounted `auth.json` needs nothing injected, neither is the blocking error.
 pub(crate) fn codex_auth_env(
     api_key: Option<&str>,
     auth_file: bool,
@@ -142,9 +119,7 @@ pub(crate) fn codex_auth_env(
 }
 
 /// The subset of [`MULTI_PROVIDER_API_KEY_ENV`] present and non-blank via
-/// `lookup` (a var name → value resolver, `std::env::var` in production, a fixture
-/// in tests), each as a `(name, value)` to forward. Order follows the constant so
-/// forwarding is deterministic.
+/// `lookup`, in constant order so forwarding is deterministic.
 pub(crate) fn present_api_keys(lookup: impl Fn(&str) -> Option<String>) -> Vec<(String, String)> {
     MULTI_PROVIDER_API_KEY_ENV
         .iter()
@@ -157,10 +132,8 @@ pub(crate) fn present_api_keys(lookup: impl Fn(&str) -> Option<String>) -> Vec<(
 }
 
 /// Shared auth rule for the multi-provider CLIs (opencode, pi): a forwarded
-/// provider key OR a credential carried on the read-write mount suffices; neither
-/// present → the caller's launch-blocking message. Returns the keys to forward
-/// (empty when the mount carries the login and no key is set), mirroring
-/// [`codex_auth_env`]'s shape.
+/// provider key OR a credential on the read-write mount suffices; neither is the
+/// caller's launch-blocking message.
 pub(crate) fn multi_provider_auth_env(
     api_keys: Vec<(String, String)>,
     credential_on_mount: bool,
@@ -173,14 +146,11 @@ pub(crate) fn multi_provider_auth_env(
     }
 }
 
-/// Fold opencode's container auth into the docker CLI's process env, then make
-/// sure the data dir exists so the read-write bind has a host source. OpenCode's
-/// login lives in its data-dir mount (the accounts DB `opencode.db`, or a legacy
-/// `auth.json`); a provider API key in the app's env is forwarded when set. Either
-/// alone suffices, so — like codex — a key-only user who never ran opencode gets
-/// the dir created rather than required. Neither present → fail the launch before
-/// touching the filesystem. Auth values ride the process env and forward by bare
-/// `-e` (invariant 3); only booleans are logged.
+/// Fold opencode's container auth into the container CLI's process env, then
+/// make sure the data dir exists so the read-write bind has a host source. Its
+/// login lives on that mount (accounts DB `opencode.db`, or a legacy
+/// `auth.json`); a provider API key does just as well, so — like codex — the dir
+/// is created rather than required. Only booleans are logged, never a value.
 pub(crate) fn prepare_opencode_launch(
     env: &mut Vec<(String, String)>,
     data_dir: &Path,
@@ -207,12 +177,10 @@ pub(crate) fn prepare_opencode_launch(
     Ok(())
 }
 
-/// Fold pi's container auth into the docker CLI's process env, then make sure
-/// `~/.pi` exists so the read-write bind has a host source. Pi's login lives in
-/// `~/.pi/agent/auth.json` on that mount; a provider API key in the app's env is
-/// forwarded when set. Either alone suffices, so a key-only user who never ran pi
-/// gets `~/.pi` created rather than required. Neither present → fail the launch
-/// before touching the filesystem. Only booleans are logged.
+/// Fold pi's container auth into the container CLI's process env, then make sure
+/// `~/.pi` exists so the read-write bind has a host source. Its login lives in
+/// `agent/auth.json` on that mount; a provider API key does just as well, so the
+/// dir is created rather than required. Only booleans are logged.
 pub(crate) fn prepare_pi_launch(
     env: &mut Vec<(String, String)>,
     data_dir: &Path,
@@ -237,17 +205,11 @@ pub(crate) fn prepare_pi_launch(
     Ok(())
 }
 
-/// Fold cursor's container auth into the docker CLI's process env, then make sure
-/// `~/.cursor` exists so the read-write bind has a host source. Cursor is a
-/// single-provider CLI, so — like codex — no cross-provider key set applies;
-/// unlike every other provider, though, its credential can't ride the mount:
-/// `cursor-agent login` writes its tokens to the host OS keychain (see
-/// [`NO_CURSOR_AUTH_MSG`]), so `CURSOR_API_KEY` (forwarded by bare `-e` — invariant
-/// 3) is the only container credential. The `~/.cursor` mount still matters: it's
-/// where cursor writes session transcripts (`agent::cursor_locate` reads them at
-/// the identical host path), so the dir is created for the bind even though it
-/// carries no auth. Fails the launch when `CURSOR_API_KEY` is unset, before
-/// touching the filesystem. Only a boolean is logged, never the key.
+/// Fold cursor's container auth into the container CLI's process env, then make
+/// sure `~/.cursor` exists so the read-write bind has a host source. Only
+/// `CURSOR_API_KEY` can authenticate (see [`NO_CURSOR_AUTH_MSG`]); the mount is
+/// still created because cursor writes session transcripts there, at the
+/// identical host path `agent::cursor_locate` reads.
 pub(crate) fn prepare_cursor_launch(
     env: &mut Vec<(String, String)>,
     config_dir: &Path,
@@ -269,11 +231,8 @@ pub(crate) fn prepare_cursor_launch(
     Ok(())
 }
 
-/// Pure core of [`prepare_cursor_launch`]: the auth env to forward given the
-/// process `CURSOR_API_KEY`. A non-blank key is forwarded (trimmed); anything
-/// else — unset or blank — is the launch-blocking error, because cursor's login
-/// token lives in the host keychain and can't reach the container by any other
-/// path (see [`NO_CURSOR_AUTH_MSG`]).
+/// Pure core of [`prepare_cursor_launch`]: a non-blank `CURSOR_API_KEY` is
+/// forwarded trimmed, unset or blank is the launch-blocking error.
 pub(crate) fn cursor_auth_env(api_key: Option<&str>) -> Result<Vec<(String, String)>> {
     match api_key.map(str::trim).filter(|k| !k.is_empty()) {
         Some(key) => Ok(vec![("CURSOR_API_KEY".to_string(), key.to_string())]),

--- a/src-tauri/src/sandbox/container/mod.rs
+++ b/src-tauri/src/sandbox/container/mod.rs
@@ -1,39 +1,10 @@
 //! Runtime-neutral container launch policy: everything about running an agent
 //! in a container that is not specific to one container runtime.
 //!
-//! `sandbox::docker` is the Docker *runtime* — binary resolution, the daemon
-//! probe, `docker build`/`run`/`rm` invocations, and the `SandboxEngine` impl.
-//! What lives here is the policy those invocations carry out, expressed as pure
-//! data and pure functions so a sibling runtime (podman) can reuse it verbatim:
-//!
-//! - [`provider`] — which providers can run in a container at all
-//!   ([`ContainerProvider`]), their ids and in-image binaries.
-//! - [`launch`] — per-launch policy: the container env, the mount sources it
-//!   creates, and the per-provider config/data/auth preparation. What both
-//!   runtimes' `launch_agent` calls before building any argv.
-//! - [`config_dir`] — non-default config-dir detection and borrowed object stores.
-//! - [`run_args`] — the `run` argv builder: mounts at identical host paths, the
-//!   per-provider config/data mounts, and the bare `-e NAME` auth forwards.
-//! - [`labels`] — the `fletch.host-pid` / `fletch.agent-id` labels every
-//!   container carries so orphan and per-agent sweeps can attribute it, plus
-//!   the pid-liveness parsing those sweeps share.
-//! - [`sweep`] — the startup orphan sweep's probe-retry schedule.
-//! - [`images`] — the embedded Dockerfiles/entrypoints and their
-//!   content-addressed tags. Content only: nothing here builds or inspects.
-//! - [`freshness`] — the image TTL and the host/in-image version-parity
-//!   decision: when a built image has gone stale enough to rebuild.
-//! - [`version_guard`] — the per-runtime loop guard that caps version-parity
-//!   rebuild attempts at one per `host@tag` pairing.
-//! - [`image_gc`] — which superseded agent images to reclaim: the listing
-//!   format, its row parsing, and the selection rule.
-//! - [`progress`] — the process-wide image-build progress sink the UI toast
-//!   listens on.
-//! - [`auth`] — the Anthropic credential chain for containerized agents.
-//! - [`launch_auth`] — per-provider launch preparation: folding resolved
-//!   credentials into the CLI process env and failing fast without one.
-//! - [`proc`] — bounded subprocess execution (timeouts, line forwarding), the
-//!   machinery every runtime CLI invocation is funneled through.
-//! - [`util`] — container naming and the reserved-exit-code messages.
+//! `sandbox::docker` and `sandbox::podman` are the *runtimes* (binary
+//! resolution, daemon probe, CLI invocations, `SandboxEngine` impls); the policy
+//! those invocations carry out lives here as pure data and pure functions, so
+//! both runtimes reuse it verbatim and no policy change can land on only one.
 
 pub mod auth;
 pub(crate) mod config_dir;

--- a/src-tauri/src/sandbox/container/proc.rs
+++ b/src-tauri/src/sandbox/container/proc.rs
@@ -1,13 +1,10 @@
 //! Bounded subprocess execution: run a command to completion under a hard
 //! timeout, or stream its output line by line while it runs.
 //!
-//! Every container-runtime CLI invocation goes through here, because an
-//! unbounded call cannot be allowed to wedge the thread that issued it (UI
-//! polling, the startup sweep): a stopped Docker Desktop, for one, leaves a
-//! socket that accepts connections and then hangs. Callers pass an explicit
-//! timeout and get a clear "timed out" error instead. Nothing here knows which
-//! runtime it is running — see `sandbox::docker::cli` and
-//! `sandbox::podman::cli` for the per-runtime wrappers.
+//! Every container-runtime CLI invocation goes through here — a stalled runtime
+//! socket accepts connections and then hangs, and no such call may wedge the
+//! thread that issued it. Runtime-neutral; see `sandbox::{docker,podman}::cli`
+//! for the per-runtime wrappers.
 
 use std::process::{Command, Output, Stdio};
 use std::time::Duration;
@@ -55,12 +52,10 @@ pub(crate) fn wait_with_deadline(
     }
 }
 
-/// Run any command to completion under `timeout`, capturing output. Both
-/// pipes are drained on scoped threads (so a chatty child can't deadlock on
-/// a full pipe) while this thread keeps ownership of the `Child` and waits
-/// with a deadline — on expiry [`wait_with_deadline`] kills and reaps it on
-/// any platform, the pipes hit EOF, and the readers finish: nothing outlives
-/// the error we return.
+/// Run any command to completion under `timeout`, capturing output. Both pipes
+/// are drained on scoped threads so a chatty child can't deadlock on a full
+/// pipe; on expiry the child is killed and reaped, so nothing outlives the
+/// error returned.
 pub(crate) fn run_with_timeout(mut cmd: Command, timeout: Duration, what: &str) -> Result<Output> {
     fn read_all(mut reader: impl std::io::Read) -> Vec<u8> {
         let mut buf = Vec::new();
@@ -99,8 +94,6 @@ fn timeout_error(what: &str, timeout: Duration) -> Error {
 mod tests {
     use super::*;
 
-    /// The property every runtime invocation relies on: a hung child comes
-    /// back as a bounded error, and the child is killed rather than orphaned.
     #[test]
     fn run_with_timeout_kills_hung_child() {
         let mut cmd = Command::new("/bin/sleep");
@@ -124,14 +117,11 @@ mod tests {
         assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "hello");
     }
 
-    /// Streaming runs deliver lines to the callback and fail loudly (with the
-    /// output tail) on a non-zero exit — the contract `docker build` needs.
     #[test]
     fn streaming_forwards_lines_and_reports_failure_tail() {
         let lines = std::sync::Mutex::new(Vec::new());
         let on_line = |line: &str| lines.lock().unwrap().push(line.to_string());
 
-        // Use /bin/sh directly (not via docker) to exercise the machinery.
         let mut child = Command::new("/bin/sh")
             .args(["-c", "echo one; echo two >&2; exit 3"])
             .stdin(Stdio::null())

--- a/src-tauri/src/sandbox/container/progress.rs
+++ b/src-tauri/src/sandbox/container/progress.rs
@@ -1,28 +1,18 @@
 //! Image-build progress broadcast to the UI, shared by both container runtimes.
 //!
-//! The embedded agent image is built on the first spawn under a given runtime —
-//! a potentially minutes-long `build` that blocks the spawn until it finishes.
-//! That work happens deep in the engine launch path, which has no `AppHandle`,
-//! so this module offers a process-wide sink the app installs once at startup
-//! ([`set_build_sink`]) to forward build events to the UI. Until a sink is
-//! installed (or in headless tests) emitting is a no-op, so the build path stays
-//! decoupled from Tauri — matching how the engines' `set_launch_settings`
-//! mirrors settings without a DB handle.
+//! The build runs deep in the launch path with no `AppHandle`, so the app
+//! installs a process-wide sink at startup ([`set_build_sink`]); emitting is a
+//! no-op until it does, keeping the build path free of Tauri.
 //!
-//! One sink for both runtimes — but NOT one build at a time: each runtime
-//! serializes builds on its own lock, so a Docker and a Podman first-build can
-//! overlap. Every event therefore carries `runtime`, its lifecycle key: the
-//! frontend keys build state on it, so interleaved lifecycles can't clear or
-//! overwrite each other's toast.
+//! One sink, but not one build at a time — each runtime serializes on its own
+//! lock, so two first-builds can overlap. Every event therefore carries
+//! `runtime`: it is the lifecycle key the frontend routes on.
 
 use parking_lot::RwLock;
 
-/// One image-build lifecycle event. Serializes tagged (`{ "phase": "line",
-/// "runtime": "Docker", "line": "…" }`) so the frontend can pattern-match a
-/// single event stream. `runtime` is the runtime's display name ("Docker" /
-/// "Podman") on every variant — it is the key that separates two overlapping
-/// lifecycles, not decoration; the frontend still treats it as optional so an
-/// event without it renders under a neutral key.
+/// One image-build lifecycle event, serialized tagged by `phase` so the
+/// frontend can pattern-match a single stream. `runtime` rides every variant —
+/// it separates two overlapping lifecycles.
 #[derive(Clone, serde::Serialize)]
 #[serde(tag = "phase", rename_all = "kebab-case")]
 pub enum BuildEvent {
@@ -49,8 +39,7 @@ pub fn set_build_sink(sink: impl Fn(BuildEvent) + Send + Sync + 'static) {
     *SINK.write() = Some(Box::new(sink));
 }
 
-/// Forward a build event to the installed sink, if any. A no-op when none is
-/// installed, so the build machinery never depends on the app being wired up.
+/// Forward a build event to the installed sink; a no-op when there is none.
 pub(crate) fn emit(event: BuildEvent) {
     if let Some(sink) = SINK.read().as_ref() {
         sink(event);
@@ -63,12 +52,10 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
 
-    // Serializes with any other test touching the process-wide sink. This is the
-    // only such test today; the guard documents the shared-global contract.
+    // The sink is a process-wide global: any further test touching it must
+    // serialize with this one.
     #[test]
     fn sink_receives_events_and_no_op_without_one() {
-        // No sink installed at first: emitting must not panic (the build path
-        // runs in headless tests with no app wired up).
         emit(BuildEvent::Started { runtime: "Docker" });
 
         let count = Arc::new(AtomicUsize::new(0));
@@ -86,10 +73,6 @@ mod tests {
         assert_eq!(count.load(Ordering::SeqCst), 3);
     }
 
-    /// `runtime` rides every phase, not just `started`: it is the lifecycle
-    /// key that keeps two overlapping runtimes' events from clearing or
-    /// overwriting each other's toast state. Fields are additive, so a
-    /// consumer that only reads `phase` still works.
     #[test]
     fn build_event_serializes_tagged_with_runtime_on_every_phase() {
         assert_eq!(

--- a/src-tauri/src/sandbox/container/provider.rs
+++ b/src-tauri/src/sandbox/container/provider.rs
@@ -1,21 +1,14 @@
 //! Which providers Fletch can run inside a container, and the facts about each
 //! one that every container runtime needs.
 
-/// A provider Fletch can run inside a container sandbox. This is the single
-/// capability gate the rest of the app consults instead of string-matching
-/// `provider == "claude"`: [`supervisor::lifecycle::ensure_engine_supports_provider`]
-/// refuses anything [`from_id`](ContainerProvider::from_id) doesn't recognize, and
-/// the launch path (`sandbox::docker::engine`) branches on the variant for the
-/// provider-specific image ([`images`](super::images)), config-dir mount, and
-/// auth. Everything else about a container (workspace / RPC / object-store
-/// mounts, naming, teardown) is provider-agnostic.
+/// A provider Fletch can run inside a container sandbox — the single capability
+/// gate, consulted instead of string-matching provider ids. Only the image,
+/// config-dir mount and auth are provider-specific; the rest of a container is
+/// provider-agnostic.
 ///
-/// Seatbelt runs six providers; containers are being brought up one at a time as
-/// each gets its image + config-mount + auth wired — claude, codex, opencode, pi,
-/// and cursor so far. antigravity remains gated: its CLI (`agy`) has no
-/// non-interactive credential path — auth is browser OAuth with its tokens in the
-/// host keychain and no API-key env fallback (maintainer-confirmed), so a fresh
-/// container cannot authenticate. See `ensure_engine_supports_provider`.
+/// antigravity is absent deliberately: its CLI has no non-interactive credential
+/// path (browser OAuth into the host keychain, no API-key fallback), so a fresh
+/// container cannot authenticate.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ContainerProvider {
     Claude,
@@ -26,12 +19,9 @@ pub enum ContainerProvider {
 }
 
 impl ContainerProvider {
-    /// Every container-supported provider. The image GC derives "the current
-    /// expected images" from this list, so a variant missing here would make
-    /// the GC treat that provider's live image as stale — when adding a
-    /// variant, extend this list (the exhaustive `match` in
-    /// [`images::image_spec`](super::images::image_spec) will already force you
-    /// into that file).
+    /// Every container-supported provider. The image GC derives the current
+    /// expected images from this list — a variant missing here has its live
+    /// image GC'd as stale.
     pub const ALL: [Self; 5] = [
         Self::Claude,
         Self::Codex,
@@ -40,10 +30,8 @@ impl ContainerProvider {
         Self::Cursor,
     ];
 
-    /// Map a provider id (as stamped on `AgentRecord.provider` / used by the
-    /// frontend) to its container support, or `None` when the provider has no
-    /// container support yet — the launch gate turns `None` into the
-    /// user-facing "isn't available in container sandboxes yet" refusal.
+    /// Map a provider id to its container support, or `None` when there is none
+    /// — the launch gate turns `None` into a user-facing refusal.
     pub fn from_id(provider: &str) -> Option<Self> {
         match provider {
             "claude" => Some(Self::Claude),
@@ -55,11 +43,8 @@ impl ContainerProvider {
         }
     }
 
-    /// The provider id string — [`from_id`](Self::from_id)'s inverse
-    /// (round-trip enforced by a test in [`images`](super::images)). Used where
-    /// a variant must key string-indexed state shared with the rest of the app,
-    /// e.g. the host version probe (`agent::cached_provider_version`) and the
-    /// persisted version-refresh loop guard (see `sandbox::docker::engine`).
+    /// The provider id string — [`from_id`](Self::from_id)'s inverse, and the
+    /// key for string-indexed state shared with the rest of the app.
     pub fn id(self) -> &'static str {
         match self {
             Self::Claude => "claude",
@@ -70,12 +55,8 @@ impl ContainerProvider {
         }
     }
 
-    /// The command name on the image's PATH — what this provider's npm package
-    /// installs as its executable. Handed to `launch_agent` as the in-image
-    /// `agent_bin` (a host-resolved absolute path would be meaningless inside
-    /// the container). Matches the provider's `bin` field for both supported
-    /// providers today, but named explicitly so it stays an image fact, not a
-    /// coincidence.
+    /// The command name on the image's PATH, used as the in-image `agent_bin` —
+    /// a host-resolved absolute path would be meaningless inside the container.
     pub fn image_bin(self) -> &'static str {
         match self {
             Self::Claude => "claude",

--- a/src-tauri/src/sandbox/container/run_args.rs
+++ b/src-tauri/src/sandbox/container/run_args.rs
@@ -1,7 +1,10 @@
-//! The container `run` argv builder: the provider-agnostic `--rm --init` shape,
-//! the mounts at identical host paths (invariant 1), the per-provider config/
-//! data mounts, and the bare `-e NAME` forwards (invariant 3). Pure over its
-//! [`RunSpec`] so the argv shape is unit-testable without a daemon.
+//! The container `run` argv builder. Pure over its [`RunSpec`] so the argv
+//! shape is unit-testable without a daemon.
+//!
+//! Invariants it encodes: mounts land at identical host paths (1), borrowed
+//! history is read-only (2), credential values reach the container as bare
+//! `-e NAME` and never appear in argv (3), claude's shared config dir is
+//! read-only but for its named carve-outs (5).
 
 use std::path::{Path, PathBuf};
 
@@ -13,77 +16,48 @@ use crate::sandbox::policy::{
 use super::labels;
 
 /// The one file under a claude config dir that stays writable when the dir is
-/// bind-mounted read-only: claude's OAuth refresh rewrites the rotated token
-/// here, and the `CredentialsFile` auth chain (see [`super::auth`]) needs that
-/// write to land on the host. Mounted read-write on top of the read-only dir.
-/// The name is shared with seatbelt via [`CLAUDE_CREDENTIALS_FILE`] so
-/// the two engines can't drift.
+/// bind-mounted read-only: claude's OAuth refresh must land on the host for the
+/// `CredentialsFile` chain (see [`super::auth`]) to see the rotated token.
+/// Shared with seatbelt via [`CLAUDE_CREDENTIALS_FILE`] so the two can't drift.
 pub(crate) const CREDENTIALS_FILE: &str = CLAUDE_CREDENTIALS_FILE;
 
-/// Resource caps a container launch carries when the user has set none. Shared
-/// by every runtime: the ceiling is a property of what an agent needs to build
-/// and test, not of who runs the container.
+/// Resource caps when the user has set none — a property of what an agent needs
+/// to build and test, so every runtime shares them.
 pub(crate) const DEFAULT_MEMORY: &str = "4g";
 pub(crate) const DEFAULT_CPUS: &str = "2";
 
-/// Subdirs of a claude config dir that Claude Code creates and writes *afresh
-/// every session* — the per-session env store (`mkdir session-env/<id>` at
-/// startup) and the shell-environment snapshot the Bash tool sources. The
-/// config dir is bind-mounted read-only (invariant 5), so a bare write here
-/// fails with `EROFS` and aborts the agent before it runs. Each gets an
-/// ephemeral **tmpfs** overlay instead: claude writes its own per-session
-/// scaffolding into throwaway container-local storage, nothing reaches the
-/// shared host config, and nothing persists across runs.
-///
-/// Deliberately narrow — only claude-regenerated, non-config, non-executable
-/// state belongs here. Everything else under the config dir stays read-only so
-/// a prompt-injected agent can't plant a host-executed `hook`/`plugin`/`skill`,
-/// a `settings.json` permission grant, a `CLAUDE.md` instruction, or a
-/// `projects/<cwd>/memory` entry a later session would trust (invariant 5).
-/// `projects/` in particular is left read-only on purpose: the RO mount already
-/// lets claude *read* config and memory, and its transcript writes are
-/// best-effort (a failed write logs and continues), so it needs no overlay —
-/// while making it writable would reopen exactly the injection surface this
-/// design closes.
-///
-/// Shared with seatbelt via [`CLAUDE_EPHEMERAL_RUNTIME_SUBDIRS`] (which
-/// grants the real dirs as writable islands) so the two engines can't drift.
+/// Subdirs Claude Code rewrites every session, which a bare write to the
+/// read-only config dir would fail with `EROFS`; each gets a throwaway tmpfs
+/// overlay instead. Deliberately narrow: everything else stays read-only so a
+/// prompt-injected agent can't plant a host-executed hook/plugin/skill, a
+/// `settings.json` grant, or a memory entry a later session would trust
+/// (invariant 5). Shared with seatbelt via [`CLAUDE_EPHEMERAL_RUNTIME_SUBDIRS`].
 const EPHEMERAL_RUNTIME_SUBDIRS: &[&str] = CLAUDE_EPHEMERAL_RUNTIME_SUBDIRS;
 
-/// Claude's session-transcript subdir within a config dir (`<config-dir>/
-/// projects/<slug>/<uuid>.jsonl`). Unlike [`EPHEMERAL_RUNTIME_SUBDIRS`], this
-/// one is bind-mounted to a *persistent* per-agent host dir (not tmpfs) so
-/// `--resume` survives container recreation — see [`push_claude_config_mount`].
-/// Shared with seatbelt via [`CLAUDE_PROJECTS_SUBDIR`] so the two
-/// engines can't drift.
+/// Claude's session-transcript subdir. Unlike [`EPHEMERAL_RUNTIME_SUBDIRS`] it
+/// is bound to a *persistent* per-agent host dir so `--resume` survives
+/// container recreation — see [`push_claude_config_mount`]. Shared with seatbelt
+/// via [`CLAUDE_PROJECTS_SUBDIR`].
 const PROJECTS_SUBDIR: &str = CLAUDE_PROJECTS_SUBDIR;
 
-/// The provider-specific config/data mounts and config-dir env a launch needs —
-/// one variant per supported provider. Replaces the additive per-provider field
-/// clusters `RunSpec` used to carry (claude_config_dir, codex_config_dir, …),
-/// which grew unwieldy at four providers with three-quarters of them inert on any
-/// given launch. Each variant holds exactly its own provider's data and
-/// [`run_args`] matches once on the whole thing. Claude's read-only-except-
-/// carve-outs treatment is unique; the other three are read-write binds at
-/// identical host paths, differing only in which dirs they mount and which env
-/// var (if any) they forward.
+/// The provider-specific config/data mounts and config-dir env a launch needs.
+/// Exactly one variant is populated per launch and [`run_args`] matches once on
+/// the whole thing.
 pub(crate) enum ProviderMounts<'a> {
     /// Claude: `~/.claude` (and any non-default `CLAUDE_CONFIG_DIR`) bind-mounted
-    /// **read-only** except a writable `.credentials.json` overlay and the
-    /// per-agent `projects/` transcript bind (invariant 5); see
-    /// [`push_claude_config_mount`].
+    /// **read-only** but for the carve-outs in [`push_claude_config_mount`]
+    /// (invariant 5).
     Claude {
         /// Non-default `CLAUDE_CONFIG_DIR`, mounted + forwarded alongside
         /// `~/.claude`. `None` when unset or resolving to the default.
         config_dir: Option<&'a Path>,
         /// Whether `~/.claude/.credentials.json` exists — gates its RW overlay.
         credentials_rw: bool,
-        /// Same, for the non-default `CLAUDE_CONFIG_DIR` (meaningful only when
-        /// `config_dir` is `Some`).
+        /// Same, for the non-default `CLAUDE_CONFIG_DIR`.
         config_dir_credentials_rw: bool,
-        /// Per-agent host dir (under `writable_root`) bound read-write over each
-        /// config dir's `projects/` so the session transcript survives container
-        /// recreation while the shared `~/.claude` stays read-only.
+        /// Per-agent host dir bound read-write over each config dir's
+        /// `projects/`, so transcripts survive container recreation while the
+        /// shared `~/.claude` stays read-only.
         projects_src: &'a Path,
     },
     /// Codex: `$CODEX_HOME`/`~/.codex` bind-mounted **read-write** at its host
@@ -93,12 +67,9 @@ pub(crate) enum ProviderMounts<'a> {
         /// Forward `CODEX_HOME` (a non-default `$CODEX_HOME` only).
         forward_home: bool,
     },
-    /// OpenCode: its data dir (`$XDG_DATA_HOME/opencode` else
-    /// `~/.local/share/opencode`) bind-mounted **read-write** — it carries the
-    /// accounts DB / `auth.json` and the session storage the host transcript
-    /// reader tails — plus its config dir (`$XDG_CONFIG_HOME/opencode` else
-    /// `~/.config/opencode`) when it exists (custom providers + plugin installs,
-    /// which opencode writes → also RW).
+    /// OpenCode: its data dir (accounts DB / `auth.json` / session storage the
+    /// host transcript reader tails) plus its config dir when it exists, both
+    /// bind-mounted **read-write**.
     Opencode {
         data_dir: &'a Path,
         config_dir: Option<&'a Path>,
@@ -106,19 +77,16 @@ pub(crate) enum ProviderMounts<'a> {
         forward_xdg_data_home: bool,
         forward_xdg_config_home: bool,
     },
-    /// Pi: `~/.pi` bind-mounted **read-write** — it holds `agent/auth.json`,
-    /// `agent/settings.json`, and the `agent/sessions/` transcripts the host
-    /// reader tails at the identical path.
+    /// Pi: `~/.pi` bind-mounted **read-write** — auth, settings, and the
+    /// `agent/sessions/` transcripts the host reader tails at the identical path.
     Pi { data_dir: &'a Path },
-    /// Cursor: `~/.cursor` bind-mounted **read-write** — it holds the
-    /// `projects/<slug>/agent-transcripts/` session logs the host reader tails at
-    /// the identical path. Carries no credential (cursor's login token is
+    /// Cursor: `~/.cursor` bind-mounted **read-write** for the session logs the
+    /// host reader tails. Carries no credential (the login token is
     /// keychain-bound); auth is the forwarded `CURSOR_API_KEY` only.
     Cursor { data_dir: &'a Path },
 }
 
-/// Everything [`run_args`] needs, bundled so the builder is pure and the argv
-/// shape unit-testable without a daemon.
+/// Everything [`run_args`] needs, bundled so the builder stays pure.
 pub(crate) struct RunSpec<'a> {
     pub interactive: bool,
     pub name: &'a str,
@@ -127,31 +95,28 @@ pub(crate) struct RunSpec<'a> {
     pub rpc_dir: &'a Path,
     pub home: &'a Path,
     pub cwd: &'a Path,
-    /// A workflow step agent's blackboard directory, bind-mounted read-write at
-    /// its identical host path and forwarded as `WF_BLACKBOARD`. `None` for
-    /// ordinary agents.
+    /// A workflow step agent's blackboard, bound read-write at its identical
+    /// host path and forwarded as `WF_BLACKBOARD`. `None` for ordinary agents.
     pub blackboard: Option<&'a Path>,
     /// The launching provider's config/data mounts + config-dir env forwards.
     pub mounts: ProviderMounts<'a>,
-    /// Object stores borrowed via git alternates (a `--shared` clone),
-    /// bind-mounted read-only at their identical host paths. Empty for a
-    /// worktree or an old full-copy clone.
+    /// Object stores borrowed via git alternates, bound read-only at their
+    /// identical host paths. Empty for a worktree or a full-copy clone.
     pub borrowed_object_stores: &'a [PathBuf],
     pub memory: &'a str,
     pub cpus: &'a str,
     pub image: &'a str,
     pub agent_bin: &'a str,
-    /// Auth var *names* the chain resolved ([`resolve`]), each forwarded
-    /// with a bare `-e NAME` so its value (set on the docker CLI process env)
-    /// never appears in argv. Only the resolved set is forwarded: an ambient
-    /// credential the chain didn't pick must not reach the container and
-    /// override the resolved login.
+    /// Auth var *names* the chain resolved ([`resolve`]), forwarded as bare
+    /// `-e NAME` so values never appear in argv (invariant 3). Only the resolved
+    /// set: an ambient credential the chain didn't pick must not reach the
+    /// container and override the resolved login.
     ///
     /// [`resolve`]: crate::sandbox::container::auth::resolve
     pub auth_vars: &'a [&'a str],
 }
 
-/// The `docker run` argv (everything after the docker binary), ending with
+/// The `run` argv (everything after the runtime binary), ending with
 /// `<image> <agent_bin>` so the caller can append agent CLI args — the
 /// `prefix_args` contract of [`SandboxEngine::launch_agent`].
 ///
@@ -169,35 +134,28 @@ pub(crate) fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
     args.push("--label".into());
     args.push(labels::agent_id_label(spec.agent_id));
     // Mounts at identical host paths (invariant 1). Exactly these — nothing
-    // else from the host enters the container. The workspace and RPC mailbox
-    // are read-write; the claude config dir(s) are read-only except their
-    // `.credentials.json` (invariant 5) — see [`push_claude_config_mount`].
+    // else from the host enters the container.
     for path in [spec.writable_root, spec.rpc_dir] {
         let path = path.to_string_lossy();
         args.push("-v".into());
         args.push(format!("{path}:{path}"));
     }
-    // A workflow step agent's blackboard, bind-mounted read-write at its
-    // identical host path (invariant 1) so `$WF_BLACKBOARD` resolves the same
-    // in-container as on the host — the same shape as the RPC mailbox mount.
+    // At its identical host path so `$WF_BLACKBOARD` resolves the same
+    // in-container as on the host (invariant 1).
     if let Some(board) = spec.blackboard {
         push_rw_bind(&mut args, board);
     }
-    // Object stores borrowed by a --shared clone, mounted read-only at their
-    // identical host path so the alternates file resolves in-container with no
-    // rewriting. RO keeps invariant 2: borrowed history is readable, but the
-    // source store (and, since we mount only `objects`, never `.git/hooks` or
-    // config) can't be mutated from inside the container. The list already
-    // includes any transitively-chained stores (see `borrowed_object_stores`).
+    // Identical host path so the alternates file resolves in-container with no
+    // rewriting; read-only so borrowed history is readable but the source store
+    // can't be mutated from inside the container (invariant 2). Only `objects`,
+    // never `.git/hooks` or config.
     for store in spec.borrowed_object_stores {
         let path = store.to_string_lossy();
         args.push("-v".into());
         args.push(format!("{path}:{path}:ro"));
     }
     // Provider config-dir mount(s), layered after the workspace/mailbox/object
-    // stores. Claude gets the read-only-except-carve-outs treatment; the other
-    // three get read-write binds at their identical host paths (see the
-    // `ProviderMounts` variant docs).
+    // stores.
     match &spec.mounts {
         ProviderMounts::Claude {
             config_dir,
@@ -231,9 +189,8 @@ pub(crate) fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
     }
     args.push("-w".into());
     args.push(spec.cwd.to_string_lossy().into_owned());
-    // Bare `-e NAME` forwards from the docker CLI's own environment without
-    // the value ever appearing in argv (invariant 3 for the auth vars). Auth
-    // vars come from `spec.auth_vars` — the set the chain actually resolved.
+    // Bare `-e NAME` forwards from the runtime CLI's own environment, so no
+    // value appears in argv (invariant 3).
     let mut forwarded: Vec<&str> = vec!["HOME", "FLETCH_RPC_DIR", "TERM", "COLORTERM"];
     if spec.blackboard.is_some() {
         forwarded.push(crate::workflow::blackboard::WF_BLACKBOARD_ENV);
@@ -262,8 +219,7 @@ pub(crate) fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
             }
         }
         ProviderMounts::Pi { .. } => {}
-        // Cursor forwards no config-dir env; its sole auth var (CURSOR_API_KEY)
-        // rides `spec.auth_vars` like every other resolved credential.
+        // No config-dir env; CURSOR_API_KEY rides `spec.auth_vars`.
         ProviderMounts::Cursor { .. } => {}
     }
     forwarded.extend(spec.auth_vars.iter().copied());
@@ -280,14 +236,11 @@ pub(crate) fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
     args
 }
 
-/// Every *host* path [`run_args`] turns into a bind mount, in argv order.
-/// Deliberately excludes the tmpfs overlays (no source) and the `projects/`
-/// target (its source is `projects_src`, which is listed).
-///
-/// Lives next to [`run_args`] so the two can't drift: a runtime that has to
-/// vet mount sources before launching (Podman's machine shares only configured
-/// host dirs — see `podman::machine`) must see exactly what will be bound, and
-/// a mount added above without an entry here would go unvetted.
+/// Every *host* path [`run_args`] turns into a bind mount, in argv order —
+/// excluding the tmpfs overlays (no source) and the `projects/` target (its
+/// source, `projects_src`, is listed). A runtime that vets mount sources before
+/// launching (see `podman::machine`) must see exactly what will be bound, so a
+/// mount added to [`run_args`] without an entry here would go unvetted.
 pub(crate) fn mount_sources(spec: &RunSpec<'_>) -> Vec<PathBuf> {
     let mut out: Vec<PathBuf> = vec![spec.writable_root.into(), spec.rpc_dir.into()];
     if let Some(board) = spec.blackboard {
@@ -325,26 +278,19 @@ pub(crate) fn mount_sources(spec: &RunSpec<'_>) -> Vec<PathBuf> {
     out
 }
 
-/// Bind-mount `dir` **read-write** at its identical host path (no `:ro`). The
-/// shape codex/opencode/pi share: the CLI refreshes its auth and writes session
-/// state in place, and writing at the host path is what keeps the host-side
-/// transcript reader working (invariant 1). Unlike claude's config mount there
-/// are no read-only carve-outs — the user accepted a full read-write config dir
-/// for these self-authenticating CLIs (same call as codex's `~/.codex`).
+/// Bind-mount `dir` **read-write** at its identical host path (invariant 1), so
+/// the CLI's in-place auth refresh and session writes stay visible to the
+/// host-side transcript reader.
 fn push_rw_bind(args: &mut Vec<String>, dir: &Path) {
     let path = dir.to_string_lossy();
     args.push("-v".into());
     args.push(format!("{path}:{path}"));
 }
 
-/// Create a claude config dir and its overlay mountpoints before it's handed to
-/// `-v`. The dir itself must exist or Docker would materialize it root-owned;
-/// each overlay target must exist *inside* it too, because the overlay
-/// ([`push_claude_config_mount`]) mounts onto that subpath and the RO parent
-/// bind can't grow a fresh mountpoint at run time. The overlays are the
-/// [`EPHEMERAL_RUNTIME_SUBDIRS`] tmpfs targets plus `projects/` (the read-write
-/// per-agent transcript bind). Creating empty dirs is harmless — the overlay
-/// shadows each, so nothing the agent writes there lands on this shared dir.
+/// Create a claude config dir and its overlay mountpoints before `-v` sees it:
+/// a missing source is materialized root-owned by the runtime, and each overlay
+/// target must already exist *inside* the dir because the read-only parent bind
+/// can't grow a fresh mountpoint at run time.
 pub(crate) fn prepare_config_mount_dir(dir: &Path) -> Result<()> {
     let overlays = EPHEMERAL_RUNTIME_SUBDIRS
         .iter()
@@ -361,29 +307,20 @@ pub(crate) fn prepare_config_mount_dir(dir: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Bind-mount a claude config dir **read-only**, then layer the writable
-/// exceptions on top. The dir is shared host state whose `settings.json` can
-/// define hooks Claude Code executes on the host, so a container agent must not
-/// be able to write it (invariant 5); these are the sole exceptions, and each is
-/// deliberately either the host credential file, throwaway container-local
-/// storage, or a per-agent host dir that never touches the shared config:
+/// Bind-mount a claude config dir **read-only**, then layer the sole writable
+/// exceptions on top (order matters — the runtime layers later `-v`s over
+/// earlier ones). The dir is shared host state whose `settings.json` can define
+/// hooks Claude Code runs on the *host*, so a container agent must not be able
+/// to write it (invariant 5). The exceptions:
 ///
-/// - `.credentials.json` (when `credentials_rw`) — remounted read-write so
-///   claude's OAuth token refresh persists to the host. Skipped when the file
-///   is absent (a bare `-v` on a missing source would have Docker create a
-///   root-owned dir there).
-/// - each [`EPHEMERAL_RUNTIME_SUBDIRS`] entry (`session-env`, `shell-snapshots`)
-///   — an ephemeral tmpfs so claude's per-session scaffolding can be written
-///   without a bare write to the RO dir failing with `EROFS`. Needs no source.
-/// - `projects/` — `projects_src` (a per-agent host dir under `writable_root`)
-///   bound read-write over it, so claude's session transcript persists across
-///   container recreation (`--resume` after an app relaunch) while the shared
-///   `~/.claude/projects` — other agents' transcripts, global memory — stays
-///   unreadable and unwritable. This is a *non-identical-path* bind: it departs
-///   from invariant 1's identical-host-path rule, which `projects/` doesn't need
-///   since claude references it only through its config dir.
-///
-/// Every overlay is pushed *after* the RO dir mount so Docker layers it on top.
+/// - `.credentials.json` (only when `credentials_rw`, since a bare `-v` on a
+///   missing source is materialized root-owned) — so OAuth refresh persists.
+/// - each [`EPHEMERAL_RUNTIME_SUBDIRS`] entry — throwaway tmpfs, no host source.
+/// - `projects/` — backed by the per-agent `projects_src` so `--resume` survives
+///   container recreation while the shared `~/.claude/projects` (other agents'
+///   transcripts, global memory) stays unreachable. The one bind that departs
+///   from invariant 1's identical-host-path rule; claude reaches it only through
+///   its config dir, so it doesn't need one.
 fn push_claude_config_mount(
     args: &mut Vec<String>,
     dir: &Path,
@@ -416,10 +353,8 @@ fn push_claude_config_mount(
 mod tests {
     use super::*;
 
-    /// Every host path `run_args` binds must be vetted by [`mount_sources`] —
-    /// Podman refuses a launch whose sources aren't shared by its machine, and a
-    /// `-v` with no entry here would be bound unvetted and arrive empty.
-    /// Asserted per provider shape, since each contributes its own mounts.
+    /// Podman refuses a launch whose sources its machine doesn't share, so an
+    /// unvetted `-v` would be bound and arrive empty.
     #[test]
     fn every_bind_source_is_covered_by_mount_sources() {
         let root = Path::new("/tmp/fletch-run-args/work");

--- a/src-tauri/src/sandbox/container/run_args.rs
+++ b/src-tauri/src/sandbox/container/run_args.rs
@@ -411,3 +411,93 @@ fn push_claude_config_mount(
         args.push(dir.join(sub).to_string_lossy().into_owned());
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every host path `run_args` binds must be vetted by [`mount_sources`] —
+    /// Podman refuses a launch whose sources aren't shared by its machine, and a
+    /// `-v` with no entry here would be bound unvetted and arrive empty.
+    /// Asserted per provider shape, since each contributes its own mounts.
+    #[test]
+    fn every_bind_source_is_covered_by_mount_sources() {
+        let root = Path::new("/tmp/fletch-run-args/work");
+        let rpc = Path::new("/tmp/fletch-run-args/rpc");
+        let home = Path::new("/tmp/fletch-run-args/home");
+        let board = Path::new("/tmp/fletch-run-args/board");
+        let alt = Path::new("/tmp/fletch-run-args/alt");
+        let stores = vec![
+            PathBuf::from("/tmp/fletch-run-args/store-a/objects"),
+            PathBuf::from("/tmp/fletch-run-args/store-b/objects"),
+        ];
+        let projects = root.join("claude-projects");
+
+        let shapes = [
+            ProviderMounts::Claude {
+                config_dir: Some(alt),
+                credentials_rw: true,
+                config_dir_credentials_rw: true,
+                projects_src: &projects,
+            },
+            ProviderMounts::Codex {
+                config_dir: alt,
+                forward_home: true,
+            },
+            ProviderMounts::Opencode {
+                data_dir: alt,
+                config_dir: Some(home),
+                forward_xdg_data_home: true,
+                forward_xdg_config_home: true,
+            },
+            ProviderMounts::Pi { data_dir: alt },
+            ProviderMounts::Cursor { data_dir: alt },
+        ];
+
+        for mounts in shapes {
+            let spec = RunSpec {
+                interactive: true,
+                name: "fletch-agent-test",
+                agent_id: "agent-1",
+                writable_root: root,
+                rpc_dir: rpc,
+                home,
+                cwd: root,
+                blackboard: Some(board),
+                mounts,
+                borrowed_object_stores: &stores,
+                memory: DEFAULT_MEMORY,
+                cpus: DEFAULT_CPUS,
+                image: "fletch-agent:cafe00000000",
+                agent_bin: "claude",
+                auth_vars: &["ANTHROPIC_API_KEY"],
+            };
+            let sources = mount_sources(&spec);
+            let args = run_args(&spec);
+
+            let mut binds = 0;
+            for (flag, value) in args.iter().zip(args.iter().skip(1)) {
+                match flag.as_str() {
+                    "-v" => {
+                        binds += 1;
+                        // `src:dst[:ro]` — the source is the leading segment.
+                        let src = Path::new(value.split(':').next().unwrap());
+                        assert!(
+                            sources.iter().any(|s| src == s || src.starts_with(s)),
+                            "unvetted bind source {src:?} (vetted: {sources:?})",
+                        );
+                    }
+                    "--tmpfs" => assert!(
+                        !sources.iter().any(|s| s == Path::new(value)),
+                        "a tmpfs overlay has no host source: {value}",
+                    ),
+                    _ => {}
+                }
+            }
+            assert!(
+                binds >= 3,
+                "expected the workspace/rpc/config binds at least"
+            );
+        }
+    }
+}

--- a/src-tauri/src/sandbox/container/sweep.rs
+++ b/src-tauri/src/sandbox/container/sweep.rs
@@ -1,33 +1,21 @@
 //! The startup orphan sweep's retry schedule, shared by every container
 //! runtime.
 //!
-//! A single probe at startup loses a race it usually can't win: a container
-//! runtime takes tens of seconds after login to answer (Docker Desktop's boot,
-//! a `podman machine` starting), the probe times out at 2s, and a Fletch
-//! launched from the dock or as a login item therefore reports "down" and
-//! sweeps nothing. The sweeps are the only thing that ever reclaims a dead
-//! instance's containers, so a user who loses that race every launch
-//! accumulates them forever. Retrying costs an idle thread and one probe
-//! round-trip per [`SWEEP_RETRY_INTERVAL`], bounded by [`SWEEP_RETRY_BUDGET`].
+//! A single 2s probe at startup loses the race against a runtime that takes
+//! tens of seconds after login to answer, and the sweeps are the only thing
+//! that ever reclaims a dead instance's containers — so the probe retries on
+//! [`SWEEP_RETRY_INTERVAL`], bounded by [`SWEEP_RETRY_BUDGET`].
 
 use std::time::Duration;
 
-/// How long the startup sweep waits between probes while the runtime is still
-/// coming up. Comfortably above each probe's 5s cache TTL, so every poll is one
-/// genuine round-trip rather than a re-read of the same cached answer, and
-/// short enough that the sweeps start within half a minute of the runtime
-/// finishing its boot.
+/// Wait between probes while the runtime comes up. Must stay above each probe's
+/// 5s cache TTL, or a poll re-reads the same cached answer.
 pub(crate) const SWEEP_RETRY_INTERVAL: Duration = Duration::from_secs(30);
 
-/// How long the startup sweep keeps waiting for a down runtime before giving
-/// up. Ten minutes covers a cold login — Docker Desktop's own 20-60s (or a
-/// `podman machine` boot) plus a slow disk, a VPN prompt, or a user who starts
-/// it by hand a few minutes in — while staying strictly bounded: a machine
-/// where the runtime simply never runs must not keep a thread ticking for the
-/// life of the app. The budget gates when we stop *scheduling* waits, so the
-/// final probe can land up to one [`SWEEP_RETRY_INTERVAL`] past it. Giving up
-/// is cheap: the next app start sweeps again, so the cost of a miss is one
-/// run's worth of unreclaimed containers, not a permanent leak.
+/// How long the startup sweep waits on a down runtime before giving up — long
+/// enough for a cold login, bounded so a machine without the runtime never
+/// keeps a thread ticking. It gates when waits stop being *scheduled*, so the
+/// final probe can land one [`SWEEP_RETRY_INTERVAL`] past it.
 pub(crate) const SWEEP_RETRY_BUDGET: Duration = Duration::from_secs(10 * 60);
 
 /// What the startup sweep thread does after one probe — see [`sweep_step`].
@@ -42,14 +30,9 @@ pub(crate) enum SweepStep {
     Stop,
 }
 
-/// The retry schedule as a pure decision over the two questions every runtime
-/// probe answers: is it usable now, and is it even installed.
-///
-/// A missing binary stops immediately rather than retrying: a runtime being
-/// *installed* mid-run is rare, the next app start covers it, and each retry
-/// would re-pay the binary-resolution stat walk for a state that essentially
-/// never flips. "Installed but down" is the state we expect to flip — that's
-/// the whole point of the retry.
+/// The retry schedule, as a pure decision over "usable now?" and "installed at
+/// all?". A missing binary stops immediately — only "installed but down" is a
+/// state worth waiting on.
 pub(crate) fn sweep_step(usable: bool, installed: bool, elapsed: Duration) -> SweepStep {
     if usable {
         SweepStep::Sweep

--- a/src-tauri/src/sandbox/container/util.rs
+++ b/src-tauri/src/sandbox/container/util.rs
@@ -1,15 +1,12 @@
-//! Container naming and the runtime-reserved exit-code messages: the pieces of
-//! the launch/teardown path that carry no runtime coupling at all.
-//!
-//! Liveness lookups stay per-runtime — they shell out — and live next to their
-//! runtime's CLI wrapper (`docker::engine::util`, `podman::engine::util`).
+//! Container naming and the runtime-reserved exit-code messages — the pieces of
+//! the launch/teardown path with no runtime coupling. Liveness lookups shell
+//! out, so they stay next to their runtime's CLI wrapper.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 
-/// `fletch-<agent_id>-<8-char nonce>`. The nonce keeps respawns (view switch,
-/// binary swap) from colliding with a predecessor container of the same agent
-/// that `--rm` hasn't finished reaping yet; hashing in the pid keeps two
-/// side-by-side Fletch instances apart even for a same-named agent.
+/// `fletch-<agent_id>-<8-char nonce>`. The nonce keeps a respawn from colliding
+/// with a predecessor `--rm` hasn't reaped yet; the pid in it keeps two
+/// side-by-side Fletch instances apart for a same-named agent.
 pub(crate) fn container_name(agent_id: &str) -> String {
     // Container names must match [a-zA-Z0-9][a-zA-Z0-9_.-]* under both docker
     // and podman; the `fletch-` prefix fixes the first char, sanitize the rest.
@@ -26,8 +23,8 @@ pub(crate) fn container_name(agent_id: &str) -> String {
     format!("fletch-{sanitized}-{}", nonce())
 }
 
-/// 8 hex chars from (pid, monotonic counter): unique within a host across
-/// concurrently running instances for the lifetime of any one container.
+/// 8 hex chars from (pid, monotonic counter): unique across side-by-side Fletch
+/// instances for the lifetime of any one container.
 fn nonce() -> String {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     use std::hash::{Hash, Hasher};
@@ -44,7 +41,7 @@ pub(crate) fn non_blank(value: Option<&str>) -> Option<&str> {
     value.map(str::trim).filter(|v| !v.is_empty())
 }
 
-/// The runtime-specific wording [`describe_exit_code`] renders around. One
+/// The runtime-specific wording [`describe_exit_code`] renders around — one
 /// value per runtime, declared next to that runtime's engine.
 pub(crate) struct ExitCopy {
     /// Display name of the runtime whose CLI reserved the code.
@@ -53,22 +50,16 @@ pub(crate) struct ExitCopy {
     pub error_source: &'static str,
     /// One check the user can act on when the runtime couldn't start.
     pub remedy: &'static str,
-    /// Settings key naming a user-supplied image, for runtimes that honor one.
-    /// `None` drops the custom-image clause: a runtime with no override must
-    /// not point the user at a setting it ignores.
+    /// Settings key naming a user-supplied image. `None` drops the
+    /// custom-image clause rather than name a setting the runtime ignores.
     pub image_setting: Option<&'static str>,
 }
 
 /// User-readable meanings for a container CLI's reserved exit codes; other
 /// codes are the contained agent's own and pass through unmapped. `run` relays
-/// the agent's own exit status, so an agent that starts fine and later exits
-/// 125/126/127 is indistinguishable from a launcher/image failure — the
-/// messages name the likely runtime-layer cause but flag the agent-exit
-/// possibility so they don't mislead when the container did launch.
-///
-/// Provider-neutral: the teardown plan carries only the container name, and the
-/// sandbox image varies per provider, so these speak of "the agent binary"
-/// rather than naming `claude`.
+/// the agent's exit status, so a contained agent exiting 125/126/127 is
+/// indistinguishable from a launcher failure — hence the hedge in every
+/// message. Wording is provider-neutral; the image varies per provider.
 pub(crate) fn describe_exit_code(code: i32, copy: &ExitCopy) -> Option<String> {
     let ExitCopy {
         runtime,
@@ -105,8 +96,6 @@ pub(crate) fn describe_exit_code(code: i32, copy: &ExitCopy) -> Option<String> {
 mod tests {
     use super::*;
 
-    /// A runtime with no image override must not mention one, and every message
-    /// must still hedge about the agent's own exit status.
     #[test]
     fn exit_copy_without_an_image_setting_omits_the_override_clause() {
         let copy = ExitCopy {

--- a/src-tauri/src/sandbox/container/version_guard.rs
+++ b/src-tauri/src/sandbox/container/version_guard.rs
@@ -13,12 +13,14 @@
 //! image present in one store says nothing about the other's.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use parking_lot::RwLock;
 
 /// Writes the guard map back to its settings row (installed by
-/// [`VersionGuard::init`]).
-type Persist = Box<dyn Fn(&HashMap<String, String>) + Send + Sync>;
+/// [`VersionGuard::init`]). An `Arc` so [`VersionGuard::record`] can clone it out
+/// and call it with the lock released.
+type Persist = Arc<dyn Fn(&HashMap<String, String>) + Send + Sync>;
 
 /// provider id → `"host_version@image_tag"` last successfully rebuilt for, plus
 /// the write-back. One pair per provider suffices — any change to either side
@@ -49,7 +51,7 @@ impl VersionGuard {
     ) {
         *self.0.write() = Some(State {
             attempted,
-            persist: Some(Box::new(persist)),
+            persist: Some(Arc::new(persist)),
         });
     }
 
@@ -68,14 +70,19 @@ impl VersionGuard {
     /// success only — failures must retry on a later run, exactly like TTL
     /// rebuild failures.
     pub(crate) fn record(&self, provider_id: &str, pair: String) {
-        let mut guard = self.0.write();
-        let state = guard.get_or_insert_with(|| State {
-            attempted: HashMap::new(),
-            persist: None,
-        });
-        state.attempted.insert(provider_id.to_string(), pair);
-        if let Some(persist) = &state.persist {
-            persist(&state.attempted);
+        // The persister writes the DB; calling it under the lock would order
+        // guard-before-db and invite a deadlock. Snapshot, unlock, then persist.
+        let (snapshot, persist) = {
+            let mut guard = self.0.write();
+            let state = guard.get_or_insert_with(|| State {
+                attempted: HashMap::new(),
+                persist: None,
+            });
+            state.attempted.insert(provider_id.to_string(), pair);
+            (state.attempted.clone(), state.persist.clone())
+        };
+        if let Some(persist) = persist {
+            persist(&snapshot);
         }
     }
 }

--- a/src-tauri/src/sandbox/container/version_guard.rs
+++ b/src-tauri/src/sandbox/container/version_guard.rs
@@ -1,40 +1,34 @@
 //! The version-refresh loop guard: one per container runtime, sharing this
 //! implementation.
 //!
-//! The guard caps the version-parity rebuild trigger at one attempt per
-//! `host_version@image_tag` pairing *ever*, not one per app run. In the guarded
-//! case — a host CLI pinned away from the registry's latest, so the mismatch
-//! survives even a successful rebuild — an in-memory-only guard would decay into
-//! one full `--no-cache` rebuild on every app run.
+//! It caps the version-parity rebuild trigger at one attempt per
+//! `host_version@image_tag` pairing *ever* — a host CLI pinned away from the
+//! registry's latest keeps mismatching after a successful rebuild, so an
+//! in-memory-only guard would mean a `--no-cache` rebuild every app run.
 //!
-//! Each runtime owns a `static VersionGuard` and its own settings key (docker's
-//! `docker_version_refresh_guard`, podman's `podman_version_refresh_guard`), so
-//! the two runtimes' image stores never talk each other out of a rebuild: an
-//! image present in one store says nothing about the other's.
+//! Each runtime owns its own `static` and settings key: an image present in one
+//! store says nothing about the other's.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
 
-/// Writes the guard map back to its settings row (installed by
-/// [`VersionGuard::init`]). An `Arc` so [`VersionGuard::record`] can clone it out
-/// and call it with the lock released.
+/// Writes the guard map back to its settings row. An `Arc` so
+/// [`VersionGuard::record`] can clone it out and call it with the lock released.
 type Persist = Arc<dyn Fn(&HashMap<String, String>) + Send + Sync>;
 
 /// provider id → `"host_version@image_tag"` last successfully rebuilt for, plus
-/// the write-back. One pair per provider suffices — any change to either side
-/// legitimately warrants one fresh attempt.
+/// the write-back. One pair per provider: a change to either side warrants one
+/// fresh attempt.
 struct State {
     attempted: HashMap<String, String>,
     persist: Option<Persist>,
 }
 
 /// A runtime's loop guard, mirrored in-process because the image code that
-/// consults it runs on spawn paths and background threads with no DB handle.
-/// Seeded and wired to a persister at startup by [`init`](Self::init); until
-/// then (tests, headless) it's empty and unpersisted, and recording still guards
-/// the current process run.
+/// consults it runs on threads with no DB handle. Before
+/// [`init`](Self::init) it is empty and unpersisted, but still guards this run.
 pub(crate) struct VersionGuard(RwLock<Option<State>>);
 
 impl VersionGuard {
@@ -55,9 +49,9 @@ impl VersionGuard {
         });
     }
 
-    /// Whether a version-mismatch rebuild already succeeded for exactly this
-    /// `pair` (`"host_version@image_tag"`). If so the trigger is inert: the
-    /// mismatch survived a rebuild, so it isn't rebuildable-away (pinned host).
+    /// Whether a rebuild already succeeded for exactly this `pair`. If so the
+    /// trigger is inert — the mismatch survived a rebuild, so it isn't
+    /// rebuildable away.
     pub(crate) fn attempted(&self, provider_id: &str, pair: &str) -> bool {
         self.0
             .read()
@@ -65,10 +59,8 @@ impl VersionGuard {
             .is_some_and(|g| g.attempted.get(provider_id).map(String::as_str) == Some(pair))
     }
 
-    /// Record (and persist, when wired) that a version-mismatch rebuild
-    /// succeeded for `pair`. Called from the background rebuild thread on
-    /// success only — failures must retry on a later run, exactly like TTL
-    /// rebuild failures.
+    /// Record (and persist, when wired) that a rebuild succeeded for `pair`.
+    /// Success only — a failure must retry on a later run.
     pub(crate) fn record(&self, provider_id: &str, pair: String) {
         // The persister writes the DB; calling it under the lock would order
         // guard-before-db and invite a deadlock. Snapshot, unlock, then persist.

--- a/src-tauri/src/sandbox/container/version_guard.rs
+++ b/src-tauri/src/sandbox/container/version_guard.rs
@@ -12,7 +12,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use parking_lot::RwLock;
+use parking_lot::{Mutex, RwLock};
 
 /// Writes the guard map back to its settings row. An `Arc` so
 /// [`VersionGuard::record`] can clone it out and call it with the lock released.
@@ -29,11 +29,20 @@ struct State {
 /// A runtime's loop guard, mirrored in-process because the image code that
 /// consults it runs on threads with no DB handle. Before
 /// [`init`](Self::init) it is empty and unpersisted, but still guards this run.
-pub(crate) struct VersionGuard(RwLock<Option<State>>);
+pub(crate) struct VersionGuard {
+    state: RwLock<Option<State>>,
+    /// Orders snapshot+persist pairs, so a slower [`record`](Self::record) can't
+    /// write an older snapshot over a newer row. Never held with `state` locked
+    /// for writing, and the DB call never runs under `state` at all.
+    persist_order: Mutex<()>,
+}
 
 impl VersionGuard {
     pub(crate) const fn new() -> Self {
-        Self(RwLock::new(None))
+        Self {
+            state: RwLock::new(None),
+            persist_order: Mutex::new(()),
+        }
     }
 
     /// Install the guard state: `attempted` as loaded from the runtime's
@@ -43,7 +52,7 @@ impl VersionGuard {
         attempted: HashMap<String, String>,
         persist: impl Fn(&HashMap<String, String>) + Send + Sync + 'static,
     ) {
-        *self.0.write() = Some(State {
+        *self.state.write() = Some(State {
             attempted,
             persist: Some(Arc::new(persist)),
         });
@@ -53,7 +62,7 @@ impl VersionGuard {
     /// trigger is inert — the mismatch survived a rebuild, so it isn't
     /// rebuildable away.
     pub(crate) fn attempted(&self, provider_id: &str, pair: &str) -> bool {
-        self.0
+        self.state
             .read()
             .as_ref()
             .is_some_and(|g| g.attempted.get(provider_id).map(String::as_str) == Some(pair))
@@ -62,19 +71,55 @@ impl VersionGuard {
     /// Record (and persist, when wired) that a rebuild succeeded for `pair`.
     /// Success only — a failure must retry on a later run.
     pub(crate) fn record(&self, provider_id: &str, pair: String) {
-        // The persister writes the DB; calling it under the lock would order
-        // guard-before-db and invite a deadlock. Snapshot, unlock, then persist.
-        let (snapshot, persist) = {
-            let mut guard = self.0.write();
+        {
+            let mut guard = self.state.write();
             let state = guard.get_or_insert_with(|| State {
                 attempted: HashMap::new(),
                 persist: None,
             });
             state.attempted.insert(provider_id.to_string(), pair);
+        }
+        // Snapshot under `persist_order` (not the write lock above): persists
+        // are serialized AND each snapshots after every previously persisted
+        // insert, so a concurrent record can't write an older map over a newer
+        // row. The DB call itself stays outside `state` — persisting under it
+        // would order guard-before-db and invite a deadlock.
+        let _order = self.persist_order.lock();
+        let (snapshot, persist) = {
+            let guard = self.state.read();
+            let Some(state) = guard.as_ref() else { return };
             (state.attempted.clone(), state.persist.clone())
         };
         if let Some(persist) = persist {
             persist(&snapshot);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two concurrent records must never leave the persisted row missing one of
+    /// them: the last persist to run snapshots after every previously persisted
+    /// insert, so it always carries both entries.
+    #[test]
+    fn concurrent_records_never_persist_a_regressed_row() {
+        let guard = VersionGuard::new();
+        let persisted: Arc<Mutex<Vec<HashMap<String, String>>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = persisted.clone();
+        guard.init(HashMap::new(), move |map| sink.lock().push(map.clone()));
+
+        std::thread::scope(|s| {
+            s.spawn(|| guard.record("claude", "v1@aaaaaaaaaaaa".into()));
+            s.spawn(|| guard.record("codex", "v2@bbbbbbbbbbbb".into()));
+        });
+
+        let persisted = persisted.lock();
+        let last = persisted.last().expect("both records persist");
+        assert!(
+            last.contains_key("claude") && last.contains_key("codex"),
+            "last persisted row regressed: {last:?}"
+        );
     }
 }

--- a/src-tauri/src/sandbox/docker/cleanup.rs
+++ b/src-tauri/src/sandbox/docker/cleanup.rs
@@ -222,8 +222,20 @@ pub fn sweep_stale_images() -> Result<usize> {
     for image_ref in &refs {
         // One rmi per image (not batched): a single in-use image must not
         // taint the exit status the others report. No `-f` — an image backing
-        // a running container stays, by design.
-        let out = cli::run_docker(&["rmi", image_ref], REMOVE_TIMEOUT)?;
+        // a running container stays, by design. A transport failure is per-image
+        // too: it must not strand the candidates behind it.
+        let out = match cli::run_docker(&["rmi", image_ref], REMOVE_TIMEOUT) {
+            Ok(out) => out,
+            Err(e) => {
+                tracing::warn!(
+                    target: "fletch::docker",
+                    image = %image_ref,
+                    error = %e,
+                    "docker rmi could not run for this image; continuing the pass",
+                );
+                continue;
+            }
+        };
         if out.status.success() {
             removed += 1;
         } else {
@@ -335,6 +347,29 @@ mod tests {
             assert!(owned.contains(repo), "unknown legacy repo: {repo}");
             assert!(is_content_addressed_tag(tag), "malformed legacy tag: {tag}");
         }
+    }
+
+    /// The legacy arm at its real call site: the shipped [`LEGACY_TAGS`] and the
+    /// sets `sweep_stale_images` builds must actually select a pre-label image.
+    /// Nothing else exercises this arm — podman passes an empty list.
+    #[test]
+    fn the_shipped_legacy_list_selects_a_pre_label_image() {
+        let (repo, tag) = LEGACY_TAGS[0].split_once(':').unwrap();
+        let legacy = vec![ImageRow {
+            id: "aaa".into(),
+            repo: repo.into(),
+            tag: tag.into(),
+        }];
+        let refs = image_removal_refs(
+            &[],
+            &legacy,
+            &current_tags(),
+            &known_repos(),
+            RETIRED_REPOS,
+            LEGACY_TAGS,
+            None,
+        );
+        assert_eq!(refs, vec![LEGACY_TAGS[0].to_string()]);
     }
 
     /// Integration: a labeled image under a Fletch repo with a non-current tag

--- a/src-tauri/src/sandbox/docker/engine/mod.rs
+++ b/src-tauri/src/sandbox/docker/engine/mod.rs
@@ -143,8 +143,12 @@ impl DockerEngine {
         override_image: Option<&str>,
     ) -> Result<String> {
         let key = (provider, override_image.map(str::to_string));
-        let mut cache = self.resolved_image.lock().unwrap();
-        if let Some(tag) = cache.get(&key) {
+        // The lock is dropped before resolving: a build can take ten minutes,
+        // and holding it would serialize every other provider's cache-hit launch
+        // behind it. Two cold launches may then resolve the same key at once,
+        // which is safe — `BUILD_LOCK` plus the re-check under it make the
+        // second resolver a cheap no-op.
+        if let Some(tag) = self.resolved_image.lock().unwrap().get(&key) {
             return Ok(tag.clone());
         }
         // Skip the host probe entirely on the override path: the user's image
@@ -170,7 +174,7 @@ impl DockerEngine {
             &on_progress,
         )
         .map_err(|e| Error::Other(format!("preparing the Docker sandbox image failed: {e}")))?;
-        cache.insert(key, tag.clone());
+        self.resolved_image.lock().unwrap().insert(key, tag.clone());
         Ok(tag)
     }
 }

--- a/src-tauri/src/sandbox/docker/image.rs
+++ b/src-tauri/src/sandbox/docker/image.rs
@@ -348,11 +348,27 @@ enum RefreshReason {
     VersionMismatch { guard_pair: String },
 }
 
-/// Decide whether an existing image needs a background rebuild — TTL first,
-/// then host/container version parity — and kick it if so. Returns
-/// immediately either way. Freshness is never a launch concern: inspect
-/// failures, unparseable timestamps, missing versions, and rebuild failures
-/// all leave the existing image serving launches. Logged, never propagated.
+/// Kick the whole freshness decision onto a background thread and return: the
+/// decision itself costs an `image inspect` and, past it, a full container start
+/// for the in-image `--version` probe, neither of which a launch may wait on.
+///
+/// The thread owns its data — it outlives the borrows this call was given.
+fn refresh_in_background_if_needed(
+    provider: DockerProvider,
+    tag: &str,
+    host_cli_version: Option<&str>,
+) {
+    let tag = tag.to_string();
+    let host_cli_version = host_cli_version.map(str::to_string);
+    std::thread::spawn(move || refresh_if_needed(provider, tag, host_cli_version.as_deref()));
+}
+
+/// Decide whether an existing image needs a rebuild — TTL first, then
+/// host/container version parity — and run it if so. Already off the launch path
+/// (see [`refresh_in_background_if_needed`]). Freshness is never a launch
+/// concern: inspect failures, unparseable timestamps, missing versions, and
+/// rebuild failures all leave the existing image serving launches. Logged,
+/// never propagated.
 /// The rebuild is silent for the UI (log lines only): the build toast
 /// presents a blocking first-run build ("this can take a few minutes"),
 /// which is the wrong message for a refresh the user never waits on, and its
@@ -362,13 +378,14 @@ enum RefreshReason {
 /// just updated their host CLI expects container parity. It compares with
 /// plain inequality (no semver ordering) and is inert whenever a side is
 /// missing: no host CLI installed, or the container probe failed (the TTL
-/// still covers those). Cadence for both triggers is once per app run
-/// (`DockerEngine::resolve_image_cached` caches resolution).
-fn refresh_in_background_if_needed(
-    provider: DockerProvider,
-    tag: &str,
-    host_cli_version: Option<&str>,
-) {
+/// still covers those). Cadence for both triggers is once per app run:
+/// resolution is cached per (provider, override) (`DockerEngine::
+/// resolve_image_cached`), which still holds now that the cache lock is released
+/// across the resolve — two simultaneously *cold* launches of the same key could
+/// each land here, and the second's rebuild is serialized behind the first on
+/// [`BUILD_LOCK`].
+fn refresh_if_needed(provider: DockerProvider, tag: String, host_cli_version: Option<&str>) {
+    let tag = tag.as_str();
     // One inspect serves both triggers: build date for the TTL, image id to
     // key the container-version cache.
     let (image_id, created_raw) = match cli::run_docker(
@@ -398,7 +415,7 @@ fn refresh_in_background_if_needed(
                 created = %created_raw,
                 "agent image is older than IMAGE_MAX_AGE; rebuilding in the background",
             );
-            spawn_refresh_rebuild(provider, tag.to_string(), RefreshReason::Ttl);
+            run_refresh_rebuild(provider, tag, RefreshReason::Ttl);
             return;
         }
         Freshness::Unknown => {
@@ -433,19 +450,17 @@ fn refresh_in_background_if_needed(
         container = %container.as_deref().unwrap_or_default(),
         "host CLI version differs from container image; rebuilding in the background",
     );
-    spawn_refresh_rebuild(
-        provider,
-        tag.to_string(),
-        RefreshReason::VersionMismatch { guard_pair },
-    );
+    run_refresh_rebuild(provider, tag, RefreshReason::VersionMismatch { guard_pair });
 }
 
-/// Kick the background stale-while-revalidate rebuild shared by both refresh
-/// triggers: rebuild the same tag, then (on success) record the version
-/// trigger's loop guard, re-probe the fresh image's CLI version, and reap the
-/// just-untagged predecessor. On failure, warn and keep serving the old image.
-fn spawn_refresh_rebuild(provider: DockerProvider, tag: String, reason: RefreshReason) {
-    std::thread::spawn(move || match rebuild_image(provider, &tag) {
+/// The stale-while-revalidate rebuild shared by both refresh triggers: rebuild
+/// the same tag, then (on success) record the version trigger's loop guard,
+/// re-probe the fresh image's CLI version, and reap the just-untagged
+/// predecessor. On failure, warn and keep serving the old image.
+///
+/// Runs on [`refresh_in_background_if_needed`]'s thread, never a launch's.
+fn run_refresh_rebuild(provider: DockerProvider, tag: &str, reason: RefreshReason) {
+    match rebuild_image(provider, tag) {
         Ok(()) => {
             tracing::info!(target: "fletch::docker", tag, "agent image refreshed");
             if let RefreshReason::VersionMismatch { guard_pair } = reason {
@@ -454,7 +469,7 @@ fn spawn_refresh_rebuild(provider: DockerProvider, tag: String, reason: RefreshR
                 // mismatches (host pinned away from latest) must never loop.
                 super::engine::record_version_refresh(provider.id(), guard_pair);
             }
-            cache_image_version_post_build(provider, &tag);
+            cache_image_version_post_build(provider, tag);
             // Docker retagged atomically; the predecessor is now untagged.
             // Reap it (and anything else stale) right away.
             match super::cleanup::sweep_stale_images() {
@@ -477,7 +492,7 @@ fn spawn_refresh_rebuild(provider: DockerProvider, tag: String, reason: RefreshR
             error = %e,
             "background image refresh failed; keeping the existing image",
         ),
-    });
+    }
 }
 
 /// Rebuild `provider`'s image under the same `tag`, unconditionally (no

--- a/src-tauri/src/sandbox/guarantees.rs
+++ b/src-tauri/src/sandbox/guarantees.rs
@@ -117,16 +117,18 @@ impl Guarantee {
                 git_config_host_backstop!(),
             )),
             // Same mount model as Docker (`container::run_args`): identical-path
-            // binds, the checkout read-write. Rootless is worth stating because
-            // it is the difference a Podman user expects to matter — and worth
-            // bounding, because it does not matter here.
+            // binds, the checkout read-write. Rootlessness is worth stating
+            // because it is the difference a Podman user expects to matter — and
+            // worth bounding, because it does not matter here. Hedged: a machine
+            // can be rootful, and the conclusion is the same either way.
             (Self::WithheldGitConfig, Podman) => Coverage::Partial(concat!(
                 "the checkout is bind-mounted read-write, so an agent can still write its own \
                  .git/config — nested read-only binds would stop a direct write but not a \
                  rename, because a Podman bind mount follows the inode just as Docker's does, \
-                 where seatbelt's path rules do not. Podman running rootless narrows what a \
-                 container escape would own on the host, but it does not narrow this: the agent \
-                 is handed that checkout read-write by design. ",
+                 where seatbelt's path rules do not. Where Podman runs rootless it narrows what \
+                 a container escape would own on the host, but it does not narrow this — and a \
+                 rootful machine does not change it either: the agent is handed that checkout \
+                 read-write by design. ",
                 git_config_host_backstop!(),
             )),
 
@@ -285,6 +287,32 @@ mod tests {
             Guarantee::ConfinedReads.coverage(SandboxExec),
             Coverage::Unenforced(_)
         ));
+    }
+
+    /// Golden: Docker's isolation-panel copy for this claim, byte for byte. The
+    /// engine-independent half comes from a shared macro, so a Podman-side edit
+    /// to it would silently rewrite what a Docker user reads.
+    #[test]
+    fn docker_withheld_git_config_note_is_pinned() {
+        let Coverage::Partial(note) = Guarantee::WithheldGitConfig.coverage(EngineKind::Docker)
+        else {
+            panic!("Docker's coverage for this claim is Partial");
+        };
+        assert_eq!(
+            note,
+            "the checkout is bind-mounted read-write, so an agent can still write its own \
+             .git/config — nested read-only binds would stop a direct write but not a rename, \
+             because Docker mounts follow the inode where seatbelt's path rules do not. \
+             Instead host-side git refuses to run in a checkout whose config would execute a \
+             program (crate::git::hardening), which is engine-independent. It reads every scope \
+             the agent can write (local and worktree, via --show-scope), so a key smuggled into \
+             .git/config.worktree is caught too. That refusal covers every command that can \
+             trigger one: the git::cmd helper seam plus the read, pull and push/fetch paths that \
+             build a command directly. push/fetch run no filter or merge driver but do run the \
+             transport-executing keys core.sshCommand, core.gitProxy and \
+             remote.<name>.uploadpack/receivepack, which the -c overrides omit, so the refusal \
+             covers them there too",
+        );
     }
 
     /// The report is what the UI and a reviewer read, so pin its shape: one

--- a/src-tauri/src/sandbox/mod.rs
+++ b/src-tauri/src/sandbox/mod.rs
@@ -16,7 +16,10 @@ use crate::error::{Error, Result};
 pub use docker::{availability as docker_availability, DockerAvailability};
 pub use engine::{AgentLaunchCtx, EngineKind, KillHandle, LaunchPlan, SandboxEngine};
 pub use guarantees::{describe as describe_isolation, IsolationReport};
-pub use podman::{availability as podman_availability, PodmanAvailability};
+pub use podman::{
+    availability as podman_availability, launch_blocker as podman_launch_blocker,
+    PodmanAvailability,
+};
 pub use policy::{toolchain_cache_env, toolchain_cache_root};
 pub use seatbelt::{
     build_run_profile, cleanup_nested_checkouts_roots, cleanup_nested_rpc_roots,

--- a/src-tauri/src/sandbox/podman/cleanup.rs
+++ b/src-tauri/src/sandbox/podman/cleanup.rs
@@ -130,7 +130,8 @@ fn remove_agent_containers_on(connection: Option<&str>, agent_id: &str) -> Resul
 /// Best-effort per connection, in keeping with the under-reclaim bias: a
 /// stopped or wedged machine logs and the remaining ones still get swept —
 /// stopping at the first failure would leave reclaimable containers on
-/// machines that answer fine.
+/// machines that answer fine. Total failure is not laundered into `Ok(0)`
+/// though: if no connection answered, the caller hears the last error.
 fn across_machines(
     what: &str,
     mut pass: impl FnMut(Option<&str>) -> Result<usize>,
@@ -140,18 +141,29 @@ fn across_machines(
         return pass(None);
     }
     let mut total = 0;
+    let mut succeeded = false;
+    let mut last_error = None;
     for connection in &connections {
         match pass(Some(connection)) {
-            Ok(n) => total += n,
-            Err(e) => tracing::warn!(
-                target: "fletch::podman",
-                connection = %connection,
-                error = %e,
-                "{what} failed on this connection",
-            ),
+            Ok(n) => {
+                succeeded = true;
+                total += n;
+            }
+            Err(e) => {
+                tracing::warn!(
+                    target: "fletch::podman",
+                    connection = %connection,
+                    error = %e,
+                    "{what} failed on this connection",
+                );
+                last_error = Some(e);
+            }
         }
     }
-    Ok(total)
+    match last_error {
+        Some(e) if !succeeded => Err(e),
+        _ => Ok(total),
+    }
 }
 
 /// One connection name per Podman machine, from
@@ -291,8 +303,20 @@ pub(super) fn sweep_stale_images_on(connection: Option<&str>) -> Result<usize> {
     for image_ref in &refs {
         // One rmi per image (not batched): a single in-use image must not taint
         // the exit status the others report. No `-f` — an image backing a running
-        // container stays, by design.
-        let out = cli::run_podman_on(connection, &["rmi", image_ref], REMOVE_TIMEOUT)?;
+        // container stays, by design. A transport failure is per-image too: it
+        // must not strand the candidates behind it.
+        let out = match cli::run_podman_on(connection, &["rmi", image_ref], REMOVE_TIMEOUT) {
+            Ok(out) => out,
+            Err(e) => {
+                tracing::warn!(
+                    target: "fletch::podman",
+                    image = %image_ref,
+                    error = %e,
+                    "podman rmi could not run for this image; continuing the pass",
+                );
+                continue;
+            }
+        };
         if out.status.success() {
             removed += 1;
         } else {
@@ -474,9 +498,11 @@ mod tests {
             ],
         )
         .unwrap();
+        // The normalized repo, not the verbatim one: podman prints locally
+        // built images as `localhost/fletch-agent`.
         assert!(
             rows.iter()
-                .any(|r| r.repo == "fletch-agent" && r.tag == "000000000000"),
+                .any(|r| r.compare_repo() == "fletch-agent" && r.tag == "000000000000"),
             "podman's --format output must parse into the shared row shape: {rows:?}",
         );
 

--- a/src-tauri/src/sandbox/podman/cleanup.rs
+++ b/src-tauri/src/sandbox/podman/cleanup.rs
@@ -11,11 +11,12 @@
 //! invocations differ.
 //!
 //! One invocation shape does differ in kind: docker has a single daemon, while
-//! podman has one container store *and one image store* per machine, and
+//! podman has one container store *and one image store* per machine *endpoint*
+//! — a machine's rootless and rootful connections are two of them — and
 //! launches pin themselves to the connection they resolved at the time (see
-//! [`super::machine`]). Asking only the current default would strand containers —
-//! and superseded images — on every other machine, so all three sweeps run once
-//! per machine connection ([`across_machines`]).
+//! [`super::machine`]). Asking only the current default would strand containers
+//! — and superseded images — on every other endpoint, so all three sweeps run
+//! once per machine connection ([`across_machines`]).
 //!
 //! One difference in the image GC: podman runs the labeled arm only. Docker's
 //! second arm exists for images built before the `fletch.agent` label shipped,
@@ -173,9 +174,10 @@ fn machine_connections() -> Vec<String> {
 /// `IsMachine: false` (older podman omits the field, and a non-machine entry is
 /// a socket or a remote host, neither of which is ours to sweep).
 ///
-/// Each machine appears twice, as `<machine>` and `<machine>-root`. Both list
-/// containers of the same machine, so the pair collapses to whichever podman
-/// listed first — sweeping both would ask the same machine twice.
+/// A machine's `<machine>` and `<machine>-root` entries are both kept: they
+/// reach two podman services with disjoint container stores, so collapsing the
+/// pair leaves one store swept by nobody. Only entries sharing a `URI` are the
+/// same endpoint, and those dedupe to the first.
 fn parse_machine_connections(stdout: &str) -> Vec<String> {
     let Ok(connections) = serde_json::from_str::<Vec<serde_json::Value>>(stdout) else {
         return Vec::new();
@@ -196,11 +198,19 @@ fn parse_machine_connections(stdout: &str) -> Vec<String> {
         if name.is_empty() {
             continue;
         }
-        let machine = name.strip_suffix("-root").unwrap_or(name);
-        if seen.contains(&machine) {
-            continue;
+        // No URI names no endpoint, so it can't be deduped against — keep it and
+        // risk sweeping twice rather than skipping a store.
+        let uri = connection
+            .get("URI")
+            .and_then(|u| u.as_str())
+            .map(str::trim)
+            .unwrap_or_default();
+        if !uri.is_empty() {
+            if seen.contains(&uri) {
+                continue;
+            }
+            seen.push(uri);
         }
-        seen.push(machine);
         out.push(name.to_string());
     }
     out
@@ -331,17 +341,17 @@ mod tests {
     use super::*;
     use crate::sandbox::container::labels::host_pid_label;
 
-    /// The sweep set is one connection per machine: rootful pairs collapse
-    /// (both name the same container store), non-machine entries are somebody
-    /// else's containers, and an unreadable listing leaves the caller with the
-    /// default connection alone.
+    /// The sweep set is one connection per *endpoint*: a rootless/rootful pair
+    /// has two stores and must yield both entries, entries sharing a URI are one
+    /// endpoint and dedupe, non-machine entries are somebody else's containers,
+    /// and an unreadable listing leaves the caller with the default alone.
     #[test]
-    fn machine_connections_are_one_per_machine() {
+    fn machine_connections_are_one_per_endpoint() {
         let listing = r#"[
-          { "Name": "podman-machine-default", "IsMachine": true, "Default": true },
-          { "Name": "podman-machine-default-root", "IsMachine": true, "Default": false },
-          { "Name": "work-vm-root", "IsMachine": true, "Default": false },
-          { "Name": "work-vm", "IsMachine": true, "Default": false },
+          { "Name": "podman-machine-default", "IsMachine": true, "Default": true, "URI": "ssh://core@127.0.0.1:52001/run/user/501/podman/podman.sock" },
+          { "Name": "podman-machine-default-root", "IsMachine": true, "Default": false, "URI": "ssh://root@127.0.0.1:52001/run/podman/podman.sock" },
+          { "Name": "work-vm-alias", "IsMachine": true, "Default": false, "URI": "ssh://core@127.0.0.1:52001/run/user/501/podman/podman.sock" },
+          { "Name": "work-vm", "IsMachine": true, "Default": false, "URI": "ssh://core@127.0.0.1:52002/run/user/501/podman/podman.sock" },
           { "Name": "build-box", "IsMachine": false, "Default": false, "URI": "ssh://core@build.example.com:22/run/podman/podman.sock" },
           { "Name": "local", "IsMachine": false, "Default": false, "URI": "unix:///run/podman/podman.sock" },
           { "Name": "  ", "IsMachine": true },
@@ -350,7 +360,12 @@ mod tests {
         ]"#;
         assert_eq!(
             parse_machine_connections(listing),
-            ["podman-machine-default", "work-vm-root", "legacy-no-flag"],
+            [
+                "podman-machine-default",
+                "podman-machine-default-root",
+                "work-vm",
+                "legacy-no-flag",
+            ],
         );
 
         assert!(parse_machine_connections("[]").is_empty());

--- a/src-tauri/src/sandbox/podman/cleanup.rs
+++ b/src-tauri/src/sandbox/podman/cleanup.rs
@@ -1,27 +1,16 @@
 //! The dead-instance orphan sweep, the per-agent container removal, and the
 //! stale-image GC, for podman.
 //!
-//! The same questions [`docker::cleanup`](crate::sandbox::docker) answers,
-//! against the same labels ([`container::labels`](crate::sandbox::container::labels)):
-//! "whose owning instance is dead?" (startup), "is anything still running for
-//! *this* agent?" (archive/discard), and "which agent images has a rebuild
-//! superseded?" ([`sweep_stale_images`]). The label parsing, the selection rule
-//! and the under-reclaim bias are shared with docker
+//! Same questions and same labels as [`docker::cleanup`](crate::sandbox::docker),
+//! sharing its selection rule and under-reclaim bias
 //! ([`container::image_gc`](crate::sandbox::container::image_gc)); only the
-//! invocations differ.
+//! invocations differ. Podman has one container store *and* image store per
+//! machine endpoint (a machine's rootless and rootful connections are two), and
+//! launches pin to the connection they resolved at the time, so every sweep
+//! runs once per machine connection ([`across_machines`]).
 //!
-//! One invocation shape does differ in kind: docker has a single daemon, while
-//! podman has one container store *and one image store* per machine *endpoint*
-//! — a machine's rootless and rootful connections are two of them — and
-//! launches pin themselves to the connection they resolved at the time (see
-//! [`super::machine`]). Asking only the current default would strand containers
-//! — and superseded images — on every other endpoint, so all three sweeps run
-//! once per machine connection ([`across_machines`]).
-//!
-//! One difference in the image GC: podman runs the labeled arm only. Docker's
-//! second arm exists for images built before the `fletch.agent` label shipped,
-//! and Podman support lands well after it — a Podman store can hold no
-//! pre-label Fletch image, so there is nothing for a legacy allowlist to match.
+//! The image GC runs the labeled arm only: docker's legacy arm covers images
+//! built before the `fletch.agent` label, which no Podman store can hold.
 
 use std::time::Duration;
 
@@ -37,24 +26,22 @@ use crate::sandbox::container::labels::{
 
 use super::cli;
 
-/// Listing/inspect are metadata-only; generous next to their usual
-/// milliseconds, so tripping one means the machine connection is wedged.
+/// Listing/inspect are metadata-only; tripping this means the machine
+/// connection is wedged.
 const QUERY_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// `podman rm -f` also kills a still-running container's process; give the
-/// batched removal room without letting a hung machine pin the sweep thread.
+/// `podman rm -f` also kills a still-running container's process; room for the
+/// batched removal without letting a hung machine pin the sweep thread.
 const REMOVE_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Remove every fletch-labeled container whose owning host instance is dead,
-/// across every machine — a launch is pinned to the connection it resolved at
-/// the time, so yesterday's containers can sit on a machine that is no longer
-/// the default. Returns the number removed. Callers gate on the probe and run
-/// this off the main thread — see [`super::sweep_orphans_at_startup`].
+/// Remove every fletch-labeled container whose owning host instance is dead, on
+/// every machine — yesterday's containers can sit on a machine that is no
+/// longer the default. Returns the number removed. Callers gate on the probe
+/// and run this off the main thread — see [`super::sweep_orphans_at_startup`].
 pub(super) fn sweep_orphans() -> Result<usize> {
     across_machines("podman orphan sweep", sweep_orphans_on)
 }
 
-/// One sweep pass against a single connection.
 fn sweep_orphans_on(connection: Option<&str>) -> Result<usize> {
     let ids = list_ids(connection, &format!("label={HOST_PID_LABEL}"))?;
     if ids.is_empty() {
@@ -65,9 +52,8 @@ fn sweep_orphans_on(connection: Option<&str>) -> Result<usize> {
     let mut inspect_args = vec!["inspect", "-f", INSPECT_FORMAT];
     inspect_args.extend(&id_refs);
     let inspected = cli::run_podman_on(connection, &inspect_args, QUERY_TIMEOUT)?;
-    // Don't require a zero exit: inspect exits non-zero if ANY id vanished
-    // between ps and inspect (e.g. a `--rm` container finishing), but still
-    // prints the rows it found — those are the ones we act on.
+    // No zero-exit requirement: inspect exits non-zero if ANY id vanished
+    // between ps and inspect, but still prints the rows it found.
     let stdout = String::from_utf8_lossy(&inspected.stdout);
     let orphans = orphaned_ids(&stdout, crate::sandbox::seatbelt::pid_alive);
     if orphans.is_empty() {
@@ -85,27 +71,17 @@ fn sweep_orphans_on(connection: Option<&str>) -> Result<usize> {
     Ok(orphans.len())
 }
 
-/// Remove every container stamped with `fletch.agent-id=<agent_id>`, running or
-/// not, on every machine. Returns the number removed.
-///
-/// The disposal counterpart to [`sweep_orphans`], and deliberately *without*
-/// its pid-liveness check: the caller has decided this specific agent is going
-/// away, so every container bearing its id is fair game — including one owned
-/// by this very live instance, which is the whole point (the supervisor may no
-/// longer hold a kill handle for it). Attribution is still exact: the label is
-/// stamped only by our own launches, and it names one agent.
-///
-/// Matching on the label rather than the container name is required, not a
-/// preference — names carry a random nonce
-/// ([`container::util::container_name`](crate::sandbox::container::util::container_name)),
-/// so only the launching process ever knew them.
+/// Remove every container labeled with this agent id, on every machine
+/// endpoint. Returns the number removed. Disposal has decided, so no
+/// pid-liveness check, and labels are the only stable handle — names carry a
+/// launch nonce
+/// ([`container::util::container_name`](crate::sandbox::container::util::container_name)).
 pub fn remove_agent_containers(agent_id: &str) -> Result<usize> {
     across_machines("podman disposal removal", |connection| {
         remove_agent_containers_on(connection, agent_id)
     })
 }
 
-/// One removal pass against a single connection.
 fn remove_agent_containers_on(connection: Option<&str>, agent_id: &str) -> Result<usize> {
     let ids = list_ids(connection, &agent_id_filter(agent_id))?;
     if ids.is_empty() {
@@ -124,14 +100,11 @@ fn remove_agent_containers_on(connection: Option<&str>, agent_id: &str) -> Resul
 }
 
 /// Run `pass` once per machine connection and total what it reclaimed, or once
-/// unpinned when there are no machine connections (native Linux, where the
-/// single local endpoint is the whole story).
+/// unpinned when there are none (native Linux).
 ///
-/// Best-effort per connection, in keeping with the under-reclaim bias: a
-/// stopped or wedged machine logs and the remaining ones still get swept —
-/// stopping at the first failure would leave reclaimable containers on
-/// machines that answer fine. Total failure is not laundered into `Ok(0)`
-/// though: if no connection answered, the caller hears the last error.
+/// Best-effort per connection: a wedged machine logs and the rest are still
+/// swept. Total failure is not laundered into `Ok(0)` — with no connection
+/// answering, the caller hears the last error.
 fn across_machines(
     what: &str,
     mut pass: impl FnMut(Option<&str>) -> Result<usize>,
@@ -166,9 +139,8 @@ fn across_machines(
     }
 }
 
-/// One connection name per Podman machine, from
-/// `podman system connection list --format json`. Anything we can't run or read
-/// yields none, which the caller reads as "just use the default".
+/// One connection name per Podman machine. Anything we can't run or read yields
+/// none, which the caller reads as "just use the default".
 fn machine_connections() -> Vec<String> {
     let Ok(out) = cli::run_podman(
         &["system", "connection", "list", "--format", "json"],
@@ -182,14 +154,10 @@ fn machine_connections() -> Vec<String> {
     parse_machine_connections(&String::from_utf8_lossy(&out.stdout))
 }
 
-/// The machine connection names in a connection listing: entries not explicitly
-/// `IsMachine: false` (older podman omits the field, and a non-machine entry is
-/// a socket or a remote host, neither of which is ours to sweep).
-///
-/// A machine's `<machine>` and `<machine>-root` entries are both kept: they
-/// reach two podman services with disjoint container stores, so collapsing the
-/// pair leaves one store swept by nobody. Only entries sharing a `URI` are the
-/// same endpoint, and those dedupe to the first.
+/// The machine connection names in a listing: entries not explicitly
+/// `IsMachine: false` (older podman omits the field). A machine's `<machine>`
+/// and `<machine>-root` entries are both kept — disjoint stores, so collapsing
+/// the pair leaves one swept by nobody; only a shared `URI` is one endpoint.
 fn parse_machine_connections(stdout: &str) -> Vec<String> {
     let Ok(connections) = serde_json::from_str::<Vec<serde_json::Value>>(stdout) else {
         return Vec::new();
@@ -210,8 +178,7 @@ fn parse_machine_connections(stdout: &str) -> Vec<String> {
         if name.is_empty() {
             continue;
         }
-        // No URI names no endpoint, so it can't be deduped against — keep it and
-        // risk sweeping twice rather than skipping a store.
+        // No URI can't be deduped against: sweep twice rather than skip a store.
         let uri = connection
             .get("URI")
             .and_then(|u| u.as_str())
@@ -228,7 +195,6 @@ fn parse_machine_connections(stdout: &str) -> Vec<String> {
     out
 }
 
-/// Container ids matching one `--filter` expression, on one connection.
 fn list_ids(connection: Option<&str>, filter: &str) -> Result<Vec<String>> {
     let list = cli::run_podman_on(
         connection,
@@ -249,28 +215,19 @@ fn list_ids(connection: Option<&str>, filter: &str) -> Result<Vec<String>> {
         .collect())
 }
 
-/// Remove superseded Fletch agent images from every machine's store. One rule:
-/// an image carrying the `fletch.agent` label that is not one of the current
-/// expected tags is removed — old-hash tags from Dockerfile revisions and
-/// untagged leftovers from refresh rebuilds alike.
+/// Remove `fletch.agent`-labeled images that aren't a current expected tag,
+/// from every machine's store. Returns the number removed; callers treat
+/// failures as non-fatal.
 ///
-/// Fanned out like the container sweeps, and for the same reason turned up a
-/// level: image stores are per-machine too, so an unpinned pass would GC only
-/// whichever machine happens to be the default and leave every image a launch on
-/// another machine superseded sitting there forever.
-///
-/// Never touched: current tags, the user's `podman_image` override (excluded
-/// defensively even though it can't carry the label), any unlabeled image, and
-/// images in use by a container — `podman rmi` runs WITHOUT `-f`, so an in-use
-/// image fails removal, which is expected and logged at debug. Returns the number
-/// of images actually removed; callers treat all failures as non-fatal.
+/// Never touched: current tags, the user's `podman_image` override, unlabeled
+/// images, and images in use — `podman rmi` runs WITHOUT `-f`, so an in-use
+/// image fails removal, which is expected and logged at debug.
 pub(super) fn sweep_stale_images() -> Result<usize> {
     across_machines("podman image sweep", sweep_stale_images_on)
 }
 
-/// One image-GC pass against a single connection's store — what
-/// [`sweep_stale_images`] fans out, and what a background refresh rebuild calls
-/// directly for the one store it just rebuilt in.
+/// One image-GC pass against a single connection's store; a background refresh
+/// rebuild calls this directly for the one store it just rebuilt in.
 pub(super) fn sweep_stale_images_on(connection: Option<&str>) -> Result<usize> {
     let refs = image_removal_refs(
         &list_images(
@@ -301,10 +258,8 @@ pub(super) fn sweep_stale_images_on(connection: Option<&str>) -> Result<usize> {
     );
     let mut removed = 0;
     for image_ref in &refs {
-        // One rmi per image (not batched): a single in-use image must not taint
-        // the exit status the others report. No `-f` — an image backing a running
-        // container stays, by design. A transport failure is per-image too: it
-        // must not strand the candidates behind it.
+        // One rmi per image, not batched: a single in-use image or transport
+        // failure must not taint the others' exit status or strand them.
         let out = match cli::run_podman_on(connection, &["rmi", image_ref], REMOVE_TIMEOUT) {
             Ok(out) => out,
             Err(e) => {
@@ -331,7 +286,6 @@ pub(super) fn sweep_stale_images_on(connection: Option<&str>) -> Result<usize> {
     Ok(removed)
 }
 
-/// Run one `podman images` listing on one connection and parse its rows.
 fn list_images(connection: Option<&str>, args: &[&str]) -> Result<Vec<ImageRow>> {
     let out = cli::run_podman_on(connection, args, QUERY_TIMEOUT)?;
     if !out.status.success() {
@@ -346,7 +300,6 @@ fn list_images(connection: Option<&str>, args: &[&str]) -> Result<Vec<ImageRow>>
         .collect())
 }
 
-/// `podman rm -f` over a batch of ids, on one connection.
 fn remove(connection: Option<&str>, ids: &[&str]) -> Result<()> {
     let mut rm_args = vec!["rm", "-f"];
     rm_args.extend(ids);
@@ -365,10 +318,8 @@ mod tests {
     use super::*;
     use crate::sandbox::container::labels::host_pid_label;
 
-    /// The sweep set is one connection per *endpoint*: a rootless/rootful pair
-    /// has two stores and must yield both entries, entries sharing a URI are one
-    /// endpoint and dedupe, non-machine entries are somebody else's containers,
-    /// and an unreadable listing leaves the caller with the default alone.
+    /// One connection per *endpoint*: a rootless/rootful pair is two stores,
+    /// a shared URI is one, and non-machine entries aren't ours to sweep.
     #[test]
     fn machine_connections_are_one_per_endpoint() {
         let listing = r#"[
@@ -398,8 +349,6 @@ mod tests {
         assert!(parse_machine_connections(r#"{"Name":"m"}"#).is_empty());
     }
 
-    /// Integration: a container labeled with a dead pid is swept; one labeled
-    /// with our own (live) pid survives.
     /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
     #[test]
     #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]
@@ -444,16 +393,10 @@ mod tests {
         let _ = cli::run_podman(&["rm", "-f", &live_name], Duration::from_secs(30));
     }
 
-    /// Integration: a labeled image under a Fletch repo with a non-current tag
-    /// is swept from podman's store; an unlabeled image outside Fletch's repos
-    /// survives. Also pins the one podman-side assumption the shared selection
-    /// rule rests on — that `podman images --format` prints the same three
-    /// whitespace-separated columns docker does, so [`parse_images_line`] reads
-    /// both.
-    ///
-    /// Runs against the default connection (`None`) throughout, which is where
-    /// the images it builds land; [`sweep_stale_images`]'s fan-out then covers it
-    /// as one of the connections it visits.
+    /// Also pins the assumption the shared selection rule rests on: `podman
+    /// images --format` prints the same three columns docker does, so
+    /// [`parse_images_line`] reads both. Runs against the default connection
+    /// (`None`), which is where the images it builds land.
     /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
     #[test]
     #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]
@@ -475,14 +418,13 @@ mod tests {
                 String::from_utf8_lossy(&out.stderr),
             );
         };
-        // A labeled image under Fletch's repo with a tag no provider owns —
-        // exactly what a superseded image looks like.
+        // A tag no provider owns: what a superseded image looks like.
         let stale_tag = "fletch-agent:000000000000";
         build(
             &format!("FROM busybox\nLABEL {AGENT_IMAGE_LABEL}=claude\n"),
             stale_tag,
         );
-        // An unlabeled image outside Fletch's repos: must survive.
+        // Unlabeled, outside Fletch's repos: must survive.
         let bystander = "fletch-gc-test-bystander:keep";
         build("FROM busybox\nENV FLETCH_GC_TEST=1\n", bystander);
 
@@ -498,8 +440,8 @@ mod tests {
             ],
         )
         .unwrap();
-        // The normalized repo, not the verbatim one: podman prints locally
-        // built images as `localhost/fletch-agent`.
+        // The normalized repo: podman prints local builds as
+        // `localhost/fletch-agent`.
         assert!(
             rows.iter()
                 .any(|r| r.compare_repo() == "fletch-agent" && r.tag == "000000000000"),

--- a/src-tauri/src/sandbox/podman/cli.rs
+++ b/src-tauri/src/sandbox/podman/cli.rs
@@ -1,20 +1,10 @@
-//! Locate the podman binary and run it with hard timeouts.
+//! Locate the podman binary and run it with hard timeouts, over the
+//! runtime-neutral machinery in
+//! [`container::proc`](crate::sandbox::container::proc).
 //!
-//! The same two rules as [`docker::cli`](crate::sandbox::docker::cli), enforced
-//! by funneling every podman invocation through this module:
-//!
-//! 1. **Resolve the binary like a GUI app.** Podman installs the CLI into
-//!    `/opt/homebrew/bin` or `/usr/local/bin`, neither of which a
-//!    Finder-launched Tauri app's PATH reliably includes —
-//!    `bin_resolve::resolve_bin` handles that (its common-dirs fallback already
-//!    covers both).
-//! 2. **Bound every call.** Podman has no daemon on macOS, but it does talk to a
-//!    `podman machine` VM over a socket, and a VM that is suspended or
-//!    mid-shutdown leaves a socket that accepts and then stalls — the same hazard
-//!    a stopped Docker Desktop poses. Callers pass an explicit timeout and get a
-//!    clear "timed out" error instead. The bounding machinery is runtime-neutral
-//!    and lives in [`container::proc`](crate::sandbox::container::proc); what's
-//!    here is the thin Podman-specific layer over it.
+//! Every podman invocation goes through here: a Finder-launched app's PATH
+//! misses homebrew, and a suspended `podman machine` leaves a socket that
+//! accepts and then stalls forever, so no call may be unbounded.
 
 use std::process::{Command, Output, Stdio};
 use std::time::Duration;
@@ -23,29 +13,24 @@ use crate::error::{Error, Result};
 use crate::sandbox::container::proc::{forward_lines, run_with_timeout, wait_with_deadline};
 
 /// Absolute path of the podman CLI, or `None` when it isn't installed.
-/// Resolved fresh on every call (the underlying login-shell env is cached, so
-/// this is just a stat walk): caching a `None` here would pin the probe to
-/// `NotInstalled` for the whole app run even after the user installs Podman,
-/// and the probe's own 5s cache already bounds the frequency.
+/// Resolved fresh per call — caching a `None` would pin the probe to
+/// `NotInstalled` for the whole run even after the user installs Podman.
 pub(super) fn podman_bin() -> Option<std::path::PathBuf> {
     let home = dirs::home_dir()?;
     crate::bin_resolve::resolve_bin("podman", &home).map(std::path::PathBuf::from)
 }
 
-/// Run `podman <args>` on whichever connection is the default. For anything
-/// belonging to one container's lifetime, use [`run_podman_on`] with that
+/// Run `podman <args>` on whichever connection is the default. Anything
+/// belonging to one container's lifetime must use [`run_podman_on`] with that
 /// container's pinned connection instead — the default can change mid-run.
 pub(super) fn run_podman(args: &[&str], timeout: Duration) -> Result<Output> {
     run_podman_on(None, args, timeout)
 }
 
 /// Run `podman [--connection <name>] <args>` capturing stdout/stderr, failing
-/// after `timeout`. Returns the raw `Output` — callers inspect the exit status
+/// after `timeout`. Returns the raw `Output`: callers inspect the exit status
 /// themselves, since several podman commands use non-zero exits as answers
 /// (e.g. `image inspect` on a missing image), not as errors.
-///
-/// The pin is a *global* flag, so it goes ahead of the subcommand; the error
-/// label still names the subcommand, which is the part a user can act on.
 pub(super) fn run_podman_on(
     connection: Option<&str>,
     args: &[&str],
@@ -54,6 +39,7 @@ pub(super) fn run_podman_on(
     let bin = podman_bin()
         .ok_or_else(|| Error::Other("podman binary not found — is Podman installed?".into()))?;
     let mut cmd = Command::new(bin);
+    // `--connection` is a global flag: it has to precede the subcommand.
     if let Some(connection) = connection {
         cmd.args(["--connection", connection]);
     }
@@ -62,12 +48,11 @@ pub(super) fn run_podman_on(
     run_with_timeout(cmd, timeout, &what)
 }
 
-/// Run `podman [--connection <name>] <args>` streaming every output line
-/// (stdout and stderr) to `on_line` as it appears — the shape `podman build`
-/// needs so a minutes-long image build reaches the log while it runs. Fails on
-/// non-zero exit with the last output lines in the message, or on `timeout`
-/// expiry. `connection` matters here too: images live per-machine, so a build
-/// has to land on the machine the run will use.
+/// Run `podman [--connection <name>] <args>` streaming every stdout/stderr line
+/// to `on_line` as it appears, so a minutes-long build reaches the log while it
+/// runs. Fails on non-zero exit with the last output lines in the message, or on
+/// `timeout` expiry. `connection` matters here too: images live per-machine, so
+/// a build has to land on the machine the run will use.
 pub(super) fn run_podman_streaming(
     connection: Option<&str>,
     args: &[&str],
@@ -90,14 +75,12 @@ pub(super) fn run_podman_streaming(
     let stdout = child.stdout.take().expect("stdout piped above");
     let stderr = child.stderr.take().expect("stderr piped above");
 
-    // Keep a bounded tail of everything seen, so a failure message carries the
-    // actual podman error (which lands near the end of the stream) without
-    // buffering an entire multi-minute build log.
+    // Bounded: podman's error lands near the end of the stream, so a tail
+    // carries it without buffering an entire multi-minute build log.
     let tail = std::sync::Mutex::new(std::collections::VecDeque::<String>::new());
 
-    // Scoped threads: the readers borrow `on_line` and `tail`, and both pipes
-    // are drained continuously so the child can never block on a full pipe
-    // while we sit in the wait loop below.
+    // Both pipes must be drained continuously, or the child blocks on a full
+    // pipe while we sit in the wait loop.
     let status = std::thread::scope(|scope| {
         scope.spawn(|| forward_lines(stdout, on_line, &tail));
         scope.spawn(|| forward_lines(stderr, on_line, &tail));

--- a/src-tauri/src/sandbox/podman/engine.rs
+++ b/src-tauri/src/sandbox/podman/engine.rs
@@ -113,8 +113,12 @@ impl PodmanEngine {
             override_image.map(str::to_string),
             connection.map(str::to_string),
         );
-        let mut cache = self.resolved_image.lock().unwrap();
-        if let Some(tag) = cache.get(&key) {
+        // The lock is dropped before resolving: a build can take ten minutes,
+        // and holding it would serialize every other provider's cache-hit launch
+        // behind it. Two cold launches may then resolve the same key at once,
+        // which is safe — `BUILD_LOCK` plus the re-check under it make the
+        // second resolver a cheap no-op.
+        if let Some(tag) = self.resolved_image.lock().unwrap().get(&key) {
             return Ok(tag.clone());
         }
         // Skip the host probe entirely on the override path: the user's image is
@@ -137,7 +141,7 @@ impl PodmanEngine {
             &on_progress,
         )
         .map_err(|e| Error::Other(format!("preparing the Podman sandbox image failed: {e}")))?;
-        cache.insert(key, tag.clone());
+        self.resolved_image.lock().unwrap().insert(key, tag.clone());
         Ok(tag)
     }
 }
@@ -181,17 +185,12 @@ impl SandboxEngine for PodmanEngine {
         let target = machine::resolve_launch_target()?;
         let connection = target.connection.clone();
         let settings = LAUNCH_SETTINGS.read().clone();
-        let image = self.resolve_image_cached(
-            provider,
-            settings.image_override.as_deref(),
-            connection.as_deref(),
-        )?;
         let name = container_name(ctx.agent_id);
         let prep = crate::sandbox::container::launch::prepare(ctx, provider)?;
 
         let prefix_args = {
             let auth_vars = prep.auth_vars();
-            let spec = RunSpec {
+            let mut spec = RunSpec {
                 interactive: ctx.interactive,
                 name: &name,
                 agent_id: ctx.agent_id,
@@ -204,14 +203,22 @@ impl SandboxEngine for PodmanEngine {
                 borrowed_object_stores: &prep.borrowed_object_stores,
                 memory: non_blank(settings.memory.as_deref()).unwrap_or(DEFAULT_MEMORY),
                 cpus: non_blank(settings.cpus.as_deref()).unwrap_or(DEFAULT_CPUS),
-                image: &image,
+                // Filled in below, once the preflight has passed; the mount
+                // sources don't depend on it.
+                image: "",
                 agent_bin,
                 auth_vars: &auth_vars,
             };
-            // Before the run, not after: an unshared source mounts empty rather
-            // than failing, so the launch has to be refused while we can still
-            // name the path.
+            // Before the run *and before the image*: an unshared source mounts
+            // empty rather than failing, so the launch has to be refused while we
+            // can still name the path — and without first waiting out a build.
             machine::ensure_sources_are_shared(&mount_sources(&spec), &target)?;
+            let image = self.resolve_image_cached(
+                provider,
+                settings.image_override.as_deref(),
+                connection.as_deref(),
+            )?;
+            spec.image = &image;
             pinned_argv(connection.as_deref(), run_args(&spec))
         };
 

--- a/src-tauri/src/sandbox/podman/engine.rs
+++ b/src-tauri/src/sandbox/podman/engine.rs
@@ -1,28 +1,11 @@
 //! The Podman sandbox engine: one container per agent process, agent ≈ PID 1.
 //!
-//! Behaviourally the Docker engine with a different binary. Every invariant
-//! [`docker::engine`](crate::sandbox::docker) documents holds here unchanged and
-//! for the same reason, because the parts that carry them are the same code:
-//! the mounts, env and auth come from
-//! [`container::launch`](crate::sandbox::container::launch), the argv from
-//! [`container::run_args`](crate::sandbox::container::run_args), the labels from
-//! [`container::labels`](crate::sandbox::container::labels), the image content
-//! from [`container::images`](crate::sandbox::container::images), and the
-//! image-freshness policy from
-//! [`container::freshness`](crate::sandbox::container::freshness). What this file
-//! adds is the podman binary, the podman teardown commands, and one
-//! Podman-specific reliability gate.
-//!
-//! **The machine preflight.** Podman's macOS VM sees only the host directories
-//! the machine shares, and a bind mount from outside them silently yields an
-//! empty dir rather than an error (see [`super::machine`]). Docker Desktop has
-//! no equivalent failure — its VM shares the whole filesystem — so this check
-//! exists on this side only, and it runs before the launch rather than after so
-//! the user gets the path instead of a broken checkout.
-//!
-//! Containers run as root, like Docker's: the launch is shared, and podman's
-//! rootless mode is a narrowing the guarantee declarations already account for
-//! (see `sandbox::guarantees`).
+//! Behaviourally the Docker engine with a different binary — the shared parts
+//! live under [`container`](crate::sandbox::container). What this file adds is
+//! the podman binary, the podman teardown commands, and the machine preflight:
+//! a bind mount from outside the machine's shares silently yields an empty dir
+//! rather than an error (see [`super::machine`]), so it is checked before the
+//! launch, while the path can still be named.
 
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::Duration;
@@ -42,15 +25,12 @@ use super::{cli, image, machine};
 
 /// Signal/removal podman calls during teardown.
 const KILL_TIMEOUT: Duration = Duration::from_secs(10);
-/// How long a TERM'd container gets to exit before escalating to KILL — same
-/// order as the session-side process-group escalation grace windows.
+/// How long a TERM'd container gets to exit before escalating to KILL.
 const TERM_GRACE: Duration = Duration::from_millis(500);
 /// Liveness lookups (`podman inspect`).
 const INSPECT_TIMEOUT: Duration = Duration::from_secs(5);
 
-/// Podman's wording for the shared reserved-exit-code messages. The machine is
-/// what reports a start failure, `podman machine` is what the user restarts, and
-/// `podman_image` is the override a 126/127 may be pointing at.
+/// Podman's wording for the shared reserved-exit-code messages.
 const EXIT_COPY: ExitCopy = ExitCopy {
     runtime: super::RUNTIME_NAME,
     error_source: "the machine",
@@ -59,18 +39,12 @@ const EXIT_COPY: ExitCopy = ExitCopy {
 };
 
 /// The `SandboxEngine` implementation for Podman. Obtain it via
-/// [`PodmanEngine::shared`]: launches embed an `Arc` of the engine in their
-/// [`KillHandle`], and sharing one instance also shares the once-per-app-run
+/// [`PodmanEngine::shared`] — one instance per app run, so launches share the
 /// image resolution cache.
 pub struct PodmanEngine {
-    /// Images resolved for this app run, keyed by `(provider, override,
-    /// connection)` so each provider's image is resolved (and built) at most
-    /// once per machine, and a mid-run settings change re-resolves. The
-    /// connection is part of the key because image stores are per-machine: a tag
-    /// present on one says nothing about another, and a launch pinned elsewhere
-    /// would run on an image that isn't there. Only successes are cached — a
-    /// failed build retries on the next spawn (the user may have started the
-    /// machine or fixed their network since).
+    /// Images resolved for this app run. The connection is part of the key
+    /// because image stores are per-machine: a tag present on one says nothing
+    /// about another. Only successes are cached, so a failed build retries.
     resolved_image: Mutex<ImageCache>,
 }
 
@@ -79,8 +53,7 @@ type ImageCache =
     std::collections::HashMap<(ContainerProvider, Option<String>, Option<String>), String>;
 
 impl PodmanEngine {
-    /// The process-wide engine instance — the same `Arc` that `engine_for`
-    /// hands to launch paths and that every launch parks in its `KillHandle`.
+    /// The process-wide engine instance.
     pub fn shared() -> Arc<PodmanEngine> {
         static ENGINE: OnceLock<Arc<PodmanEngine>> = OnceLock::new();
         ENGINE
@@ -93,15 +66,9 @@ impl PodmanEngine {
     }
 
     /// The image to launch `provider` from on `connection`, resolving (and
-    /// building, if that machine's store lacks it) at most once per app run per
-    /// (provider, override, connection) triple. Resolution also runs the
-    /// background freshness checks (TTL + host/container version parity — see
-    /// `image::resolve_image`), so their cadence is once per app run too. The
-    /// host version comes from the existing memoized probe
-    /// (`agent::cached_provider_version` — at most one `--version` subprocess per
-    /// provider per run, shared with ingest); a machine with no host CLI yields
-    /// `None` and the version trigger is simply inert, leaving the TTL as the
-    /// backstop.
+    /// building) at most once per app run per (provider, override, connection)
+    /// triple — which is also the cadence of the freshness checks
+    /// `image::resolve_image` kicks off.
     fn resolve_image_cached(
         &self,
         provider: ContainerProvider,
@@ -113,25 +80,21 @@ impl PodmanEngine {
             override_image.map(str::to_string),
             connection.map(str::to_string),
         );
-        // The lock is dropped before resolving: a build can take ten minutes,
-        // and holding it would serialize every other provider's cache-hit launch
-        // behind it. Two cold launches may then resolve the same key at once,
-        // which is safe — `BUILD_LOCK` plus the re-check under it make the
-        // second resolver a cheap no-op.
+        // The lock is dropped before resolving: a build can take ten minutes and
+        // would otherwise block every cache-hit launch. Two cold launches racing
+        // the same key is safe — `BUILD_LOCK` makes the second a no-op.
         if let Some(tag) = self.resolved_image.lock().unwrap().get(&key) {
             return Ok(tag.clone());
         }
-        // Skip the host probe entirely on the override path: the user's image is
-        // never inspected or refreshed, so there is nothing to compare.
+        // No host probe on the override path: the user's image is never
+        // inspected or refreshed, so there is nothing to compare.
         let host_cli_version = if non_blank(override_image).is_none() {
             crate::agent::cached_provider_version(provider.id())
         } else {
             None
         };
-        // Per-line build output goes to the log; the UI build toast is driven
-        // separately by the `container::progress` sink inside `image`. Free-form
-        // output rides in the `line` field (not the message) so the sentry
-        // scrubber drops it — see the privacy invariant in `lib.rs`.
+        // Free-form output rides in the `line` field, not the message, so the
+        // sentry scrubber drops it — see the privacy invariant in `lib.rs`.
         let on_progress = |line: &str| tracing::info!(target: "fletch::podman_build", line = %line, "podman build output");
         let tag = image::resolve_image(
             provider,
@@ -147,8 +110,7 @@ impl PodmanEngine {
 }
 
 /// `run_argv` with this launch's connection pin ahead of it. `--connection` is a
-/// *global* flag, so it precedes the subcommand — appending it after `run` would
-/// make podman read it as a container argument. An unpinned target adds nothing.
+/// *global* flag: after `run` podman would read it as a container argument.
 fn pinned_argv(connection: Option<&str>, run_argv: Vec<String>) -> Vec<String> {
     let Some(connection) = connection else {
         return run_argv;
@@ -163,11 +125,8 @@ impl SandboxEngine for PodmanEngine {
         EngineKind::Podman
     }
 
-    /// Launch a container for `ctx.provider`. Identical to the Docker engine's
-    /// launch but for the binary, the resolved image, the machine preflight,
-    /// and the connection pin that ties those to the run.
-    /// `ensure_engine_supports_provider` gates this to a supported provider, so
-    /// the `from_id` failure below is defensive only.
+    /// Launch a container for `ctx.provider`. `ensure_engine_supports_provider`
+    /// gates this, so the `from_id` failure below is defensive only.
     fn launch_agent(&self, ctx: &AgentLaunchCtx, agent_bin: &str) -> Result<LaunchPlan> {
         let provider = ContainerProvider::from_id(ctx.provider).ok_or_else(|| {
             Error::Other(format!(
@@ -177,11 +136,9 @@ impl SandboxEngine for PodmanEngine {
         })?;
         let podman = cli::podman_bin()
             .ok_or_else(|| Error::Other("podman binary not found — is Podman installed?".into()))?;
-        // Resolved before the image: everything this launch touches — the image
-        // store, the mount check, the run, the teardown — has to be the one
-        // endpoint named here, and a remote default is refused before any of it
-        // (in particular before a minutes-long build for a machine we would then
-        // refuse to launch on).
+        // Resolved first: the image store, the mount check, the run and the
+        // teardown all have to be the one endpoint named here, and a remote
+        // default is refused before a minutes-long build for it.
         let target = machine::resolve_launch_target()?;
         let connection = target.connection.clone();
         let settings = LAUNCH_SETTINGS.read().clone();
@@ -203,15 +160,14 @@ impl SandboxEngine for PodmanEngine {
                 borrowed_object_stores: &prep.borrowed_object_stores,
                 memory: non_blank(settings.memory.as_deref()).unwrap_or(DEFAULT_MEMORY),
                 cpus: non_blank(settings.cpus.as_deref()).unwrap_or(DEFAULT_CPUS),
-                // Filled in below, once the preflight has passed; the mount
-                // sources don't depend on it.
+                // Filled in below, once the preflight has passed.
                 image: "",
                 agent_bin,
                 auth_vars: &auth_vars,
             };
-            // Before the run *and before the image*: an unshared source mounts
-            // empty rather than failing, so the launch has to be refused while we
-            // can still name the path — and without first waiting out a build.
+            // Before the image, not just before the run: an unshared source
+            // mounts empty rather than failing, and the refusal shouldn't come
+            // after waiting out a build.
             machine::ensure_sources_are_shared(&mount_sources(&spec), &target)?;
             let image = self.resolve_image_cached(
                 provider,
@@ -233,15 +189,12 @@ impl SandboxEngine for PodmanEngine {
         })
     }
 
-    /// Tear the container down: TERM, a grace window, then KILL, then a
-    /// best-effort `rm -f`. Best-effort throughout and always `Ok` — the
-    /// container is usually already gone (`--rm`, machine stopped, normal
-    /// exit), and an error here would abort the caller's local process-group
-    /// teardown of the podman CLI child.
+    /// TERM, a grace window, then KILL, then a best-effort `rm -f`. Always `Ok`:
+    /// the container is usually already gone, and an error here would abort the
+    /// caller's local process-group teardown of the podman CLI child.
     fn kill(&self, plan: &KillPlan) -> Result<()> {
-        // Every call here rides the connection the launch pinned, not the
-        // current default: the container lives on one machine, and a default
-        // that moved since would leave us signalling into the wrong one.
+        // The launch's pinned connection, not the current default — a default
+        // that moved since would signal into the wrong machine.
         let KillPlan::Container { name, connection } = plan;
         let on = connection.as_deref();
         match cli::run_podman_on(on, &["kill", "-s", "TERM", name], KILL_TIMEOUT) {
@@ -266,9 +219,8 @@ impl SandboxEngine for PodmanEngine {
     }
 }
 
-/// Whether podman says the container is currently running, asked of the
-/// connection it was launched on. Errors (container gone, machine down,
-/// timeout) read as not running.
+/// Whether the container is running on the connection it was launched on.
+/// Errors (container gone, machine down, timeout) read as not running.
 fn container_running(name: &str, connection: Option<&str>) -> bool {
     match cli::run_podman_on(
         connection,
@@ -303,9 +255,6 @@ mod tests {
     use crate::sandbox::container::run_args::prepare_config_mount_dir;
     use std::path::PathBuf;
 
-    /// Podman's exit-code wording names the machine (it has no daemon) and
-    /// points at `podman machine`, while still hedging that the code may be the
-    /// agent's own. The image clauses name `podman_image`, never docker's key.
     #[test]
     fn exit_code_wording_is_podman_shaped() {
         let daemon = describe_exit_code(125, &EXIT_COPY).unwrap();
@@ -324,9 +273,6 @@ mod tests {
         assert_eq!(describe_exit_code(1, &EXIT_COPY), None);
     }
 
-    /// The pin is a global flag: it lands before `run`, verbatim (a rootful
-    /// connection keeps its `-root`), and an unpinned launch emits no flag at
-    /// all rather than an empty one.
     #[test]
     fn the_connection_pin_precedes_the_run_subcommand() {
         let run_argv = vec![
@@ -349,10 +295,8 @@ mod tests {
         assert_eq!(pinned_argv(None, run_argv.clone()), run_argv);
     }
 
-    /// Integration: a real `podman run` through the engine's own launch plan
-    /// round-trips a marker file the host wrote into the workspace mount, which
-    /// is the whole path-identity contract in one assertion.
-    /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
+    /// Integration: a marker file round-trips through the workspace mount at its
+    /// identical host path. `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
     #[test]
     #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]
     fn podman_run_echo_round_trip() {
@@ -360,9 +304,8 @@ mod tests {
             return;
         }
         // Under `$HOME`, not `$TMPDIR`: the machine shares `$HOME` by default,
-        // and a mount from outside its shares would come up *empty* rather than
-        // failing — the exact confusion `machine::ensure_sources_are_shared`
-        // exists to head off, and it would make this test's failure unreadable.
+        // and a mount from outside its shares comes up empty rather than
+        // failing, which would make this test's failure unreadable.
         let td = tempfile::tempdir_in(dirs::home_dir().unwrap()).unwrap();
         let root = td.path().join("workspace");
         let rpc = td.path().join("rpc");
@@ -405,8 +348,8 @@ mod tests {
         let marker = root.join("marker.txt").to_string_lossy().into_owned();
         argv.push(&marker);
 
-        // Pinned like the engine pins it, so the run lands on the very machine
-        // whose shares were just validated.
+        // Pinned like the engine pins it, so the run lands on the machine whose
+        // shares were just validated.
         let out = cli::run_podman_on(
             target.connection.as_deref(),
             &argv,
@@ -425,9 +368,7 @@ mod tests {
         );
     }
 
-    /// Integration: the engine's kill escalation actually stops a live
-    /// container, and the liveness probe tracks it both ways.
-    /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
+    /// Integration. `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
     #[test]
     #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]
     fn kill_and_liveness_against_live_container() {
@@ -464,9 +405,7 @@ mod tests {
         );
     }
 
-    /// Integration: the preflight accepts a path under the machine's shares and
-    /// refuses one outside them, naming the offending path. Skipped on a host
-    /// with no machine (native Linux), where the check is inert by design.
+    /// Integration; skipped on a host with no machine, where the check is inert.
     /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
     #[test]
     #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]

--- a/src-tauri/src/sandbox/podman/image.rs
+++ b/src-tauri/src/sandbox/podman/image.rs
@@ -1,41 +1,16 @@
 //! Building, inspecting and refreshing the embedded agent images with podman.
-//! Their *content* — the Dockerfiles, entrypoints, and content-addressed tags —
-//! is runtime-neutral and lives in
-//! [`container::images`](crate::sandbox::container::images), so a Podman agent
-//! runs the byte-identical image a Docker agent does (different local store,
-//! same recipe, same tag). Everything here shells out to podman.
+//! The image content itself is runtime-neutral —
+//! [`container::images`](crate::sandbox::container::images).
 //!
 //! Every invocation carries the launch's pinned connection (see
-//! [`super::machine`]). That is not a detail: podman keeps one image store per
-//! machine, so an image built or found on one connection says nothing about the
-//! one the run will use — an unpinned inspect could report "present" for a store
-//! the container never touches, and an unpinned build would land the image on the
-//! wrong machine.
+//! [`super::machine`]): podman keeps one image store per machine, so an image
+//! built or found on one connection says nothing about the one the run uses.
 //!
-//! Content addressing alone would freeze the *packages inside* an image
-//! forever: every image installs "latest at build time" (npm installs, cursor's
-//! installer), so a stable Dockerfile means a user's containerized CLI never
-//! updates while the host CLI does. The shared TTL
-//! ([`IMAGE_MAX_AGE`](crate::sandbox::container::freshness::IMAGE_MAX_AGE))
-//! fixes that: at resolution, an existing image older than the TTL is served for
-//! the current launch and rebuilt under the same tag in the background
-//! (stale-while-revalidate — see [`refresh_in_background_if_needed`]). A
-//! host/container CLI version mismatch triggers the same background rebuild even
-//! inside the TTL window — a user who just updated their host CLI expects
-//! container parity — while the TTL remains the backstop for Podman-only users
-//! with no host CLI to compare against.
-//!
-//! Users can bypass all of this with the `podman_image` settings key (see
-//! [`resolve_image`]): a user-supplied image is used verbatim — never built,
-//! never inspected — and must have the launching provider's CLI on PATH and git
-//! installed.
-//!
-//! What Podman's freshness path does *not* mirror is docker's
-//! `reap_superseded_base`: reclaiming a base image a `--pull` displaced needs a
-//! before/after id snapshot around every build plus a retry queue, and podman's
-//! rootless store makes a stranded base cheaper to leave than to chase. The
-//! label-driven GC in [`super::cleanup`] covers everything Fletch's own builds
-//! tag.
+//! Images install "latest at build time", so a content-addressed tag alone would
+//! freeze their contents forever. The shared TTL
+//! ([`IMAGE_MAX_AGE`](crate::sandbox::container::freshness::IMAGE_MAX_AGE)) and a
+//! host/container CLI version mismatch each trigger a background rebuild under
+//! the same tag, the current launch still using the existing image.
 
 use std::sync::Mutex;
 use std::time::Duration;
@@ -51,40 +26,30 @@ use super::cli;
 /// Progress sink for image builds: called once per podman output line.
 pub type Progress<'a> = &'a (dyn Fn(&str) + Send + Sync);
 
-/// Builds are slow (base image pull + apt + npm) but bounded: past this we
-/// assume a wedged machine connection or dead network and fail the spawn with a
-/// clear error rather than letting it hang indefinitely.
+/// Builds are slow (base image pull + apt + npm); past this, assume a wedged
+/// connection or dead network and fail the spawn rather than hang.
 const BUILD_TIMEOUT: Duration = Duration::from_secs(600);
 
 /// Quick metadata lookups (`podman image inspect`).
 const INSPECT_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// One-shot in-container version probes are a container start + a node CLI's
-/// `--version` — seconds normally, and this bound only reaps a wedged machine.
+/// In-container `--version` probes: seconds normally; this only reaps a wedged
+/// machine.
 const VERSION_PROBE_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Serializes every image build process-wide — foreground first-builds and
-/// background refresh rebuilds alike. Concurrent spawns during a cold start
-/// would otherwise race podman into building the same image N times, and a
-/// refresh rebuild must never interleave with a foreground build of the same
-/// tag. Separate from docker's lock by design: the two runtimes keep separate
-/// image stores, so a docker build is no reason to hold up a podman one.
+/// Serializes every image build process-wide, foreground and background alike,
+/// so concurrent spawns can't race podman into building the same tag N times.
+/// Separate from docker's lock: the two runtimes keep separate image stores.
 static BUILD_LOCK: Mutex<()> = Mutex::new(());
 
-/// The image to launch `provider`'s containers from on `connection`, honoring
-/// the `podman_image` settings key: a non-empty override is returned verbatim
-/// (no build, no inspect, no TTL, no version check — the user owns that image's
-/// lifecycle); otherwise the embedded image is built if the store behind
-/// `connection` doesn't have it, refreshed in the background if stale or
-/// version-divergent from the host CLI, and its tag returned.
+/// The image to launch `provider`'s containers from on `connection`. A non-empty
+/// `override_image` (the `podman_image` settings key) is returned verbatim — no
+/// build, no inspect, no freshness check — since the user owns that image's
+/// lifecycle. Otherwise the embedded image is built if `connection`'s store
+/// lacks it, refreshed in the background if stale, and its tag returned.
 ///
-/// `connection` is the launch's pinned one, not the default: each machine keeps
-/// its own image store, so an image built or found elsewhere says nothing about
-/// the one the run uses.
-///
-/// Callers read the settings key and probe the host CLI (`host_cli_version` —
-/// see `agent::cached_provider_version`) and pass both in, so this module stays
-/// DB-free and host-probe-free.
+/// The override and `host_cli_version` are passed in rather than read here, so
+/// this module stays DB-free and host-probe-free.
 pub(super) fn resolve_image(
     provider: ContainerProvider,
     connection: Option<&str>,
@@ -110,17 +75,13 @@ pub(super) fn resolve_image(
         on_progress,
     )?;
     if already_existed {
-        // A just-built image is fresh by construction (it installed today's
-        // latest — if the host still differs, a rebuild can't fix that); a
-        // pre-existing one may have passed the TTL or drifted from the host CLI.
-        // Stale-while-revalidate: this launch still uses the existing tag, the
-        // refresh (if any) happens off-thread.
+        // A just-built image is fresh by construction; only a pre-existing one
+        // can have passed the TTL or drifted from the host CLI.
         refresh_in_background_if_needed(provider, connection, &tag, host_cli_version);
     } else {
-        // Post-build version probe, off-thread: warms the image-version cache
-        // for the mismatch trigger without delaying (or ever failing) the launch
-        // that just waited out the build. The spawned thread owns its connection
-        // — it outlives the borrow this call was given.
+        // Warms the image-version cache for the mismatch trigger without
+        // delaying the launch that just waited out the build. The thread owns
+        // its connection — it outlives the borrow this call was given.
         let tag = tag.clone();
         let connection = connection.map(str::to_string);
         std::thread::spawn(move || {
@@ -131,9 +92,8 @@ pub(super) fn resolve_image(
 }
 
 /// Make sure `tag` exists in `connection`'s store, building `dockerfile` under
-/// it if it doesn't. Returns whether the image already existed. Takes the
-/// content explicitly so the integration test can exercise the build machinery
-/// with a tiny Dockerfile instead of the full agent image.
+/// it if it doesn't; returns whether it already existed. The content is a
+/// parameter so the integration test can build a tiny Dockerfile instead.
 fn ensure_image(
     connection: Option<&str>,
     tag: &str,
@@ -151,12 +111,8 @@ fn ensure_image(
     }
 
     tracing::info!(tag, "building agent podman image");
-    // Broadcast the build lifecycle to the UI. `Started`/`Finished`/`Failed`
-    // fire only here, where a foreground build actually runs (a cached image
-    // returns above without emitting), so the toast appears only for builds the
-    // user is actually waiting on. Each output line is forwarded alongside the
-    // caller's own sink so the tracing forwarder / test counter keep working
-    // unchanged.
+    // The UI build lifecycle is emitted only here, past the cached-image
+    // returns, so the toast appears only for builds the user waits on.
     progress::emit(BuildEvent::Started {
         runtime: super::RUNTIME_NAME,
     });
@@ -183,10 +139,8 @@ fn ensure_image(
 }
 
 /// Write the build context and run `podman build -t tag` on `connection`,
-/// streaming output to `on_line`. Shared by the foreground first-build
-/// ([`ensure_image`], `no_cache: false`) and the background refresh rebuild
-/// ([`rebuild_image`], `no_cache: true`); callers hold [`BUILD_LOCK`] and own
-/// their event/progress policy.
+/// streaming output to `on_line`. Callers hold [`BUILD_LOCK`] and own their
+/// event/progress policy.
 fn run_build(
     connection: Option<&str>,
     dockerfile: &str,
@@ -195,8 +149,7 @@ fn run_build(
     no_cache: bool,
     on_line: Progress,
 ) -> Result<()> {
-    // A throwaway context dir, so nothing from the host repo can leak into the
-    // image.
+    // A throwaway context dir, so nothing from the host repo leaks in.
     let ctx = tempfile::tempdir()?;
     write_build_context(ctx.path(), dockerfile, entrypoint)?;
     let args = build_args(tag, ctx.path(), no_cache);
@@ -204,21 +157,15 @@ fn run_build(
     cli::run_podman_streaming(connection, &args, BUILD_TIMEOUT, on_line)
 }
 
-/// `podman build` argv for `tag` from context `ctx`. `--pull` on every build,
-/// first build and refresh rebuild alike: the images exist to capture "latest at
-/// build time", and a months-old locally cached base would silently defeat that.
-/// It adds no new failure mode — every agent build already needs the network for
-/// its install step.
-///
-/// `--no-cache` on refresh rebuilds only: `--pull` alone re-fetches the base, but
-/// the install `RUN` layer is keyed on its instruction text and would be served
+/// `podman build` argv for `tag` from context `ctx`. `--pull` on every build: a
+/// months-old cached base would defeat the "latest at build time" the images
+/// exist to capture. `--no-cache` on refresh rebuilds only, because the install
+/// `RUN` layer is keyed on its instruction text and would otherwise be served
 /// from cache whenever the base digest hasn't moved — a rebuild that changes
-/// nothing, silently defeating both the TTL and the version-mismatch trigger.
-/// First builds keep the cache: a brand-new image has nothing stale to bust, and
-/// cross-provider base-layer sharing on cold starts is worth keeping.
+/// nothing; first builds keep the cache for cross-provider base-layer sharing.
 ///
-/// The connection pin is *not* here: it's a global flag that has to precede the
-/// subcommand, so [`cli::run_podman_streaming`] prepends it.
+/// The connection pin is a global flag, so [`cli::run_podman_streaming`]
+/// prepends it rather than it appearing here.
 fn build_args(tag: &str, ctx: &std::path::Path, no_cache: bool) -> Vec<String> {
     let mut args: Vec<String> = vec!["build".into(), "--pull".into()];
     if no_cache {
@@ -233,17 +180,15 @@ fn build_args(tag: &str, ctx: &std::path::Path, no_cache: bool) -> Vec<String> {
 enum RefreshReason {
     /// The image's build date passed the shared TTL.
     Ttl,
-    /// The host CLI's probed version differs from the container image's;
-    /// `guard_pair` is the `host@tag` pair recorded (persistently, on rebuild
-    /// success) so the same combination is never retried.
+    /// `guard_pair` is the `host@tag` pair recorded on rebuild success, so the
+    /// same combination is never retried.
     VersionMismatch { guard_pair: String },
 }
 
-/// Kick the whole freshness decision onto a background thread and return: the
-/// decision itself costs an `image inspect` and, past it, a full container start
-/// for the in-image `--version` probe, neither of which a launch may wait on.
-///
-/// The thread owns its data — it outlives the borrows this call was given.
+/// Kick the whole freshness decision onto a background thread: deciding costs an
+/// `image inspect` and possibly a container start for the `--version` probe,
+/// neither of which a launch may wait on. The thread owns its data — it outlives
+/// the borrows this call was given.
 fn refresh_in_background_if_needed(
     provider: ContainerProvider,
     connection: Option<&str>,
@@ -259,23 +204,10 @@ fn refresh_in_background_if_needed(
 }
 
 /// Decide whether the image in `connection`'s store needs a rebuild — TTL first,
-/// then host/container version parity — and run it if so. Already off the launch
-/// path (see [`refresh_in_background_if_needed`]). Freshness is never a launch
-/// concern: inspect failures, unparseable timestamps, missing versions, and
-/// rebuild failures all leave the existing image serving launches. Logged, never
-/// propagated. The rebuild is silent for the UI (log lines only): the build toast
-/// presents a blocking first-run build, which is the wrong message for a refresh
-/// the user never waits on.
-///
-/// Everything below — inspect, probe, rebuild, post-rebuild sweep — rides the
-/// connection that triggered it, so a refresh replaces the image in the store the
-/// launch actually read from.
-///
-/// Cadence for both triggers is once per app run: resolution is cached per
-/// (provider, override, connection) (`PodmanEngine::resolve_image_cached`), which
-/// still holds now that the cache lock is released across the resolve — two
-/// simultaneously *cold* launches of the same key could each land here, and the
-/// second's rebuild is serialized behind the first on [`BUILD_LOCK`].
+/// then host/container version parity — and run it if so. Every failure mode
+/// leaves the existing image serving launches; logged, never propagated. Silent
+/// for the UI: the build toast means a blocking first-run build, not a refresh
+/// nobody waits on.
 fn refresh_if_needed(
     provider: ContainerProvider,
     connection: Option<String>,
@@ -287,8 +219,8 @@ fn refresh_if_needed(
     // One inspect serves both triggers: build date for the TTL, image id to key
     // the container-version cache.
     let Some((image_id, created_raw)) = inspect_id_and_created(connection, tag) else {
-        // The image resolved a moment ago; a metadata miss now is not worth
-        // failing a launch or rebuilding over. Next app run re-checks.
+        // The image resolved a moment ago; a metadata miss now isn't worth
+        // rebuilding over. Next app run re-checks.
         return;
     };
 
@@ -304,8 +236,8 @@ fn refresh_if_needed(
             return;
         }
         Freshness::Unknown => {
-            // Once per app run in practice: resolution is cached per run
-            // (`PodmanEngine::resolve_image_cached`), so this can't spam.
+            // Can't spam: resolution is cached per app run
+            // (`PodmanEngine::resolve_image_cached`).
             tracing::warn!(
                 target: "fletch::podman",
                 tag,
@@ -317,8 +249,8 @@ fn refresh_if_needed(
     }
 
     // TTL-fresh: check version parity. Ordered so the podman-run probe only
-    // happens when there's a host version to compare and the pair hasn't already
-    // been tried (the pure decision below re-validates everything).
+    // happens when there's a host version to compare and the pair hasn't
+    // already been tried.
     let Some(host) = host_cli_version else { return };
     let guard_pair = format!("{host}@{tag}");
     if super::settings::version_refresh_attempted(provider.id(), &guard_pair) {
@@ -344,13 +276,9 @@ fn refresh_if_needed(
 }
 
 /// The stale-while-revalidate rebuild shared by both refresh triggers: rebuild
-/// the same tag, then (on success) record the version trigger's loop guard,
-/// re-probe the fresh image's CLI version, and sweep the just-untagged
-/// predecessor. On failure, warn and keep serving the old image.
-///
-/// Runs on [`refresh_in_background_if_needed`]'s thread, never a launch's, and
-/// every call it makes rides the launch's `connection` rather than whatever the
-/// default has become in the meantime.
+/// the same tag, then on success record the loop guard, re-probe the CLI
+/// version, and sweep the untagged predecessor. On failure, warn and keep
+/// serving the old image.
 fn run_refresh_rebuild(
     provider: ContainerProvider,
     connection: Option<&str>,
@@ -361,15 +289,14 @@ fn run_refresh_rebuild(
         Ok(()) => {
             tracing::info!(target: "fletch::podman", tag, "agent image refreshed");
             if let RefreshReason::VersionMismatch { guard_pair } = reason {
-                // Recorded on success only: a transient build failure should
-                // retry next run, but a *successful* rebuild that still
-                // mismatches (host pinned away from latest) must never loop.
+                // On success only: a transient build failure should retry next
+                // run, but a successful rebuild that still mismatches (host
+                // pinned away from latest) must never loop.
                 super::settings::record_version_refresh(provider.id(), guard_pair);
             }
             cache_image_version_post_build(provider, connection, tag);
-            // Podman retagged in place; the predecessor is now untagged. Reap
-            // it (and anything else stale) right away — in this store only,
-            // since this is the only one the rebuild touched.
+            // Podman retagged in place, so the predecessor is now untagged.
+            // This store only — the rebuild touched no other.
             match super::cleanup::sweep_stale_images_on(connection) {
                 Ok(0) => {}
                 Ok(n) => tracing::info!(
@@ -394,17 +321,13 @@ fn run_refresh_rebuild(
 }
 
 /// Rebuild `provider`'s image under the same `tag` in `connection`'s store,
-/// unconditionally (no exists-check — the point is to replace an image that
-/// exists). Serialized on [`BUILD_LOCK`] with foreground builds; `--pull
-/// --no-cache` (see [`build_args`]) so neither a stale base nor a cached install
-/// layer can defeat the refresh. On success podman retags in place and the old
-/// image becomes untagged; on failure the old tag is untouched and keeps serving
-/// launches.
+/// unconditionally — the point is to replace an image that exists. On failure
+/// the old tag is untouched and keeps serving launches.
 fn rebuild_image(provider: ContainerProvider, connection: Option<&str>, tag: &str) -> Result<()> {
     let spec = image_spec(provider);
     let _guard = BUILD_LOCK.lock().unwrap();
-    // Build output is free-form (`line` in a field, not the message) so the
-    // sentry scrubber drops it — see the privacy invariant in `lib.rs`.
+    // Free-form output rides in the `line` field, not the message, so the sentry
+    // scrubber drops it — see the privacy invariant in `lib.rs`.
     let on_line = |line: &str| tracing::info!(target: "fletch::podman_build", line = %line, "podman build output");
     run_build(
         connection,
@@ -418,12 +341,9 @@ fn rebuild_image(provider: ContainerProvider, connection: Option<&str>, tag: &st
 
 /// The provider CLI's version inside image `tag`, memoized by `image_id` for
 /// this app run. The id is a content digest, so the memo is correct across
-/// connections: the same id names the same bytes on every machine. In-memory by
-/// choice: persistence would buy one skipped `podman run` per provider per app
-/// run — not worth a storage surface, and a restart-time re-probe also self-heals
-/// if a probe ever cached garbage. A failed probe caches nothing and returns
-/// `None` — the version trigger stays inert for that image (the TTL still covers
-/// it) and the next app run retries.
+/// connections: the same id names the same bytes on every machine. A failed
+/// probe caches nothing and returns `None`, leaving the version trigger inert
+/// for that image until the next app run.
 fn image_cli_version(
     provider: ContainerProvider,
     connection: Option<&str>,
@@ -444,14 +364,11 @@ fn image_cli_version(
     Some(version)
 }
 
-/// Run `podman run --rm <tag> <bin> --version` on `connection` — no mounts, no
-/// agent scaffolding; the image's entrypoint just `exec`s the argv — and extract
-/// the version with the same parser the host probe uses (`agent::parse_semver`),
-/// so the two sides compare like-for-like. The `fletch.host-pid` label is stamped
-/// on so that if the CLI probe is killed at timeout while podman keeps the
-/// container alive, the next startup's orphan sweep can still attribute and reap
-/// it — and because that sweep runs per connection, the pin is what puts the
-/// container where the sweep will look.
+/// Run `podman run --rm <tag> <bin> --version` on `connection`, parsed with the
+/// same `agent::parse_semver` the host probe uses so the two sides compare
+/// like-for-like. The `fletch.host-pid` label is what lets the next startup's
+/// orphan sweep reap this container if the CLI is killed at timeout while podman
+/// keeps it alive.
 fn probe_image_cli_version(
     provider: ContainerProvider,
     connection: Option<&str>,
@@ -483,11 +400,9 @@ fn probe_image_cli_version(
     crate::agent::parse_semver(&text)
 }
 
-/// After a successful build (foreground and background): probe the fresh image's
-/// CLI version and warm the [`image_cli_version`] cache so the mismatch trigger
-/// has a container side to compare. Best-effort — a failed probe logs at debug
-/// and the trigger stays inert for this image; it never fails or delays the build
-/// that preceded it.
+/// Warm the [`image_cli_version`] cache after a build, so the mismatch trigger
+/// has a container side to compare. Best-effort: a failed probe leaves the
+/// trigger inert for this image.
 fn cache_image_version_post_build(
     provider: ContainerProvider,
     connection: Option<&str>,
@@ -514,11 +429,9 @@ fn cache_image_version_post_build(
 /// `(image id, creation timestamp)` for `tag` in `connection`'s store, or `None`
 /// when podman can't answer or its output doesn't parse.
 ///
-/// Read from `podman image inspect`'s plain JSON rather than a `--format` Go
-/// template: podman models `Created` as a `time.Time`, which a template renders
-/// through its `String()` method (`2026-07-01 12:00:00 +0000 UTC`) while the JSON
-/// encoding is RFC3339 — the shape [`classify_freshness`] parses and docker's
-/// template happens to already produce.
+/// Plain JSON rather than a `--format` Go template: a template renders `Created`
+/// through `time.Time`'s `String()` (`2026-07-01 12:00:00 +0000 UTC`), while the
+/// JSON encoding is the RFC3339 shape [`classify_freshness`] parses.
 fn inspect_id_and_created(connection: Option<&str>, tag: &str) -> Option<(String, String)> {
     let out = cli::run_podman_on(connection, &["image", "inspect", tag], INSPECT_TIMEOUT).ok()?;
     if !out.status.success() {
@@ -527,11 +440,8 @@ fn inspect_id_and_created(connection: Option<&str>, tag: &str) -> Option<(String
     parse_inspect_json(&String::from_utf8_lossy(&out.stdout))
 }
 
-/// Pull `Id` and `Created` out of an `image inspect` JSON array (one entry per
-/// inspected image; we always inspect exactly one). Split out of
-/// [`inspect_id_and_created`] so the parsing is unit-testable without a machine.
-/// Missing or non-string fields read as "can't answer" — the caller's
-/// under-reclaim bias then leaves the image alone.
+/// Pull `Id` and `Created` out of an `image inspect` JSON array. Missing or
+/// non-string fields read as "can't answer", which leaves the image alone.
 fn parse_inspect_json(stdout: &str) -> Option<(String, String)> {
     let parsed: serde_json::Value = serde_json::from_str(stdout).ok()?;
     let entry = parsed.get(0)?;
@@ -541,9 +451,8 @@ fn parse_inspect_json(stdout: &str) -> Option<(String, String)> {
 }
 
 /// Whether `tag` exists in `connection`'s store. A non-zero `image inspect` exit
-/// is podman's "no such image" answer (it also covers an unreachable machine —
-/// the subsequent build then fails with podman's own connectivity error, which is
-/// the right message for that state).
+/// is podman's "no such image" answer; it also covers an unreachable machine,
+/// where the subsequent build fails with podman's own connectivity error.
 fn image_exists(connection: Option<&str>, tag: &str) -> Result<bool> {
     let out = cli::run_podman_on(connection, &["image", "inspect", tag], INSPECT_TIMEOUT)?;
     Ok(out.status.success())
@@ -556,9 +465,8 @@ mod tests {
 
     #[test]
     fn build_argv_shape() {
-        // `--pull` on every build, `--no-cache` on refresh rebuilds only: see
-        // the `build_args` doc — neither a stale cached base nor a cached
-        // install layer may defeat the freshness the rebuilds exist for.
+        // `--pull` always, `--no-cache` on refresh rebuilds only — see the
+        // `build_args` doc.
         assert_eq!(
             build_args(
                 "fletch-agent:abc123def456",
@@ -590,9 +498,6 @@ mod tests {
         );
     }
 
-    /// The inspect parse, on podman's real output shape: an RFC3339 `Created`
-    /// (which the shared TTL classifier accepts) and the short-form `Id`.
-    /// Anything malformed reads as "can't answer".
     #[test]
     fn inspect_json_parsing() {
         let stdout = r#"[
@@ -609,7 +514,6 @@ mod tests {
                 "2026-07-01T12:00:00.123456789Z".to_string()
             )),
         );
-        // The timestamp it yields must be the shape the shared classifier reads.
         let (_, created) = parse_inspect_json(stdout).unwrap();
         assert_ne!(
             classify_freshness(&created, chrono::Utc::now()),
@@ -617,8 +521,6 @@ mod tests {
             "podman's JSON timestamp must parse as RFC3339",
         );
 
-        // Empty array (image vanished between calls), missing fields, blank
-        // values, and non-JSON all read as "no answer".
         assert_eq!(parse_inspect_json("[]"), None);
         assert_eq!(parse_inspect_json(r#"[{"Id": "sha256:a"}]"#), None);
         assert_eq!(
@@ -629,16 +531,14 @@ mod tests {
         assert_eq!(parse_inspect_json(""), None);
     }
 
-    /// The override path must not touch podman at all — it has to work (and
-    /// return instantly) on machines where podman isn't even installed, and it
-    /// takes the connection like every other path without ever using it.
+    /// The override path must not touch podman at all: it has to work on hosts
+    /// where podman isn't installed.
     #[test]
     fn override_image_skips_build_entirely() {
         let called = std::sync::atomic::AtomicBool::new(false);
         let progress = |_: &str| called.store(true, std::sync::atomic::Ordering::SeqCst);
 
-        // A host version is passed to prove the override path ignores it too:
-        // the user's image is never inspected, so there's nothing to compare.
+        // The bogus connection and host version prove both are ignored here.
         let image = resolve_image(
             ContainerProvider::Claude,
             Some("no-such-connection"),
@@ -657,9 +557,7 @@ mod tests {
         );
     }
 
-    /// Integration: builds a tiny image (busybox base) through the real
-    /// machinery, then verifies the second call is a cached no-op.
-    /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
+    /// Integration. `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
     #[test]
     #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]
     fn builds_tiny_image_and_reuses_it() {
@@ -687,7 +585,6 @@ mod tests {
             "build should have streamed progress lines",
         );
 
-        // Second call: image present, no build, no progress.
         lines.store(0, std::sync::atomic::Ordering::SeqCst);
         let existed = ensure_image(None, &tag, dockerfile, ENTRYPOINT_SH, &progress).unwrap();
         assert!(existed, "second call must report the cached image");
@@ -697,8 +594,6 @@ mod tests {
             "an existing image must not rebuild",
         );
 
-        // The freshness path's inspect must resolve against a real image: an id
-        // and an RFC3339 build date the shared classifier calls fresh.
         let (id, created) = inspect_id_and_created(None, &tag).expect("inspect must answer");
         assert!(!id.is_empty());
         assert_eq!(
@@ -710,10 +605,7 @@ mod tests {
         let _ = cli::run_podman(&["rmi", "-f", &tag], Duration::from_secs(30));
     }
 
-    /// Integration: the in-container version probe runs `<image_bin> --version`
-    /// through the image's argv path and extracts the version with the host
-    /// probe's parser — a fake `claude` script in a busybox image must come back
-    /// as `v9.9.9`, and the result must be memoized by image id.
+    /// Integration: a fake `claude` script in a busybox image.
     /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`
     #[test]
     #[ignore = "requires Podman; opt in via FLETCH_PODMAN_TESTS=1"]
@@ -731,9 +623,8 @@ mod tests {
             Some("v9.9.9"),
             "container probe must parse the CLI's --version output",
         );
-        // The cached path returns the same answer without another podman run
-        // (indirectly observable: it works even against a bogus tag once the id
-        // is cached).
+        // The cache is observable through the bogus tag below: it answers
+        // without a podman run.
         assert_eq!(
             image_cli_version(ContainerProvider::Claude, None, &tag, "test-id-123").as_deref(),
             Some("v9.9.9"),

--- a/src-tauri/src/sandbox/podman/image.rs
+++ b/src-tauri/src/sandbox/podman/image.rs
@@ -239,27 +239,51 @@ enum RefreshReason {
     VersionMismatch { guard_pair: String },
 }
 
-/// Decide whether the image in `connection`'s store needs a background rebuild —
-/// TTL first, then host/container version parity — and kick it if so. Returns
-/// immediately either way. Freshness is never a launch concern: inspect
-/// failures, unparseable timestamps, missing versions, and rebuild failures all
-/// leave the existing image serving launches. Logged, never propagated. The
-/// rebuild is silent for the UI (log lines only): the build toast presents a
-/// blocking first-run build, which is the wrong message for a refresh the user
-/// never waits on.
+/// Kick the whole freshness decision onto a background thread and return: the
+/// decision itself costs an `image inspect` and, past it, a full container start
+/// for the in-image `--version` probe, neither of which a launch may wait on.
 ///
-/// Everything below — inspect, probe, rebuild, post-rebuild sweep — rides the
-/// connection that triggered it, so a refresh replaces the image in the store the
-/// launch actually read from.
-///
-/// Cadence for both triggers is once per app run
-/// (`PodmanEngine::resolve_image_cached` caches resolution).
+/// The thread owns its data — it outlives the borrows this call was given.
 fn refresh_in_background_if_needed(
     provider: ContainerProvider,
     connection: Option<&str>,
     tag: &str,
     host_cli_version: Option<&str>,
 ) {
+    let connection = connection.map(str::to_string);
+    let tag = tag.to_string();
+    let host_cli_version = host_cli_version.map(str::to_string);
+    std::thread::spawn(move || {
+        refresh_if_needed(provider, connection, tag, host_cli_version.as_deref())
+    });
+}
+
+/// Decide whether the image in `connection`'s store needs a rebuild — TTL first,
+/// then host/container version parity — and run it if so. Already off the launch
+/// path (see [`refresh_in_background_if_needed`]). Freshness is never a launch
+/// concern: inspect failures, unparseable timestamps, missing versions, and
+/// rebuild failures all leave the existing image serving launches. Logged, never
+/// propagated. The rebuild is silent for the UI (log lines only): the build toast
+/// presents a blocking first-run build, which is the wrong message for a refresh
+/// the user never waits on.
+///
+/// Everything below — inspect, probe, rebuild, post-rebuild sweep — rides the
+/// connection that triggered it, so a refresh replaces the image in the store the
+/// launch actually read from.
+///
+/// Cadence for both triggers is once per app run: resolution is cached per
+/// (provider, override, connection) (`PodmanEngine::resolve_image_cached`), which
+/// still holds now that the cache lock is released across the resolve — two
+/// simultaneously *cold* launches of the same key could each land here, and the
+/// second's rebuild is serialized behind the first on [`BUILD_LOCK`].
+fn refresh_if_needed(
+    provider: ContainerProvider,
+    connection: Option<String>,
+    tag: String,
+    host_cli_version: Option<&str>,
+) {
+    let connection = connection.as_deref();
+    let tag = tag.as_str();
     // One inspect serves both triggers: build date for the TTL, image id to key
     // the container-version cache.
     let Some((image_id, created_raw)) = inspect_id_and_created(connection, tag) else {
@@ -276,12 +300,7 @@ fn refresh_in_background_if_needed(
                 created = %created_raw,
                 "agent image is older than IMAGE_MAX_AGE; rebuilding in the background",
             );
-            spawn_refresh_rebuild(
-                provider,
-                connection.map(str::to_string),
-                tag.to_string(),
-                RefreshReason::Ttl,
-            );
+            run_refresh_rebuild(provider, connection, tag, RefreshReason::Ttl);
             return;
         }
         Freshness::Unknown => {
@@ -316,65 +335,62 @@ fn refresh_in_background_if_needed(
         container = %container.as_deref().unwrap_or_default(),
         "host CLI version differs from container image; rebuilding in the background",
     );
-    spawn_refresh_rebuild(
+    run_refresh_rebuild(
         provider,
-        connection.map(str::to_string),
-        tag.to_string(),
+        connection,
+        tag,
         RefreshReason::VersionMismatch { guard_pair },
     );
 }
 
-/// Kick the background stale-while-revalidate rebuild shared by both refresh
-/// triggers: rebuild the same tag, then (on success) record the version
-/// trigger's loop guard, re-probe the fresh image's CLI version, and sweep the
-/// just-untagged predecessor. On failure, warn and keep serving the old image.
+/// The stale-while-revalidate rebuild shared by both refresh triggers: rebuild
+/// the same tag, then (on success) record the version trigger's loop guard,
+/// re-probe the fresh image's CLI version, and sweep the just-untagged
+/// predecessor. On failure, warn and keep serving the old image.
 ///
-/// The thread owns its `connection` — it outlives the launch that spawned it, and
-/// every call it makes must still reach that launch's store rather than whatever
-/// the default has become in the meantime.
-fn spawn_refresh_rebuild(
+/// Runs on [`refresh_in_background_if_needed`]'s thread, never a launch's, and
+/// every call it makes rides the launch's `connection` rather than whatever the
+/// default has become in the meantime.
+fn run_refresh_rebuild(
     provider: ContainerProvider,
-    connection: Option<String>,
-    tag: String,
+    connection: Option<&str>,
+    tag: &str,
     reason: RefreshReason,
 ) {
-    std::thread::spawn(move || {
-        let on = connection.as_deref();
-        match rebuild_image(provider, on, &tag) {
-            Ok(()) => {
-                tracing::info!(target: "fletch::podman", tag, "agent image refreshed");
-                if let RefreshReason::VersionMismatch { guard_pair } = reason {
-                    // Recorded on success only: a transient build failure should
-                    // retry next run, but a *successful* rebuild that still
-                    // mismatches (host pinned away from latest) must never loop.
-                    super::settings::record_version_refresh(provider.id(), guard_pair);
-                }
-                cache_image_version_post_build(provider, on, &tag);
-                // Podman retagged in place; the predecessor is now untagged. Reap
-                // it (and anything else stale) right away — in this store only,
-                // since this is the only one the rebuild touched.
-                match super::cleanup::sweep_stale_images_on(on) {
-                    Ok(0) => {}
-                    Ok(n) => tracing::info!(
-                        target: "fletch::podman",
-                        removed = n,
-                        "swept superseded agent images after refresh",
-                    ),
-                    Err(e) => tracing::debug!(
-                        target: "fletch::podman",
-                        error = %e,
-                        "post-refresh image sweep failed",
-                    ),
-                }
+    match rebuild_image(provider, connection, tag) {
+        Ok(()) => {
+            tracing::info!(target: "fletch::podman", tag, "agent image refreshed");
+            if let RefreshReason::VersionMismatch { guard_pair } = reason {
+                // Recorded on success only: a transient build failure should
+                // retry next run, but a *successful* rebuild that still
+                // mismatches (host pinned away from latest) must never loop.
+                super::settings::record_version_refresh(provider.id(), guard_pair);
             }
-            Err(e) => tracing::warn!(
-                target: "fletch::podman",
-                tag,
-                error = %e,
-                "background image refresh failed; keeping the existing image",
-            ),
+            cache_image_version_post_build(provider, connection, tag);
+            // Podman retagged in place; the predecessor is now untagged. Reap
+            // it (and anything else stale) right away — in this store only,
+            // since this is the only one the rebuild touched.
+            match super::cleanup::sweep_stale_images_on(connection) {
+                Ok(0) => {}
+                Ok(n) => tracing::info!(
+                    target: "fletch::podman",
+                    removed = n,
+                    "swept superseded agent images after refresh",
+                ),
+                Err(e) => tracing::debug!(
+                    target: "fletch::podman",
+                    error = %e,
+                    "post-refresh image sweep failed",
+                ),
+            }
         }
-    });
+        Err(e) => tracing::warn!(
+            target: "fletch::podman",
+            tag,
+            error = %e,
+            "background image refresh failed; keeping the existing image",
+        ),
+    }
 }
 
 /// Rebuild `provider`'s image under the same `tag` in `connection`'s store,

--- a/src-tauri/src/sandbox/podman/machine.rs
+++ b/src-tauri/src/sandbox/podman/machine.rs
@@ -14,10 +14,11 @@
 //! `podman run` will use — never from any other machine, whose mounts say
 //! nothing about where this run's binds resolve. A default connection that
 //! targets a remote host is refused outright (the identical-path binds cannot
-//! exist there); the check is skipped only when it genuinely can't be answered
-//! (no machine at all — a native Linux host or a local socket runs containers
-//! directly — or a connection list / inspect we couldn't read): guessing
-//! "unshared" there would refuse launches that work fine.
+//! exist there), as is a connection list we couldn't read after a retry — not
+//! knowing where the run goes is no reason to drop the check. It is skipped only
+//! when there is genuinely nothing to check: no machine at all (a native Linux
+//! host or a local socket runs containers directly) or an inspect that reported
+//! no mounts, where guessing "unshared" would refuse launches that work fine.
 //!
 //! The same resolution names the connection the launch is *pinned* to
 //! ([`LaunchTarget`]), which is what makes the check and the run agree: reading
@@ -66,11 +67,8 @@ pub(super) fn resolve_launch_target() -> Result<LaunchTarget> {
     // fallback: mounts of a machine this launch does not use can pass a path
     // that then arrives empty in the one it does.
     match connection_target() {
-        ConnectionTarget::Machine {
-            connection,
-            machine,
-        } => {
-            let shared_dirs = machine_shared_dirs(&machine);
+        ConnectionTarget::Machine { connection } => {
+            let shared_dirs = machine_shared_dirs(&connection);
             Ok(LaunchTarget {
                 connection: Some(connection),
                 shared_dirs,
@@ -83,7 +81,7 @@ pub(super) fn resolve_launch_target() -> Result<LaunchTarget> {
             connection: Some(connection),
             shared_dirs: None,
         }),
-        ConnectionTarget::Unknown => {
+        ConnectionTarget::NoDefault => {
             tracing::debug!(
                 target: "fletch::podman",
                 "podman default connection names no machine; skipping the shared-path preflight",
@@ -93,6 +91,15 @@ pub(super) fn resolve_launch_target() -> Result<LaunchTarget> {
                 shared_dirs: None,
             })
         }
+        // Not the same as "no connections": we don't know what the run would go
+        // through, so we can't validate its mounts. Refuse instead of quietly
+        // dropping both the pin and the preflight.
+        ConnectionTarget::Unreadable => Err(Error::SandboxUnavailable(
+            "couldn't read podman's connection list, so the launch can't be validated against \
+             the machine it would run in — the agent's mounts (workspace, RPC mailbox, \
+             credentials) could arrive empty. Retry, or check `podman system connection list`."
+                .to_string(),
+        )),
         ConnectionTarget::Remote { connection } => Err(Error::SandboxUnavailable(format!(
             "podman's default connection `{connection}` targets a remote host, so the \
              agent's mounts (workspace, RPC mailbox, credentials) would not exist inside \
@@ -102,24 +109,27 @@ pub(super) fn resolve_launch_target() -> Result<LaunchTarget> {
     }
 }
 
-/// The shared host dirs of `machine`, or `None` when the question can't be
-/// answered (a stale connection naming a deleted machine, a wedged CLI, or no
-/// mounts reported) — `podman run` will then fail on its own terms.
+/// The shared host dirs behind the connection `connection`, or `None` when the
+/// question can't be answered (a stale connection naming a deleted machine, a
+/// wedged CLI, or no mounts reported) — `podman run` will then fail on its own
+/// terms.
 ///
-/// Unpinned by design: `machine inspect` reads local machine config by name,
-/// which is exactly the name the pin strips its `-root` suffix from.
-fn machine_shared_dirs(machine: &str) -> Option<Vec<PathBuf>> {
-    let inspect = cli::run_podman(&["machine", "inspect", machine], INSPECT_TIMEOUT);
-    let out = match inspect {
-        Ok(out) if out.status.success() => out,
-        _ => {
-            tracing::debug!(
-                target: "fletch::podman",
-                machine = %machine,
-                "podman machine inspect failed; skipping the shared-path preflight",
-            );
-            return None;
-        }
+/// Unpinned by design: `machine inspect` reads local machine config by name, and
+/// the name is one of [`machine_candidates`].
+fn machine_shared_dirs(connection: &str) -> Option<Vec<PathBuf>> {
+    let inspected = machine_candidates(connection).into_iter().find_map(|name| {
+        cli::run_podman(&["machine", "inspect", name], INSPECT_TIMEOUT)
+            .ok()
+            .filter(|out| out.status.success())
+            .map(|out| (name, out))
+    });
+    let Some((machine, out)) = inspected else {
+        tracing::debug!(
+            target: "fletch::podman",
+            connection = %connection,
+            "podman machine inspect failed; skipping the shared-path preflight",
+        );
+        return None;
     };
     let dirs = parse_shared_dirs(&String::from_utf8_lossy(&out.stdout));
     if dirs.is_empty() {
@@ -134,6 +144,21 @@ fn machine_shared_dirs(machine: &str) -> Option<Vec<PathBuf>> {
     Some(dirs)
 }
 
+/// Machine names to try `podman machine inspect` with, in order. Verbatim
+/// first: a machine can genuinely be *named* `foo-root`, and stripping the
+/// suffix outright would inspect another machine's mounts. The stripped form
+/// follows for the rootful half of a `<machine>`/`<machine>-root` pair.
+fn machine_candidates(connection: &str) -> Vec<&str> {
+    let mut names = vec![connection];
+    if let Some(stripped) = connection
+        .strip_suffix("-root")
+        .filter(|name| !name.is_empty())
+    {
+        names.push(stripped);
+    }
+    names
+}
+
 /// Refuse the launch when any of `sources` lies outside the shared directories
 /// of `target` — the connection this launch is pinned to, so the dirs checked
 /// are the dirs the run resolves against. `sources` is every host path the run
@@ -143,10 +168,25 @@ pub(super) fn ensure_sources_are_shared(sources: &[PathBuf], target: &LaunchTarg
     let Some(shared) = target.shared_dirs.as_deref() else {
         return Ok(());
     };
-    let roots: Vec<PathBuf> = shared.iter().map(|p| resolve_existing_prefix(p)).collect();
-    let Some(outside) = sources
+    // Both spellings of every share. The run binds the *literal* source path and
+    // podman resolves it again inside the VM, so a source counts as shared only
+    // when both readings land in the shares: `/opt/repos/api` symlinked into
+    // `$HOME` isn't there in the VM, and `/tmp` is the VM's own tmpfs, not the
+    // host's `/private/tmp` share.
+    let mut roots: Vec<PathBuf> = Vec::new();
+    for dir in shared {
+        for root in [dir.clone(), resolve_existing_prefix(dir)] {
+            if !roots.contains(&root) {
+                roots.push(root);
+            }
+        }
+    }
+    let Some((outside, resolved)) = sources
         .iter()
-        .find(|src| !is_under_any(&resolve_existing_prefix(src), &roots))
+        .map(|src| (src, resolve_existing_prefix(src)))
+        .find(|(src, resolved)| {
+            !is_under_any(src.as_path(), &roots) || !is_under_any(resolved, &roots)
+        })
     else {
         return Ok(());
     };
@@ -155,8 +195,15 @@ pub(super) fn ensure_sources_are_shared(sources: &[PathBuf], target: &LaunchTarg
         .map(|p| p.display().to_string())
         .collect::<Vec<_>>()
         .join(", ");
+    // Name the resolved path too: "X is outside the shares" is unactionable when
+    // the real cause is where X resolves to.
+    let via = if resolved == *outside {
+        String::new()
+    } else {
+        format!(" (it resolves to {})", resolved.display())
+    };
     Err(Error::SandboxUnavailable(format!(
-        "{} is outside the Podman machine's shared directories ({listed}), so it would mount \
+        "{}{via} is outside the Podman machine's shared directories ({listed}), so it would mount \
          empty inside the container. Share it with `podman machine set --volume <dir>` and \
          restart the machine, or keep the agent's workspace under a shared directory.",
         outside.display(),
@@ -174,40 +221,56 @@ fn is_under_any(path: &Path, roots: &[PathBuf]) -> bool {
 /// Where podman's default connection points.
 #[derive(Debug, PartialEq, Eq)]
 enum ConnectionTarget {
-    /// A machine. The two names differ and are not interchangeable:
-    /// `connection` is the verbatim entry name (`work-vm-root`) that
-    /// `--connection` takes, `machine` is the `-root`-stripped name
-    /// (`work-vm`) that `podman machine inspect` takes.
-    Machine { connection: String, machine: String },
+    /// A machine, named by its verbatim entry name (`work-vm-root`) — the name
+    /// `--connection` takes. `podman machine inspect` takes a *machine* name,
+    /// which is one of [`machine_candidates`].
+    Machine { connection: String },
     /// A local unix socket (rootful Linux, say): no VM in the path, every
     /// host path is reachable, nothing to check — but still an endpoint worth
     /// pinning, hence the name.
     LocalSocket { connection: String },
     /// A remote host: bind sources don't exist there, refuse the launch.
     Remote { connection: String },
-    /// No default entry, or a list we couldn't run or read.
-    Unknown,
+    /// The list ran and parsed but names no default (or is empty): a native
+    /// Linux host or an install with no connections at all.
+    NoDefault,
+    /// The list wouldn't run, timed out, or didn't parse — the target is
+    /// unknown, which is not the same as absent.
+    Unreadable,
 }
 
+/// The default connection's target, retrying an unreadable listing once — a
+/// wedged or racing CLI read is transient, and the answer decides between
+/// pinning the launch and refusing it.
 fn connection_target() -> ConnectionTarget {
+    let target = read_connection_target();
+    if target != ConnectionTarget::Unreadable {
+        return target;
+    }
+    tracing::debug!(
+        target: "fletch::podman",
+        "podman connection list unreadable; retrying once",
+    );
+    read_connection_target()
+}
+
+fn read_connection_target() -> ConnectionTarget {
     let Ok(out) = cli::run_podman(
         &["system", "connection", "list", "--format", "json"],
         INSPECT_TIMEOUT,
     ) else {
-        return ConnectionTarget::Unknown;
+        return ConnectionTarget::Unreadable;
     };
     if !out.status.success() {
-        return ConnectionTarget::Unknown;
+        return ConnectionTarget::Unreadable;
     }
     classify_default_connection(&String::from_utf8_lossy(&out.stdout))
 }
 
 /// Classify the default entry of `podman system connection list --format json`.
-/// Machine connections come in `<machine>` / `<machine>-root` pairs, so the
-/// machine name strips a trailing `-root` while the connection name stays
-/// verbatim — pinning `--connection work-vm` when the default is
-/// `work-vm-root` would silently move the run to the rootless endpoint.
-/// `IsMachine: false` splits on the URI: a
+/// The connection name is kept verbatim — pinning `--connection work-vm` when
+/// the default is `work-vm-root` would silently move the run to the rootless
+/// endpoint. `IsMachine: false` splits on the URI: a
 /// `unix://` socket is this host (no VM, nothing to check), anything else —
 /// `ssh://`, `tcp://`, or a URI we can't read — is treated as remote and
 /// refused rather than guessed at. Older podman omits `IsMachine`; the name is
@@ -215,21 +278,23 @@ fn connection_target() -> ConnectionTarget {
 /// really is one.
 fn classify_default_connection(stdout: &str) -> ConnectionTarget {
     let Ok(connections) = serde_json::from_str::<Vec<serde_json::Value>>(stdout) else {
-        return ConnectionTarget::Unknown;
+        return ConnectionTarget::Unreadable;
     };
     let Some(default) = connections
         .iter()
         .find(|c| c.get("Default").and_then(|d| d.as_bool()) == Some(true))
     else {
-        return ConnectionTarget::Unknown;
+        return ConnectionTarget::NoDefault;
     };
     let name = default
         .get("Name")
         .and_then(|n| n.as_str())
         .map(str::trim)
         .unwrap_or_default();
+    // A default we found but can't name is a shape we don't understand, not an
+    // absent default.
     if name.is_empty() {
-        return ConnectionTarget::Unknown;
+        return ConnectionTarget::Unreadable;
     }
     if default.get("IsMachine").and_then(|m| m.as_bool()) == Some(false) {
         let uri = default.get("URI").and_then(|u| u.as_str()).unwrap_or("");
@@ -245,7 +310,6 @@ fn classify_default_connection(stdout: &str) -> ConnectionTarget {
     }
     ConnectionTarget::Machine {
         connection: name.to_string(),
-        machine: name.strip_suffix("-root").unwrap_or(name).to_string(),
     }
 }
 
@@ -254,6 +318,11 @@ fn classify_default_connection(stdout: &str) -> ConnectionTarget {
 /// the in-VM path as `Target`). Only the first machine is read — the caller
 /// inspects one machine by name (or podman's default), and any further array
 /// entries would belong to machines this launch does not go through.
+///
+/// Only mounts whose `Target` equals `Source` count: Fletch binds identical
+/// host paths (invariant 1), which exist in the VM only where the share is
+/// mounted at its own host path — a `--volume /host/x:/vm/y` share would
+/// validate binds that then mount empty.
 ///
 /// Tolerant by design: a shape we don't recognize yields an empty set, which
 /// the caller reads as "unanswerable" and skips.
@@ -272,8 +341,9 @@ fn parse_shared_dirs(stdout: &str) -> Vec<PathBuf> {
         let Some(source) = mount.get("Source").and_then(|s| s.as_str()) else {
             continue;
         };
+        let target = mount.get("Target").and_then(|t| t.as_str()).unwrap_or("");
         let source = source.trim();
-        if source.is_empty() {
+        if source.is_empty() || !same_path(source, target.trim()) {
             continue;
         }
         let path = PathBuf::from(source);
@@ -282,6 +352,11 @@ fn parse_shared_dirs(stdout: &str) -> Vec<PathBuf> {
         }
     }
     out
+}
+
+/// Component-wise path equality, so `/Users/ada/` and `/Users/ada` are one path.
+fn same_path(a: &str, b: &str) -> bool {
+    Path::new(a).components().eq(Path::new(b).components())
 }
 
 #[cfg(test)]
@@ -313,7 +388,8 @@ mod tests {
     /// each mount's `Source`. Only the first machine counts — a mount shared
     /// only by a second machine must NOT pass the preflight, or the launch
     /// would proceed and bind an empty directory in the machine it actually
-    /// runs in.
+    /// runs in. A share remapped to another in-VM path counts for nothing
+    /// either: our binds use the host path, which isn't what the VM mounted.
     #[test]
     fn parses_mount_sources_from_first_machine_only() {
         let stdout = r#"[
@@ -322,8 +398,10 @@ mod tests {
             "State": "running",
             "Mounts": [
               { "ReadOnly": false, "Source": "/Users/ada", "Tag": "vol0", "Target": "/Users/ada", "Type": "virtiofs" },
-              { "ReadOnly": false, "Source": "/private/tmp", "Tag": "vol1", "Target": "/private/tmp", "Type": "virtiofs" },
+              { "ReadOnly": false, "Source": "/private/tmp/", "Tag": "vol1", "Target": "/private/tmp", "Type": "virtiofs" },
+              { "ReadOnly": false, "Source": "/Volumes/data", "Tag": "vol2", "Target": "/mnt/data", "Type": "virtiofs" },
               { "Source": "  ", "Target": "/blank" },
+              { "Source": "/no-target" },
               { "Target": "/no-source" }
             ]
           },
@@ -341,10 +419,10 @@ mod tests {
     }
 
     /// The default connection decides which machine (if any) the preflight may
-    /// consult: `-root` pairs collapse to the machine name, a local unix socket
-    /// means no VM at all, and a remote default must classify as `Remote` —
-    /// never fall back to some local machine whose mounts say nothing about
-    /// where this run's binds resolve.
+    /// consult: the name is kept verbatim for the pin, a local unix socket means
+    /// no VM at all, and a remote default must classify as `Remote` — never fall
+    /// back to some local machine whose mounts say nothing about where this
+    /// run's binds resolve.
     #[test]
     fn default_connection_classifies_machine_socket_and_remote() {
         let rootful = r#"[
@@ -356,7 +434,6 @@ mod tests {
             classify_default_connection(rootful),
             ConnectionTarget::Machine {
                 connection: "work-vm-root".to_string(),
-                machine: "work-vm".to_string(),
             }
         );
 
@@ -397,37 +474,52 @@ mod tests {
             classify_default_connection(legacy),
             ConnectionTarget::Machine {
                 connection: "podman-machine-default".to_string(),
-                machine: "podman-machine-default".to_string(),
             }
-        );
-
-        assert_eq!(classify_default_connection("[]"), ConnectionTarget::Unknown);
-        assert_eq!(
-            classify_default_connection("Error: unknown"),
-            ConnectionTarget::Unknown
-        );
-        assert_eq!(
-            classify_default_connection(r#"[{ "Name": "m", "Default": false }]"#),
-            ConnectionTarget::Unknown
         );
     }
 
-    /// The two names a machine connection carries are not interchangeable: the
-    /// pin needs the verbatim entry name, the inspect needs the stripped one.
-    /// Conflating them sends the run to the other endpoint of a rootful pair.
+    /// "No default" and "couldn't read the list" are different answers: the
+    /// first is a genuine no-connections host and launches unpinned, the second
+    /// is unknown and must reach the caller's retry-then-refuse path rather than
+    /// silently disabling the preflight.
     #[test]
-    fn rootful_default_keeps_the_connection_and_machine_names_apart() {
-        let listing =
-            r#"[ { "Name": "podman-machine-default-root", "IsMachine": true, "Default": true } ]"#;
-        let ConnectionTarget::Machine {
-            connection,
-            machine,
-        } = classify_default_connection(listing)
-        else {
-            panic!("a rootful machine entry must classify as a machine");
-        };
-        assert_eq!(connection, "podman-machine-default-root");
-        assert_eq!(machine, "podman-machine-default");
+    fn no_default_and_unreadable_are_distinct() {
+        assert_eq!(
+            classify_default_connection("[]"),
+            ConnectionTarget::NoDefault
+        );
+        assert_eq!(
+            classify_default_connection(r#"[{ "Name": "m", "Default": false }]"#),
+            ConnectionTarget::NoDefault
+        );
+
+        assert_eq!(
+            classify_default_connection("Error: unknown"),
+            ConnectionTarget::Unreadable
+        );
+        assert_eq!(
+            classify_default_connection(""),
+            ConnectionTarget::Unreadable
+        );
+        // A default we found but can't name is a shape we don't understand.
+        assert_eq!(
+            classify_default_connection(r#"[{ "Name": "  ", "Default": true }]"#),
+            ConnectionTarget::Unreadable
+        );
+    }
+
+    /// The inspect name is tried verbatim before the `-root`-stripped form: a
+    /// machine genuinely named `foo-root` must not resolve to `foo`, whose
+    /// mounts say nothing about where this run's binds land.
+    #[test]
+    fn machine_candidates_try_the_verbatim_name_first() {
+        assert_eq!(
+            machine_candidates("podman-machine-default-root"),
+            ["podman-machine-default-root", "podman-machine-default"],
+        );
+        assert_eq!(machine_candidates("foo-root"), ["foo-root", "foo"]);
+        assert_eq!(machine_candidates("work-vm"), ["work-vm"]);
+        assert_eq!(machine_candidates("-root"), ["-root"]);
     }
 
     /// The check reads the target's own dirs, and a target with none (no VM, or
@@ -452,6 +544,52 @@ mod tests {
             shared_dirs: None,
         };
         ensure_sources_are_shared(&[outside], &unanswerable).unwrap();
+    }
+
+    /// The run binds the literal path and podman resolves it inside the VM, so
+    /// both readings have to be shared. A source that merely *sits* in a share
+    /// but resolves out of it mounts empty, and so does `/tmp` against a
+    /// `/private/tmp` share — the VM's `/tmp` is its own tmpfs.
+    #[test]
+    fn both_the_literal_and_the_resolved_source_must_be_shared() {
+        let td = tempfile::tempdir().unwrap();
+        let root = std::fs::canonicalize(td.path()).unwrap();
+        let share = root.join("share");
+        let elsewhere = root.join("elsewhere");
+        std::fs::create_dir_all(&share).unwrap();
+        std::fs::create_dir_all(&elsewhere).unwrap();
+        let target = LaunchTarget {
+            connection: Some("podman-machine-default".to_string()),
+            shared_dirs: Some(vec![share.clone()]),
+        };
+
+        // Both forms inside the share: nothing to refuse.
+        let inside = share.join("repo");
+        std::fs::create_dir_all(&inside).unwrap();
+        ensure_sources_are_shared(&[inside], &target).unwrap();
+
+        // Literal inside, resolved outside: the VM binds the literal path and
+        // finds nothing there.
+        let link = share.join("api");
+        std::os::unix::fs::symlink(&elsewhere, &link).unwrap();
+        let err = ensure_sources_are_shared(std::slice::from_ref(&link), &target).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains(&link.display().to_string()), "{msg}");
+        assert!(
+            msg.contains(&elsewhere.display().to_string()),
+            "the refusal must name where the path resolves to: {msg}",
+        );
+
+        // `/tmp` against a `/private/tmp` share: resolved is shared, literal is
+        // the VM's own tmpfs.
+        let tmp_share = LaunchTarget {
+            connection: None,
+            shared_dirs: Some(vec![PathBuf::from("/private/tmp")]),
+        };
+        let err =
+            ensure_sources_are_shared(&[PathBuf::from("/tmp/fletch-x")], &tmp_share).unwrap_err();
+        assert!(err.to_string().contains("/tmp/fletch-x"), "{err}");
+        ensure_sources_are_shared(&[PathBuf::from("/private/tmp/fletch-x")], &tmp_share).unwrap();
     }
 
     /// Anything we can't read yields an empty set, so the caller skips the

--- a/src-tauri/src/sandbox/podman/machine.rs
+++ b/src-tauri/src/sandbox/podman/machine.rs
@@ -1,29 +1,11 @@
 //! The `podman machine` shared-directory preflight.
 //!
-//! Podman on macOS runs containers inside a Linux VM, and that VM sees only the
-//! host directories the machine was configured to share (by default `$HOME`).
-//! A bind mount whose source lies outside them does not fail — the VM has
-//! nothing at that path, so the container gets an **empty directory**. Every
-//! Fletch mount is at its identical host path (invariant 1), so an agent whose
-//! workspace or RPC mailbox lands outside the shared set would start, find an
-//! empty checkout and an unreachable mailbox, and fail in ways that look like
-//! anything but a mount problem.
-//!
-//! So the launch is refused up front, naming the path and the shared dirs. The
-//! dirs come from the machine behind podman's *default connection* — the one
-//! `podman run` will use — never from any other machine, whose mounts say
-//! nothing about where this run's binds resolve. A default connection that
-//! targets a remote host is refused outright (the identical-path binds cannot
-//! exist there), as is a connection list we couldn't read after a retry — not
-//! knowing where the run goes is no reason to drop the check. It is skipped only
-//! when there is genuinely nothing to check: no machine at all (a native Linux
-//! host or a local socket runs containers directly) or an inspect that reported
-//! no mounts, where guessing "unshared" would refuse launches that work fine.
-//!
-//! The same resolution names the connection the launch is *pinned* to
-//! ([`LaunchTarget`]), which is what makes the check and the run agree: reading
-//! the state here and letting `podman run` pick its own target later is how a
-//! validated path ends up mounting empty somewhere else.
+//! A bind mount whose source is outside the VM's shared dirs doesn't fail — it
+//! mounts empty — so the launch is refused up front instead. The preflight must
+//! consult the same connection the launch is pinned to ([`LaunchTarget`]);
+//! another machine's mounts say nothing about where this run's binds resolve.
+//! When the answer is unknowable the check is skipped rather than guessed at,
+//! except for a remote or unreadable target, which is refused.
 
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -38,34 +20,23 @@ use super::cli;
 const INSPECT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Where one launch's podman invocations go, and what its mounts must live
-/// under to be visible there. Resolved once per launch and carried through the
-/// container's whole life, so validate, run, kill and reap all speak to the
-/// same endpoint.
+/// under to be visible there. Carried through the container's whole life, so
+/// validate, run, kill and reap all speak to the same endpoint.
 pub(super) struct LaunchTarget {
     /// The connection to pin every podman invocation for this container to.
-    /// `None` = no connections configured (bare native podman), where there is
-    /// no endpoint to name and the default is the only one.
+    /// `None` = no connections configured (bare native podman).
     pub(super) connection: Option<String>,
-    /// Shared host dirs to validate mount sources against. `None` = no VM in
-    /// the path, or the question is unanswerable, so the check is skipped —
-    /// guessing "unshared" would refuse launches that work.
+    /// Shared host dirs to validate mount sources against. `None` skips the
+    /// check — guessing "unshared" would refuse launches that work.
     shared_dirs: Option<Vec<PathBuf>>,
 }
 
 /// Resolve the target for one launch: which connection `podman run` must be
 /// pinned to, and that connection's shared host dirs.
 ///
-/// Deliberately uncached, and re-run on every launch. The two reads are local
-/// config (`podman system connection list`, `podman machine inspect`) and
-/// negligible next to a container start, while a process-wide cache retains
-/// roots from a connection or machine the next launch no longer uses — a
-/// reviewed bug, not a hypothetical. A TTL cache can come back if the cost ever
-/// shows up under a spawn storm.
+/// Deliberately uncached and re-run per launch — a process-wide cache retained
+/// roots from a connection the next launch no longer used.
 pub(super) fn resolve_launch_target() -> Result<LaunchTarget> {
-    // The machine the launch will actually go through, pinned by name from here
-    // on — never a union across machines and never a "some other machine"
-    // fallback: mounts of a machine this launch does not use can pass a path
-    // that then arrives empty in the one it does.
     match connection_target() {
         ConnectionTarget::Machine { connection } => {
             let shared_dirs = machine_shared_dirs(&connection);
@@ -74,9 +45,8 @@ pub(super) fn resolve_launch_target() -> Result<LaunchTarget> {
                 shared_dirs,
             })
         }
-        // A socket endpoint still gets pinned — the default connection can
-        // change mid-run, and teardown has to reach the container's own
-        // endpoint — but there is no VM, so every host path is reachable.
+        // Still pinned (the default can change mid-run, and teardown must reach
+        // this container's endpoint), but no VM means every host path is there.
         ConnectionTarget::LocalSocket { connection } => Ok(LaunchTarget {
             connection: Some(connection),
             shared_dirs: None,
@@ -91,9 +61,8 @@ pub(super) fn resolve_launch_target() -> Result<LaunchTarget> {
                 shared_dirs: None,
             })
         }
-        // Not the same as "no connections": we don't know what the run would go
-        // through, so we can't validate its mounts. Refuse instead of quietly
-        // dropping both the pin and the preflight.
+        // Not the same as "no connections": an unknown target can't be
+        // validated, so refuse rather than drop both the pin and the preflight.
         ConnectionTarget::Unreadable => Err(Error::SandboxUnavailable(
             "couldn't read podman's connection list, so the launch can't be validated against \
              the machine it would run in — the agent's mounts (workspace, RPC mailbox, \
@@ -109,13 +78,10 @@ pub(super) fn resolve_launch_target() -> Result<LaunchTarget> {
     }
 }
 
-/// The shared host dirs behind the connection `connection`, or `None` when the
-/// question can't be answered (a stale connection naming a deleted machine, a
-/// wedged CLI, or no mounts reported) — `podman run` will then fail on its own
-/// terms.
+/// The shared host dirs behind `connection`, or `None` when the question can't
+/// be answered (deleted machine, wedged CLI, no mounts reported).
 ///
-/// Unpinned by design: `machine inspect` reads local machine config by name, and
-/// the name is one of [`machine_candidates`].
+/// Unpinned by design: `machine inspect` reads local machine config by name.
 fn machine_shared_dirs(connection: &str) -> Option<Vec<PathBuf>> {
     let inspected = machine_candidates(connection).into_iter().find_map(|name| {
         cli::run_podman(&["machine", "inspect", name], INSPECT_TIMEOUT)
@@ -146,8 +112,7 @@ fn machine_shared_dirs(connection: &str) -> Option<Vec<PathBuf>> {
 
 /// Machine names to try `podman machine inspect` with, in order. Verbatim
 /// first: a machine can genuinely be *named* `foo-root`, and stripping the
-/// suffix outright would inspect another machine's mounts. The stripped form
-/// follows for the rootful half of a `<machine>`/`<machine>-root` pair.
+/// suffix outright would inspect another machine's mounts.
 fn machine_candidates(connection: &str) -> Vec<&str> {
     let mut names = vec![connection];
     if let Some(stripped) = connection
@@ -159,20 +124,15 @@ fn machine_candidates(connection: &str) -> Vec<&str> {
     names
 }
 
-/// Refuse the launch when any of `sources` lies outside the shared directories
-/// of `target` — the connection this launch is pinned to, so the dirs checked
-/// are the dirs the run resolves against. `sources` is every host path the run
-/// will bind-mount — see
+/// Refuse the launch when any of `sources` lies outside `target`'s shared
+/// directories. `sources` is every host path the run will bind-mount — see
 /// [`run_args::mount_sources`](crate::sandbox::container::run_args::mount_sources).
 pub(super) fn ensure_sources_are_shared(sources: &[PathBuf], target: &LaunchTarget) -> Result<()> {
     let Some(shared) = target.shared_dirs.as_deref() else {
         return Ok(());
     };
-    // Both spellings of every share. The run binds the *literal* source path and
-    // podman resolves it again inside the VM, so a source counts as shared only
-    // when both readings land in the shares: `/opt/repos/api` symlinked into
-    // `$HOME` isn't there in the VM, and `/tmp` is the VM's own tmpfs, not the
-    // host's `/private/tmp` share.
+    // The run binds the *literal* source and podman resolves it again inside the
+    // VM, so both readings must land in the shares.
     let mut roots: Vec<PathBuf> = Vec::new();
     for dir in shared {
         for root in [dir.clone(), resolve_existing_prefix(dir)] {
@@ -196,7 +156,7 @@ pub(super) fn ensure_sources_are_shared(sources: &[PathBuf], target: &LaunchTarg
         .collect::<Vec<_>>()
         .join(", ");
     // Name the resolved path too: "X is outside the shares" is unactionable when
-    // the real cause is where X resolves to.
+    // the cause is where X resolves to.
     let via = if resolved == *outside {
         String::new()
     } else {
@@ -210,10 +170,8 @@ pub(super) fn ensure_sources_are_shared(sources: &[PathBuf], target: &LaunchTarg
     )))
 }
 
-/// Whether `path` is at or below one of `roots`. Pure over already-resolved
-/// paths — component-wise, so `/Users/ab` is not read as being under
-/// `/Users/a`. An empty `roots` covers nothing, which is why the caller treats
-/// "no shared dirs reported" as unanswerable rather than passing it through.
+/// Whether `path` is at or below one of `roots`, component-wise, so `/Users/ab`
+/// is not read as being under `/Users/a`. An empty `roots` covers nothing.
 fn is_under_any(path: &Path, roots: &[PathBuf]) -> bool {
     roots.iter().any(|root| path.starts_with(root))
 }
@@ -221,25 +179,21 @@ fn is_under_any(path: &Path, roots: &[PathBuf]) -> bool {
 /// Where podman's default connection points.
 #[derive(Debug, PartialEq, Eq)]
 enum ConnectionTarget {
-    /// A machine, named by its verbatim entry name (`work-vm-root`) — the name
-    /// `--connection` takes. `podman machine inspect` takes a *machine* name,
-    /// which is one of [`machine_candidates`].
+    /// A machine, under the verbatim entry name `--connection` takes
+    /// (`work-vm-root`); `podman machine inspect` wants a *machine* name, one
+    /// of [`machine_candidates`].
     Machine { connection: String },
-    /// A local unix socket (rootful Linux, say): no VM in the path, every
-    /// host path is reachable, nothing to check — but still an endpoint worth
-    /// pinning, hence the name.
+    /// A local unix socket: no VM, nothing to check, but still worth pinning.
     LocalSocket { connection: String },
     /// A remote host: bind sources don't exist there, refuse the launch.
     Remote { connection: String },
-    /// The list ran and parsed but names no default (or is empty): a native
-    /// Linux host or an install with no connections at all.
+    /// Ran and parsed but names no default: native Linux, or no connections.
     NoDefault,
-    /// The list wouldn't run, timed out, or didn't parse — the target is
-    /// unknown, which is not the same as absent.
+    /// Wouldn't run, timed out, or didn't parse — unknown, not absent.
     Unreadable,
 }
 
-/// The default connection's target, retrying an unreadable listing once — a
+/// The default connection's target, retrying an unreadable listing once: a
 /// wedged or racing CLI read is transient, and the answer decides between
 /// pinning the launch and refusing it.
 fn connection_target() -> ConnectionTarget {
@@ -268,14 +222,9 @@ fn read_connection_target() -> ConnectionTarget {
 }
 
 /// Classify the default entry of `podman system connection list --format json`.
-/// The connection name is kept verbatim — pinning `--connection work-vm` when
-/// the default is `work-vm-root` would silently move the run to the rootless
-/// endpoint. `IsMachine: false` splits on the URI: a
-/// `unix://` socket is this host (no VM, nothing to check), anything else —
-/// `ssh://`, `tcp://`, or a URI we can't read — is treated as remote and
-/// refused rather than guessed at. Older podman omits `IsMachine`; the name is
-/// taken as a machine name, and the inspect that follows settles whether it
-/// really is one.
+/// The name is kept verbatim — pinning `--connection work-vm` when the default
+/// is `work-vm-root` would silently move the run to the rootless endpoint. An
+/// unreadable URI on a non-machine entry counts as remote rather than guessed.
 fn classify_default_connection(stdout: &str) -> ConnectionTarget {
     let Ok(connections) = serde_json::from_str::<Vec<serde_json::Value>>(stdout) else {
         return ConnectionTarget::Unreadable;
@@ -291,8 +240,7 @@ fn classify_default_connection(stdout: &str) -> ConnectionTarget {
         .and_then(|n| n.as_str())
         .map(str::trim)
         .unwrap_or_default();
-    // A default we found but can't name is a shape we don't understand, not an
-    // absent default.
+    // A default we found but can't name is an unknown shape, not an absent one.
     if name.is_empty() {
         return ConnectionTarget::Unreadable;
     }
@@ -313,19 +261,12 @@ fn classify_default_connection(stdout: &str) -> ConnectionTarget {
     }
 }
 
-/// Host-side sources from `podman machine inspect` output: a JSON array whose
-/// **first** machine's `Mounts` entries carry the host path as `Source` (and
-/// the in-VM path as `Target`). Only the first machine is read — the caller
-/// inspects one machine by name (or podman's default), and any further array
-/// entries would belong to machines this launch does not go through.
-///
-/// Only mounts whose `Target` equals `Source` count: Fletch binds identical
-/// host paths (invariant 1), which exist in the VM only where the share is
-/// mounted at its own host path — a `--volume /host/x:/vm/y` share would
-/// validate binds that then mount empty.
-///
-/// Tolerant by design: a shape we don't recognize yields an empty set, which
-/// the caller reads as "unanswerable" and skips.
+/// Host-side sources from `podman machine inspect` output. Only the **first**
+/// machine counts (later entries are machines this launch doesn't use), and
+/// only mounts whose `Target` equals `Source`: Fletch binds identical host
+/// paths (invariant 1), so a remapped share would validate binds that then
+/// mount empty. An unrecognized shape yields an empty set, which the caller
+/// reads as unanswerable.
 fn parse_shared_dirs(stdout: &str) -> Vec<PathBuf> {
     let Ok(machines) = serde_json::from_str::<Vec<serde_json::Value>>(stdout) else {
         return Vec::new();
@@ -363,8 +304,6 @@ fn same_path(a: &str, b: &str) -> bool {
 mod tests {
     use super::*;
 
-    /// Containment is component-wise: a sibling whose name merely starts with a
-    /// shared dir's name is not inside it.
     #[test]
     fn containment_is_component_wise() {
         let roots = vec![PathBuf::from("/Users/ada"), PathBuf::from("/private/tmp")];
@@ -379,17 +318,13 @@ mod tests {
         assert!(!is_under_any(Path::new("/Users/adamant/repo"), &roots));
         assert!(!is_under_any(Path::new("/Volumes/ext/repo"), &roots));
         assert!(!is_under_any(Path::new("/Users"), &roots));
-        // Nothing is shared when nothing is reported — which is why the caller
-        // treats an empty set as unanswerable instead of refusing every launch.
+        // Nothing is shared when nothing is reported, hence the caller's
+        // unanswerable path.
         assert!(!is_under_any(Path::new("/Users/ada"), &[]));
     }
 
-    /// The `podman machine inspect` shape: an array of machines, host paths in
-    /// each mount's `Source`. Only the first machine counts — a mount shared
-    /// only by a second machine must NOT pass the preflight, or the launch
-    /// would proceed and bind an empty directory in the machine it actually
-    /// runs in. A share remapped to another in-VM path counts for nothing
-    /// either: our binds use the host path, which isn't what the VM mounted.
+    /// A mount shared only by a second machine, or remapped to another in-VM
+    /// path, must not pass the preflight.
     #[test]
     fn parses_mount_sources_from_first_machine_only() {
         let stdout = r#"[
@@ -418,11 +353,8 @@ mod tests {
         );
     }
 
-    /// The default connection decides which machine (if any) the preflight may
-    /// consult: the name is kept verbatim for the pin, a local unix socket means
-    /// no VM at all, and a remote default must classify as `Remote` — never fall
-    /// back to some local machine whose mounts say nothing about where this
-    /// run's binds resolve.
+    /// A remote default must classify as `Remote`, never fall back to a local
+    /// machine whose mounts say nothing about this run's binds.
     #[test]
     fn default_connection_classifies_machine_socket_and_remote() {
         let rootful = r#"[
@@ -467,8 +399,7 @@ mod tests {
             }
         );
 
-        // Older podman omits IsMachine; the name is taken as a machine name
-        // and the inspect that follows settles it.
+        // Older podman omits IsMachine; the inspect that follows settles it.
         let legacy = r#"[ { "Name": "podman-machine-default", "Default": true } ]"#;
         assert_eq!(
             classify_default_connection(legacy),
@@ -478,10 +409,8 @@ mod tests {
         );
     }
 
-    /// "No default" and "couldn't read the list" are different answers: the
-    /// first is a genuine no-connections host and launches unpinned, the second
-    /// is unknown and must reach the caller's retry-then-refuse path rather than
-    /// silently disabling the preflight.
+    /// "No default" launches unpinned; "unreadable" must reach the caller's
+    /// retry-then-refuse path instead of silently disabling the preflight.
     #[test]
     fn no_default_and_unreadable_are_distinct() {
         assert_eq!(
@@ -501,16 +430,13 @@ mod tests {
             classify_default_connection(""),
             ConnectionTarget::Unreadable
         );
-        // A default we found but can't name is a shape we don't understand.
         assert_eq!(
             classify_default_connection(r#"[{ "Name": "  ", "Default": true }]"#),
             ConnectionTarget::Unreadable
         );
     }
 
-    /// The inspect name is tried verbatim before the `-root`-stripped form: a
-    /// machine genuinely named `foo-root` must not resolve to `foo`, whose
-    /// mounts say nothing about where this run's binds land.
+    /// A machine genuinely named `foo-root` must not resolve to `foo`.
     #[test]
     fn machine_candidates_try_the_verbatim_name_first() {
         assert_eq!(
@@ -522,8 +448,7 @@ mod tests {
         assert_eq!(machine_candidates("-root"), ["-root"]);
     }
 
-    /// The check reads the target's own dirs, and a target with none (no VM, or
-    /// an unanswerable inspect) passes everything through.
+    /// A target with no shared dirs passes everything through.
     #[test]
     fn the_check_follows_the_targets_shared_dirs() {
         let home = dirs::home_dir().unwrap();
@@ -546,10 +471,8 @@ mod tests {
         ensure_sources_are_shared(&[outside], &unanswerable).unwrap();
     }
 
-    /// The run binds the literal path and podman resolves it inside the VM, so
-    /// both readings have to be shared. A source that merely *sits* in a share
-    /// but resolves out of it mounts empty, and so does `/tmp` against a
-    /// `/private/tmp` share — the VM's `/tmp` is its own tmpfs.
+    /// A source that sits in a share but resolves out of it mounts empty, and
+    /// so does `/tmp` against a `/private/tmp` share.
     #[test]
     fn both_the_literal_and_the_resolved_source_must_be_shared() {
         let td = tempfile::tempdir().unwrap();
@@ -563,13 +486,11 @@ mod tests {
             shared_dirs: Some(vec![share.clone()]),
         };
 
-        // Both forms inside the share: nothing to refuse.
         let inside = share.join("repo");
         std::fs::create_dir_all(&inside).unwrap();
         ensure_sources_are_shared(&[inside], &target).unwrap();
 
-        // Literal inside, resolved outside: the VM binds the literal path and
-        // finds nothing there.
+        // Literal inside, resolved outside.
         let link = share.join("api");
         std::os::unix::fs::symlink(&elsewhere, &link).unwrap();
         let err = ensure_sources_are_shared(std::slice::from_ref(&link), &target).unwrap_err();
@@ -580,8 +501,7 @@ mod tests {
             "the refusal must name where the path resolves to: {msg}",
         );
 
-        // `/tmp` against a `/private/tmp` share: resolved is shared, literal is
-        // the VM's own tmpfs.
+        // `/tmp` resolves into the share, but the VM's `/tmp` is its own tmpfs.
         let tmp_share = LaunchTarget {
             connection: None,
             shared_dirs: Some(vec![PathBuf::from("/private/tmp")]),
@@ -592,8 +512,7 @@ mod tests {
         ensure_sources_are_shared(&[PathBuf::from("/private/tmp/fletch-x")], &tmp_share).unwrap();
     }
 
-    /// Anything we can't read yields an empty set, so the caller skips the
-    /// check rather than refusing launches on a shape change.
+    /// An unreadable shape skips the check rather than refusing every launch.
     #[test]
     fn unrecognized_inspect_output_yields_no_dirs() {
         assert!(parse_shared_dirs("[]").is_empty());

--- a/src-tauri/src/sandbox/podman/mod.rs
+++ b/src-tauri/src/sandbox/podman/mod.rs
@@ -105,6 +105,20 @@ pub fn sweep_orphans_at_startup() {
     });
 }
 
+/// Why a launch would be refused right now even though [`availability`] answers
+/// `Available`, or `None` when nothing stands in the way. `podman info` succeeds
+/// over a *remote* default connection, but every launch then refuses it (mounts
+/// of host paths cannot exist there) — so engine selection has to ask this too,
+/// or the user picks an engine that fails on every spawn.
+///
+/// The message is [`machine::resolve_launch_target`]'s own refusal, verbatim, so
+/// the selection error and the launch error can't drift.
+pub fn launch_blocker() -> Option<String> {
+    machine::resolve_launch_target()
+        .err()
+        .map(|e| e.to_string())
+}
+
 /// Gate for the `#[ignore]`d integration tests: they touch a real Podman
 /// machine, so they run only when explicitly opted in via
 /// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`.

--- a/src-tauri/src/sandbox/podman/mod.rs
+++ b/src-tauri/src/sandbox/podman/mod.rs
@@ -1,31 +1,11 @@
-//! The Podman sandbox engine and its primitives: availability probing, the
-//! agent image, orphaned-container cleanup, and the launch path.
+//! The Podman sandbox engine: availability probing, the agent image,
+//! orphaned-container cleanup, and the launch path. Layout mirrors
+//! [`docker`](crate::sandbox::docker), over the runtime-neutral policy in
+//! [`crate::sandbox::container`].
 //!
-//! Everything here must work when Podman is absent or its machine is down:
-//! probing reports that state instead of erroring, the startup sweep is
-//! probe-gated so an install-less machine never pays for a podman invocation,
-//! and `sandbox::engine_for` only routes launches here when the probe says the
-//! machine answers. "Down" and "absent" are distinguished throughout: a down
-//! machine is a state that flips (see [`sweep_orphans_at_startup`], which waits
-//! one out), an absent binary is treated as settled for the run.
-//!
-//! Layout mirrors [`docker`](crate::sandbox::docker) — the Podman *runtime* on
-//! top of the runtime-neutral policy in [`crate::sandbox::container`], which it
-//! reuses unchanged (identical-path binds, the same labels, the same image
-//! content, the same per-provider auth):
-//! - [`cli`] — podman binary resolution + bounded-invocation wrappers. Every
-//!   podman call in this module goes through it, so no invocation can hang the
-//!   app on a wedged machine connection.
-//! - [`probe`] — cached availability for UI polling.
-//! - [`image`] — building, inspecting and refreshing the agent images.
-//! - [`machine`] — the shared-directory preflight, Podman's one behavioural
-//!   difference from Docker at launch time.
-//! - [`cleanup`] — the dead-instance orphan sweep, per-agent removal, and the
-//!   stale agent-image GC.
-//! - [`settings`] — the launch knobs (`podman_image` / `podman_memory` /
-//!   `podman_cpus`) and the version-refresh loop guard.
-//! - [`engine`] — `PodmanEngine`, the `SandboxEngine` implementation (one
-//!   `podman run --rm --init` container per agent process).
+//! Everything here must work when Podman is absent or its machine is down. The
+//! two are distinct: a down machine is a state that flips and is waited out, an
+//! absent binary is settled for the run.
 
 use std::time::Instant;
 
@@ -47,34 +27,24 @@ pub use settings::{
     MEMORY_SETTING, VERSION_GUARD_SETTING,
 };
 
-/// This runtime's display name in user-facing copy — the build toast's
-/// [`BuildEvent::Started`](crate::sandbox::container::progress::BuildEvent) and
-/// the reserved-exit-code messages.
+/// This runtime's display name in user-facing copy.
 pub(super) const RUNTIME_NAME: &str = "Podman";
 
 /// Map a Podman probe result onto the shared retry schedule
-/// ([`container::sweep`](crate::sandbox::container::sweep)). A missing binary is
-/// settled for the run; a down machine is the state we expect to flip — a user
-/// who runs `podman machine start` a minute after login is the case this exists
-/// for.
+/// ([`container::sweep`](crate::sandbox::container::sweep)): a missing binary is
+/// settled for the run, a down machine is expected to flip.
 fn sweep_step(availability: &PodmanAvailability, elapsed: std::time::Duration) -> SweepStep {
     let usable = matches!(availability, PodmanAvailability::Available { .. });
     let installed = !matches!(availability, PodmanAvailability::NotInstalled);
     crate::sandbox::container::sweep::sweep_step(usable, installed, elapsed)
 }
 
-/// Best-effort reclamation of containers left behind by dead Fletch instances —
-/// and of superseded agent images — for app startup (`lib.rs`, next to the docker
-/// sweep). Runs on its own thread, so startup never waits on Podman — not even
-/// for the 2s probe timeout — and a machine without Podman skips both sweeps
-/// entirely. The image sweep runs second: a removed orphan container can unpin
-/// the stale image it was running. Both sweeps are non-fatal by construction.
-///
-/// These two sweeps and the post-refresh one are the *only* thing that ever
-/// reclaims superseded agent images from podman's store, which is why the probe
-/// retries on the [`sweep_step`] schedule rather than giving up on the first
-/// answer — a user who loses the `podman machine start` race every launch would
-/// otherwise accumulate dangling images forever.
+/// Best-effort startup reclamation of containers left by dead Fletch instances,
+/// then of superseded agent images. Own thread, so startup never waits on
+/// Podman. Image sweep runs second: removing an orphan can unpin the stale image
+/// it was running. These sweeps and the post-refresh one are the only thing that
+/// reclaims agent images, hence the [`sweep_step`] retries rather than accepting
+/// the first probe answer.
 pub fn sweep_orphans_at_startup() {
     std::thread::spawn(|| {
         let waiting_since = Instant::now();
@@ -106,22 +76,18 @@ pub fn sweep_orphans_at_startup() {
 }
 
 /// Why a launch would be refused right now even though [`availability`] answers
-/// `Available`, or `None` when nothing stands in the way. `podman info` succeeds
-/// over a *remote* default connection, but every launch then refuses it (mounts
-/// of host paths cannot exist there) — so engine selection has to ask this too,
-/// or the user picks an engine that fails on every spawn.
-///
+/// `Available`, or `None` when nothing stands in the way — `podman info`
+/// succeeds over a remote default connection that every launch then refuses.
 /// The message is [`machine::resolve_launch_target`]'s own refusal, verbatim, so
-/// the selection error and the launch error can't drift.
+/// selection and launch errors can't drift.
 pub fn launch_blocker() -> Option<String> {
     machine::resolve_launch_target()
         .err()
         .map(|e| e.to_string())
 }
 
-/// Gate for the `#[ignore]`d integration tests: they touch a real Podman
-/// machine, so they run only when explicitly opted in via
-/// `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`.
+/// Gate for the `#[ignore]`d integration tests, which touch a real Podman
+/// machine: `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored`.
 #[cfg(test)]
 pub(crate) fn podman_tests_enabled() -> bool {
     std::env::var("FLETCH_PODMAN_TESTS").as_deref() == Ok("1")
@@ -133,9 +99,6 @@ mod tests {
     use crate::sandbox::container::sweep::SWEEP_RETRY_BUDGET;
     use std::time::Duration;
 
-    /// The Podman probe's mapping onto the shared schedule: an answering
-    /// machine sweeps, a missing binary never retries, and a down machine
-    /// retries until — and only until — the budget is spent.
     #[test]
     fn sweep_retry_schedule() {
         let available = PodmanAvailability::Available {
@@ -157,7 +120,6 @@ mod tests {
             SweepStep::Retry,
             "the first probe usually loses the `podman machine start` race",
         );
-        // The budget is a deadline, not a suggestion: the loop is bounded.
         assert_eq!(
             sweep_step(&PodmanAvailability::MachineDown, SWEEP_RETRY_BUDGET),
             SweepStep::Stop,

--- a/src-tauri/src/sandbox/podman/probe.rs
+++ b/src-tauri/src/sandbox/podman/probe.rs
@@ -1,39 +1,28 @@
 //! Podman availability probe, cached for UI polling.
 //!
 //! Same contract as [`docker::probe`](crate::sandbox::docker::probe): the
-//! settings pane polls this to enable/disable the Podman engine option, and
-//! spawn paths gate on it — so it must be cheap to call repeatedly and must
-//! never hang. The underlying `podman info` call is bounded at 2s and results
-//! are cached for 5s, so a polling UI costs at most one round-trip per window.
+//! settings pane polls this and spawn paths gate on it, so it must be cheap to
+//! call repeatedly and must never hang.
 
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
 use super::cli;
 
-/// How long a probe result stays fresh. UI polling is expected at ~1s
-/// intervals; 5s keeps the traffic negligible while still flipping the UI within
-/// a beat of `podman machine start` finishing.
+/// How long a probe result stays fresh, against ~1s UI polling.
 const CACHE_TTL: Duration = Duration::from_secs(5);
 
-/// Hard cap on the `podman info` round-trip. A running machine answers in
-/// milliseconds; anything slower is indistinguishable from down for our
-/// purposes, and 2s keeps a first uncached call from stalling its caller.
+/// Hard cap on the `podman info` round-trip — a running machine answers in
+/// milliseconds, so anything slower is indistinguishable from down.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// The three states the UI distinguishes: usable now, fixable by starting the
 /// `podman machine`, or fixable only by installing Podman.
-///
-/// [`MachineDown`](Self::MachineDown) is the Podman analogue of Docker's
-/// `DaemonDown`, named for what the user actually fixes: Podman runs the
-/// containers itself with no daemon in the picture, but on macOS it needs a
-/// Linux VM, and a stopped or suspended `podman machine` is the common
-/// recoverable state. The same variant covers a Linux install whose user socket
-/// is unreachable — one remedy the user can act on either way.
+/// [`MachineDown`](Self::MachineDown) also covers a Linux install whose user
+/// socket is unreachable — one remedy the user can act on either way.
 ///
 /// Serializes to the wire shape the settings UI consumes:
-/// `{ "status": "...", "version"?: "..." }` (the `probe_podman_engine` command
-/// in `lib.rs` returns it directly).
+/// `{ "status": "...", "version"?: "..." }`.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
 #[serde(tag = "status", rename_all = "kebab-case")]
 pub enum PodmanAvailability {
@@ -47,10 +36,8 @@ pub enum PodmanAvailability {
 
 /// Current Podman availability, at most [`CACHE_TTL`] stale.
 ///
-/// The cache lock is held across the probe itself — deliberate: concurrent
-/// callers while the machine is down would otherwise each burn their own 2s
-/// timeout, and serializing them means followers get the fresh cached answer
-/// immediately.
+/// The cache lock is held across the probe deliberately: concurrent callers
+/// would otherwise each burn their own timeout on a down machine.
 pub fn availability() -> PodmanAvailability {
     static CACHE: Mutex<Option<(Instant, PodmanAvailability)>> = Mutex::new(None);
     let mut cache = CACHE.lock().unwrap();
@@ -64,17 +51,12 @@ pub fn availability() -> PodmanAvailability {
     fresh
 }
 
-/// One uncached probe: binary present? machine connection answering?
 fn probe() -> PodmanAvailability {
     if cli::podman_bin().is_none() {
         return PodmanAvailability::NotInstalled;
     }
-    // `podman info` — not `podman version`, which reports the client build from
-    // the binary alone and so answers happily with the machine stopped. `info`
-    // round-trips the machine connection, which is the thing that has to work
-    // before a launch can, and exits non-zero when it can't be reached. A
-    // timeout means a socket that accepts but never answers — same user remedy,
-    // same classification.
+    // `info`, not `version`: `version` reports the client build from the binary
+    // alone and answers happily with the machine stopped.
     match cli::run_podman(&["info", "--format", "{{.Version.Version}}"], PROBE_TIMEOUT) {
         Ok(out) if out.status.success() => {
             classify_version_stdout(&String::from_utf8_lossy(&out.stdout))
@@ -83,13 +65,12 @@ fn probe() -> PodmanAvailability {
     }
 }
 
-/// Map a successful `podman info` stdout to availability. Split out of [`probe`]
-/// so the parsing is unit-testable without a machine.
+/// Map a successful `podman info` stdout to availability.
 fn classify_version_stdout(stdout: &str) -> PodmanAvailability {
     let version = stdout.trim();
     if version.is_empty() {
-        // Zero exit but no version — treat as down rather than inventing an
-        // "unknown" state the UI would have to render.
+        // Zero exit but no version: down, rather than an "unknown" state the UI
+        // would have to render.
         PodmanAvailability::MachineDown
     } else {
         PodmanAvailability::Available {

--- a/src-tauri/src/sandbox/podman/settings.rs
+++ b/src-tauri/src/sandbox/podman/settings.rs
@@ -8,6 +8,12 @@
 //! user running both engines can point each at its own image and limits, and
 //! the version guard must stay per runtime because the two keep separate image
 //! stores — an image present in one says nothing about the other.
+//!
+//! The guard is per runtime but *not* per connection, though podman's image
+//! stores are per machine. Naively appending the connection to the pair string
+//! would ping-pong rebuilds between two machines — the map holds one pair per
+//! provider, so each machine's record would evict the other's. Left as is; the
+//! TTL backstops the second machine.
 
 use parking_lot::RwLock;
 

--- a/src-tauri/src/sandbox/podman/settings.rs
+++ b/src-tauri/src/sandbox/podman/settings.rs
@@ -1,19 +1,11 @@
 //! Launch knobs and the version-refresh loop guard, both mirrored in-process
-//! (the spawn path and background threads have no DB handle). Seeded at startup
-//! and kept in sync by the settings set-commands — see [`set_launch_settings`]
-//! and [`init_version_refresh_guard`].
+//! (the spawn path and background threads have no DB handle).
 //!
-//! Deliberately a sibling of `docker::engine::settings` rather than a shared
-//! module: the keys are per runtime (`podman_image` next to `docker_image`) so a
-//! user running both engines can point each at its own image and limits, and
-//! the version guard must stay per runtime because the two keep separate image
-//! stores — an image present in one says nothing about the other.
-//!
-//! The guard is per runtime but *not* per connection, though podman's image
-//! stores are per machine. Naively appending the connection to the pair string
-//! would ping-pong rebuilds between two machines — the map holds one pair per
-//! provider, so each machine's record would evict the other's. Left as is; the
-//! TTL backstops the second machine.
+//! Per runtime rather than shared with `docker::engine::settings`: the two keep
+//! separate image stores, so an image present in one says nothing about the
+//! other. The guard is not per *connection* even though podman's stores are
+//! per machine — the map holds one pair per provider, so two machines would
+//! evict each other and ping-pong rebuilds. The TTL backstops the second one.
 
 use parking_lot::RwLock;
 
@@ -29,10 +21,8 @@ pub const CPUS_SETTING: &str = "podman_cpus";
 // The launch defaults are container policy, not podman's: they live in
 // [`crate::sandbox::container::run_args`] so both runtimes cap the same way.
 
-/// Launch knobs read from the `settings` table, mirrored in-process (the spawn
-/// path has no DB handle — same pattern as `sandbox::set_selected_engine_kind`).
-/// Seeded at startup in `lib.rs setup` and kept in sync by the settings
-/// set-commands.
+/// Launch knobs read from the `settings` table. Seeded at startup in `lib.rs
+/// setup` and kept in sync by the settings set-commands.
 #[derive(Clone, Default)]
 pub struct LaunchSettings {
     /// `podman_image` — a non-empty value is used verbatim, skipping the
@@ -57,19 +47,17 @@ pub fn set_launch_settings(settings: LaunchSettings) {
 }
 
 /// Settings key persisting the version-refresh loop guard: a JSON object of
-/// `provider id → "host_version@image_tag"`, recording the last host/image
-/// pairing a version-mismatch rebuild *succeeded* for. Not a user-facing
-/// setting — private bookkeeping that must survive restarts, for the reason
-/// [`container::version_guard`](crate::sandbox::container::version_guard)
-/// documents.
+/// `provider id → "host_version@image_tag"`, the last pairing a rebuild
+/// succeeded for. Private bookkeeping that must survive restarts, not a
+/// user-facing setting — see
+/// [`container::version_guard`](crate::sandbox::container::version_guard).
 pub const VERSION_GUARD_SETTING: &str = "podman_version_refresh_guard";
 
 /// Podman's loop-guard state, mirrored in-process like [`LAUNCH_SETTINGS`].
 static VERSION_GUARD: VersionGuard = VersionGuard::new();
 
 /// Install the loop-guard state: `attempted` as loaded from
-/// [`VERSION_GUARD_SETTING`], `persist` writing it back. The app wires this to a
-/// `database::set_setting` closure at startup.
+/// [`VERSION_GUARD_SETTING`], `persist` writing it back.
 pub fn init_version_refresh_guard(
     attempted: std::collections::HashMap<String, String>,
     persist: impl Fn(&std::collections::HashMap<String, String>) + Send + Sync + 'static,
@@ -77,24 +65,21 @@ pub fn init_version_refresh_guard(
     VERSION_GUARD.init(attempted, persist);
 }
 
-/// Whether a version-mismatch rebuild already succeeded for exactly this `pair`
+/// Whether a rebuild already succeeded for exactly this `pair`
 /// (`"host_version@image_tag"`).
 pub(super) fn version_refresh_attempted(provider_id: &str, pair: &str) -> bool {
     VERSION_GUARD.attempted(provider_id, pair)
 }
 
-/// Record (and persist, when wired) that a version-mismatch rebuild succeeded
-/// for `pair`. Called from the background rebuild thread on success only.
+/// Record (and persist, when wired) a rebuild that succeeded for `pair`.
 pub(super) fn record_version_refresh(provider_id: &str, pair: String) {
     VERSION_GUARD.record(provider_id, pair);
 }
 
-/// The current `podman_image` override, trimmed, `None` when unset/blank — read
-/// by the image GC ([`super::cleanup::sweep_stale_images`]) to defensively
-/// exclude the user's image from removal. Structurally it should never be a
-/// candidate (Fletch never builds it, so it carries no `fletch.agent` label and
-/// lives outside Fletch's repos), but a lifecycle we don't own gets a second
-/// fence.
+/// The current `podman_image` override, trimmed, `None` when unset/blank. The
+/// image GC ([`super::cleanup::sweep_stale_images`]) excludes it: it should
+/// never be a candidate anyway (unlabelled, outside Fletch's repos), but a
+/// lifecycle we don't own gets a second fence.
 pub(super) fn image_override() -> Option<String> {
     LAUNCH_SETTINGS
         .read()
@@ -109,9 +94,6 @@ pub(super) fn image_override() -> Option<String> {
 mod tests {
     use super::*;
 
-    /// The keys mirror docker's shape one-for-one under a `podman_` prefix, so
-    /// the settings table stays readable and neither runtime can clobber the
-    /// other's knobs.
     #[test]
     fn keys_mirror_dockers_shape_under_a_podman_prefix() {
         use crate::sandbox::docker;
@@ -130,8 +112,6 @@ mod tests {
         }
     }
 
-    /// The override reader treats blank as unset — the same
-    /// blank-falls-back-to-default semantics the launch path applies.
     #[test]
     fn blank_override_reads_as_unset() {
         set_launch_settings(LaunchSettings {
@@ -150,10 +130,8 @@ mod tests {
         assert_eq!(image_override(), None);
     }
 
-    /// Podman's guard is its own static: exact-pair matching and per-provider
-    /// isolation hold here independently of docker's (the shared machinery is
-    /// covered in `docker::engine::tests`), and recording works before `init` so
-    /// a headless run still guards its own process.
+    /// Podman's guard is its own static, and works before `init` so a headless
+    /// run still guards its own process.
     #[test]
     fn version_guard_records_before_init() {
         let pair = "v1@fletch-agent:podmanonly";

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -190,7 +190,7 @@ impl Supervisor {
             };
 
             // Warm the codegraph index for the restored checkout too (best-effort;
-            // no-op when indexing is off or under Docker).
+            // no-op when indexing is off or under a container engine).
             provision_codegraph_index(
                 record.project_id.clone(),
                 snap.repo_path.clone(),
@@ -436,9 +436,7 @@ async fn choose_restore_branch_name(repo_path: &Path, desired: &str) -> String {
 ///    seatbelt agent never had a container, so it never pays for a probe.
 ///    `record: None` (discard tolerates a missing row) can't prove which
 ///    runtime launched it, so it asks both — the label match is exact, so
-///    looking costs nothing but the queries, and nothing else would reclaim
-///    the container this app run: the startup sweep keys on a *dead* owner
-///    pid, and a rowless agent's owner is this still-running process.
+///    looking costs nothing but the queries.
 /// 2. The runtime's own availability probe — a machine without that runtime
 ///    installed must never see one of its invocations, the same precedent the
 ///    startup sweeps set.
@@ -465,8 +463,7 @@ fn reap_agent_containers(agent_id: &str, record: Option<&AgentRecord>, op: &'sta
                 tracing::warn!(agent_id = %agent_id, op, runtime, error = %e, "agent container removal failed")
             }
         };
-        // A stamped engine narrows this to one runtime; a missing record asks
-        // both, each behind its own availability gate.
+        // A stamped engine narrows to one runtime; a rowless agent asks both.
         if engine != Some(EngineKind::Podman)
             && matches!(
                 docker::availability(),

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -942,16 +942,18 @@ impl Supervisor {
 
         let engine = stamped_engine(record);
         // Re-checked on every launch path (resume, view switch, binary-swap
-        // respawn), not just fresh spawns: only claude runs under docker.
+        // respawn), not just fresh spawns: not every provider is wired up to run
+        // under a container engine.
         ensure_engine_supports_provider(engine, &record.provider)?;
 
         // Dynamically fold the codegraph MCP server into the session's snapshot
-        // for this launch, when code indexing is on, the engine isn't Docker,
-        // the binary is installed, and this provider can actually receive an
-        // MCP server at all. Injected here (not persisted onto the session
-        // snapshot) so this runs identically for fresh spawns and resumes and
-        // the toggle's *current* state always wins. A user-defined "codegraph"
-        // server suppresses injection (see `codegraph`).
+        // for this launch, when code indexing is on, the engine isn't a
+        // container engine, the binary is installed, and this provider can
+        // actually receive an MCP server at all. Injected here (not persisted
+        // onto the session snapshot) so this runs identically for fresh spawns
+        // and resumes and the toggle's *current* state always wins. A
+        // user-defined "codegraph" server suppresses injection (see
+        // `codegraph`).
         let crate::codegraph::McpInjection {
             servers: mcp_servers,
             codegraph_available,

--- a/src/components/DockerBuildToast.tsx
+++ b/src/components/DockerBuildToast.tsx
@@ -9,10 +9,8 @@ import { Button } from "./ui/Button";
  * minutes-long) image build; this surfaces its progress so the wait is legible,
  * then clears itself when the build finishes. A failed build stays up with the
  * reason and a dismiss. Renders nothing when no build is in flight. Fed by the
- * `docker:build-progress` event (see store/eventListeners), keyed by the
- * runtime each event names — the runtimes build on independent locks, so a
- * Docker and a Podman build can be in flight (and rendered) at once. An event
- * without a runtime renders under neutral copy rather than guessing.
+ * `docker:build-progress` event (see store/eventListeners); Docker and Podman
+ * builds are independent, so both can be in flight and rendered at once.
  */
 export function DockerBuildToast() {
   const builds = useAppStore((s) => s.containerBuilds);

--- a/src/components/SettingsScreen/ContainerAuth.tsx
+++ b/src/components/SettingsScreen/ContainerAuth.tsx
@@ -24,7 +24,8 @@ const SETUP_COMMAND = "claude setup-token";
 /** Settings › General › Sandbox: how containerized agents authenticate to
  *  Anthropic. Shows which chain step is active and opens the connect modal —
  *  the path for Keychain-only claude logins, which containers can't see.
- *  Docker-only: seatbelt agents keep the user's own login. */
+ *  Containers only (Docker and Podman share the chain): seatbelt agents keep
+ *  the user's own login. */
 export function ContainerAuth() {
   const containerAuth = useAppStore((s) => s.containerAuth);
   const refreshContainerAuth = useAppStore((s) => s.refreshContainerAuth);
@@ -43,7 +44,7 @@ export function ContainerAuth() {
     <>
       <SetRow
         title="Claude auth for containers"
-        sub="Docker agents use your macOS Keychain Claude login, falling back to an API key or setup-token if it's unavailable. Seatbelt agents keep your own login."
+        sub="Container agents (Docker and Podman) use your macOS Keychain Claude login, falling back to an API key or setup-token if it's unavailable. Seatbelt agents keep your own login."
       >
         <span className={`set-cauth-status text-sm ${connected ? "connected" : ""}`}>
           {status ? STATUS_LABELS[status] : "Checking…"}

--- a/src/components/SettingsScreen/ExperimentalPane.tsx
+++ b/src/components/SettingsScreen/ExperimentalPane.tsx
@@ -42,10 +42,8 @@ export function ExperimentalPane() {
   );
 }
 
-/** The two container runtimes that carry launch knobs, and the copy that differs
- *  between them: the group heading and the `run` command the limits are passed
- *  to. Everything else about the three fields is identical, which is why one
- *  component serves both. */
+/** The two container runtimes that carry launch knobs, and the only copy that
+ *  differs between them: the group heading and the `run` command name. */
 const RUNTIMES = {
   docker: { label: "Docker", bin: "docker" },
   podman: { label: "Podman", bin: "podman" },

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -86,22 +86,27 @@ export function GeneralPane() {
     };
   }, [refreshDockerProbe, refreshPodmanProbe]);
 
-  // Three states for each container option: enabled when the runtime answered
-  // the probe; otherwise disabled with a hint saying how to fix it. `null`
-  // (probe still in flight) gates off too — never offer an engine we can't
-  // confirm.
+  // Four states for each container option: enabled when the runtime answered
+  // the probe; otherwise disabled with a hint saying how to fix it. A `null`
+  // probe is still in flight (up to a couple of seconds) — it gates the option
+  // off, but says "Checking…" rather than accusing an installed runtime of
+  // being missing until the answer lands.
   const dockerAvailable = dockerProbe?.status === "available";
   const dockerHint = dockerAvailable
     ? dockerProbe?.version && `v${dockerProbe.version}`
-    : dockerProbe?.status === "daemon-down"
-      ? "Start Docker Desktop"
-      : "Install Docker Desktop";
+    : !dockerProbe
+      ? "Checking…"
+      : dockerProbe.status === "daemon-down"
+        ? "Start Docker Desktop"
+        : "Install Docker Desktop";
   const podmanAvailable = podmanProbe?.status === "available";
   const podmanHint = podmanAvailable
     ? podmanProbe?.version && `v${podmanProbe.version}`
-    : podmanProbe?.status === "machine-down"
-      ? "Run podman machine start"
-      : "Install Podman";
+    : !podmanProbe
+      ? "Checking…"
+      : podmanProbe.status === "machine-down"
+        ? "Run podman machine start"
+        : "Install Podman";
 
   const FeatureRow = ({ item }: { item: FeatureItem }) => (
     <SetRow title={item.title} sub={item.sub}>

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -86,11 +86,10 @@ export function GeneralPane() {
     };
   }, [refreshDockerProbe, refreshPodmanProbe]);
 
-  // Four states for each container option: enabled when the runtime answered
-  // the probe; otherwise disabled with a hint saying how to fix it. A `null`
-  // probe is still in flight (up to a couple of seconds) — it gates the option
-  // off, but says "Checking…" rather than accusing an installed runtime of
-  // being missing until the answer lands.
+  // Each container option is enabled only when the runtime answered the probe;
+  // otherwise it's disabled with a hint saying how to fix it. A `null` probe is
+  // still in flight, so it gates the option off but says "Checking…" rather
+  // than calling an installed runtime missing.
   const dockerAvailable = dockerProbe?.status === "available";
   const dockerHint = dockerAvailable
     ? dockerProbe?.version && `v${dockerProbe.version}`

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -3,6 +3,7 @@ import type { AgentRecord } from "@/api";
 import { Icon } from "@/components/Icon";
 import { PanelToggle } from "@/components/PanelToggle";
 import { Button } from "@/components/ui/Button";
+import { CopyButton } from "@/components/ui/CopyButton";
 import { providerLabel } from "@/data/providers";
 import { EMPTY_AGENTS, useAppStore } from "@/store";
 import { RunView } from "@/workflows/run/RunView";
@@ -75,17 +76,28 @@ export function Workspace() {
   );
 }
 
-/** Classify a docker agent's crash reason so the banner can offer the right
+/** The one recovery for a stopped Podman machine — there is no auto-start
+ *  command for it, so the banner offers the command to copy instead. */
+const PODMAN_START_COMMAND = "podman machine start";
+
+/** Classify a container agent's crash reason so the banner can offer the right
  *  recovery action. Keys off the backend's own error strings (engine exit-code
- *  mapping + launch/build errors in sandbox/docker, and the D1 auth CTA):
+ *  mapping + launch/build errors in sandbox/docker and sandbox/podman, and the
+ *  D1 auth CTA):
  *   - "docker-down": daemon stopped / not installed / build couldn't connect →
  *     "Start Docker Desktop".
+ *   - "podman-down": machine stopped / not installed / build couldn't reach it →
+ *     copy `podman machine start`.
  *   - "image":       a bad image (missing/broken `claude`, exit 126/127) →
  *     point at the sandbox settings to fix `docker_image`.
  *   - "auth":        no Anthropic credentials in the container → connect Claude.
- *  Order matters: daemon-down is checked first (its message also mentions the
- *  image). Returns null for non-docker crashes (the plain banner). */
-function dockerCrashKind(msg: string | null | undefined): "docker-down" | "image" | "auth" | null {
+ *  Order matters: both engine-down arms are checked before "image", because a
+ *  machine that's down also fails while *preparing* the image — pointing at the
+ *  image settings there would be the wrong remedy. Returns null for
+ *  non-container crashes (the plain banner). */
+function dockerCrashKind(
+  msg: string | null | undefined,
+): "docker-down" | "podman-down" | "image" | "auth" | null {
   if (!msg) return null;
   const m = msg.toLowerCase();
   if (
@@ -97,6 +109,14 @@ function dockerCrashKind(msg: string | null | undefined): "docker-down" | "image
     m.includes("preparing the docker sandbox image failed")
   ) {
     return "docker-down";
+  }
+  if (
+    m.includes("podman machine") ||
+    m.includes("podman binary not found") ||
+    m.includes("is podman installed") ||
+    m.includes("preparing the podman sandbox image failed")
+  ) {
+    return "podman-down";
   }
   if (
     m.includes("connect claude for containers") ||
@@ -114,8 +134,9 @@ function dockerCrashKind(msg: string | null | undefined): "docker-down" | "image
  *  reason (otherwise only a red dot in the sidebar) and a Resume action —
  *  both already captured on the record / available in the store, just never
  *  rendered. Sits under the header so the transcript leading up to the crash
- *  stays visible. Docker crashes additionally get a targeted recovery action
- *  (start the daemon / fix the image / connect Claude). */
+ *  stays visible. Container crashes additionally get a targeted recovery action
+ *  (start the daemon / start the podman machine / fix the image / connect
+ *  Claude). */
 function CrashBanner({ agent }: { agent: AgentRecord }) {
   const resume = useAppStore((s) => s.resume);
   const startDockerDesktop = useAppStore((s) => s.startDockerDesktop);
@@ -133,19 +154,30 @@ function CrashBanner({ agent }: { agent: AgentRecord }) {
         <span className="crash-title">
           {dockerKind === "docker-down"
             ? "Docker isn't available"
-            : dockerKind === "image"
-              ? "Sandbox image problem"
-              : dockerKind === "auth"
-                ? "Claude isn't connected for containers"
-                : "Agent stopped unexpectedly"}
+            : dockerKind === "podman-down"
+              ? "Podman isn't available"
+              : dockerKind === "image"
+                ? "Sandbox image problem"
+                : dockerKind === "auth"
+                  ? "Claude isn't connected for containers"
+                  : "Agent stopped unexpectedly"}
         </span>
         {agent.last_error && <span className="crash-detail">{agent.last_error}</span>}
+        {dockerKind === "podman-down" && (
+          <span className="crash-hint">
+            Fletch can't start Podman for you — run{" "}
+            <span className="mono">{PODMAN_START_COMMAND}</span> in a terminal, then Resume.
+          </span>
+        )}
       </div>
       {dockerKind === "docker-down" && (
         <Button variant="outline" onClick={() => void startDockerDesktop()}>
           <Icon name="play" size={12} />
           Start Docker Desktop
         </Button>
+      )}
+      {dockerKind === "podman-down" && (
+        <CopyButton text={PODMAN_START_COMMAND} tip="Copy command" />
       )}
       {dockerKind === "image" && (
         <Button variant="outline" onClick={() => openSettingsScreen("experimental")}>

--- a/src/components/Workspace/index.tsx
+++ b/src/components/Workspace/index.tsx
@@ -76,8 +76,8 @@ export function Workspace() {
   );
 }
 
-/** The one recovery for a stopped Podman machine — there is no auto-start
- *  command for it, so the banner offers the command to copy instead. */
+/** Fletch can't start a stopped Podman machine itself, so the banner offers
+ *  this to copy instead of a button. */
 const PODMAN_START_COMMAND = "podman machine start";
 
 /** Classify a container agent's crash reason so the banner can offer the right
@@ -91,9 +91,8 @@ const PODMAN_START_COMMAND = "podman machine start";
  *   - "image":       a bad image (missing/broken `claude`, exit 126/127) →
  *     point at the sandbox settings to fix `docker_image`.
  *   - "auth":        no Anthropic credentials in the container → connect Claude.
- *  Order matters: both engine-down arms are checked before "image", because a
- *  machine that's down also fails while *preparing* the image — pointing at the
- *  image settings there would be the wrong remedy. Returns null for
+ *  Order matters: both engine-down arms are checked before "image", since a
+ *  down engine also fails while *preparing* the image. Returns null for
  *  non-container crashes (the plain banner). */
 function dockerCrashKind(
   msg: string | null | undefined,

--- a/src/components/ui/CopyButton.tsx
+++ b/src/components/ui/CopyButton.tsx
@@ -37,14 +37,10 @@ export function CopyButton({
     timer.current = setTimeout(() => setCopied(false), 1500);
   };
 
+  // No explicit aria-label: IconButton falls back to `tip`, so each call site's
+  // own wording ("Copy command") becomes the accessible name.
   return (
-    <IconButton
-      size="xs"
-      tip={copied ? "Copied" : tip}
-      className={className}
-      onClick={onCopy}
-      aria-label="Copy message"
-    >
+    <IconButton size="xs" tip={copied ? "Copied" : tip} className={className} onClick={onCopy}>
       <Icon name={copied ? "check" : "copy"} size={12} />
     </IconButton>
   );

--- a/src/components/ui/SandboxBadge.tsx
+++ b/src/components/ui/SandboxBadge.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@/components/Icon";
+import { isContainerEngine } from "@/storage/preferences";
 import { Badge } from "./Badge";
 
 /** Why the path looks like the host: container agents bind-mount the workspace
@@ -13,12 +14,13 @@ function hint(runtime: string) {
 
 /** A subtle container chip shown next to the workspace path on containerized
  *  agents. Renders nothing for the default seatbelt engine, so it only appears
- *  when the sandbox engine is a container one. `engine` is the agent's stamped
- *  `sandbox_engine` value; both container runtimes share the chip's tone,
- *  because what it tells the user about their paths is the same either way. */
+ *  when the sandbox engine is a container one (via `isContainerEngine`, the
+ *  single definition of that). `engine` is the agent's stamped `sandbox_engine`
+ *  value; both container runtimes share the chip's tone, because what it tells
+ *  the user about their paths is the same either way. */
 export function SandboxBadge({ engine }: { engine?: string | null }) {
-  const runtime = engine === "docker" ? "Docker" : engine === "podman" ? "Podman" : null;
-  if (!runtime) return null;
+  if (!isContainerEngine(engine)) return null;
+  const runtime = engine === "podman" ? "Podman" : "Docker";
   return (
     <Badge
       variant="docker"

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -25,6 +25,15 @@ interface Props<T extends string> {
   ariaLabel?: string;
 }
 
+/** Disabled options aren't focusable, so every keyboard path walks only the
+ *  enabled ones — otherwise a list whose options are all disabled (both
+ *  container engines missing, a common first run) swallows the arrow keys. */
+function focusableItems(list: HTMLDivElement | null) {
+  return Array.from(
+    list?.querySelectorAll<HTMLButtonElement>("[role='option']:not([disabled])") ?? [],
+  );
+}
+
 /** A styled single-select dropdown — a drop-in replacement for a native
  *  `<select>` that matches the app's `.dd` popover look (built on `Scrim`).
  *  Generic over the option value type so callers keep their string unions.
@@ -44,24 +53,17 @@ export function Select<T extends string>({
   const selected = options.find((o) => o.value === value);
   const listRef = useRef<HTMLDivElement>(null);
 
-  // On open, move focus to the selected option (or the first) so arrow keys
-  // and Enter work immediately without a Tab.
+  // On open, move focus to the selected option (or the first selectable one) so
+  // arrow keys and Enter work immediately without a Tab.
   useEffect(() => {
     if (!open) return;
-    const list = listRef.current;
-    if (!list) return;
-    const items = list.querySelectorAll<HTMLButtonElement>("[role='option']");
-    const activeIdx = Math.max(
-      0,
-      options.findIndex((o) => o.value === value),
-    );
-    items[activeIdx]?.focus();
-  }, [open, options, value]);
+    const items = focusableItems(listRef.current);
+    const active = items.find((el) => el.getAttribute("aria-selected") === "true");
+    (active ?? items[0])?.focus();
+  }, [open]);
 
   function onListKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
-    const items = Array.from(
-      listRef.current?.querySelectorAll<HTMLButtonElement>("[role='option']") ?? [],
-    );
+    const items = focusableItems(listRef.current);
     if (items.length === 0) return;
     const current = items.indexOf(document.activeElement as HTMLButtonElement);
     if (e.key === "ArrowDown") {

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -222,11 +222,10 @@ export function parseSandboxEngine(raw: string | undefined): SandboxEngine {
 }
 
 /** Whether an engine runs the agent inside a container — mirrors the backend's
- *  `EngineKind::is_container`. Every surface that gates on "containerized"
- *  (provider support, the workspace badge) asks this instead of comparing
- *  against `"docker"`, so a third container runtime lands in one place. Takes a
- *  loose string because the badge reads an agent's stamped `sandbox_engine`
- *  straight off the record, where it is unparsed and may be absent. */
+ *  `EngineKind::is_container`. Every "containerized" gate calls this rather
+ *  than comparing against `"docker"`. Takes a loose string because callers read
+ *  an agent's stamped `sandbox_engine` off the record, unparsed and possibly
+ *  absent. */
 export function isContainerEngine(engine: string | null | undefined): boolean {
   return engine === "docker" || engine === "podman";
 }

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -224,8 +224,10 @@ export function parseSandboxEngine(raw: string | undefined): SandboxEngine {
 /** Whether an engine runs the agent inside a container — mirrors the backend's
  *  `EngineKind::is_container`. Every surface that gates on "containerized"
  *  (provider support, the workspace badge) asks this instead of comparing
- *  against `"docker"`, so a third container runtime lands in one place. */
-export function isContainerEngine(engine: SandboxEngine): boolean {
+ *  against `"docker"`, so a third container runtime lands in one place. Takes a
+ *  loose string because the badge reads an agent's stamped `sandbox_engine`
+ *  straight off the record, where it is unparsed and may be absent. */
+export function isContainerEngine(engine: string | null | undefined): boolean {
   return engine === "docker" || engine === "podman";
 }
 

--- a/src/store/buildEvents.test.ts
+++ b/src/store/buildEvents.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import type { DockerBuildEvent } from "@/api";
+import { applyBuildEvent, type DockerBuildProgress, NEUTRAL_BUILD_RUNTIME } from "./sandbox";
+
+const ev = (e: DockerBuildEvent) => e;
+const building = (lastLine: string | null = null): DockerBuildProgress => ({
+  status: "building",
+  lastLine,
+  error: null,
+});
+
+describe("applyBuildEvent", () => {
+  it("opens a build entry keyed by the event's runtime", () => {
+    const next = applyBuildEvent({}, ev({ phase: "started", runtime: "Podman" }));
+    expect(next).toEqual({ Podman: building() });
+  });
+
+  it("routes an event without a runtime to the neutral key", () => {
+    const next = applyBuildEvent({}, ev({ phase: "started" }));
+    expect(Object.keys(next)).toEqual([NEUTRAL_BUILD_RUNTIME]);
+    expect(next[NEUTRAL_BUILD_RUNTIME]).toEqual(building());
+  });
+
+  it("updates only its own key's tail on a line", () => {
+    const before = { Docker: building("step 1"), Podman: building("pulling") };
+    const next = applyBuildEvent(before, ev({ phase: "line", runtime: "Docker", line: "step 2" }));
+    expect(next.Docker).toEqual(building("step 2"));
+    expect(next.Podman).toBe(before.Podman);
+  });
+
+  it("materializes a building entry when a line arrives with no entry (reload mid-build)", () => {
+    const next = applyBuildEvent({}, ev({ phase: "line", runtime: "Docker", line: "step 7" }));
+    expect(next).toEqual({ Docker: building("step 7") });
+  });
+
+  it("keeps the previous tail when a line event carries no text", () => {
+    const next = applyBuildEvent(
+      { Docker: building("step 2") },
+      ev({ phase: "line", runtime: "Docker" }),
+    );
+    expect(next.Docker).toEqual(building("step 2"));
+  });
+
+  it("deletes only its own key on finished", () => {
+    const before = { Docker: building("step 2"), Podman: building("pulling") };
+    const next = applyBuildEvent(before, ev({ phase: "finished", runtime: "Docker" }));
+    expect(next).toEqual({ Podman: building("pulling") });
+  });
+
+  it("ignores a finished for a runtime with no entry", () => {
+    const before = { Podman: building("pulling") };
+    expect(applyBuildEvent(before, ev({ phase: "finished", runtime: "Docker" }))).toBe(before);
+  });
+
+  it("sets the error on its own key and leaves the other runtime building", () => {
+    const before = { Podman: building("pulling") };
+    const next = applyBuildEvent(
+      before,
+      ev({ phase: "failed", runtime: "Docker", error: "no space left" }),
+    );
+    expect(next.Docker).toEqual({ status: "failed", lastLine: null, error: "no space left" });
+    expect(next.Podman).toBe(before.Podman);
+  });
+
+  it("falls back to generic copy when a failure carries no reason", () => {
+    const next = applyBuildEvent({}, ev({ phase: "failed", runtime: "Podman" }));
+    expect(next.Podman?.error).toBe("Image build failed");
+  });
+
+  it("clears a displayed failure when the build is retried", () => {
+    const failed = applyBuildEvent(
+      {},
+      ev({ phase: "failed", runtime: "Podman", error: "no space left" }),
+    );
+    const retried = applyBuildEvent(failed, ev({ phase: "started", runtime: "Podman" }));
+    expect(retried.Podman).toEqual(building());
+  });
+
+  it("never lets interleaved Docker and Podman lifecycles clear each other", () => {
+    const events: DockerBuildEvent[] = [
+      { phase: "started", runtime: "Docker" },
+      { phase: "started", runtime: "Podman" },
+      { phase: "line", runtime: "Docker", line: "docker step 1" },
+      { phase: "line", runtime: "Podman", line: "podman step 1" },
+      { phase: "finished", runtime: "Docker" },
+      { phase: "line", runtime: "Podman", line: "podman step 2" },
+    ];
+    const state = events.reduce(applyBuildEvent, {} as Record<string, DockerBuildProgress>);
+    // Docker's finish removed only Docker; Podman's build kept streaming.
+    expect(state).toEqual({ Podman: building("podman step 2") });
+  });
+
+  it("keeps one runtime's failure visible while the other finishes", () => {
+    const events: DockerBuildEvent[] = [
+      { phase: "started", runtime: "Docker" },
+      { phase: "started", runtime: "Podman" },
+      { phase: "failed", runtime: "Docker", error: "build kaput" },
+      { phase: "finished", runtime: "Podman" },
+    ];
+    const state = events.reduce(applyBuildEvent, {} as Record<string, DockerBuildProgress>);
+    expect(state).toEqual({
+      Docker: { status: "failed", lastLine: null, error: "build kaput" },
+    });
+  });
+
+  it("does not mutate the state it is given", () => {
+    const before = { Docker: building("step 1") };
+    const snapshot = structuredClone(before);
+    applyBuildEvent(before, ev({ phase: "failed", runtime: "Docker", error: "boom" }));
+    applyBuildEvent(before, ev({ phase: "finished", runtime: "Docker" }));
+    expect(before).toEqual(snapshot);
+  });
+});

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -491,8 +491,7 @@ export const registerEventListeners = async (set: AppSet, get: AppGet) => {
   });
 
   // Container image-build progress (first spawn under a runtime). Drives the
-  // build toast; `applyBuildEvent` owns the per-runtime routing (see
-  // store/sandbox), so it stays testable outside a live event stream.
+  // build toast; `applyBuildEvent` (store/sandbox) owns the per-runtime routing.
   await onDockerBuildProgress((e) => {
     set((s) => ({ containerBuilds: applyBuildEvent(s.containerBuilds, e) }));
   });

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -66,7 +66,7 @@ import { AUTOPILOT_SETTING, parseAutopilotEnrollment } from "./autopilot";
 import { interruptedAgents } from "./interrupted";
 import { stampPrWrite } from "./prWriteOrder";
 import { refreshWorkspace } from "./refreshWorkspace";
-import { NEUTRAL_BUILD_RUNTIME } from "./sandbox";
+import { applyBuildEvent } from "./sandbox";
 import type { AppSlice, SliceCreator } from "./types";
 
 type AppSet = Parameters<SliceCreator<AppSlice>>[0];
@@ -491,45 +491,10 @@ export const registerEventListeners = async (set: AppSet, get: AppGet) => {
   });
 
   // Container image-build progress (first spawn under a runtime). Drives the
-  // build toast: started opens it, lines update the tail, finished clears it,
-  // failed keeps it up (with the reason) until the user dismisses. Every phase
-  // is routed by the event's runtime — Docker and Podman build on independent
-  // locks, so their lifecycles can interleave and one runtime's finished/failed
-  // must never touch the other's entry.
+  // build toast; `applyBuildEvent` owns the per-runtime routing (see
+  // store/sandbox), so it stays testable outside a live event stream.
   await onDockerBuildProgress((e) => {
-    const key = e.runtime ?? NEUTRAL_BUILD_RUNTIME;
-    if (e.phase === "started") {
-      set((s) => ({
-        containerBuilds: {
-          ...s.containerBuilds,
-          [key]: { status: "building", lastLine: null, error: null },
-        },
-      }));
-    } else if (e.phase === "line") {
-      set((s) => {
-        const build = s.containerBuilds[key];
-        return build
-          ? {
-              containerBuilds: {
-                ...s.containerBuilds,
-                [key]: { ...build, lastLine: e.line ?? build.lastLine },
-              },
-            }
-          : {};
-      });
-    } else if (e.phase === "finished") {
-      set((s) => {
-        const { [key]: _, ...rest } = s.containerBuilds;
-        return { containerBuilds: rest };
-      });
-    } else if (e.phase === "failed") {
-      set((s) => ({
-        containerBuilds: {
-          ...s.containerBuilds,
-          [key]: { status: "failed", lastLine: null, error: e.error ?? "Image build failed" },
-        },
-      }));
-    }
+    set((s) => ({ containerBuilds: applyBuildEvent(s.containerBuilds, e) }));
   });
 };
 

--- a/src/store/sandbox.ts
+++ b/src/store/sandbox.ts
@@ -1,6 +1,7 @@
 import {
   api,
   type ContainerAuthStatus,
+  type DockerBuildEvent,
   type DockerProbe,
   type PodmanProbe,
   type PublishApproval,
@@ -27,6 +28,46 @@ export interface DockerBuildProgress {
 /** `containerBuilds` key for events that didn't name a runtime — the toast
  *  shows neutral copy for it instead of guessing. */
 export const NEUTRAL_BUILD_RUNTIME = "container";
+
+/** Fold one `docker:build-progress` event into the keyed build state that
+ *  drives the toast. Pure so the routing is testable without a live event
+ *  stream — it is the whole reason two runtimes' overlapping builds don't clear
+ *  each other, and every phase touches only its own runtime's key.
+ *
+ *  `line` materializes a missing entry rather than dropping the event: a window
+ *  reload mid-build loses the `started` we already handled, and without this
+ *  the toast would stay hidden for the rest of that (minutes-long) build. */
+export function applyBuildEvent(
+  builds: Record<string, DockerBuildProgress>,
+  e: DockerBuildEvent,
+): Record<string, DockerBuildProgress> {
+  const key = e.runtime ?? NEUTRAL_BUILD_RUNTIME;
+  switch (e.phase) {
+    case "started":
+      // Overwrites, so a retry clears the previous attempt's displayed error.
+      return { ...builds, [key]: { status: "building", lastLine: null, error: null } };
+    case "line": {
+      const build: DockerBuildProgress = builds[key] ?? {
+        status: "building",
+        lastLine: null,
+        error: null,
+      };
+      return { ...builds, [key]: { ...build, lastLine: e.line ?? build.lastLine } };
+    }
+    case "finished": {
+      if (!(key in builds)) return builds;
+      const { [key]: _done, ...rest } = builds;
+      return rest;
+    }
+    case "failed":
+      return {
+        ...builds,
+        [key]: { status: "failed", lastLine: null, error: e.error ?? "Image build failed" },
+      };
+    default:
+      return builds;
+  }
+}
 
 export interface SandboxSlice {
   /** Engine new agents are stamped with. Mirrors the backend-owned

--- a/src/store/sandbox.ts
+++ b/src/store/sandbox.ts
@@ -14,9 +14,8 @@ import type { SliceCreator } from "./types";
 /** Live state of one embedded container image build (first spawn under a
  *  runtime). `building` streams the latest output line; `failed` stays up
  *  (with `error`) until dismissed; success removes the entry. The runtime is
- *  the map key in `containerBuilds`, not a field here — each runtime's build
- *  serializes on its own lock, so Docker and Podman builds can overlap and
- *  must not share one state slot. */
+ *  the `containerBuilds` key rather than a field here — Docker and Podman
+ *  builds run on independent locks and can overlap. */
 export interface DockerBuildProgress {
   status: "building" | "failed";
   /** Most recent `build` output line (building only). */
@@ -30,13 +29,8 @@ export interface DockerBuildProgress {
 export const NEUTRAL_BUILD_RUNTIME = "container";
 
 /** Fold one `docker:build-progress` event into the keyed build state that
- *  drives the toast. Pure so the routing is testable without a live event
- *  stream — it is the whole reason two runtimes' overlapping builds don't clear
- *  each other, and every phase touches only its own runtime's key.
- *
- *  `line` materializes a missing entry rather than dropping the event: a window
- *  reload mid-build loses the `started` we already handled, and without this
- *  the toast would stay hidden for the rest of that (minutes-long) build. */
+ *  drives the toast. Every phase touches only its own runtime's key, so
+ *  overlapping builds don't clear each other. */
 export function applyBuildEvent(
   builds: Record<string, DockerBuildProgress>,
   e: DockerBuildEvent,
@@ -47,6 +41,8 @@ export function applyBuildEvent(
       // Overwrites, so a retry clears the previous attempt's displayed error.
       return { ...builds, [key]: { status: "building", lastLine: null, error: null } };
     case "line": {
+      // Materializes a missing entry: a reload mid-build loses the `started`,
+      // and the toast would stay hidden for the rest of a minutes-long build.
       const build: DockerBuildProgress = builds[key] ?? {
         status: "building",
         lastLine: null,
@@ -82,9 +78,8 @@ export interface SandboxSlice {
   containerAuth: ContainerAuthStatus | null;
   /** Live image-build progress for the build toast, keyed by the runtime
    *  display name from the event stream ("Docker" / "Podman", or
-   *  [`NEUTRAL_BUILD_RUNTIME`]). Keyed because the runtimes build
-   *  independently: one runtime's `finished` must not clear the other's
-   *  still-running toast. Empty = no build in flight. */
+   *  [`NEUTRAL_BUILD_RUNTIME`]) so one runtime's `finished` can't clear the
+   *  other's still-running toast. Empty = no build in flight. */
   containerBuilds: Record<string, DockerBuildProgress>;
   /** Advanced docker launch knobs, mirrored from the backend-owned
    *  `docker_image` / `docker_memory` / `docker_cpus` settings. Empty string =
@@ -93,9 +88,8 @@ export interface SandboxSlice {
   dockerImage: string;
   dockerMemory: string;
   dockerCpus: string;
-  /** The same three knobs for podman (`podman_image` / `podman_memory` /
-   *  `podman_cpus`), with the same defaults and the same blank-is-unset rule.
-   *  Separate keys so a user running both engines configures each. */
+  /** The same three knobs for podman, under separate settings keys so a user
+   *  running both engines configures each. */
   podmanImage: string;
   podmanMemory: string;
   podmanCpus: string;
@@ -125,8 +119,7 @@ export interface SandboxSlice {
   /** Re-probe Docker availability into `dockerProbe` (settings pane open).
    *  Returns the probe result so callers can poll until the daemon answers. */
   refreshDockerProbe: () => Promise<DockerProbe>;
-  /** Re-probe Podman availability into `podmanProbe`; sibling of
-   *  `refreshDockerProbe`, polled by the same settings-pane loop. */
+  /** Re-probe Podman availability into `podmanProbe`. */
   refreshPodmanProbe: () => Promise<PodmanProbe>;
   /** Re-resolve the container auth chain into `containerAuth`. */
   refreshContainerAuth: () => Promise<void>;
@@ -137,9 +130,7 @@ export interface SandboxSlice {
   /** Drop the stored container token, then refresh the status (a later chain
    *  step — shell env / credentials file — may take over). */
   clearContainerAuthToken: () => Promise<void>;
-  /** Dismiss one runtime's build toast (used after a failed build). Takes the
-   *  `containerBuilds` key so dismissing one runtime's failure leaves the
-   *  other's live toast alone. */
+  /** Dismiss one runtime's build toast (used after a failed build). */
   dismissDockerBuild: (runtime: string) => void;
   /** Persist the advanced docker launch knobs (image / memory / cpus) via the
    *  backend, which writes the settings AND updates the spawn-path mirror.

--- a/src/styles/shared/banners.css
+++ b/src/styles/shared/banners.css
@@ -68,6 +68,13 @@
   max-height: 4.5em;
   overflow: auto;
 }
+/* Prose recovery guidance under the raw crash reason (e.g. the terminal command
+   to bring a stopped Podman machine back), so it reads as instruction rather
+   than as more of the mono error text above it. */
+.crash-hint {
+  color: var(--fg-2);
+  font-size: var(--fs-sm);
+}
 .crash-banner .btn-t {
   flex-shrink: 0;
 }


### PR DESCRIPTION
Follow-up to #625–#629: a six-lens adversarial review of the merged Podman work (lifecycle/concurrency, image lifecycle, preflight edges, frontend/IPC, Docker-regression, guarantees/gates — every finding independently verified before fixing), plus the comment trim. Four commits, reviewable independently.

## 1. `fix(sandbox): harden the podman preflight and sweep enumeration`
The #628 fixes that missed its merge window:
- **Rootful/rootless sweeps**: `<machine>` / `<machine>-root` reach two *disjoint* stores; the sweep set now dedupes by connection URI instead of collapsing the pair, so a rootful-default user's containers and images are actually reclaimed.
- **Unreadable connection list fails closed** (one retry, then refusal) instead of silently disabling both the pin and the mount preflight; a genuine no-connections host still skips cleanly.
- **Mount preflight checks literal *and* resolved source paths** — a source symlinked into `$HOME` (or `/tmp` vs a `/private/tmp` share) no longer passes validation and then bind-mounts empty in the VM.
- Shares remapped to a different VM path (`Target != Source`) are excluded; machines genuinely named `*-root` are inspected verbatim-first.

## 2. `fix(ui): surface podman failures and harden the build-toast state`
- A `podman-down` crash-banner arm (matched before the "sandbox image" fallback) with `podman machine start` guidance + copy button — a machine-down build failure no longer routes users to the image-override knobs.
- Engine select is keyboard-navigable with disabled options; probe-pending shows "Checking…" instead of flashing "Install Podman"; a reload mid-build re-materializes the progress toast; ContainerAuth copy covers both runtimes; `isContainerEngine` now backs the badge as documented.
- The `containerBuilds` reducer extracted pure + 13 vitest tests pinning the per-runtime lifecycle routing.

## 3. `fix(sandbox): close the review findings on the podman hardening layer`
- **Podman image GC actually reclaims**: podman reports `localhost/`-qualified repos, which the shared rules never matched — every superseded image survived forever. Comparison keys normalize the prefix; removal refs stay verbatim.
- **Launches stop serializing behind builds**: both engines' image caches are two-phase (never held across a up-to-10-minute build), and the freshness decision (inspect + in-image version probe, up to 40s) moved fully off-thread — stale-while-revalidate now means what it says.
- Preflight runs before the image build; `set_sandbox_engine` refuses a remote default connection at selection time (`launch_blocker`); `across_machines` reports total failure instead of `Ok(0)`; a transport error no longer strands a store's remaining GC candidates; overrides referenced by full ID/digest are GC-protected; version-guard persistence no longer runs under its write lock.
- New guards: a golden test pinning Docker's isolation-panel note against edits to the shared macro, a call-site test for the legacy-image GC arm, and a drift test proving every bind source `run_args` emits is covered by `mount_sources`.

## 4. `chore(sandbox): trim comments across the podman work`
Net **−1,052 comment lines** across 34 files, verified comment-only (zero non-comment lines changed). Module docs compressed to their load-bearing invariants; narration, design history, and cross-file re-explanations deleted. Kept deliberately: the security blocks (agent-writable `alternates`, auth argv invariants), the numbered mount invariants, and the GC safety-fence parameter docs. Stale claims fixed ("Podman is refused outright", "only claude runs under docker").

## Verification
rustfmt + clippy clean; `cargo test` 1457 passed; tsc clean; vitest 1012 passed. Golden-string tests pin the user-facing copy through the trim.

## Known deferred (documented in-code)
Superseded *base*-image reclamation for podman (weekly `--pull` strands ~200 MB per base-digest move in the fixed-size machine disk — the one item worth a scheduled follow-up); version guard is per-runtime, not per-connection (TTL backstops; the naive fix ping-pongs rebuilds). Real-machine validation still pending: `FLETCH_PODMAN_TESTS=1 cargo test -- --ignored` on a host with a Podman machine.