### PR TITLE
feat(supervisor): adopt a pre-provisioned workspace at spawn

### DIFF
--- a/src-tauri/migrations/0038_worktree_adopted_checkout.sql
+++ b/src-tauri/migrations/0038_worktree_adopted_checkout.sql
@@ -1,0 +1,17 @@
+-- A working tree the agent adopted rather than provisioned.
+--
+-- Every checkout so far has been agent-owned: the spawn cloned it at
+-- `~/.fletch/workspaces/<workspace-id>/<subdir>/` and archive/discard removed
+-- it. The workflow kernel introduces the other ownership direction — all
+-- sequential steps of a run share ONE pre-provisioned working tree (the run
+-- repo at `~/.fletch/runs/<run-id>/repo`), so a step agent is a tenant of a
+-- directory the *run* owns: it is never cloned per step, and it must outlive
+-- every agent that works in it.
+--
+-- Holding the path here rather than re-deriving it makes that one fact
+-- authoritative for every consumer (the CLI's working dir, git facts, the
+-- shell, the file tree, teardown), so no reader can resolve the agent-owned
+-- layout for a tree that isn't there. NULL — the only value an existing row can
+-- have, and the default for every ordinary spawn — means the agent owns its
+-- checkout at the derived path.
+ALTER TABLE worktrees ADD COLUMN adopted_checkout TEXT;

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -55,6 +55,8 @@ pub async fn spawn_agent(
             // and are never run-owned; the scheduler sets both for a step spawn.
             run_repo: None,
             owner_run_id: None,
+            // Adopting a shared run workspace is a workflow-kernel-only path.
+            existing_workspace: None,
             // Carrying another workspace's working tree is a fork-only path.
             carry_from: None,
             // Set when the spawn originates from a Home-inbox issue.

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -7,7 +7,7 @@ use tauri::State;
 use crate::error::{Error, Result};
 use crate::git;
 use crate::supervisor::Supervisor;
-use crate::workspace::{repo_checkout_path, AgentRecord, DiffStats, Workspace};
+use crate::workspace::{AgentRecord, DiffStats, Workspace};
 
 use super::files::{agent_repo_checkout, diff_base, primary_repo_checkout};
 
@@ -108,7 +108,7 @@ pub async fn get_agent_diff_stats(
     let mut stats = DiffStats::default();
 
     for repo in &record.repos {
-        let checkout = repo_checkout_path(&agent_id, &repo.subdir)?;
+        let checkout = repo.checkout_path(&agent_id)?;
         let base = diff_base(repo);
         let base_ref = base.as_deref().unwrap_or("HEAD");
         let diff = match git::checkout_diff_shortstat(&checkout, base_ref).await {

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -12,7 +12,7 @@ use crate::error::{Error, Result};
 use crate::git;
 use crate::git_state::{self, FileStatus, StatusKind};
 use crate::supervisor::Supervisor;
-use crate::workspace::{repo_checkout_path, TrackedRepo};
+use crate::workspace::TrackedRepo;
 
 /// The ref a checkout's *committed* changes are diffed against: the immutable
 /// fork-point SHA captured at spawn when known, else the parent branch name
@@ -231,7 +231,7 @@ pub(super) fn primary_repo_checkout(
     agent_id: &str,
 ) -> Result<(TrackedRepo, PathBuf)> {
     let repo = primary_repo(supervisor, agent_id)?;
-    let checkout = repo_checkout_path(agent_id, &repo.subdir)?;
+    let checkout = repo.checkout_path(agent_id)?;
     Ok((repo, checkout))
 }
 
@@ -252,7 +252,7 @@ pub(super) fn agent_repo_checkout(
         .into_iter()
         .find(|r| r.subdir == s)
         .ok_or_else(|| Error::Other(format!("agent has no tracked repo {s:?}")))?;
-    let checkout = repo_checkout_path(agent_id, &repo.subdir)?;
+    let checkout = repo.checkout_path(agent_id)?;
     Ok((repo, checkout))
 }
 
@@ -274,7 +274,7 @@ pub(super) fn agent_repo_checkout_opt(
     let Some(repo) = repo else {
         return Ok(None);
     };
-    let checkout = repo_checkout_path(agent_id, &repo.subdir)?;
+    let checkout = repo.checkout_path(agent_id)?;
     Ok(Some((repo, checkout)))
 }
 
@@ -332,7 +332,7 @@ fn checkout_scope_for_path(
         return Ok((checkout, parent, path.to_string()));
     }
     let (repo, rel) = split_repo_path(&record.repos, path)?;
-    let checkout = repo_checkout_path(agent_id, &repo.subdir)?;
+    let checkout = repo.checkout_path(agent_id)?;
     let parent = diff_base(repo).unwrap_or_else(|| "main".to_string());
     Ok((checkout, parent, rel))
 }
@@ -411,7 +411,7 @@ pub async fn list_checkout_tree(
     for repo in &record.repos {
         // One broken checkout shouldn't blank the whole tree — skip it and
         // keep listing the others.
-        let Ok(checkout) = repo_checkout_path(&agent_id, &repo.subdir) else {
+        let Ok(checkout) = repo.checkout_path(&agent_id) else {
             continue;
         };
         let parent = diff_base(repo).unwrap_or_else(|| "main".to_string());
@@ -698,6 +698,7 @@ mod split_repo_path_tests {
             pr_title: None,
             pr_state: None,
             label: None,
+            adopted_checkout: None,
         }
     }
 

--- a/src-tauri/src/commands/git_state.rs
+++ b/src-tauri/src/commands/git_state.rs
@@ -11,7 +11,6 @@ use crate::git;
 use crate::git_state::{self, GitState, ShortStats};
 use crate::github as gh;
 use crate::supervisor::Supervisor;
-use crate::workspace::repo_checkout_path;
 
 use super::files::agent_repo_checkout_opt;
 
@@ -75,7 +74,7 @@ pub async fn get_all_shortstats(
         // sum across all of its repos (matching the archive metadata, which
         // also aggregates). Single-repo agents behave exactly as before.
         for repo in &agent.repos {
-            let Ok(checkout) = repo_checkout_path(&agent.id, &repo.subdir) else {
+            let Ok(checkout) = repo.checkout_path(&agent.id) else {
                 continue;
             };
             let agent_id = agent.id.clone();
@@ -129,7 +128,7 @@ pub async fn get_all_git_meta(
             continue;
         }
         for (i, repo) in agent.repos.iter().enumerate() {
-            let Ok(checkout) = repo_checkout_path(&agent.id, &repo.subdir) else {
+            let Ok(checkout) = repo.checkout_path(&agent.id) else {
                 continue;
             };
             let key = crate::supervisor::pr_map_key(&agent.id, &repo.subdir, i == 0);

--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -71,6 +71,7 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0035_roadmap_items_drop_dormant.sql"),
     include_str!("../../migrations/0036_roadmap_issue_url.sql"),
     include_str!("../../migrations/0037_roadmap_close_reason.sql"),
+    include_str!("../../migrations/0038_worktree_adopted_checkout.sql"),
 ];
 
 pub(crate) fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/git/hardening.rs
+++ b/src-tauri/src/git/hardening.rs
@@ -134,7 +134,10 @@ const EXEC_CONFIG: &[(&str, &str)] = &[
 /// Refuse to run host-side git in `dir` when the checkout's own config would make
 /// git execute a program.
 ///
-/// Scoped to **agent checkouts**. A user's own repository legitimately carries
+/// Scoped to **agent-writable trees**: agent checkouts, and run directories
+/// (`~/.fletch/runs/…`) — a kernel step agent writes its adopted run workspace
+/// as freely as a normal agent writes its checkout, so both roots are poisoned
+/// ground for host-side git. A user's own repository legitimately carries
 /// these keys — husky sets `core.hooksPath`, git-lfs sets `filter.lfs.*` — and
 /// refusing there would break the app for them. Their repo is also not
 /// agent-writable, so there is nothing to defend against. Only the **local and
@@ -149,10 +152,13 @@ const EXEC_CONFIG: &[(&str, &str)] = &[
 /// which also surfaces the attack instead of quietly repairing it. The agent's own
 /// sandboxed git keeps working; what stops is Fletch acting on the checkout.
 pub(crate) async fn refuse_steerable_config(dir: &Path) -> Result<()> {
-    let Ok(root) = crate::workspace::checkouts_root() else {
-        return Ok(());
-    };
-    refuse_steerable_config_under(dir, &root).await
+    if let Ok(root) = crate::workspace::checkouts_root() {
+        refuse_steerable_config_under(dir, &root).await?;
+    }
+    if let Ok(root) = crate::workflow::blackboard::runs_root() {
+        refuse_steerable_config_under(dir, &root).await?;
+    }
+    Ok(())
 }
 
 /// Whether git may be run in `dir` — [`refuse_steerable_config`] for callers whose

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -535,6 +535,7 @@ mod tests {
                 pr_title: None,
                 pr_state: None,
                 label: label.map(str::to_string),
+                adopted_checkout: None,
             }
         }
 

--- a/src-tauri/src/sandbox/container/launch.rs
+++ b/src-tauri/src/sandbox/container/launch.rs
@@ -150,6 +150,17 @@ pub(crate) fn prepare(
             board.to_string_lossy().into_owned(),
         ));
     }
+    // The adopted tree is this launch's `cwd`: bound missing, the runtime would
+    // invent an empty root-owned dir and the agent would start in a workspace
+    // with none of the run's work in it. Fail with the path instead.
+    if let Some(tree) = ctx.adopted_workspace() {
+        if !tree.is_dir() {
+            return Err(Error::Other(format!(
+                "adopted workspace missing at launch: {}",
+                tree.display()
+            )));
+        }
+    }
 
     // Owned per-provider mount inputs, borrowed into a `ProviderMounts` by
     // `ContainerLaunch::mounts`. Only the matched arm fills any of these in.

--- a/src-tauri/src/sandbox/container/run_args.rs
+++ b/src-tauri/src/sandbox/container/run_args.rs
@@ -98,6 +98,12 @@ pub(crate) struct RunSpec<'a> {
     /// A workflow step agent's blackboard, bound read-write at its identical
     /// host path and forwarded as `WF_BLACKBOARD`. `None` for ordinary agents.
     pub blackboard: Option<&'a Path>,
+    /// A working tree adopted from outside the writable root (the kernel's
+    /// shared run workspace), bound read-write at its identical host path.
+    /// It is also `cwd`, so without the bind the container would start in a
+    /// directory the runtime had to invent. `None` for ordinary agents, whose
+    /// `cwd` is a checkout inside `writable_root`.
+    pub adopted_workspace: Option<&'a Path>,
     /// The launching provider's config/data mounts + config-dir env forwards.
     pub mounts: ProviderMounts<'a>,
     /// Object stores borrowed via git alternates, bound read-only at their
@@ -144,6 +150,11 @@ pub(crate) fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
     // in-container as on the host (invariant 1).
     if let Some(board) = spec.blackboard {
         push_rw_bind(&mut args, board);
+    }
+    // Same identical-path rule (invariant 1): the agent's own checkout, which
+    // for an adopting launch lives outside the writable root.
+    if let Some(tree) = spec.adopted_workspace {
+        push_rw_bind(&mut args, tree);
     }
     // Identical host path so the alternates file resolves in-container with no
     // rewriting; read-only so borrowed history is readable but the source store
@@ -245,6 +256,9 @@ pub(crate) fn mount_sources(spec: &RunSpec<'_>) -> Vec<PathBuf> {
     let mut out: Vec<PathBuf> = vec![spec.writable_root.into(), spec.rpc_dir.into()];
     if let Some(board) = spec.blackboard {
         out.push(board.into());
+    }
+    if let Some(tree) = spec.adopted_workspace {
+        out.push(tree.into());
     }
     out.extend(spec.borrowed_object_stores.iter().cloned());
     match &spec.mounts {
@@ -361,6 +375,7 @@ mod tests {
         let rpc = Path::new("/tmp/fletch-run-args/rpc");
         let home = Path::new("/tmp/fletch-run-args/home");
         let board = Path::new("/tmp/fletch-run-args/board");
+        let tree = Path::new("/tmp/fletch-run-args/run/repo");
         let alt = Path::new("/tmp/fletch-run-args/alt");
         let stores = vec![
             PathBuf::from("/tmp/fletch-run-args/store-a/objects"),
@@ -397,8 +412,9 @@ mod tests {
                 writable_root: root,
                 rpc_dir: rpc,
                 home,
-                cwd: root,
+                cwd: tree,
                 blackboard: Some(board),
+                adopted_workspace: Some(tree),
                 mounts,
                 borrowed_object_stores: &stores,
                 memory: DEFAULT_MEMORY,
@@ -434,5 +450,46 @@ mod tests {
                 "expected the workspace/rpc/config binds at least"
             );
         }
+    }
+
+    /// A kernel step's working tree lives outside the writable root, so without
+    /// its own bind the container would start in a directory the runtime
+    /// invented — the agent would see an empty workspace and none of the run's
+    /// work. Read-write, at the identical host path (invariant 1).
+    #[test]
+    fn an_adopted_workspace_is_bound_read_write_at_its_host_path() {
+        let root = Path::new("/tmp/fletch-adopt/work");
+        let tree = Path::new("/tmp/fletch-adopt/run/repo");
+        let projects = root.join("claude-projects");
+        let spec = RunSpec {
+            interactive: false,
+            name: "fletch-agent-test",
+            agent_id: "agent-1",
+            writable_root: root,
+            rpc_dir: Path::new("/tmp/fletch-adopt/rpc"),
+            home: Path::new("/tmp/fletch-adopt/home"),
+            cwd: tree,
+            blackboard: None,
+            adopted_workspace: Some(tree),
+            mounts: ProviderMounts::Claude {
+                config_dir: None,
+                credentials_rw: false,
+                config_dir_credentials_rw: false,
+                projects_src: &projects,
+            },
+            borrowed_object_stores: &[],
+            memory: DEFAULT_MEMORY,
+            cpus: DEFAULT_CPUS,
+            image: "fletch-agent:cafe00000000",
+            agent_bin: "claude",
+            auth_vars: &[],
+        };
+        let args = run_args(&spec);
+        let bind = format!("{0}:{0}", tree.to_string_lossy());
+        assert!(args.contains(&bind), "expected {bind} in {args:?}");
+        // The workdir is that same path, so the bind is what makes it exist.
+        let w = args.iter().position(|a| a == "-w").expect("-w");
+        assert_eq!(args[w + 1], tree.to_string_lossy());
+        assert!(mount_sources(&spec).contains(&tree.to_path_buf()));
     }
 }

--- a/src-tauri/src/sandbox/docker/engine/mod.rs
+++ b/src-tauri/src/sandbox/docker/engine/mod.rs
@@ -222,6 +222,7 @@ impl SandboxEngine for DockerEngine {
                 home: ctx.home,
                 cwd: ctx.cwd,
                 blackboard: ctx.blackboard,
+                adopted_workspace: ctx.adopted_workspace(),
                 mounts: prep.mounts(),
                 borrowed_object_stores: &prep.borrowed_object_stores,
                 memory: non_blank(settings.memory.as_deref()).unwrap_or(DEFAULT_MEMORY),

--- a/src-tauri/src/sandbox/docker/engine/tests.rs
+++ b/src-tauri/src/sandbox/docker/engine/tests.rs
@@ -102,6 +102,7 @@ fn test_spec<'a>(interactive: bool) -> RunSpec<'a> {
         home: Path::new("/Users/u"),
         cwd: Path::new("/Users/u/.fletch/worktrees/orkney/repo"),
         blackboard: None,
+        adopted_workspace: None,
         mounts: claude_mounts(None, false, false),
         borrowed_object_stores: &[],
         memory: "4g",
@@ -135,6 +136,7 @@ fn rw_config_spec<'a>(
         home: Path::new("/Users/u"),
         cwd: Path::new("/Users/u/.fletch/worktrees/orkney/repo"),
         blackboard: None,
+        adopted_workspace: None,
         mounts,
         borrowed_object_stores: &[],
         memory: "4g",
@@ -1247,6 +1249,7 @@ fn docker_run_echo_round_trip() {
         home: &home,
         cwd: &root,
         blackboard: None,
+        adopted_workspace: None,
         mounts: ProviderMounts::Claude {
             config_dir: None,
             credentials_rw: false,

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -85,6 +85,25 @@ pub struct AgentLaunchCtx<'a> {
     pub blackboard: Option<&'a Path>,
 }
 
+impl<'a> AgentLaunchCtx<'a> {
+    /// The working tree this launch must be able to write *outside* the writable
+    /// root — an adopted checkout, i.e. the workflow kernel's shared run
+    /// workspace (`~/.fletch/runs/<run-id>/repo`), which every step of a run
+    /// works in instead of cloning one under its own root.
+    ///
+    /// Derived from `cwd` rather than declared by the caller: an agent always
+    /// runs in its own checkout, so a `cwd` outside `writable_root` IS an
+    /// adopted tree — and a launch path that forgot to declare it would hand the
+    /// agent a working directory it cannot write (seatbelt) or that the runtime
+    /// invents empty (containers). Both engines grant it the same way they grant
+    /// [`blackboard`](Self::blackboard): seatbelt as a writable subpath (with
+    /// its own invariant-3 deny), a container runtime as a read-write bind at
+    /// the identical host path.
+    pub fn adopted_workspace(&self) -> Option<&'a Path> {
+        (!self.cwd.starts_with(self.writable_root)).then_some(self.cwd)
+    }
+}
+
 /// Engine-specific data describing how to tear down what was launched.
 #[derive(Clone)]
 pub enum KillPlan {
@@ -178,7 +197,38 @@ pub trait SandboxEngine: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use super::EngineKind;
+    use super::{AgentLaunchCtx, EngineKind};
+    use std::path::{Path, PathBuf};
+
+    fn ctx<'a>(writable_root: &'a Path, cwd: &'a Path) -> AgentLaunchCtx<'a> {
+        AgentLaunchCtx {
+            agent_id: "yosemite",
+            provider: "claude",
+            writable_root,
+            source_repos: &[],
+            rpc_dir: Path::new("/rpc/yosemite"),
+            cwd,
+            home: Path::new("/home/u"),
+            interactive: true,
+            blackboard: None,
+        }
+    }
+
+    /// An ordinary agent's cwd is one of its own checkouts under the writable
+    /// root, so it needs no grant of its own; a kernel step's cwd is the run's
+    /// shared tree, which does.
+    #[test]
+    fn adopted_workspace_is_the_cwd_only_when_it_escapes_the_writable_root() {
+        let root = PathBuf::from("/w/yosemite");
+        assert_eq!(ctx(&root, &root.join("repo")).adopted_workspace(), None);
+        assert_eq!(ctx(&root, &root).adopted_workspace(), None);
+
+        let run_tree = PathBuf::from("/runs/run-7/repo");
+        assert_eq!(
+            ctx(&root, &run_tree).adopted_workspace(),
+            Some(run_tree.as_path())
+        );
+    }
 
     #[test]
     fn engine_kind_setting_round_trips() {

--- a/src-tauri/src/sandbox/podman/engine.rs
+++ b/src-tauri/src/sandbox/podman/engine.rs
@@ -156,6 +156,7 @@ impl SandboxEngine for PodmanEngine {
                 home: ctx.home,
                 cwd: ctx.cwd,
                 blackboard: ctx.blackboard,
+                adopted_workspace: ctx.adopted_workspace(),
                 mounts: prep.mounts(),
                 borrowed_object_stores: &prep.borrowed_object_stores,
                 memory: non_blank(settings.memory.as_deref()).unwrap_or(DEFAULT_MEMORY),
@@ -331,6 +332,7 @@ mod tests {
             home: &home,
             cwd: &root,
             blackboard: None,
+            adopted_workspace: None,
             mounts: crate::sandbox::container::run_args::ProviderMounts::Claude {
                 config_dir: None,
                 credentials_rw: false,

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -57,6 +57,7 @@ impl SandboxEngine for SandboxExecEngine {
             ctx.home,
             claude_config_dir.as_deref(),
             ctx.blackboard,
+            ctx.adopted_workspace(),
         )?;
         // A workflow step agent's blackboard is granted writable in the profile
         // above; also point the agent at it via `WF_BLACKBOARD` (the same host
@@ -511,12 +512,17 @@ pub(crate) fn pid_alive(_pid: i32) -> bool {
 /// `claude_config_dir` is the value of `CLAUDE_CONFIG_DIR` the agent runs with
 /// (`None` = default `~/.claude`); when set elsewhere the agent writes its
 /// config/transcripts/auth there, so it must be writable too.
+/// `adopted_workspace` is a working tree the agent adopted instead of one under
+/// `writable_root` (the workflow kernel's shared run workspace) — its own
+/// writable subpath, and its own invariant-3 deny, since the agent's checkout
+/// isn't under the root this profile is otherwise built around.
 pub fn build_profile(
     writable_root: &Path,
     rpc_dir: &Path,
     home: &Path,
     claude_config_dir: Option<&Path>,
     blackboard: Option<&Path>,
+    adopted_workspace: Option<&Path>,
 ) -> Result<String> {
     let writable_root = canonical(writable_root)?;
     let rpc_root = canonical(rpc_dir)?;
@@ -535,6 +541,18 @@ pub fn build_profile(
             let board = canonical(board)?;
             format!("\n  (subpath {})", sbpl_string(&board.to_string_lossy()))
         }
+        None => String::new(),
+    };
+
+    // An adopted working tree is the agent's *checkout*, living outside the
+    // writable root because the run owns it — so without this grant the agent
+    // couldn't write the files it was spawned to change.
+    let adopted = match adopted_workspace {
+        Some(dir) => Some(canonical(dir)?),
+        None => None,
+    };
+    let adopted_grant = match &adopted {
+        Some(dir) => format!("\n  (subpath {})", sbpl_string(&dir.to_string_lossy())),
         None => String::new(),
     };
 
@@ -616,7 +634,15 @@ pub fn build_profile(
     // husky project legitimately writes `core.hooksPath`. Run is already
     // documented as the weaker boundary (see `RUN_TOOLCHAIN_DIRS`), so the
     // asymmetry follows the existing split rather than inventing one.
-    let deny_git_config = deny_git_exec_config(&writable_root.to_string_lossy());
+    // Emitted per writable checkout root: an adopted tree is a repo the app runs
+    // git on exactly like a provisioned one, so invariant 3 has to cover it too
+    // — its grant above would otherwise leave `.git/config` (hooks, filters,
+    // merge drivers) agent-writable.
+    let deny_git_config = std::iter::once(writable_root.to_string_lossy())
+        .chain(adopted.iter().map(|dir| dir.to_string_lossy()))
+        .map(|root| deny_git_exec_config(&root))
+        .collect::<Vec<_>>()
+        .join("\n\n");
 
     // Invariant 2 for the non-claude provider config roots (agent profile only,
     // like `deny_git_config`): deny their command-defining config back out of the
@@ -640,7 +666,7 @@ pub fn build_profile(
 (deny file-write*)
 (allow file-write*
   (subpath {writable_root_s})
-  (subpath {rpc_root_s}){blackboard_grant}
+  (subpath {rpc_root_s}){blackboard_grant}{adopted_grant}
   (subpath "/private/tmp")
   (subpath "/private/var/folders")
   (subpath "/private/var/tmp")
@@ -809,7 +835,7 @@ mod tests {
         std::fs::create_dir_all(&rpc).unwrap();
         std::fs::create_dir_all(&home).unwrap();
 
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_root = std::fs::canonicalize(&root).unwrap();
         let canonical_rpc = std::fs::canonicalize(&rpc).unwrap();
 
@@ -838,7 +864,7 @@ mod tests {
         for d in [&root, &rpc, &home] {
             std::fs::create_dir_all(d).unwrap();
         }
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_root = std::fs::canonicalize(&root).unwrap();
         let escaped = sbpl_regex_escape(&canonical_root.to_string_lossy());
 
@@ -891,7 +917,7 @@ mod tests {
         for d in [&rpc, &home, &repo.join(".git/hooks")] {
             std::fs::create_dir_all(d).unwrap();
         }
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
 
         // `sh -c 'printf x > <path>'` under the profile: exit 0 means the write
         // landed, non-zero means the sandbox refused it.
@@ -943,7 +969,7 @@ mod tests {
             std::fs::create_dir_all(d).unwrap();
         }
         let home = std::fs::canonicalize(&home).unwrap();
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
 
         let denied = policy::provider_exec_config_denials(&home);
         assert!(!denied.files.is_empty() && !denied.dirs.is_empty());
@@ -986,7 +1012,7 @@ mod tests {
         let cache_root = policy::toolchain_cache_root(&canonical_home);
         let expected = format!("\"{}\"", cache_root.display());
 
-        let agent = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let agent = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         assert!(
             agent.contains(&expected),
             "agent profile is missing the toolchain cache root"
@@ -1007,7 +1033,7 @@ mod tests {
         // It grants the narrow replacements instead, and every provider dot-dir
         // and cache dir stays exactly as before.
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         let h = canonical_home.display();
 
@@ -1128,7 +1154,7 @@ mod tests {
         std::fs::create_dir_all(&target).unwrap();
         std::os::unix::fs::symlink(&target, home.join(".claude")).unwrap();
 
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         assert!(
             !profile.contains(".local/bin"),
@@ -1151,7 +1177,7 @@ mod tests {
         let cfg = home.join(".local/bin/claude-cfg");
         std::fs::create_dir_all(&cfg).unwrap();
 
-        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path()), None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path()), None, None).unwrap();
         assert!(
             !profile.contains(".local/bin"),
             "bin-resident CLAUDE_CONFIG_DIR must not appear on the allow-list"
@@ -1167,14 +1193,14 @@ mod tests {
         let canonical_board = std::fs::canonicalize(&board).unwrap();
 
         // Absent by default: an ordinary (non-workflow) agent gets no grant.
-        let plain = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let plain = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         assert!(
             !plain.contains(&canonical_board.to_string_lossy().to_string()),
             "no blackboard grant without a blackboard"
         );
 
         // Granted: the *exact* blackboard dir is a writable subpath.
-        let granted = build_profile(&root, &rpc, &home, None, Some(board.as_path())).unwrap();
+        let granted = build_profile(&root, &rpc, &home, None, Some(board.as_path()), None).unwrap();
         assert!(
             granted.contains(&format!("(subpath \"{}\")", canonical_board.display())),
             "granted profile must allow writing inside the blackboard"
@@ -1186,6 +1212,44 @@ mod tests {
         assert!(
             !granted.contains(&format!("(subpath \"{}\")", parent.display())),
             "the blackboard's parent must not be granted"
+        );
+    }
+
+    /// A kernel step's checkout is the run's shared tree, outside the writable
+    /// root — so the profile has to grant it (or the agent can't edit the code
+    /// it was spawned for) *and* carry invariant 3 into it (or `.git/config`
+    /// becomes host code execution the next time Fletch runs git there).
+    #[test]
+    fn agent_profile_grants_an_adopted_tree_and_keeps_invariant_3_over_it() {
+        let (td, root, rpc, home) = sandbox_dirs();
+        let tree = td.path().join("runs/run-1/repo");
+        std::fs::create_dir_all(&tree).unwrap();
+        let canonical_tree = std::fs::canonicalize(&tree).unwrap();
+
+        let plain = build_profile(&root, &rpc, &home, None, None, None).unwrap();
+        assert!(
+            !plain.contains(&canonical_tree.to_string_lossy().to_string()),
+            "no adoption grant for an agent that owns its checkout"
+        );
+
+        let granted = build_profile(&root, &rpc, &home, None, None, Some(tree.as_path())).unwrap();
+        assert!(
+            granted.contains(&format!("(subpath \"{}\")", canonical_tree.display())),
+            "the adopted tree must be writable: it is the agent's checkout"
+        );
+        // Its parent (the run dir, holding the blackboard and export area) is
+        // not swept in by the grant.
+        let parent = canonical_tree.parent().unwrap();
+        assert!(
+            !granted.contains(&format!("(subpath \"{}\")", parent.display())),
+            "the run dir itself must not be granted"
+        );
+        // Invariant 3 follows the grant: one deny block per writable checkout
+        // root, so `.git/config` is unwritable in the adopted tree too.
+        let escaped = sbpl_regex_escape(&canonical_tree.to_string_lossy());
+        assert!(
+            granted.contains(&format!("^{escaped}(/.*)?/\\.git/")),
+            "invariant 3 must cover the adopted tree: {granted}"
         );
     }
 
@@ -1210,7 +1274,7 @@ mod tests {
         let cfg = home.join(".claude-eve");
         std::fs::create_dir_all(&cfg).unwrap();
 
-        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path()), None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path()), None, None).unwrap();
         // The emitted paths must be canonical (symlink-resolved) so they match
         // what the sandbox resolves at write time — e.g. on macOS the tempdir
         // lives under /var → /private/var.
@@ -1275,8 +1339,15 @@ mod tests {
         let (_td, root, rpc, home) = sandbox_dirs();
         let default_claude = std::fs::canonicalize(&home).unwrap().join(".claude");
 
-        let profile =
-            build_profile(&root, &rpc, &home, Some(default_claude.as_path()), None).unwrap();
+        let profile = build_profile(
+            &root,
+            &rpc,
+            &home,
+            Some(default_claude.as_path()),
+            None,
+            None,
+        )
+        .unwrap();
         for island in policy::claude_write_island_dirs(&default_claude) {
             let needle = format!("(subpath \"{}\")", island.display());
             assert_eq!(
@@ -1303,7 +1374,7 @@ mod tests {
         // credential file. `settings.json` (host hooks), `plugins/`, `CLAUDE.md`,
         // etc. must be covered by no grant.
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         let claude = canonical_home.join(".claude");
         let h = canonical_home.display();
@@ -1369,7 +1440,7 @@ mod tests {
         // reads (exfiltration) and writes (forging state). The deny only bites if
         // it comes AFTER the write allow-list, since SBPL is last-match-wins.
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
 
         let deny = format!(
@@ -1394,7 +1465,7 @@ mod tests {
         // Agents never legitimately touch any Fletch data dir — no `dev`
         // exception (that carve-out is Run-profile-only).
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         let dev = format!(
             "{}/Library/Application Support/{}/dev",
@@ -1414,7 +1485,7 @@ mod tests {
     #[test]
     fn agent_profile_denies_appsupport_auto_exec_but_keeps_the_grant() {
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         let app_support = format!("{}/Library/Application Support", canonical_home.display());
 
@@ -1526,7 +1597,7 @@ mod tests {
         for d in [&root, &rpc, &home] {
             std::fs::create_dir_all(d).unwrap();
         }
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         let app_support = canonical_home.join("Library/Application Support");
 

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -219,6 +219,10 @@ impl Supervisor {
                 pr_title: None,
                 pr_state: None,
                 label: None,
+                // Restore rebuilt an agent-owned clone at the derived path, so
+                // the row's adoption (if it had one) is cleared by
+                // `restore_agent` rather than carried forward.
+                adopted_checkout: None,
             });
         }
 
@@ -331,7 +335,7 @@ async fn capture_repo_snapshots(
     let mut total_dels: u32 = 0;
 
     for repo in repos {
-        let checkout = repo_checkout_path(agent_id, &repo.subdir).ok();
+        let checkout = repo.checkout_path(agent_id).ok();
         let branch_tip_sha = match &checkout {
             Some(wt) => git::rev_parse(wt, "HEAD").await.ok(),
             None => None,
@@ -487,9 +491,19 @@ fn reap_agent_containers(agent_id: &str, record: Option<&AgentRecord>, op: &'sta
 /// agent's parent dir. Failures are logged (tagged with `op` for context) but
 /// never abort the sweep — the caller's intent is to get rid of the agent.
 /// Shared by archive and discard.
+///
+/// An *adopted* checkout is skipped: the agent was a tenant of a working tree
+/// something else owns (the workflow kernel's shared run workspace, which the
+/// run's own delete reclaims — see `workflow::scheduler`), so disposing of the
+/// agent must leave the directory exactly where it is. Every step of a run
+/// passes through here as it is archived, so the run's work would not survive
+/// its first completed step otherwise.
 async fn teardown_agent_checkouts(agent_id: &str, repos: &[TrackedRepo], op: &str) {
     for repo in repos {
-        let checkout = match repo_checkout_path(agent_id, &repo.subdir) {
+        if repo.is_adopted() {
+            continue;
+        }
+        let checkout = match repo.checkout_path(agent_id) {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!(error = %e, subdir = %repo.subdir, op, "checkout path resolution failed");
@@ -583,6 +597,40 @@ mod tests {
             out.status.success(),
             "git {args:?}: {}",
             String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// Every step of a workflow run is archived as it finishes, and each one
+    /// runs in the *same* adopted tree — so a teardown that removed it would
+    /// destroy the run's work at the first step boundary. The agent's own dirs
+    /// still go; the directory the run owns stays.
+    #[tokio::test]
+    async fn teardown_spares_an_adopted_checkout() {
+        let td = tempfile::tempdir().unwrap();
+        let adopted = td.path().join("run-repo");
+        std::fs::create_dir_all(adopted.join(".git")).unwrap();
+        std::fs::write(adopted.join("step.txt"), "work so far").unwrap();
+
+        let repo = TrackedRepo {
+            repo_path: td.path().join("source"),
+            subdir: "repo".into(),
+            branch: None,
+            parent_branch: None,
+            base_sha: None,
+            pr_number: None,
+            pr_url: None,
+            pr_title: None,
+            pr_state: None,
+            label: None,
+            adopted_checkout: Some(adopted.clone()),
+        };
+        // An id no agent ever had: the agent-owned paths this resolves resolve
+        // to nothing, which is the point — only the adopted tree exists.
+        teardown_agent_checkouts("adoption-teardown-test", &[repo], "test").await;
+
+        assert!(
+            adopted.join("step.txt").is_file(),
+            "the run's working tree must outlive the step agent"
         );
     }
 

--- a/src-tauri/src/supervisor/fork.rs
+++ b/src-tauri/src/supervisor/fork.rs
@@ -145,10 +145,7 @@ impl Supervisor {
         let fork_base = primary.parent_branch.clone();
         let carry_from = match code {
             ForkCode::Clean => None,
-            ForkCode::Carry => Some(crate::workspace::repo_checkout_path(
-                parent_id,
-                &primary.subdir,
-            )?),
+            ForkCode::Carry => Some(primary.checkout_path(parent_id)?),
         };
 
         let req = SpawnRequest {
@@ -166,6 +163,7 @@ impl Supervisor {
             fork_base,
             run_repo: None,
             owner_run_id: None,
+            existing_workspace: None,
             carry_from,
             // A fork is a fresh line of work; it doesn't inherit the parent's
             // originating issue (only one workspace should close it).

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -2,7 +2,7 @@
 //! respawns, and the shared output/exit/watchdog handlers.
 
 use serde_json::Value;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Manager};
@@ -159,6 +159,20 @@ pub(super) async fn provision_codegraph_index(
     });
 }
 
+/// Undo what a failed spawn created: the checkout it provisioned, then the
+/// agent's dir. `checkout` is `None` when the spawn *adopted* its working tree
+/// — that directory belongs to the run, not the agent, so a step whose process
+/// never came up must not take the run's work down with it. The agent dir is
+/// always removed: it holds only Fletch-generated per-agent artifacts, and an
+/// adopted tree is never inside it (adoption records the real path rather than
+/// linking to it, so no recursive delete can reach through).
+async fn discard_failed_spawn(checkout: Option<&Path>, parent_dir: &Path) {
+    if let Some(checkout) = checkout {
+        let _ = provision::teardown(checkout).await;
+    }
+    let _ = tokio::fs::remove_dir_all(parent_dir).await;
+}
+
 /// Resolved, per-spawn inputs for `spawn_agent_process` — everything that
 /// isn't already carried on the `AgentRecord` (paths, session id, and this
 /// spawn's generation number).
@@ -243,6 +257,12 @@ pub struct SpawnRequest {
     /// normal sidebar and cleaned up by `wf_delete_run`. `None` for a normal
     /// user spawn.
     pub owner_run_id: Option<String>,
+    /// A pre-provisioned checkout this agent adopts as its primary workspace
+    /// instead of cloning one — the workflow kernel's shared run workspace.
+    /// When set, provisioning is skipped (`fork_base`/`run_repo` are ignored)
+    /// and teardown must never remove the directory: the run owns it, not the
+    /// agent. `None` for every non-kernel spawn.
+    pub existing_workspace: Option<PathBuf>,
     /// Fork "carry code": another workspace's primary checkout whose current
     /// working tree (incl. uncommitted work) is overlaid onto this fresh
     /// checkout after provisioning, so the fork starts from that workspace's
@@ -281,6 +301,7 @@ impl Supervisor {
             fork_base,
             run_repo,
             owner_run_id,
+            existing_workspace,
             carry_from,
             issue_ref,
             purpose,
@@ -340,6 +361,25 @@ impl Supervisor {
             Some(base) if !base.trim().is_empty() => base.trim().to_string(),
             _ => git::default_branch(&repo_path).await,
         };
+        // Adopting a pre-provisioned tree must be decided before anything else:
+        // it is the one mode in which no clone happens, so the base the caller
+        // asked for is only ever the *recorded* parent branch, never a fork
+        // point. The directory must already be a working tree — the run
+        // provisions it before the first step (see `SpawnRequest`), and
+        // discovering otherwise later means a spawn that failed after the record
+        // was written.
+        let adopted = match existing_workspace {
+            Some(path) => {
+                if !path.join(".git").exists() {
+                    return Err(Error::InvalidPath(format!(
+                        "adopted workspace is not a git repository: {}",
+                        path.display()
+                    )));
+                }
+                Some(path)
+            }
+            None => None,
+        };
         let subdir = allocate_repo_subdir(&repo_path, &[]);
         // Cloned for the background fork task — `parent_branch`/`subdir` are
         // moved into `primary` below.
@@ -362,6 +402,9 @@ impl Supervisor {
             pr_title: None,
             pr_state: None,
             label: None,
+            // Set only by the kernel's adopting spawn; every other spawn owns
+            // the checkout the fork task provisions below.
+            adopted_checkout: adopted.clone(),
         };
 
         let mut record = new_agent_record(
@@ -414,7 +457,9 @@ impl Supervisor {
         }
         let agent_id = record.id.clone();
         let parent_dir = agent_parent_dir(&agent_id)?;
-        let primary_checkout = repo_checkout_path(&agent_id, &subdir)?;
+        // Resolved through the record's own repo entry so the adopted tree and
+        // the derived layout can't disagree here and in `start_process`.
+        let primary_checkout = record.repos[0].checkout_path(&agent_id)?;
         crate::telemetry::track(
             "agent_spawned",
             serde_json::json!({
@@ -432,6 +477,7 @@ impl Supervisor {
         let project_id_for_task = record.project_id.clone();
         let provider_for_task = record.provider.clone();
         let mcp_servers_for_task = record.mcp_servers.clone();
+        let adopted_for_task = adopted.is_some();
         tauri::async_runtime::spawn(async move {
             if let Err(e) = tokio::fs::create_dir_all(&parent_dir).await {
                 fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
@@ -451,8 +497,15 @@ impl Supervisor {
             // source's HEAD branch as a local branch, so checking out any
             // *other* branch by name trips git's remote-DWIM (an implicit `-b`),
             // which is fatal combined with `--detach`.
+            //
+            // An adopted tree skips every rung of this: it already exists at the
+            // commit the run put it on, so there is no fork to make, no base to
+            // fetch, and no freshness to degrade — `fork_base`/`run_repo` are
+            // inputs to provisioning only, and provisioning is what adoption
+            // replaces.
             let mut base_freshness = None;
             let provision_result = match &run_repo_for_task {
+                _ if adopted_for_task => Ok(()),
                 // Workflow step (§12.1): fork from `fork_base` in the run repo.
                 // `base_ref` is used as-is and never fetched from `origin` —
                 // it's a run-internal commit-ish, not a branch: step 1's
@@ -497,9 +550,15 @@ impl Supervisor {
                 sup.stale_base.lock().insert(id_for_task.clone());
             }
 
+            // What a failed spawn below is allowed to remove — never an adopted
+            // tree (see `discard_failed_spawn`).
+            let owned_checkout = (!adopted_for_task).then(|| primary_checkout.clone());
+
             // Record the fork point so diffs measure against the exact starting
             // commit rather than a branch name that can drift. Non-fatal: a
-            // missing base_sha just falls back to the parent branch name.
+            // missing base_sha just falls back to the parent branch name. Read
+            // from the checkout either way, so an adopted tree's base is the
+            // commit the run left it on rather than a fork that never happened.
             let base_sha = git::rev_parse(&primary_checkout, "HEAD").await.ok();
             if let Some(sha) = &base_sha {
                 let _ = sup
@@ -538,8 +597,7 @@ impl Supervisor {
                     )),
                 };
                 if let Err(e) = carried {
-                    let _ = provision::teardown(&primary_checkout).await;
-                    let _ = tokio::fs::remove_dir_all(&parent_dir).await;
+                    discard_failed_spawn(owned_checkout.as_deref(), &parent_dir).await;
                     fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
                     return;
                 }
@@ -550,8 +608,9 @@ impl Supervisor {
             // (untouched repos are just clean clones). Runs before
             // start_process so the Docker engine's mounts and the git RPC
             // dispatcher see the full repo set. Workflow step agents stay
-            // single-repo — a run targets one repo (see `wf_launch`).
-            if run_repo_for_task.is_none() {
+            // single-repo — a run targets one repo (see `wf_launch`), which
+            // covers both the forking and the adopting shape of a step spawn.
+            if run_repo_for_task.is_none() && !adopted_for_task {
                 for source in sup.workspace.project_repo_paths(&project_id_for_task) {
                     if source == repo_path {
                         continue;
@@ -560,8 +619,7 @@ impl Supervisor {
                         .attach_repo_checkout(&app_for_task, &id_for_task, source.clone(), false)
                         .await
                     {
-                        let _ = provision::teardown(&primary_checkout).await;
-                        let _ = tokio::fs::remove_dir_all(&parent_dir).await;
+                        discard_failed_spawn(owned_checkout.as_deref(), &parent_dir).await;
                         fail_spawn(
                             &sup,
                             &app_for_task,
@@ -576,8 +634,7 @@ impl Supervisor {
             tokio::time::sleep(Duration::from_millis(350)).await;
 
             if let Err(e) = sup.start_process(&app_for_task, &id_for_task, true).await {
-                let _ = provision::teardown(&primary_checkout).await;
-                let _ = tokio::fs::remove_dir_all(&parent_dir).await;
+                discard_failed_spawn(owned_checkout.as_deref(), &parent_dir).await;
                 fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
             }
         });
@@ -682,6 +739,7 @@ impl Supervisor {
             pr_title: None,
             pr_state: None,
             label: None,
+            adopted_checkout: None,
         };
         self.workspace.append_tracked_repo(agent_id, repo.clone())?;
         emit_repo_added(app, agent_id, repo.clone());
@@ -711,7 +769,7 @@ impl Supervisor {
             .repos
             .first()
             .ok_or_else(|| Error::Other("agent has no tracked repos".into()))?;
-        let cwd = repo_checkout_path(agent_id, &primary.subdir)?;
+        let cwd = primary.checkout_path(agent_id)?;
         // Sandbox writable root — the agent's parent dir. Every agent (claude
         // and per-turn alike) now runs under sandbox-exec rooted here.
         let sandbox_root = agent_parent_dir(agent_id)?;
@@ -742,7 +800,7 @@ impl Supervisor {
         // agents (and old prompts) behave exactly as before.
         let mut repo_targets = Vec::new();
         for r in &record.repos {
-            let checkout = repo_checkout_path(agent_id, &r.subdir)?;
+            let checkout = r.checkout_path(agent_id)?;
             let base = r
                 .parent_branch
                 .clone()

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -772,6 +772,7 @@ mod tests {
                 pr_title: None,
                 pr_state: None,
                 label: None,
+                adopted_checkout: None,
             },
             String::new(),
             AgentView::Custom,
@@ -843,6 +844,7 @@ mod tests {
             pr_title: None,
             pr_state: None,
             label: None,
+            adopted_checkout: None,
         };
         let mut record = new_agent_record(
             "yosemite".into(),

--- a/src-tauri/src/supervisor/pr_set.rs
+++ b/src-tauri/src/supervisor/pr_set.rs
@@ -9,7 +9,7 @@
 //! bodies the agent wrote itself. Everything here is best-effort: a body edit
 //! is decoration, so failures are logged, never surfaced.
 
-use crate::workspace::{repo_checkout_path, WorkspaceManager};
+use crate::workspace::WorkspaceManager;
 
 /// Sentinels marking the generated trailer inside a PR body. Content between
 /// them is owned by Fletch and replaced wholesale on every sync.
@@ -73,7 +73,7 @@ pub(crate) async fn sync_pr_set_links(workspace: &WorkspaceManager, agent_id: &s
         let Some(number) = repo.pr_number else {
             continue;
         };
-        let Ok(checkout) = repo_checkout_path(agent_id, &repo.subdir) else {
+        let Ok(checkout) = repo.checkout_path(agent_id) else {
             continue;
         };
         let Some((owner, name)) =

--- a/src-tauri/src/supervisor/run.rs
+++ b/src-tauri/src/supervisor/run.rs
@@ -7,7 +7,6 @@ use tauri::AppHandle;
 
 use crate::error::{Error, Result};
 use crate::run_session::{self, shell_args, user_shell, RunPhase, RunSession, RunStateSnapshot};
-use crate::workspace::repo_checkout_path;
 
 use super::events::{emit_run_output, emit_run_port, emit_run_state};
 use super::Supervisor;
@@ -33,7 +32,7 @@ impl Supervisor {
             .repos
             .first()
             .ok_or_else(|| Error::Other("agent has no repos".into()))?;
-        let cwd = repo_checkout_path(agent_id, &primary.subdir)?;
+        let cwd = primary.checkout_path(agent_id)?;
 
         let (setup_cmd, run_cmd, intended_port) =
             self.read_run_config(agent_id, &record.project_id, &cwd);
@@ -208,7 +207,7 @@ impl Supervisor {
             .repos
             .first()
             .ok_or_else(|| Error::Other("agent has no repos".into()))?;
-        let checkout = repo_checkout_path(agent_id, &primary.subdir)?;
+        let checkout = primary.checkout_path(agent_id)?;
         Ok(crate::run_detect::detect_all(&checkout))
     }
 

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -6,9 +6,7 @@ use tauri::AppHandle;
 
 use crate::agent::per_turn_descriptor;
 use crate::github::{MergeableState, PrState, PrStatus};
-use crate::workspace::{
-    repo_checkout_path, AgentRecord, AgentStatus, AgentView, TrackedRepo, WorkspaceManager,
-};
+use crate::workspace::{AgentRecord, AgentStatus, AgentView, TrackedRepo, WorkspaceManager};
 
 use super::events::{
     emit_pr_state, emit_session_records_appended, emit_session_sync_health, emit_verification,
@@ -157,7 +155,7 @@ impl Supervisor {
         let Some(primary) = record.repos.first() else {
             return;
         };
-        let Ok(checkout) = repo_checkout_path(&agent_id, &primary.subdir) else {
+        let Ok(checkout) = primary.checkout_path(&agent_id) else {
             return;
         };
         // Debounce: skip if a verification for this agent is already running.
@@ -346,7 +344,7 @@ pub(crate) async fn resolve_pr_state(
     };
     // No branch yet → nothing pushed, so no PR to find or bind.
     repo.branch.as_ref()?;
-    let checkout = repo_checkout_path(agent_id, &repo.subdir).ok()?;
+    let checkout = repo.checkout_path(agent_id).ok()?;
 
     if let Some(number) = repo.pr_number {
         // Merged is the one terminal state — it can't be undone, so it's
@@ -516,7 +514,7 @@ pub(crate) async fn resolve_all_pr_status(
             // Resolve the slug now (local git); the network cost is deferred to the
             // one batched query below. A broken checkout / non-GitHub origin can't
             // be fetched — hold the snapshot instead.
-            let slug = match repo_checkout_path(&agent.id, &repo.subdir) {
+            let slug = match repo.checkout_path(&agent.id) {
                 Ok(checkout) => crate::github::resolve_slug(&checkout, Some(&repo.repo_path)).await,
                 Err(_) => None,
             };
@@ -991,7 +989,7 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
     let Some(repo) = record.repos.first() else {
         return Some(pending());
     };
-    let Ok(cwd) = repo_checkout_path(agent_id, &repo.subdir) else {
+    let Ok(cwd) = repo.checkout_path(agent_id) else {
         return Some(pending());
     };
 
@@ -1447,6 +1445,7 @@ mod tests {
             pr_title: Some("feat: x".into()),
             pr_state: Some("merged".into()),
             label: None,
+            adopted_checkout: None,
         }
     }
 

--- a/src-tauri/src/supervisor/shell.rs
+++ b/src-tauri/src/supervisor/shell.rs
@@ -5,7 +5,6 @@ use tauri::AppHandle;
 
 use crate::error::{Error, Result};
 use crate::pty_session::{PtySession, PtySpawn};
-use crate::workspace::repo_checkout_path;
 
 use super::events::emit_shell_output;
 use super::Supervisor;
@@ -24,7 +23,7 @@ impl Supervisor {
             .repos
             .first()
             .ok_or_else(|| Error::Other("agent has no repos".into()))?;
-        let checkout = repo_checkout_path(agent_id, &repo.subdir)?;
+        let checkout = repo.checkout_path(agent_id)?;
 
         let shell_str = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
         let shell_path = std::path::PathBuf::from(&shell_str);

--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -914,6 +914,7 @@ mod tests {
                 fork_base: Some("base-sha".into()),
                 run_repo: None,
                 owner_run_id: "run-1".into(),
+                existing_workspace: None,
             },
             pre_spawned: None,
             blackboard,

--- a/src-tauri/src/workflow/driver.rs
+++ b/src-tauri/src/workflow/driver.rs
@@ -54,6 +54,12 @@ pub struct SpawnReq {
     /// `wf_delete_run`. The blackboard write-grant is derived from it at spawn,
     /// keeping the run directory the single source of truth.
     pub owner_run_id: String,
+    /// A pre-provisioned checkout the agent adopts as its primary workspace
+    /// instead of cloning one — the workflow kernel's shared run workspace,
+    /// where every sequential step works in the same tree. When set, `fork_base`
+    /// / `run_repo` provisioning is skipped entirely, and teardown (archive /
+    /// delete) must never remove the directory: the run owns it, not the agent.
+    pub existing_workspace: Option<PathBuf>,
 }
 
 /// A freshly spawned step agent.
@@ -131,6 +137,7 @@ impl AgentDriver for SupervisorDriver {
                 fork_base,
                 run_repo,
                 owner_run_id,
+                existing_workspace,
             } = req;
 
             let record = self
@@ -155,6 +162,7 @@ impl AgentDriver for SupervisorDriver {
                         fork_base,
                         run_repo,
                         owner_run_id: Some(owner_run_id),
+                        existing_workspace,
                         carry_from: None,
                         // Workflow-step spawns aren't issue-intake spawns.
                         issue_ref: None,
@@ -168,7 +176,7 @@ impl AgentDriver for SupervisorDriver {
             // The primary checkout path — provisioned by the spawn's background
             // task; the caller waits for `Idle` before reading it.
             let worktree = match record.repos.first() {
-                Some(primary) => crate::workspace::repo_checkout_path(&record.id, &primary.subdir)?,
+                Some(primary) => primary.checkout_path(&record.id)?,
                 None => {
                     return Err(crate::error::Error::Other(
                         "spawned step agent has no tracked repo".into(),
@@ -533,6 +541,7 @@ mod tests {
                 fork_base: None,
                 run_repo: None,
                 owner_run_id: "run-1".into(),
+                existing_workspace: None,
             })
             .await
             .unwrap();
@@ -561,6 +570,7 @@ mod tests {
                 fork_base: None,
                 run_repo: None,
                 owner_run_id: "run-1".into(),
+                existing_workspace: None,
             })
             .await;
         assert!(err.is_err());

--- a/src-tauri/src/workflow/scheduler/parallel.rs
+++ b/src-tauri/src/workflow/scheduler/parallel.rs
@@ -1315,6 +1315,9 @@ pub(crate) fn build_spawn_req(
         fork_base: Some(fork_base.to_string()),
         run_repo: Some(run_repo.to_path_buf()),
         owner_run_id: run_id.to_string(),
+        // The clone-per-step engine never shares a workspace; only the kernel
+        // runner sets this.
+        existing_workspace: None,
     }
 }
 

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -500,11 +500,16 @@ impl WorkspaceManager {
         )?;
 
         // Update checkout records with new branch info and clear snapshot fields.
+        // `adopted_checkout` is dropped with them: restore always provisions an
+        // agent-owned clone at the derived path (see `restore_agent` in
+        // `supervisor::disposition`), so a row still naming the adopted tree
+        // would point every reader away from the checkout that was just built.
         for repo in &repos {
             conn.execute(
                 "UPDATE worktrees SET branch = ?1, parent_branch = ?2,
                         branch_tip_sha = NULL, parent_branch_sha = NULL,
-                        diff_additions = 0, diff_deletions = 0
+                        diff_additions = 0, diff_deletions = 0,
+                        adopted_checkout = NULL
                  WHERE workspace_id = ?3 AND subdir = ?4",
                 rusqlite::params![repo.branch, repo.parent_branch, id, repo.subdir],
             )?;

--- a/src-tauri/src/workspace/mod.rs
+++ b/src-tauri/src/workspace/mod.rs
@@ -105,6 +105,39 @@ pub struct TrackedRepo {
     /// back to the folder basename in the UI and in agent-facing notes.
     #[serde(default)]
     pub label: Option<String>,
+    /// A pre-provisioned working tree this entry *adopted* instead of the
+    /// agent-owned `~/.fletch/workspaces/<agent-id>/<subdir>/` — today only the
+    /// workflow kernel's shared run workspace (`~/.fletch/runs/<id>/repo`),
+    /// which every step of the run works in.
+    ///
+    /// Adoption inverts ownership: the agent is a tenant of a directory whose
+    /// lifetime belongs to something else. Nothing on the agent's disposal path
+    /// (archive, discard, project delete) may remove it — see
+    /// `disposition::teardown_agent_checkouts` — and nothing provisions it: the
+    /// tree already exists at spawn, with its own HEAD.
+    ///
+    /// `None` for every ordinary checkout, which the agent owns outright.
+    #[serde(default)]
+    pub adopted_checkout: Option<PathBuf>,
+}
+
+impl TrackedRepo {
+    /// Absolute path to this checkout's working tree — the single answer every
+    /// consumer (the CLI's cwd, git facts, the shell, the file tree, teardown)
+    /// must resolve through, so an adopted tree can't be reached by one caller
+    /// and missed by the next.
+    pub fn checkout_path(&self, agent_id: &str) -> Result<PathBuf> {
+        match &self.adopted_checkout {
+            Some(path) => Ok(path.clone()),
+            None => repo_checkout_path(agent_id, &self.subdir),
+        }
+    }
+
+    /// Whether this checkout is owned by something other than the agent, and so
+    /// survives the agent's disposal.
+    pub fn is_adopted(&self) -> bool {
+        self.adopted_checkout.is_some()
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/src-tauri/src/workspace/query.rs
+++ b/src-tauri/src/workspace/query.rs
@@ -195,7 +195,7 @@ impl WorkspaceManager {
     fn query_tracked_repos(conn: &Connection, agent_id: &str) -> Vec<TrackedRepo> {
         let mut stmt = match conn.prepare(
             "SELECT r.path, w.subdir, w.branch, w.parent_branch, w.base_sha, w.pr_number,
-                    w.pr_url, w.pr_title, w.pr_state, r.label
+                    w.pr_url, w.pr_title, w.pr_state, r.label, w.adopted_checkout
              FROM worktrees w
              JOIN repos r ON r.id = w.repo_id
              WHERE w.workspace_id = ?1
@@ -216,6 +216,7 @@ impl WorkspaceManager {
             let pr_title: Option<String> = row.get(7)?;
             let pr_state: Option<String> = row.get(8)?;
             let label: Option<String> = row.get(9)?;
+            let adopted: Option<String> = row.get(10)?;
             Ok(TrackedRepo {
                 repo_path: PathBuf::from(path),
                 subdir,
@@ -227,6 +228,7 @@ impl WorkspaceManager {
                 pr_title,
                 pr_state,
                 label,
+                adopted_checkout: adopted.map(PathBuf::from),
             })
         })
         .ok()
@@ -369,8 +371,8 @@ impl WorkspaceManager {
 
         let wt_id = uuid::Uuid::new_v4().to_string();
         conn.execute(
-            "INSERT INTO worktrees (id, workspace_id, repo_id, subdir, branch, parent_branch, base_sha, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            "INSERT INTO worktrees (id, workspace_id, repo_id, subdir, branch, parent_branch, base_sha, adopted_checkout, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             rusqlite::params![
                 wt_id,
                 agent_id,
@@ -379,6 +381,9 @@ impl WorkspaceManager {
                 repo.branch,
                 repo.parent_branch,
                 repo.base_sha,
+                repo.adopted_checkout
+                    .as_ref()
+                    .map(|p| p.to_string_lossy().into_owned()),
                 now_millis(),
             ],
         )?;

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -106,7 +106,71 @@ fn mk_repo(path: &str) -> TrackedRepo {
         pr_title: None,
         pr_state: None,
         label: None,
+        adopted_checkout: None,
     }
+}
+
+/// An adopted checkout is the authoritative path for that repo entry, while an
+/// ordinary entry still derives one from the agent id + subdir. Every consumer
+/// resolves through this, so the two must not be confusable.
+#[test]
+fn checkout_path_prefers_an_adopted_tree_over_the_derived_layout() {
+    let derived = mk_repo("/r").checkout_path("yosemite").unwrap();
+    assert_eq!(derived, repo_checkout_path("yosemite", "repo").unwrap());
+
+    let run_tree = PathBuf::from("/runs/run-7/repo");
+    let adopted = TrackedRepo {
+        adopted_checkout: Some(run_tree.clone()),
+        ..mk_repo("/r")
+    };
+    assert_eq!(adopted.checkout_path("yosemite").unwrap(), run_tree);
+    assert!(adopted.is_adopted());
+    assert!(!mk_repo("/r").is_adopted());
+}
+
+/// The adopted path has to survive the DB, not just the spawn call: every later
+/// launch, gate and teardown reads the record back rather than the spawn request.
+#[test]
+fn adopted_checkout_round_trips_and_is_cleared_by_restore() {
+    let db = test_db();
+    seed_repo(&db, "/r");
+    let wm = WorkspaceManager::new(db);
+    let run_tree = PathBuf::from("/runs/run-7/repo");
+
+    let mut record = new_agent_record(
+        "yosemite".into(),
+        "a".into(),
+        "claude".into(),
+        TrackedRepo {
+            adopted_checkout: Some(run_tree.clone()),
+            ..mk_repo("/r")
+        },
+        "task".into(),
+        AgentView::Custom,
+    );
+    wm.add_agent(&mut record).unwrap();
+
+    let loaded = wm.agent("yosemite").unwrap();
+    assert_eq!(loaded.repos[0].adopted_checkout, Some(run_tree));
+    assert_eq!(
+        loaded.repos[0].checkout_path("yosemite").unwrap(),
+        PathBuf::from("/runs/run-7/repo")
+    );
+
+    // Restore provisions an agent-owned clone at the derived path, so the row
+    // must stop naming the run's tree.
+    wm.archive_agent(
+        "yosemite",
+        ArchiveMetadata {
+            archived_at: chrono::Utc::now().to_rfc3339(),
+            repos: Vec::new(),
+            diff_stats: DiffStats::default(),
+        },
+    )
+    .unwrap();
+    wm.restore_agent("yosemite", vec![mk_repo("/r")]).unwrap();
+    let restored = wm.agent("yosemite").unwrap();
+    assert_eq!(restored.repos[0].adopted_checkout, None);
 }
 
 /// Helper: ensure the repo path exists in the repos table so add_agent can find it.
@@ -1643,6 +1707,7 @@ fn archive_then_restore_roundtrip() {
         pr_title: None,
         pr_state: None,
         label: None,
+        adopted_checkout: None,
     }];
     wm.restore_agent(&id, restored).unwrap();
     let a = wm.agent(&id).unwrap();
@@ -1712,6 +1777,7 @@ fn make_workspace_with_session(db: &Arc<Mutex<Connection>>) -> (String, Workspac
             pr_title: None,
             pr_state: None,
             label: None,
+            adopted_checkout: None,
         },
         "task".into(),
         AgentView::Custom,


### PR DESCRIPTION
First slice of the workflow kernel rework (see `docs/workflow-kernel-layers.md` in the follow-up PR).

## What

Adds `existing_workspace` to `SpawnReq`/`SpawnRequest`: when set, the spawned agent **adopts** the given checkout as its primary workspace instead of provisioning one — no clone, no fetch, no HEAD movement. This is the substrate for the workflow kernel runner (next PR), where every sequential step of a run works in one shared run workspace instead of getting its own clone + ferry.

## How

- `TrackedRepo.adopted_checkout` (migration `0038_worktree_adopted_checkout.sql`); all 20+ checkout-path consumers now resolve through `TrackedRepo::checkout_path(agent_id)`. No symlinks — cleanup code never gets lied to.
- **Teardown safety:** `teardown_agent_checkouts` (shared by archive + discard) skips adopted repos; the three failed-spawn cleanup paths pass `None` for an adopted tree. The run directory's own removal remains the single owner of deletion.
- **Sandbox grant is derived, not declared:** `AgentLaunchCtx::adopted_workspace()` returns the cwd when it escapes the writable root, so no launch path can forget it. Seatbelt adds a writable subpath plus a second invariant-3 `.git/config` deny over it; Docker/Podman RW-bind the tree at its host path (registered in `mount_sources`).
- **Hardening:** `refuse_steerable_config` now also scopes to `runs_root()` — an adopted run workspace is as agent-writable as an agent checkout, so host-side git must refuse poisoned config there too.
- Restore clears adoption (a restored agent gets its own clone); spawn validates the adopted path contains `.git` before any record is written.

## Deferred (documented in the kernel PR's ledger)

Run-owned container reuse: today's container model is one container per *process launch* (`run --rm --init`, CLI as PID 1) by explicit design, so v0 keeps a per-step container that mounts the adopted tree correctly.

## Tests

7 new/strengthened tests across workspace, disposition, engine, run_args, seatbelt. Full suite: `cargo test` 1476 passed / 0 failed; clippy 0 warnings; fmt clean.