### PR TITLE
feat(ui): render a sequential workflow run as one continuous thread

### DIFF
--- a/docs/workflow-kernel-layers.md
+++ b/docs/workflow-kernel-layers.md
@@ -1,0 +1,62 @@
+# Workflow kernel: the layering ledger
+
+The kernel (`src-tauri/src/workflow/runner/`) is the simple sequential success
+path for a run: one workspace (the run repository's own working tree), one agent
+per step, one line of commits. It provisions the run repo, detaches it at the run
+base, and then for each step creates the `wf_step_exec` row, spawns an agent that
+*adopts* that workspace (`SpawnReq::existing_workspace`), waits for idle, sends
+the step prompt, waits for the turn to end, evaluates the gate, boundary-commits
+and pins `refs/wf/steps/<exec>`, and archives the agent. It journals the same
+event types and writes the same `wf_step_exec` statuses as the old engine, so the
+run monitor is unchanged.
+
+The clone-per-step engine (`src-tauri/src/workflow/scheduler/`) is untouched and
+keeps serving every spec the kernel does not claim. Routing happens in one place
+— the drive-task spawn site in `scheduler/drive.rs` — and is derived from the
+run's launch-frozen spec, so every drive of a given run reaches the same runner:
+
+> A run is a kernel run iff every top-level block is a `step` and every gate is
+> `commit` or `verdict`.
+
+Layers get added to the kernel one at a time. The rule for each: ship the
+mechanism **and** the user-visible narrative together. A retry the timeline
+doesn't show, or a test gate whose progress never reaches the UI, is not a
+layer — it is a regression with extra code.
+
+## The ledger
+
+| Layer | Current home (old engine) | Plan |
+| --- | --- | --- |
+| Retries | attempt loop in `scheduler/steps.rs::execute_step` | Rebuild thin: `reset --hard` to the last pinned ref + `clean -fd`, rerun the step in the same workspace, reuse `prompts::retry_prompt`. |
+| Tests / artifact gates | `attempt.rs` gate eval + `workflow/tests_gate.rs` | Reuse the runner mechanics as-is; stream test progress into the timeline and make the re-prompt visible instead of a silent second turn. |
+| Ask / answer + approval | `workflow/comms/` | Reuse mostly as-is — the mailbox, routing and pause reasons are independent of how steps are executed. |
+| Loops | `scheduler/steps.rs::run_loop` | Rebuild thin on the kernel (iterate the body in the same workspace), reusing the spec types (`Loop`, `Until`) unchanged. |
+| Budgets | `workflow/budget.rs` | Defer. When it lands, reuse the accounting (`Ledger`, `EffectiveBudgets`) rather than re-deriving caps. |
+| Resume | run cursor + run-repo step refs | Rebuild simpler: relaunch the sandbox, `reset --hard` the workspace to the last pinned step ref, continue from the next step. |
+| Parallel / orchestrate | `scheduler/parallel.rs`, `scheduler/orchestrate.rs` | Git worktrees off the run workspace, so children fork cheaply and integrate locally. The old engine serves these specs until then. |
+| Stall / nudge watchdogs | `attempt.rs` (`drive_turn`) | Replaced by the single per-step wall timeout. Add nuance only if real hangs demand it. |
+| Latency polish | — | Straight-line pre-spawn of the next step's CLI, session reuse across loop iterations, asynchronous archive. |
+
+## v0 limitations
+
+Each of these is a deliberate omission, not an oversight. The kernel fails loudly
+rather than pretending.
+
+- **No resume.** A kernel run found non-terminal at startup is failed with
+  "kernel runs do not resume yet"; its stale execs are abandoned and their agents
+  stopped. Nothing is re-run, because the workspace already contains the finished
+  steps' commits.
+- **No retries.** A step that errors, times out, or fails its gate fails the run,
+  with the cause journaled and on `wf_run.error`.
+- **`commit` and `verdict` gates only.** `commit` is satisfied by the turn
+  ending (the boundary commit captures whatever the agent did); `verdict`
+  requires `result: "done"`. Anything else — `revise`, `blocked`, missing,
+  unparsable — fails the run. Any other gate kind makes a spec ineligible.
+- **Sequential only.** No parallel stages, no loops, no orchestrate blocks, no
+  sub-runs.
+- **No budget enforcement.** Turn/token/wall caps are not charged or checked; a
+  step's declared `turns_per_attempt` still reaches the prompt as guidance.
+- **Comms are not acted on.** A step may declare `report`/`ask` caps and the
+  prompt will describe them, but the kernel does not pause on a human ask.
+- **One guard.** A single per-step wall timeout (30 minutes) covers spawn through
+  turn end. There is no turn-start deadline, stall clock, or nudge.

--- a/src-tauri/migrations/0038_worktree_adopted_checkout.sql
+++ b/src-tauri/migrations/0038_worktree_adopted_checkout.sql
@@ -1,0 +1,17 @@
+-- A working tree the agent adopted rather than provisioned.
+--
+-- Every checkout so far has been agent-owned: the spawn cloned it at
+-- `~/.fletch/workspaces/<workspace-id>/<subdir>/` and archive/discard removed
+-- it. The workflow kernel introduces the other ownership direction — all
+-- sequential steps of a run share ONE pre-provisioned working tree (the run
+-- repo at `~/.fletch/runs/<run-id>/repo`), so a step agent is a tenant of a
+-- directory the *run* owns: it is never cloned per step, and it must outlive
+-- every agent that works in it.
+--
+-- Holding the path here rather than re-deriving it makes that one fact
+-- authoritative for every consumer (the CLI's working dir, git facts, the
+-- shell, the file tree, teardown), so no reader can resolve the agent-owned
+-- layout for a tree that isn't there. NULL — the only value an existing row can
+-- have, and the default for every ordinary spawn — means the agent owns its
+-- checkout at the derived path.
+ALTER TABLE worktrees ADD COLUMN adopted_checkout TEXT;

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -55,6 +55,8 @@ pub async fn spawn_agent(
             // and are never run-owned; the scheduler sets both for a step spawn.
             run_repo: None,
             owner_run_id: None,
+            // Adopting a shared run workspace is a workflow-kernel-only path.
+            existing_workspace: None,
             // Carrying another workspace's working tree is a fork-only path.
             carry_from: None,
             // Set when the spawn originates from a Home-inbox issue.

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -7,7 +7,7 @@ use tauri::State;
 use crate::error::{Error, Result};
 use crate::git;
 use crate::supervisor::Supervisor;
-use crate::workspace::{repo_checkout_path, AgentRecord, DiffStats, Workspace};
+use crate::workspace::{AgentRecord, DiffStats, Workspace};
 
 use super::files::{agent_repo_checkout, diff_base, primary_repo_checkout};
 
@@ -108,7 +108,7 @@ pub async fn get_agent_diff_stats(
     let mut stats = DiffStats::default();
 
     for repo in &record.repos {
-        let checkout = repo_checkout_path(&agent_id, &repo.subdir)?;
+        let checkout = repo.checkout_path(&agent_id)?;
         let base = diff_base(repo);
         let base_ref = base.as_deref().unwrap_or("HEAD");
         let diff = match git::checkout_diff_shortstat(&checkout, base_ref).await {

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -12,7 +12,7 @@ use crate::error::{Error, Result};
 use crate::git;
 use crate::git_state::{self, FileStatus, StatusKind};
 use crate::supervisor::Supervisor;
-use crate::workspace::{repo_checkout_path, TrackedRepo};
+use crate::workspace::TrackedRepo;
 
 /// The ref a checkout's *committed* changes are diffed against: the immutable
 /// fork-point SHA captured at spawn when known, else the parent branch name
@@ -231,7 +231,7 @@ pub(super) fn primary_repo_checkout(
     agent_id: &str,
 ) -> Result<(TrackedRepo, PathBuf)> {
     let repo = primary_repo(supervisor, agent_id)?;
-    let checkout = repo_checkout_path(agent_id, &repo.subdir)?;
+    let checkout = repo.checkout_path(agent_id)?;
     Ok((repo, checkout))
 }
 
@@ -252,7 +252,7 @@ pub(super) fn agent_repo_checkout(
         .into_iter()
         .find(|r| r.subdir == s)
         .ok_or_else(|| Error::Other(format!("agent has no tracked repo {s:?}")))?;
-    let checkout = repo_checkout_path(agent_id, &repo.subdir)?;
+    let checkout = repo.checkout_path(agent_id)?;
     Ok((repo, checkout))
 }
 
@@ -274,7 +274,7 @@ pub(super) fn agent_repo_checkout_opt(
     let Some(repo) = repo else {
         return Ok(None);
     };
-    let checkout = repo_checkout_path(agent_id, &repo.subdir)?;
+    let checkout = repo.checkout_path(agent_id)?;
     Ok(Some((repo, checkout)))
 }
 
@@ -332,7 +332,7 @@ fn checkout_scope_for_path(
         return Ok((checkout, parent, path.to_string()));
     }
     let (repo, rel) = split_repo_path(&record.repos, path)?;
-    let checkout = repo_checkout_path(agent_id, &repo.subdir)?;
+    let checkout = repo.checkout_path(agent_id)?;
     let parent = diff_base(repo).unwrap_or_else(|| "main".to_string());
     Ok((checkout, parent, rel))
 }
@@ -411,7 +411,7 @@ pub async fn list_checkout_tree(
     for repo in &record.repos {
         // One broken checkout shouldn't blank the whole tree — skip it and
         // keep listing the others.
-        let Ok(checkout) = repo_checkout_path(&agent_id, &repo.subdir) else {
+        let Ok(checkout) = repo.checkout_path(&agent_id) else {
             continue;
         };
         let parent = diff_base(repo).unwrap_or_else(|| "main".to_string());
@@ -698,6 +698,7 @@ mod split_repo_path_tests {
             pr_title: None,
             pr_state: None,
             label: None,
+            adopted_checkout: None,
         }
     }
 

--- a/src-tauri/src/commands/git_state.rs
+++ b/src-tauri/src/commands/git_state.rs
@@ -11,7 +11,6 @@ use crate::git;
 use crate::git_state::{self, GitState, ShortStats};
 use crate::github as gh;
 use crate::supervisor::Supervisor;
-use crate::workspace::repo_checkout_path;
 
 use super::files::agent_repo_checkout_opt;
 
@@ -75,7 +74,7 @@ pub async fn get_all_shortstats(
         // sum across all of its repos (matching the archive metadata, which
         // also aggregates). Single-repo agents behave exactly as before.
         for repo in &agent.repos {
-            let Ok(checkout) = repo_checkout_path(&agent.id, &repo.subdir) else {
+            let Ok(checkout) = repo.checkout_path(&agent.id) else {
                 continue;
             };
             let agent_id = agent.id.clone();
@@ -129,7 +128,7 @@ pub async fn get_all_git_meta(
             continue;
         }
         for (i, repo) in agent.repos.iter().enumerate() {
-            let Ok(checkout) = repo_checkout_path(&agent.id, &repo.subdir) else {
+            let Ok(checkout) = repo.checkout_path(&agent.id) else {
                 continue;
             };
             let key = crate::supervisor::pr_map_key(&agent.id, &repo.subdir, i == 0);

--- a/src-tauri/src/database/connection.rs
+++ b/src-tauri/src/database/connection.rs
@@ -71,6 +71,7 @@ pub(crate) const MIGRATIONS: &[&str] = &[
     include_str!("../../migrations/0035_roadmap_items_drop_dormant.sql"),
     include_str!("../../migrations/0036_roadmap_issue_url.sql"),
     include_str!("../../migrations/0037_roadmap_close_reason.sql"),
+    include_str!("../../migrations/0038_worktree_adopted_checkout.sql"),
 ];
 
 pub(crate) fn get_migrations() -> Migrations<'static> {

--- a/src-tauri/src/git/hardening.rs
+++ b/src-tauri/src/git/hardening.rs
@@ -134,7 +134,10 @@ const EXEC_CONFIG: &[(&str, &str)] = &[
 /// Refuse to run host-side git in `dir` when the checkout's own config would make
 /// git execute a program.
 ///
-/// Scoped to **agent checkouts**. A user's own repository legitimately carries
+/// Scoped to **agent-writable trees**: agent checkouts, and run directories
+/// (`~/.fletch/runs/…`) — a kernel step agent writes its adopted run workspace
+/// as freely as a normal agent writes its checkout, so both roots are poisoned
+/// ground for host-side git. A user's own repository legitimately carries
 /// these keys — husky sets `core.hooksPath`, git-lfs sets `filter.lfs.*` — and
 /// refusing there would break the app for them. Their repo is also not
 /// agent-writable, so there is nothing to defend against. Only the **local and
@@ -149,10 +152,13 @@ const EXEC_CONFIG: &[(&str, &str)] = &[
 /// which also surfaces the attack instead of quietly repairing it. The agent's own
 /// sandboxed git keeps working; what stops is Fletch acting on the checkout.
 pub(crate) async fn refuse_steerable_config(dir: &Path) -> Result<()> {
-    let Ok(root) = crate::workspace::checkouts_root() else {
-        return Ok(());
-    };
-    refuse_steerable_config_under(dir, &root).await
+    if let Ok(root) = crate::workspace::checkouts_root() {
+        refuse_steerable_config_under(dir, &root).await?;
+    }
+    if let Ok(root) = crate::workflow::blackboard::runs_root() {
+        refuse_steerable_config_under(dir, &root).await?;
+    }
+    Ok(())
 }
 
 /// Whether git may be run in `dir` — [`refuse_steerable_config`] for callers whose

--- a/src-tauri/src/instructions.rs
+++ b/src-tauri/src/instructions.rs
@@ -535,6 +535,7 @@ mod tests {
                 pr_title: None,
                 pr_state: None,
                 label: label.map(str::to_string),
+                adopted_checkout: None,
             }
         }
 

--- a/src-tauri/src/sandbox/container/launch.rs
+++ b/src-tauri/src/sandbox/container/launch.rs
@@ -150,6 +150,17 @@ pub(crate) fn prepare(
             board.to_string_lossy().into_owned(),
         ));
     }
+    // The adopted tree is this launch's `cwd`: bound missing, the runtime would
+    // invent an empty root-owned dir and the agent would start in a workspace
+    // with none of the run's work in it. Fail with the path instead.
+    if let Some(tree) = ctx.adopted_workspace() {
+        if !tree.is_dir() {
+            return Err(Error::Other(format!(
+                "adopted workspace missing at launch: {}",
+                tree.display()
+            )));
+        }
+    }
 
     // Owned per-provider mount inputs, borrowed into a `ProviderMounts` by
     // `ContainerLaunch::mounts`. Only the matched arm fills any of these in.

--- a/src-tauri/src/sandbox/container/run_args.rs
+++ b/src-tauri/src/sandbox/container/run_args.rs
@@ -98,6 +98,12 @@ pub(crate) struct RunSpec<'a> {
     /// A workflow step agent's blackboard, bound read-write at its identical
     /// host path and forwarded as `WF_BLACKBOARD`. `None` for ordinary agents.
     pub blackboard: Option<&'a Path>,
+    /// A working tree adopted from outside the writable root (the kernel's
+    /// shared run workspace), bound read-write at its identical host path.
+    /// It is also `cwd`, so without the bind the container would start in a
+    /// directory the runtime had to invent. `None` for ordinary agents, whose
+    /// `cwd` is a checkout inside `writable_root`.
+    pub adopted_workspace: Option<&'a Path>,
     /// The launching provider's config/data mounts + config-dir env forwards.
     pub mounts: ProviderMounts<'a>,
     /// Object stores borrowed via git alternates, bound read-only at their
@@ -144,6 +150,11 @@ pub(crate) fn run_args(spec: &RunSpec<'_>) -> Vec<String> {
     // in-container as on the host (invariant 1).
     if let Some(board) = spec.blackboard {
         push_rw_bind(&mut args, board);
+    }
+    // Same identical-path rule (invariant 1): the agent's own checkout, which
+    // for an adopting launch lives outside the writable root.
+    if let Some(tree) = spec.adopted_workspace {
+        push_rw_bind(&mut args, tree);
     }
     // Identical host path so the alternates file resolves in-container with no
     // rewriting; read-only so borrowed history is readable but the source store
@@ -245,6 +256,9 @@ pub(crate) fn mount_sources(spec: &RunSpec<'_>) -> Vec<PathBuf> {
     let mut out: Vec<PathBuf> = vec![spec.writable_root.into(), spec.rpc_dir.into()];
     if let Some(board) = spec.blackboard {
         out.push(board.into());
+    }
+    if let Some(tree) = spec.adopted_workspace {
+        out.push(tree.into());
     }
     out.extend(spec.borrowed_object_stores.iter().cloned());
     match &spec.mounts {
@@ -361,6 +375,7 @@ mod tests {
         let rpc = Path::new("/tmp/fletch-run-args/rpc");
         let home = Path::new("/tmp/fletch-run-args/home");
         let board = Path::new("/tmp/fletch-run-args/board");
+        let tree = Path::new("/tmp/fletch-run-args/run/repo");
         let alt = Path::new("/tmp/fletch-run-args/alt");
         let stores = vec![
             PathBuf::from("/tmp/fletch-run-args/store-a/objects"),
@@ -397,8 +412,9 @@ mod tests {
                 writable_root: root,
                 rpc_dir: rpc,
                 home,
-                cwd: root,
+                cwd: tree,
                 blackboard: Some(board),
+                adopted_workspace: Some(tree),
                 mounts,
                 borrowed_object_stores: &stores,
                 memory: DEFAULT_MEMORY,
@@ -434,5 +450,46 @@ mod tests {
                 "expected the workspace/rpc/config binds at least"
             );
         }
+    }
+
+    /// A kernel step's working tree lives outside the writable root, so without
+    /// its own bind the container would start in a directory the runtime
+    /// invented — the agent would see an empty workspace and none of the run's
+    /// work. Read-write, at the identical host path (invariant 1).
+    #[test]
+    fn an_adopted_workspace_is_bound_read_write_at_its_host_path() {
+        let root = Path::new("/tmp/fletch-adopt/work");
+        let tree = Path::new("/tmp/fletch-adopt/run/repo");
+        let projects = root.join("claude-projects");
+        let spec = RunSpec {
+            interactive: false,
+            name: "fletch-agent-test",
+            agent_id: "agent-1",
+            writable_root: root,
+            rpc_dir: Path::new("/tmp/fletch-adopt/rpc"),
+            home: Path::new("/tmp/fletch-adopt/home"),
+            cwd: tree,
+            blackboard: None,
+            adopted_workspace: Some(tree),
+            mounts: ProviderMounts::Claude {
+                config_dir: None,
+                credentials_rw: false,
+                config_dir_credentials_rw: false,
+                projects_src: &projects,
+            },
+            borrowed_object_stores: &[],
+            memory: DEFAULT_MEMORY,
+            cpus: DEFAULT_CPUS,
+            image: "fletch-agent:cafe00000000",
+            agent_bin: "claude",
+            auth_vars: &[],
+        };
+        let args = run_args(&spec);
+        let bind = format!("{0}:{0}", tree.to_string_lossy());
+        assert!(args.contains(&bind), "expected {bind} in {args:?}");
+        // The workdir is that same path, so the bind is what makes it exist.
+        let w = args.iter().position(|a| a == "-w").expect("-w");
+        assert_eq!(args[w + 1], tree.to_string_lossy());
+        assert!(mount_sources(&spec).contains(&tree.to_path_buf()));
     }
 }

--- a/src-tauri/src/sandbox/docker/engine/mod.rs
+++ b/src-tauri/src/sandbox/docker/engine/mod.rs
@@ -222,6 +222,7 @@ impl SandboxEngine for DockerEngine {
                 home: ctx.home,
                 cwd: ctx.cwd,
                 blackboard: ctx.blackboard,
+                adopted_workspace: ctx.adopted_workspace(),
                 mounts: prep.mounts(),
                 borrowed_object_stores: &prep.borrowed_object_stores,
                 memory: non_blank(settings.memory.as_deref()).unwrap_or(DEFAULT_MEMORY),

--- a/src-tauri/src/sandbox/docker/engine/tests.rs
+++ b/src-tauri/src/sandbox/docker/engine/tests.rs
@@ -102,6 +102,7 @@ fn test_spec<'a>(interactive: bool) -> RunSpec<'a> {
         home: Path::new("/Users/u"),
         cwd: Path::new("/Users/u/.fletch/worktrees/orkney/repo"),
         blackboard: None,
+        adopted_workspace: None,
         mounts: claude_mounts(None, false, false),
         borrowed_object_stores: &[],
         memory: "4g",
@@ -135,6 +136,7 @@ fn rw_config_spec<'a>(
         home: Path::new("/Users/u"),
         cwd: Path::new("/Users/u/.fletch/worktrees/orkney/repo"),
         blackboard: None,
+        adopted_workspace: None,
         mounts,
         borrowed_object_stores: &[],
         memory: "4g",
@@ -1247,6 +1249,7 @@ fn docker_run_echo_round_trip() {
         home: &home,
         cwd: &root,
         blackboard: None,
+        adopted_workspace: None,
         mounts: ProviderMounts::Claude {
             config_dir: None,
             credentials_rw: false,

--- a/src-tauri/src/sandbox/engine.rs
+++ b/src-tauri/src/sandbox/engine.rs
@@ -85,6 +85,25 @@ pub struct AgentLaunchCtx<'a> {
     pub blackboard: Option<&'a Path>,
 }
 
+impl<'a> AgentLaunchCtx<'a> {
+    /// The working tree this launch must be able to write *outside* the writable
+    /// root — an adopted checkout, i.e. the workflow kernel's shared run
+    /// workspace (`~/.fletch/runs/<run-id>/repo`), which every step of a run
+    /// works in instead of cloning one under its own root.
+    ///
+    /// Derived from `cwd` rather than declared by the caller: an agent always
+    /// runs in its own checkout, so a `cwd` outside `writable_root` IS an
+    /// adopted tree — and a launch path that forgot to declare it would hand the
+    /// agent a working directory it cannot write (seatbelt) or that the runtime
+    /// invents empty (containers). Both engines grant it the same way they grant
+    /// [`blackboard`](Self::blackboard): seatbelt as a writable subpath (with
+    /// its own invariant-3 deny), a container runtime as a read-write bind at
+    /// the identical host path.
+    pub fn adopted_workspace(&self) -> Option<&'a Path> {
+        (!self.cwd.starts_with(self.writable_root)).then_some(self.cwd)
+    }
+}
+
 /// Engine-specific data describing how to tear down what was launched.
 #[derive(Clone)]
 pub enum KillPlan {
@@ -178,7 +197,38 @@ pub trait SandboxEngine: Send + Sync {
 
 #[cfg(test)]
 mod tests {
-    use super::EngineKind;
+    use super::{AgentLaunchCtx, EngineKind};
+    use std::path::{Path, PathBuf};
+
+    fn ctx<'a>(writable_root: &'a Path, cwd: &'a Path) -> AgentLaunchCtx<'a> {
+        AgentLaunchCtx {
+            agent_id: "yosemite",
+            provider: "claude",
+            writable_root,
+            source_repos: &[],
+            rpc_dir: Path::new("/rpc/yosemite"),
+            cwd,
+            home: Path::new("/home/u"),
+            interactive: true,
+            blackboard: None,
+        }
+    }
+
+    /// An ordinary agent's cwd is one of its own checkouts under the writable
+    /// root, so it needs no grant of its own; a kernel step's cwd is the run's
+    /// shared tree, which does.
+    #[test]
+    fn adopted_workspace_is_the_cwd_only_when_it_escapes_the_writable_root() {
+        let root = PathBuf::from("/w/yosemite");
+        assert_eq!(ctx(&root, &root.join("repo")).adopted_workspace(), None);
+        assert_eq!(ctx(&root, &root).adopted_workspace(), None);
+
+        let run_tree = PathBuf::from("/runs/run-7/repo");
+        assert_eq!(
+            ctx(&root, &run_tree).adopted_workspace(),
+            Some(run_tree.as_path())
+        );
+    }
 
     #[test]
     fn engine_kind_setting_round_trips() {

--- a/src-tauri/src/sandbox/podman/engine.rs
+++ b/src-tauri/src/sandbox/podman/engine.rs
@@ -156,6 +156,7 @@ impl SandboxEngine for PodmanEngine {
                 home: ctx.home,
                 cwd: ctx.cwd,
                 blackboard: ctx.blackboard,
+                adopted_workspace: ctx.adopted_workspace(),
                 mounts: prep.mounts(),
                 borrowed_object_stores: &prep.borrowed_object_stores,
                 memory: non_blank(settings.memory.as_deref()).unwrap_or(DEFAULT_MEMORY),
@@ -331,6 +332,7 @@ mod tests {
             home: &home,
             cwd: &root,
             blackboard: None,
+            adopted_workspace: None,
             mounts: crate::sandbox::container::run_args::ProviderMounts::Claude {
                 config_dir: None,
                 credentials_rw: false,

--- a/src-tauri/src/sandbox/seatbelt.rs
+++ b/src-tauri/src/sandbox/seatbelt.rs
@@ -57,6 +57,7 @@ impl SandboxEngine for SandboxExecEngine {
             ctx.home,
             claude_config_dir.as_deref(),
             ctx.blackboard,
+            ctx.adopted_workspace(),
         )?;
         // A workflow step agent's blackboard is granted writable in the profile
         // above; also point the agent at it via `WF_BLACKBOARD` (the same host
@@ -511,12 +512,17 @@ pub(crate) fn pid_alive(_pid: i32) -> bool {
 /// `claude_config_dir` is the value of `CLAUDE_CONFIG_DIR` the agent runs with
 /// (`None` = default `~/.claude`); when set elsewhere the agent writes its
 /// config/transcripts/auth there, so it must be writable too.
+/// `adopted_workspace` is a working tree the agent adopted instead of one under
+/// `writable_root` (the workflow kernel's shared run workspace) — its own
+/// writable subpath, and its own invariant-3 deny, since the agent's checkout
+/// isn't under the root this profile is otherwise built around.
 pub fn build_profile(
     writable_root: &Path,
     rpc_dir: &Path,
     home: &Path,
     claude_config_dir: Option<&Path>,
     blackboard: Option<&Path>,
+    adopted_workspace: Option<&Path>,
 ) -> Result<String> {
     let writable_root = canonical(writable_root)?;
     let rpc_root = canonical(rpc_dir)?;
@@ -535,6 +541,18 @@ pub fn build_profile(
             let board = canonical(board)?;
             format!("\n  (subpath {})", sbpl_string(&board.to_string_lossy()))
         }
+        None => String::new(),
+    };
+
+    // An adopted working tree is the agent's *checkout*, living outside the
+    // writable root because the run owns it — so without this grant the agent
+    // couldn't write the files it was spawned to change.
+    let adopted = match adopted_workspace {
+        Some(dir) => Some(canonical(dir)?),
+        None => None,
+    };
+    let adopted_grant = match &adopted {
+        Some(dir) => format!("\n  (subpath {})", sbpl_string(&dir.to_string_lossy())),
         None => String::new(),
     };
 
@@ -616,7 +634,15 @@ pub fn build_profile(
     // husky project legitimately writes `core.hooksPath`. Run is already
     // documented as the weaker boundary (see `RUN_TOOLCHAIN_DIRS`), so the
     // asymmetry follows the existing split rather than inventing one.
-    let deny_git_config = deny_git_exec_config(&writable_root.to_string_lossy());
+    // Emitted per writable checkout root: an adopted tree is a repo the app runs
+    // git on exactly like a provisioned one, so invariant 3 has to cover it too
+    // — its grant above would otherwise leave `.git/config` (hooks, filters,
+    // merge drivers) agent-writable.
+    let deny_git_config = std::iter::once(writable_root.to_string_lossy())
+        .chain(adopted.iter().map(|dir| dir.to_string_lossy()))
+        .map(|root| deny_git_exec_config(&root))
+        .collect::<Vec<_>>()
+        .join("\n\n");
 
     // Invariant 2 for the non-claude provider config roots (agent profile only,
     // like `deny_git_config`): deny their command-defining config back out of the
@@ -640,7 +666,7 @@ pub fn build_profile(
 (deny file-write*)
 (allow file-write*
   (subpath {writable_root_s})
-  (subpath {rpc_root_s}){blackboard_grant}
+  (subpath {rpc_root_s}){blackboard_grant}{adopted_grant}
   (subpath "/private/tmp")
   (subpath "/private/var/folders")
   (subpath "/private/var/tmp")
@@ -809,7 +835,7 @@ mod tests {
         std::fs::create_dir_all(&rpc).unwrap();
         std::fs::create_dir_all(&home).unwrap();
 
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_root = std::fs::canonicalize(&root).unwrap();
         let canonical_rpc = std::fs::canonicalize(&rpc).unwrap();
 
@@ -838,7 +864,7 @@ mod tests {
         for d in [&root, &rpc, &home] {
             std::fs::create_dir_all(d).unwrap();
         }
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_root = std::fs::canonicalize(&root).unwrap();
         let escaped = sbpl_regex_escape(&canonical_root.to_string_lossy());
 
@@ -891,7 +917,7 @@ mod tests {
         for d in [&rpc, &home, &repo.join(".git/hooks")] {
             std::fs::create_dir_all(d).unwrap();
         }
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
 
         // `sh -c 'printf x > <path>'` under the profile: exit 0 means the write
         // landed, non-zero means the sandbox refused it.
@@ -943,7 +969,7 @@ mod tests {
             std::fs::create_dir_all(d).unwrap();
         }
         let home = std::fs::canonicalize(&home).unwrap();
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
 
         let denied = policy::provider_exec_config_denials(&home);
         assert!(!denied.files.is_empty() && !denied.dirs.is_empty());
@@ -986,7 +1012,7 @@ mod tests {
         let cache_root = policy::toolchain_cache_root(&canonical_home);
         let expected = format!("\"{}\"", cache_root.display());
 
-        let agent = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let agent = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         assert!(
             agent.contains(&expected),
             "agent profile is missing the toolchain cache root"
@@ -1007,7 +1033,7 @@ mod tests {
         // It grants the narrow replacements instead, and every provider dot-dir
         // and cache dir stays exactly as before.
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         let h = canonical_home.display();
 
@@ -1128,7 +1154,7 @@ mod tests {
         std::fs::create_dir_all(&target).unwrap();
         std::os::unix::fs::symlink(&target, home.join(".claude")).unwrap();
 
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         assert!(
             !profile.contains(".local/bin"),
@@ -1151,7 +1177,7 @@ mod tests {
         let cfg = home.join(".local/bin/claude-cfg");
         std::fs::create_dir_all(&cfg).unwrap();
 
-        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path()), None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path()), None, None).unwrap();
         assert!(
             !profile.contains(".local/bin"),
             "bin-resident CLAUDE_CONFIG_DIR must not appear on the allow-list"
@@ -1167,14 +1193,14 @@ mod tests {
         let canonical_board = std::fs::canonicalize(&board).unwrap();
 
         // Absent by default: an ordinary (non-workflow) agent gets no grant.
-        let plain = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let plain = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         assert!(
             !plain.contains(&canonical_board.to_string_lossy().to_string()),
             "no blackboard grant without a blackboard"
         );
 
         // Granted: the *exact* blackboard dir is a writable subpath.
-        let granted = build_profile(&root, &rpc, &home, None, Some(board.as_path())).unwrap();
+        let granted = build_profile(&root, &rpc, &home, None, Some(board.as_path()), None).unwrap();
         assert!(
             granted.contains(&format!("(subpath \"{}\")", canonical_board.display())),
             "granted profile must allow writing inside the blackboard"
@@ -1186,6 +1212,44 @@ mod tests {
         assert!(
             !granted.contains(&format!("(subpath \"{}\")", parent.display())),
             "the blackboard's parent must not be granted"
+        );
+    }
+
+    /// A kernel step's checkout is the run's shared tree, outside the writable
+    /// root — so the profile has to grant it (or the agent can't edit the code
+    /// it was spawned for) *and* carry invariant 3 into it (or `.git/config`
+    /// becomes host code execution the next time Fletch runs git there).
+    #[test]
+    fn agent_profile_grants_an_adopted_tree_and_keeps_invariant_3_over_it() {
+        let (td, root, rpc, home) = sandbox_dirs();
+        let tree = td.path().join("runs/run-1/repo");
+        std::fs::create_dir_all(&tree).unwrap();
+        let canonical_tree = std::fs::canonicalize(&tree).unwrap();
+
+        let plain = build_profile(&root, &rpc, &home, None, None, None).unwrap();
+        assert!(
+            !plain.contains(&canonical_tree.to_string_lossy().to_string()),
+            "no adoption grant for an agent that owns its checkout"
+        );
+
+        let granted = build_profile(&root, &rpc, &home, None, None, Some(tree.as_path())).unwrap();
+        assert!(
+            granted.contains(&format!("(subpath \"{}\")", canonical_tree.display())),
+            "the adopted tree must be writable: it is the agent's checkout"
+        );
+        // Its parent (the run dir, holding the blackboard and export area) is
+        // not swept in by the grant.
+        let parent = canonical_tree.parent().unwrap();
+        assert!(
+            !granted.contains(&format!("(subpath \"{}\")", parent.display())),
+            "the run dir itself must not be granted"
+        );
+        // Invariant 3 follows the grant: one deny block per writable checkout
+        // root, so `.git/config` is unwritable in the adopted tree too.
+        let escaped = sbpl_regex_escape(&canonical_tree.to_string_lossy());
+        assert!(
+            granted.contains(&format!("^{escaped}(/.*)?/\\.git/")),
+            "invariant 3 must cover the adopted tree: {granted}"
         );
     }
 
@@ -1210,7 +1274,7 @@ mod tests {
         let cfg = home.join(".claude-eve");
         std::fs::create_dir_all(&cfg).unwrap();
 
-        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path()), None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, Some(cfg.as_path()), None, None).unwrap();
         // The emitted paths must be canonical (symlink-resolved) so they match
         // what the sandbox resolves at write time — e.g. on macOS the tempdir
         // lives under /var → /private/var.
@@ -1275,8 +1339,15 @@ mod tests {
         let (_td, root, rpc, home) = sandbox_dirs();
         let default_claude = std::fs::canonicalize(&home).unwrap().join(".claude");
 
-        let profile =
-            build_profile(&root, &rpc, &home, Some(default_claude.as_path()), None).unwrap();
+        let profile = build_profile(
+            &root,
+            &rpc,
+            &home,
+            Some(default_claude.as_path()),
+            None,
+            None,
+        )
+        .unwrap();
         for island in policy::claude_write_island_dirs(&default_claude) {
             let needle = format!("(subpath \"{}\")", island.display());
             assert_eq!(
@@ -1303,7 +1374,7 @@ mod tests {
         // credential file. `settings.json` (host hooks), `plugins/`, `CLAUDE.md`,
         // etc. must be covered by no grant.
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         let claude = canonical_home.join(".claude");
         let h = canonical_home.display();
@@ -1369,7 +1440,7 @@ mod tests {
         // reads (exfiltration) and writes (forging state). The deny only bites if
         // it comes AFTER the write allow-list, since SBPL is last-match-wins.
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
 
         let deny = format!(
@@ -1394,7 +1465,7 @@ mod tests {
         // Agents never legitimately touch any Fletch data dir — no `dev`
         // exception (that carve-out is Run-profile-only).
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         let dev = format!(
             "{}/Library/Application Support/{}/dev",
@@ -1414,7 +1485,7 @@ mod tests {
     #[test]
     fn agent_profile_denies_appsupport_auto_exec_but_keeps_the_grant() {
         let (_td, root, rpc, home) = sandbox_dirs();
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         let app_support = format!("{}/Library/Application Support", canonical_home.display());
 
@@ -1526,7 +1597,7 @@ mod tests {
         for d in [&root, &rpc, &home] {
             std::fs::create_dir_all(d).unwrap();
         }
-        let profile = build_profile(&root, &rpc, &home, None, None).unwrap();
+        let profile = build_profile(&root, &rpc, &home, None, None, None).unwrap();
         let canonical_home = std::fs::canonicalize(&home).unwrap();
         let app_support = canonical_home.join("Library/Application Support");
 

--- a/src-tauri/src/supervisor/disposition.rs
+++ b/src-tauri/src/supervisor/disposition.rs
@@ -219,6 +219,10 @@ impl Supervisor {
                 pr_title: None,
                 pr_state: None,
                 label: None,
+                // Restore rebuilt an agent-owned clone at the derived path, so
+                // the row's adoption (if it had one) is cleared by
+                // `restore_agent` rather than carried forward.
+                adopted_checkout: None,
             });
         }
 
@@ -331,7 +335,7 @@ async fn capture_repo_snapshots(
     let mut total_dels: u32 = 0;
 
     for repo in repos {
-        let checkout = repo_checkout_path(agent_id, &repo.subdir).ok();
+        let checkout = repo.checkout_path(agent_id).ok();
         let branch_tip_sha = match &checkout {
             Some(wt) => git::rev_parse(wt, "HEAD").await.ok(),
             None => None,
@@ -487,9 +491,19 @@ fn reap_agent_containers(agent_id: &str, record: Option<&AgentRecord>, op: &'sta
 /// agent's parent dir. Failures are logged (tagged with `op` for context) but
 /// never abort the sweep — the caller's intent is to get rid of the agent.
 /// Shared by archive and discard.
+///
+/// An *adopted* checkout is skipped: the agent was a tenant of a working tree
+/// something else owns (the workflow kernel's shared run workspace, which the
+/// run's own delete reclaims — see `workflow::scheduler`), so disposing of the
+/// agent must leave the directory exactly where it is. Every step of a run
+/// passes through here as it is archived, so the run's work would not survive
+/// its first completed step otherwise.
 async fn teardown_agent_checkouts(agent_id: &str, repos: &[TrackedRepo], op: &str) {
     for repo in repos {
-        let checkout = match repo_checkout_path(agent_id, &repo.subdir) {
+        if repo.is_adopted() {
+            continue;
+        }
+        let checkout = match repo.checkout_path(agent_id) {
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!(error = %e, subdir = %repo.subdir, op, "checkout path resolution failed");
@@ -583,6 +597,40 @@ mod tests {
             out.status.success(),
             "git {args:?}: {}",
             String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// Every step of a workflow run is archived as it finishes, and each one
+    /// runs in the *same* adopted tree — so a teardown that removed it would
+    /// destroy the run's work at the first step boundary. The agent's own dirs
+    /// still go; the directory the run owns stays.
+    #[tokio::test]
+    async fn teardown_spares_an_adopted_checkout() {
+        let td = tempfile::tempdir().unwrap();
+        let adopted = td.path().join("run-repo");
+        std::fs::create_dir_all(adopted.join(".git")).unwrap();
+        std::fs::write(adopted.join("step.txt"), "work so far").unwrap();
+
+        let repo = TrackedRepo {
+            repo_path: td.path().join("source"),
+            subdir: "repo".into(),
+            branch: None,
+            parent_branch: None,
+            base_sha: None,
+            pr_number: None,
+            pr_url: None,
+            pr_title: None,
+            pr_state: None,
+            label: None,
+            adopted_checkout: Some(adopted.clone()),
+        };
+        // An id no agent ever had: the agent-owned paths this resolves resolve
+        // to nothing, which is the point — only the adopted tree exists.
+        teardown_agent_checkouts("adoption-teardown-test", &[repo], "test").await;
+
+        assert!(
+            adopted.join("step.txt").is_file(),
+            "the run's working tree must outlive the step agent"
         );
     }
 

--- a/src-tauri/src/supervisor/fork.rs
+++ b/src-tauri/src/supervisor/fork.rs
@@ -145,10 +145,7 @@ impl Supervisor {
         let fork_base = primary.parent_branch.clone();
         let carry_from = match code {
             ForkCode::Clean => None,
-            ForkCode::Carry => Some(crate::workspace::repo_checkout_path(
-                parent_id,
-                &primary.subdir,
-            )?),
+            ForkCode::Carry => Some(primary.checkout_path(parent_id)?),
         };
 
         let req = SpawnRequest {
@@ -166,6 +163,7 @@ impl Supervisor {
             fork_base,
             run_repo: None,
             owner_run_id: None,
+            existing_workspace: None,
             carry_from,
             // A fork is a fresh line of work; it doesn't inherit the parent's
             // originating issue (only one workspace should close it).

--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -2,7 +2,7 @@
 //! respawns, and the shared output/exit/watchdog handlers.
 
 use serde_json::Value;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Manager};
@@ -159,6 +159,20 @@ pub(super) async fn provision_codegraph_index(
     });
 }
 
+/// Undo what a failed spawn created: the checkout it provisioned, then the
+/// agent's dir. `checkout` is `None` when the spawn *adopted* its working tree
+/// — that directory belongs to the run, not the agent, so a step whose process
+/// never came up must not take the run's work down with it. The agent dir is
+/// always removed: it holds only Fletch-generated per-agent artifacts, and an
+/// adopted tree is never inside it (adoption records the real path rather than
+/// linking to it, so no recursive delete can reach through).
+async fn discard_failed_spawn(checkout: Option<&Path>, parent_dir: &Path) {
+    if let Some(checkout) = checkout {
+        let _ = provision::teardown(checkout).await;
+    }
+    let _ = tokio::fs::remove_dir_all(parent_dir).await;
+}
+
 /// Resolved, per-spawn inputs for `spawn_agent_process` — everything that
 /// isn't already carried on the `AgentRecord` (paths, session id, and this
 /// spawn's generation number).
@@ -243,6 +257,12 @@ pub struct SpawnRequest {
     /// normal sidebar and cleaned up by `wf_delete_run`. `None` for a normal
     /// user spawn.
     pub owner_run_id: Option<String>,
+    /// A pre-provisioned checkout this agent adopts as its primary workspace
+    /// instead of cloning one — the workflow kernel's shared run workspace.
+    /// When set, provisioning is skipped (`fork_base`/`run_repo` are ignored)
+    /// and teardown must never remove the directory: the run owns it, not the
+    /// agent. `None` for every non-kernel spawn.
+    pub existing_workspace: Option<PathBuf>,
     /// Fork "carry code": another workspace's primary checkout whose current
     /// working tree (incl. uncommitted work) is overlaid onto this fresh
     /// checkout after provisioning, so the fork starts from that workspace's
@@ -281,6 +301,7 @@ impl Supervisor {
             fork_base,
             run_repo,
             owner_run_id,
+            existing_workspace,
             carry_from,
             issue_ref,
             purpose,
@@ -340,6 +361,25 @@ impl Supervisor {
             Some(base) if !base.trim().is_empty() => base.trim().to_string(),
             _ => git::default_branch(&repo_path).await,
         };
+        // Adopting a pre-provisioned tree must be decided before anything else:
+        // it is the one mode in which no clone happens, so the base the caller
+        // asked for is only ever the *recorded* parent branch, never a fork
+        // point. The directory must already be a working tree — the run
+        // provisions it before the first step (see `SpawnRequest`), and
+        // discovering otherwise later means a spawn that failed after the record
+        // was written.
+        let adopted = match existing_workspace {
+            Some(path) => {
+                if !path.join(".git").exists() {
+                    return Err(Error::InvalidPath(format!(
+                        "adopted workspace is not a git repository: {}",
+                        path.display()
+                    )));
+                }
+                Some(path)
+            }
+            None => None,
+        };
         let subdir = allocate_repo_subdir(&repo_path, &[]);
         // Cloned for the background fork task — `parent_branch`/`subdir` are
         // moved into `primary` below.
@@ -362,6 +402,9 @@ impl Supervisor {
             pr_title: None,
             pr_state: None,
             label: None,
+            // Set only by the kernel's adopting spawn; every other spawn owns
+            // the checkout the fork task provisions below.
+            adopted_checkout: adopted.clone(),
         };
 
         let mut record = new_agent_record(
@@ -414,7 +457,9 @@ impl Supervisor {
         }
         let agent_id = record.id.clone();
         let parent_dir = agent_parent_dir(&agent_id)?;
-        let primary_checkout = repo_checkout_path(&agent_id, &subdir)?;
+        // Resolved through the record's own repo entry so the adopted tree and
+        // the derived layout can't disagree here and in `start_process`.
+        let primary_checkout = record.repos[0].checkout_path(&agent_id)?;
         crate::telemetry::track(
             "agent_spawned",
             serde_json::json!({
@@ -432,6 +477,7 @@ impl Supervisor {
         let project_id_for_task = record.project_id.clone();
         let provider_for_task = record.provider.clone();
         let mcp_servers_for_task = record.mcp_servers.clone();
+        let adopted_for_task = adopted.is_some();
         tauri::async_runtime::spawn(async move {
             if let Err(e) = tokio::fs::create_dir_all(&parent_dir).await {
                 fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
@@ -451,8 +497,15 @@ impl Supervisor {
             // source's HEAD branch as a local branch, so checking out any
             // *other* branch by name trips git's remote-DWIM (an implicit `-b`),
             // which is fatal combined with `--detach`.
+            //
+            // An adopted tree skips every rung of this: it already exists at the
+            // commit the run put it on, so there is no fork to make, no base to
+            // fetch, and no freshness to degrade — `fork_base`/`run_repo` are
+            // inputs to provisioning only, and provisioning is what adoption
+            // replaces.
             let mut base_freshness = None;
             let provision_result = match &run_repo_for_task {
+                _ if adopted_for_task => Ok(()),
                 // Workflow step (§12.1): fork from `fork_base` in the run repo.
                 // `base_ref` is used as-is and never fetched from `origin` —
                 // it's a run-internal commit-ish, not a branch: step 1's
@@ -497,9 +550,15 @@ impl Supervisor {
                 sup.stale_base.lock().insert(id_for_task.clone());
             }
 
+            // What a failed spawn below is allowed to remove — never an adopted
+            // tree (see `discard_failed_spawn`).
+            let owned_checkout = (!adopted_for_task).then(|| primary_checkout.clone());
+
             // Record the fork point so diffs measure against the exact starting
             // commit rather than a branch name that can drift. Non-fatal: a
-            // missing base_sha just falls back to the parent branch name.
+            // missing base_sha just falls back to the parent branch name. Read
+            // from the checkout either way, so an adopted tree's base is the
+            // commit the run left it on rather than a fork that never happened.
             let base_sha = git::rev_parse(&primary_checkout, "HEAD").await.ok();
             if let Some(sha) = &base_sha {
                 let _ = sup
@@ -538,8 +597,7 @@ impl Supervisor {
                     )),
                 };
                 if let Err(e) = carried {
-                    let _ = provision::teardown(&primary_checkout).await;
-                    let _ = tokio::fs::remove_dir_all(&parent_dir).await;
+                    discard_failed_spawn(owned_checkout.as_deref(), &parent_dir).await;
                     fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
                     return;
                 }
@@ -550,8 +608,9 @@ impl Supervisor {
             // (untouched repos are just clean clones). Runs before
             // start_process so the Docker engine's mounts and the git RPC
             // dispatcher see the full repo set. Workflow step agents stay
-            // single-repo — a run targets one repo (see `wf_launch`).
-            if run_repo_for_task.is_none() {
+            // single-repo — a run targets one repo (see `wf_launch`), which
+            // covers both the forking and the adopting shape of a step spawn.
+            if run_repo_for_task.is_none() && !adopted_for_task {
                 for source in sup.workspace.project_repo_paths(&project_id_for_task) {
                     if source == repo_path {
                         continue;
@@ -560,8 +619,7 @@ impl Supervisor {
                         .attach_repo_checkout(&app_for_task, &id_for_task, source.clone(), false)
                         .await
                     {
-                        let _ = provision::teardown(&primary_checkout).await;
-                        let _ = tokio::fs::remove_dir_all(&parent_dir).await;
+                        discard_failed_spawn(owned_checkout.as_deref(), &parent_dir).await;
                         fail_spawn(
                             &sup,
                             &app_for_task,
@@ -576,8 +634,7 @@ impl Supervisor {
             tokio::time::sleep(Duration::from_millis(350)).await;
 
             if let Err(e) = sup.start_process(&app_for_task, &id_for_task, true).await {
-                let _ = provision::teardown(&primary_checkout).await;
-                let _ = tokio::fs::remove_dir_all(&parent_dir).await;
+                discard_failed_spawn(owned_checkout.as_deref(), &parent_dir).await;
                 fail_spawn(&sup, &app_for_task, &id_for_task, e.to_string());
             }
         });
@@ -682,6 +739,7 @@ impl Supervisor {
             pr_title: None,
             pr_state: None,
             label: None,
+            adopted_checkout: None,
         };
         self.workspace.append_tracked_repo(agent_id, repo.clone())?;
         emit_repo_added(app, agent_id, repo.clone());
@@ -711,7 +769,7 @@ impl Supervisor {
             .repos
             .first()
             .ok_or_else(|| Error::Other("agent has no tracked repos".into()))?;
-        let cwd = repo_checkout_path(agent_id, &primary.subdir)?;
+        let cwd = primary.checkout_path(agent_id)?;
         // Sandbox writable root — the agent's parent dir. Every agent (claude
         // and per-turn alike) now runs under sandbox-exec rooted here.
         let sandbox_root = agent_parent_dir(agent_id)?;
@@ -742,7 +800,7 @@ impl Supervisor {
         // agents (and old prompts) behave exactly as before.
         let mut repo_targets = Vec::new();
         for r in &record.repos {
-            let checkout = repo_checkout_path(agent_id, &r.subdir)?;
+            let checkout = r.checkout_path(agent_id)?;
             let base = r
                 .parent_branch
                 .clone()

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -772,6 +772,7 @@ mod tests {
                 pr_title: None,
                 pr_state: None,
                 label: None,
+                adopted_checkout: None,
             },
             String::new(),
             AgentView::Custom,
@@ -843,6 +844,7 @@ mod tests {
             pr_title: None,
             pr_state: None,
             label: None,
+            adopted_checkout: None,
         };
         let mut record = new_agent_record(
             "yosemite".into(),

--- a/src-tauri/src/supervisor/pr_set.rs
+++ b/src-tauri/src/supervisor/pr_set.rs
@@ -9,7 +9,7 @@
 //! bodies the agent wrote itself. Everything here is best-effort: a body edit
 //! is decoration, so failures are logged, never surfaced.
 
-use crate::workspace::{repo_checkout_path, WorkspaceManager};
+use crate::workspace::WorkspaceManager;
 
 /// Sentinels marking the generated trailer inside a PR body. Content between
 /// them is owned by Fletch and replaced wholesale on every sync.
@@ -73,7 +73,7 @@ pub(crate) async fn sync_pr_set_links(workspace: &WorkspaceManager, agent_id: &s
         let Some(number) = repo.pr_number else {
             continue;
         };
-        let Ok(checkout) = repo_checkout_path(agent_id, &repo.subdir) else {
+        let Ok(checkout) = repo.checkout_path(agent_id) else {
             continue;
         };
         let Some((owner, name)) =

--- a/src-tauri/src/supervisor/run.rs
+++ b/src-tauri/src/supervisor/run.rs
@@ -7,7 +7,6 @@ use tauri::AppHandle;
 
 use crate::error::{Error, Result};
 use crate::run_session::{self, shell_args, user_shell, RunPhase, RunSession, RunStateSnapshot};
-use crate::workspace::repo_checkout_path;
 
 use super::events::{emit_run_output, emit_run_port, emit_run_state};
 use super::Supervisor;
@@ -33,7 +32,7 @@ impl Supervisor {
             .repos
             .first()
             .ok_or_else(|| Error::Other("agent has no repos".into()))?;
-        let cwd = repo_checkout_path(agent_id, &primary.subdir)?;
+        let cwd = primary.checkout_path(agent_id)?;
 
         let (setup_cmd, run_cmd, intended_port) =
             self.read_run_config(agent_id, &record.project_id, &cwd);
@@ -208,7 +207,7 @@ impl Supervisor {
             .repos
             .first()
             .ok_or_else(|| Error::Other("agent has no repos".into()))?;
-        let checkout = repo_checkout_path(agent_id, &primary.subdir)?;
+        let checkout = primary.checkout_path(agent_id)?;
         Ok(crate::run_detect::detect_all(&checkout))
     }
 

--- a/src-tauri/src/supervisor/session_sync.rs
+++ b/src-tauri/src/supervisor/session_sync.rs
@@ -6,9 +6,7 @@ use tauri::AppHandle;
 
 use crate::agent::per_turn_descriptor;
 use crate::github::{MergeableState, PrState, PrStatus};
-use crate::workspace::{
-    repo_checkout_path, AgentRecord, AgentStatus, AgentView, TrackedRepo, WorkspaceManager,
-};
+use crate::workspace::{AgentRecord, AgentStatus, AgentView, TrackedRepo, WorkspaceManager};
 
 use super::events::{
     emit_pr_state, emit_session_records_appended, emit_session_sync_health, emit_verification,
@@ -157,7 +155,7 @@ impl Supervisor {
         let Some(primary) = record.repos.first() else {
             return;
         };
-        let Ok(checkout) = repo_checkout_path(&agent_id, &primary.subdir) else {
+        let Ok(checkout) = primary.checkout_path(&agent_id) else {
             return;
         };
         // Debounce: skip if a verification for this agent is already running.
@@ -346,7 +344,7 @@ pub(crate) async fn resolve_pr_state(
     };
     // No branch yet → nothing pushed, so no PR to find or bind.
     repo.branch.as_ref()?;
-    let checkout = repo_checkout_path(agent_id, &repo.subdir).ok()?;
+    let checkout = repo.checkout_path(agent_id).ok()?;
 
     if let Some(number) = repo.pr_number {
         // Merged is the one terminal state — it can't be undone, so it's
@@ -516,7 +514,7 @@ pub(crate) async fn resolve_all_pr_status(
             // Resolve the slug now (local git); the network cost is deferred to the
             // one batched query below. A broken checkout / non-GitHub origin can't
             // be fetched — hold the snapshot instead.
-            let slug = match repo_checkout_path(&agent.id, &repo.subdir) {
+            let slug = match repo.checkout_path(&agent.id) {
                 Ok(checkout) => crate::github::resolve_slug(&checkout, Some(&repo.repo_path)).await,
                 Err(_) => None,
             };
@@ -991,7 +989,7 @@ fn sync_session_records(workspace: &WorkspaceManager, agent_id: &str) -> Option<
     let Some(repo) = record.repos.first() else {
         return Some(pending());
     };
-    let Ok(cwd) = repo_checkout_path(agent_id, &repo.subdir) else {
+    let Ok(cwd) = repo.checkout_path(agent_id) else {
         return Some(pending());
     };
 
@@ -1447,6 +1445,7 @@ mod tests {
             pr_title: Some("feat: x".into()),
             pr_state: Some("merged".into()),
             label: None,
+            adopted_checkout: None,
         }
     }
 

--- a/src-tauri/src/supervisor/shell.rs
+++ b/src-tauri/src/supervisor/shell.rs
@@ -5,7 +5,6 @@ use tauri::AppHandle;
 
 use crate::error::{Error, Result};
 use crate::pty_session::{PtySession, PtySpawn};
-use crate::workspace::repo_checkout_path;
 
 use super::events::emit_shell_output;
 use super::Supervisor;
@@ -24,7 +23,7 @@ impl Supervisor {
             .repos
             .first()
             .ok_or_else(|| Error::Other("agent has no repos".into()))?;
-        let checkout = repo_checkout_path(agent_id, &repo.subdir)?;
+        let checkout = repo.checkout_path(agent_id)?;
 
         let shell_str = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
         let shell_path = std::path::PathBuf::from(&shell_str);

--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -914,6 +914,7 @@ mod tests {
                 fork_base: Some("base-sha".into()),
                 run_repo: None,
                 owner_run_id: "run-1".into(),
+                existing_workspace: None,
             },
             pre_spawned: None,
             blackboard,

--- a/src-tauri/src/workflow/driver.rs
+++ b/src-tauri/src/workflow/driver.rs
@@ -54,6 +54,12 @@ pub struct SpawnReq {
     /// `wf_delete_run`. The blackboard write-grant is derived from it at spawn,
     /// keeping the run directory the single source of truth.
     pub owner_run_id: String,
+    /// A pre-provisioned checkout the agent adopts as its primary workspace
+    /// instead of cloning one — the workflow kernel's shared run workspace,
+    /// where every sequential step works in the same tree. When set, `fork_base`
+    /// / `run_repo` provisioning is skipped entirely, and teardown (archive /
+    /// delete) must never remove the directory: the run owns it, not the agent.
+    pub existing_workspace: Option<PathBuf>,
 }
 
 /// A freshly spawned step agent.
@@ -131,6 +137,7 @@ impl AgentDriver for SupervisorDriver {
                 fork_base,
                 run_repo,
                 owner_run_id,
+                existing_workspace,
             } = req;
 
             let record = self
@@ -155,6 +162,7 @@ impl AgentDriver for SupervisorDriver {
                         fork_base,
                         run_repo,
                         owner_run_id: Some(owner_run_id),
+                        existing_workspace,
                         carry_from: None,
                         // Workflow-step spawns aren't issue-intake spawns.
                         issue_ref: None,
@@ -168,7 +176,7 @@ impl AgentDriver for SupervisorDriver {
             // The primary checkout path — provisioned by the spawn's background
             // task; the caller waits for `Idle` before reading it.
             let worktree = match record.repos.first() {
-                Some(primary) => crate::workspace::repo_checkout_path(&record.id, &primary.subdir)?,
+                Some(primary) => primary.checkout_path(&record.id)?,
                 None => {
                     return Err(crate::error::Error::Other(
                         "spawned step agent has no tracked repo".into(),
@@ -533,6 +541,7 @@ mod tests {
                 fork_base: None,
                 run_repo: None,
                 owner_run_id: "run-1".into(),
+                existing_workspace: None,
             })
             .await
             .unwrap();
@@ -561,6 +570,7 @@ mod tests {
                 fork_base: None,
                 run_repo: None,
                 owner_run_id: "run-1".into(),
+                existing_workspace: None,
             })
             .await;
         assert!(err.is_err());

--- a/src-tauri/src/workflow/mod.rs
+++ b/src-tauri/src/workflow/mod.rs
@@ -18,6 +18,7 @@ pub mod gates;
 pub mod gitops;
 pub mod journal;
 pub mod prompts;
+pub mod runner;
 pub mod scheduler;
 pub mod spec;
 pub mod tests_gate;

--- a/src-tauri/src/workflow/runner/mod.rs
+++ b/src-tauri/src/workflow/runner/mod.rs
@@ -1,0 +1,656 @@
+//! The kernel runner: the simple sequential success path for a workflow run.
+//!
+//! One workspace per run (the run repository's own working tree), one agent per
+//! step, no ferry and no per-step clone: each step's agent *adopts* the shared
+//! checkout ([`SpawnReq::existing_workspace`]), so consecutive steps see each
+//! other's work as plain history instead of a re-cloned fork. A step's boundary
+//! commit and its `refs/wf/steps/<exec>` pin land directly in that workspace.
+//!
+//! Scope is deliberate: plain top-level steps, `commit` / `verdict` gates, one
+//! per-step wall timeout, and failure-on-anything-unexpected. Retries, loops,
+//! parallel stages, approvals, budgets and resume all still belong to the
+//! clone-per-step engine (`scheduler/`), which keeps serving every spec this
+//! module rejects — see `docs/workflow-kernel-layers.md` for the layer ledger
+//! and what each future layer replaces.
+//!
+//! The journal is the contract with the UI: the kernel emits the same event
+//! types and the same `wf_step_exec` status values as the old engine, so the run
+//! monitor works unchanged. Every phase is journaled — there is no state a
+//! reader of the timeline cannot see.
+
+use std::path::PathBuf;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use rusqlite::Connection;
+use serde_json::json;
+use tokio::sync::broadcast::error::RecvError;
+use tokio::sync::broadcast::Receiver;
+
+use crate::error::{Error, Result};
+use crate::supervisor::StatusEvent;
+use crate::workspace::AgentStatus;
+
+use super::blackboard::{self, VerdictError, VerdictResult};
+use super::driver::{AgentDriver, SpawnReq};
+use super::gitops;
+use super::prompts::{self, Position, StepPromptCtx};
+use super::scheduler::{
+    abandon_exec, build_spawn_req, cancel_run, create_step_exec, fail_run, finalize_run,
+    finish_step_exec, gate_mode, journal_event, load_run, resolve_agent, set_status, RunCtx,
+};
+use super::spec::{Block, Gate, Spec, Step};
+use super::types::event_type;
+
+#[cfg(test)]
+mod tests;
+
+/// The kernel's only guard: a wall-clock ceiling on one step, covering spawn →
+/// ready → prompt → turn end. Generous, because a step doing real work
+/// legitimately runs for a long time and the kernel has no notion of progress;
+/// the old engine's stall clock and nudge are deliberately not reproduced (a
+/// single honest ceiling beats four tunable ones until real hangs prove
+/// otherwise).
+#[cfg(not(test))]
+const STEP_TIMEOUT: Duration = Duration::from_secs(30 * 60);
+/// Under test the timeout *arm* is what's interesting, not the wait. Short
+/// enough to assert on, long enough for a stub's real git work.
+#[cfg(test)]
+const STEP_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// What a non-terminal kernel run is told when the app restarts under it. The
+/// kernel keeps no resume state (no cursor reads, no mid-run recovery), so
+/// pretending otherwise would silently re-run finished steps in a workspace that
+/// already contains their commits.
+const NO_RESUME: &str = "kernel runs do not resume yet (see docs/workflow-kernel-layers.md)";
+
+/// Whether a spec is within the kernel's competence: a flat sequence of steps,
+/// each gated on something the kernel can decide by itself. Any other block kind
+/// (parallel, loop, orchestrate) or gate (artifact, tests, approval) belongs to
+/// the clone-per-step engine.
+pub(crate) fn kernel_eligible(spec: &Spec) -> bool {
+    !spec.workflow.is_empty()
+        && spec.workflow.iter().all(|b| match b {
+            Block::Step(s) => matches!(s.gate, Gate::Commit | Gate::Verdict),
+            _ => false,
+        })
+}
+
+/// The routing decision for one run row, taken from its launch-frozen
+/// `spec_json` so every drive of a given run reaches the same engine. An
+/// unreadable or unparsable spec routes to the old engine, which owns the
+/// reporting of that failure.
+pub(crate) fn routes_to_kernel(db: &super::Db, run_id: &str) -> bool {
+    let spec_json: Option<String> = db
+        .lock()
+        .query_row(
+            "SELECT spec_json FROM wf_run WHERE id = ?1",
+            [run_id],
+            |r| r.get(0),
+        )
+        .ok();
+    spec_json
+        .and_then(|j| serde_json::from_str::<Spec>(&j).ok())
+        .map(|spec| kernel_eligible(&spec))
+        .unwrap_or(false)
+}
+
+/// Drive one kernel run to `done`, `failed` or `canceled`. Any error bubbling
+/// out fails the run with its cause — the kernel never leaves a run `running`
+/// with no live driver.
+pub(crate) async fn run_kernel(ctx: &RunCtx, run_id: &str) {
+    if let Err(e) = run_kernel_inner(ctx, run_id).await {
+        let conn = ctx.db.lock();
+        fail_run(&conn, ctx.app.as_ref(), run_id, &e.to_string());
+    }
+}
+
+async fn run_kernel_inner(ctx: &RunCtx, run_id: &str) -> Result<()> {
+    let run = load_run(&ctx.db.lock(), run_id)?;
+    // A stale respawn or a command racing a terminal write must not restart a
+    // finished run.
+    if matches!(run.status.as_str(), "done" | "failed" | "canceled") {
+        return Ok(());
+    }
+    if run.status != "pending" {
+        refuse_resume(ctx, run_id).await;
+        return Ok(());
+    }
+
+    let spec: Spec =
+        serde_json::from_str(&run.spec_json).map_err(|e| Error::Other(e.to_string()))?;
+    // The routing site checked this; re-check so a hand-edited row can't smuggle
+    // an unsupported block past the one gate that understands it.
+    if !kernel_eligible(&spec) {
+        return Err(Error::Other(
+            "spec is not kernel-eligible (only plain steps with commit/verdict gates)".into(),
+        ));
+    }
+
+    let repo = PathBuf::from(&run.repo_path);
+    let run_dir = PathBuf::from(&run.run_dir);
+    let blackboard = blackboard::blackboard_dir(&run_dir);
+    // The run repo is a non-bare `--shared` clone with `origin` rewritten, so
+    // its working tree doubles as the run's single workspace and finalize
+    // already pushes from here. Detach at the run base: the clone opens on the
+    // source's default branch, which is not necessarily the fork point.
+    let workspace = gitops::provision_run_repo(&repo, &run_dir).await?;
+    crate::git::run_git(
+        &workspace,
+        &["checkout", "--detach", &run.base_sha],
+        "checkout run base",
+    )
+    .await?;
+
+    {
+        let conn = ctx.db.lock();
+        journal_event(
+            &conn,
+            ctx.app.as_ref(),
+            run_id,
+            event_type::RUN_LAUNCHED,
+            None,
+            &json!({
+                "base_sha": run.base_sha,
+                "runner": "kernel",
+                "workspace": workspace.to_string_lossy(),
+            }),
+        );
+        set_status(&conn, ctx.app.as_ref(), run_id, "running", None, None);
+    }
+
+    let steps: Vec<&Step> = spec
+        .workflow
+        .iter()
+        .filter_map(|b| match b {
+            Block::Step(s) => Some(s),
+            _ => None,
+        })
+        .collect();
+    // Launch attachments belong to the run's initial task, so only the entry
+    // step renders them.
+    let attachments = blackboard::read_attachments(&run_dir);
+    // The fork base each step is journaled against, and the ref finalize pushes:
+    // the run base until a step pins one.
+    let mut last_ref = run.base_sha.clone();
+    let mut last_exec_id: Option<String> = None;
+
+    for (index, step) in steps.iter().enumerate() {
+        if ctx.cancel.load(Ordering::SeqCst) {
+            cancel_run(ctx, run_id).await;
+            return Ok(());
+        }
+
+        let agent_spec = resolve_agent(&spec, step)?;
+        let exec_id = format!("exec-{}", uuid::Uuid::new_v4());
+        {
+            let conn = ctx.db.lock();
+            create_step_exec(
+                &conn,
+                &exec_id,
+                run_id,
+                &step.id,
+                1,
+                0,
+                gate_mode(&step.gate),
+            );
+        }
+
+        let prompt = prompts::step_prompt(&StepPromptCtx {
+            run_task: &run.task,
+            attachments: if index == 0 { &attachments } else { &[] },
+            step_id: &step.id,
+            step_goal: &step.goal,
+            position: Position {
+                step_index: index,
+                step_count: steps.len(),
+                iteration: None,
+            },
+            gate: &step.gate,
+            turns_per_attempt: step.budgets.as_ref().and_then(|b| b.turns_per_attempt),
+            comms: &step.comms,
+        });
+
+        let spawn_req = {
+            let conn = ctx.db.lock();
+            let mut req = build_spawn_req(
+                &conn,
+                ctx.app.as_ref(),
+                agent_spec,
+                &last_ref,
+                &repo,
+                &workspace,
+                run_id,
+                Some(&exec_id),
+            );
+            // Adoption is what makes this a kernel run: the step agent works in
+            // the run repo's tree rather than cloning its own, so the whole run
+            // shares one checkout and one line of commits. `fork_base` stays as
+            // the journal's record of where this step started.
+            req.existing_workspace = Some(workspace.clone());
+            req
+        };
+
+        // One deadline and one cancel race around the whole step, rather than a
+        // deadline per wait: the kernel cannot tell a slow step from a stuck one,
+        // so it only promises not to hang forever.
+        let end = tokio::select! {
+            biased;
+            r = tokio::time::timeout(
+                STEP_TIMEOUT,
+                drive_step(ctx, run_id, &exec_id, spawn_req, prompt),
+            ) => r.unwrap_or_else(|_| StepEnd::Failed {
+                agent_id: agent_id_of(&ctx.db.lock(), &exec_id),
+                error: format!("step timed out after {}s", STEP_TIMEOUT.as_secs()),
+            }),
+            _ = super::attempt::wait_cancelled(&ctx.cancel) => StepEnd::Canceled,
+        };
+
+        let agent_id = match end {
+            StepEnd::TurnEnded { agent_id } => agent_id,
+            StepEnd::Failed { agent_id, error } => {
+                fail_step(ctx, run_id, &exec_id, agent_id.as_deref(), "error", &error).await;
+                return Ok(());
+            }
+            StepEnd::Canceled => {
+                cancel_step(ctx, run_id, &exec_id).await;
+                return Ok(());
+            }
+        };
+
+        // Gate, v0: a `commit` gate is satisfied by the turn ending (the boundary
+        // commit below captures whatever the agent did); a `verdict` gate needs
+        // `result: "done"`. Anything else fails the run — re-prompting and
+        // retrying are later layers, and a silent advance past an unmet gate
+        // would be worse than a loud stop.
+        let gate = evaluate_gate(&step.gate, &blackboard, &step.id);
+        journal(
+            ctx,
+            run_id,
+            &exec_id,
+            event_type::GATE_EVALUATED,
+            json!({
+                "mode": gate_mode(&step.gate),
+                "outcome": if gate.is_ok() { "done" } else { "blocked" },
+                "reason": gate.clone().err().unwrap_or_default(),
+            }),
+        );
+        if let Err(reason) = gate {
+            fail_step(ctx, run_id, &exec_id, Some(&agent_id), "blocked", &reason).await;
+            return Ok(());
+        }
+
+        // Durability: commit the step's work in the shared workspace and pin it.
+        // No ferry — the workspace *is* the run repo, so the pin is already
+        // where finalize and the diff surface read from.
+        let message = format!("wf({}): {}", spec.name, step.id);
+        let head = match commit_step(&workspace, &exec_id, &message).await {
+            Ok(head) => head,
+            Err(e) => {
+                fail_step(
+                    ctx,
+                    run_id,
+                    &exec_id,
+                    Some(&agent_id),
+                    "error",
+                    &format!("boundary commit failed: {e}"),
+                )
+                .await;
+                return Ok(());
+            }
+        };
+        {
+            let conn = ctx.db.lock();
+            journal_event(
+                &conn,
+                ctx.app.as_ref(),
+                run_id,
+                event_type::BOUNDARY_COMMIT,
+                Some(&exec_id),
+                &json!({ "sha": head, "message": message }),
+            );
+            finish_step_exec(&conn, &exec_id, "done", Some(&head));
+        }
+        // Archive, never delete: the step's chat stays replayable from the
+        // timeline after the agent is gone.
+        let _ = ctx.driver.archive(&agent_id).await;
+
+        last_ref = gitops::step_ref(&exec_id);
+        last_exec_id = Some(exec_id);
+    }
+
+    finalize_run(
+        ctx,
+        run_id,
+        &run,
+        &spec,
+        &workspace,
+        last_exec_id.as_deref(),
+    )
+    .await?;
+    let conn = ctx.db.lock();
+    journal_event(
+        &conn,
+        ctx.app.as_ref(),
+        run_id,
+        event_type::RUN_DONE,
+        None,
+        &json!({}),
+    );
+    set_status(&conn, ctx.app.as_ref(), run_id, "done", None, None);
+    Ok(())
+}
+
+/// How one step's agent-facing half ended. The gate, the commit and the run's
+/// terminal status are the caller's business.
+enum StepEnd {
+    /// The agent's turn ended cleanly; the gate has not been consulted yet.
+    TurnEnded {
+        agent_id: String,
+    },
+    /// The step never reached a turn end. `agent_id` is `None` only when the
+    /// spawn itself failed — otherwise the agent exists and must be stopped.
+    Failed {
+        agent_id: Option<String>,
+        error: String,
+    },
+    Canceled,
+}
+
+/// Spawn the step's agent into the shared workspace, wait for it to be ready,
+/// send the step prompt, and wait for the turn to end. Every transition is
+/// journaled as it happens (not batched at the end) so the monitor can mount the
+/// step's chat and show progress while the turn is still in flight.
+async fn drive_step(
+    ctx: &RunCtx,
+    run_id: &str,
+    exec_id: &str,
+    spawn_req: SpawnReq,
+    prompt: String,
+) -> StepEnd {
+    let fork_base = spawn_req.fork_base.clone();
+    let spawned = match ctx.driver.spawn(spawn_req).await {
+        Ok(s) => s,
+        Err(e) => {
+            return StepEnd::Failed {
+                agent_id: None,
+                error: format!("spawn failed: {e}"),
+            }
+        }
+    };
+    // The adopted workspace is the run repo, so `SpawnedAgent::worktree` is not
+    // consulted: the kernel commits where it provisioned, not where the driver
+    // reports.
+    let agent_id = spawned.agent_id;
+    // Link the agent before the first event, so a listener that refetches on
+    // that event already finds the step's chat mounted.
+    stamp_spawned(&ctx.db.lock(), exec_id, &agent_id);
+    journal(
+        ctx,
+        run_id,
+        exec_id,
+        event_type::ATTEMPT_SPAWNED,
+        json!({ "agent_id": agent_id, "fork_base": fork_base }),
+    );
+
+    // The per-step ceiling is the real deadline; passing it here too keeps this
+    // wait from outliving the step under a driver that never reports readiness.
+    if let Err(e) =
+        super::attempt::await_agent_ready(ctx.driver.as_ref(), &agent_id, STEP_TIMEOUT).await
+    {
+        return StepEnd::Failed {
+            agent_id: Some(agent_id),
+            error: e,
+        };
+    }
+    journal(ctx, run_id, exec_id, event_type::ATTEMPT_READY, json!({}));
+
+    // Subscribe BEFORE sending (the [`AgentDriver`] contract): a Running→Idle
+    // flap can be faster than any status read, and this buffers it.
+    let mut rx = ctx.driver.subscribe();
+    if let Err(e) = ctx.driver.send_message(&agent_id, prompt).await {
+        return StepEnd::Failed {
+            agent_id: Some(agent_id),
+            error: format!("send failed: {e}"),
+        };
+    }
+    journal(
+        ctx,
+        run_id,
+        exec_id,
+        event_type::PROMPT_SENT,
+        json!({ "kind": "step" }),
+    );
+
+    match await_turn_end(ctx.driver.as_ref(), &agent_id, &mut rx).await {
+        Ok(()) => {
+            journal(
+                ctx,
+                run_id,
+                exec_id,
+                event_type::TURN_ENDED,
+                json!({ "status": "idle" }),
+            );
+            StepEnd::TurnEnded { agent_id }
+        }
+        Err(error) => {
+            journal(
+                ctx,
+                run_id,
+                exec_id,
+                event_type::TURN_ENDED,
+                json!({ "status": "error" }),
+            );
+            StepEnd::Failed {
+                agent_id: Some(agent_id),
+                error,
+            }
+        }
+    }
+}
+
+/// Wait for the turn to end, i.e. for the agent to go `Idle`. `rx` must have been
+/// subscribed before the prompt was sent. The step's wall timeout is the only
+/// deadline: there is no turn-start clock and no stall watchdog here.
+async fn await_turn_end(
+    driver: &dyn AgentDriver,
+    agent_id: &str,
+    rx: &mut Receiver<StatusEvent>,
+) -> std::result::Result<(), String> {
+    loop {
+        match rx.recv().await {
+            Ok(e) if e.agent_id == agent_id => match e.status {
+                AgentStatus::Idle => return Ok(()),
+                AgentStatus::Error | AgentStatus::Stopped => {
+                    return Err("agent errored mid-turn".into())
+                }
+                AgentStatus::Running | AgentStatus::Spawning => {}
+            },
+            Ok(_) => {}
+            // A lagged receiver dropped transitions; the authoritative status
+            // still tells us whether the turn is over.
+            Err(RecvError::Lagged(_)) => match driver.status(agent_id) {
+                Some(AgentStatus::Idle) => return Ok(()),
+                Some(AgentStatus::Error | AgentStatus::Stopped) => {
+                    return Err("agent errored mid-turn".into())
+                }
+                _ => {}
+            },
+            Err(RecvError::Closed) => return Err("supervisor stopped".into()),
+        }
+    }
+}
+
+/// The gate verdict as `Ok(())` (advance) or `Err(reason)` (fail the run). Pure:
+/// a `commit` gate is decided by the turn having ended, a `verdict` gate by the
+/// file the step wrote.
+fn evaluate_gate(
+    gate: &Gate,
+    blackboard: &std::path::Path,
+    step_id: &str,
+) -> std::result::Result<(), String> {
+    match gate {
+        // The boundary commit records whatever the turn produced, including
+        // nothing; the kernel does not second-guess an agent that says it's done.
+        Gate::Commit => Ok(()),
+        Gate::Verdict => {
+            let dir = blackboard::step_dir(blackboard, step_id)
+                .map_err(|e| format!("blackboard error: {e}"))?;
+            match blackboard::read_verdict(&dir) {
+                Ok(v) if v.result == VerdictResult::Done => Ok(()),
+                Ok(v) => Err(format!(
+                    "verdict.json result is \"{}\"{}",
+                    match v.result {
+                        VerdictResult::Done => "done",
+                        VerdictResult::Revise => "revise",
+                        VerdictResult::Blocked => "blocked",
+                    },
+                    if v.summary.trim().is_empty() {
+                        String::new()
+                    } else {
+                        format!(": {}", v.summary.trim())
+                    }
+                )),
+                Err(VerdictError::Missing) => Err("no verdict.json was written".into()),
+                Err(VerdictError::Malformed(e)) => Err(e),
+            }
+        }
+        // `kernel_eligible` rejects every other gate before a run starts.
+        _ => Err(format!(
+            "gate '{}' is not supported by the kernel",
+            gate_mode(gate)
+        )),
+    }
+}
+
+/// Boundary-commit the shared workspace and pin the result as the step's ref.
+/// Returns the resulting HEAD.
+async fn commit_step(workspace: &std::path::Path, exec_id: &str, message: &str) -> Result<String> {
+    let bc = gitops::boundary_commit(workspace, message).await?;
+    gitops::pin_step_ref(workspace, exec_id).await?;
+    Ok(bc.head)
+}
+
+/// End the run on a step that could not finish: stop its agent (an idle-but-alive
+/// CLI must not outlive the run), close the exec row with `status`, and fail the
+/// run with the cause on both the timeline and the run row.
+async fn fail_step(
+    ctx: &RunCtx,
+    run_id: &str,
+    exec_id: &str,
+    agent_id: Option<&str>,
+    status: &str,
+    error: &str,
+) {
+    if let Some(a) = agent_id {
+        let _ = ctx.driver.stop(a).await;
+    }
+    let conn = ctx.db.lock();
+    journal_event(
+        &conn,
+        ctx.app.as_ref(),
+        run_id,
+        event_type::ATTEMPT_ERROR,
+        Some(exec_id),
+        &json!({ "error": error }),
+    );
+    finish_step_exec(&conn, exec_id, status, None);
+    fail_run(&conn, ctx.app.as_ref(), run_id, error);
+}
+
+/// Complete a cancel observed while a step was live: stop the agent, abandon its
+/// exec, archive the chat, and write the run's terminal status. The step loop
+/// never runs again after this, so the status must be written here.
+async fn cancel_step(ctx: &RunCtx, run_id: &str, exec_id: &str) {
+    let agent_id = agent_id_of(&ctx.db.lock(), exec_id);
+    if let Some(a) = &agent_id {
+        let _ = ctx.driver.stop(a).await;
+    }
+    {
+        let conn = ctx.db.lock();
+        abandon_exec(&conn, ctx.app.as_ref(), run_id, exec_id, "canceled");
+    }
+    if let Some(a) = &agent_id {
+        let _ = ctx.driver.archive(a).await;
+    }
+    let conn = ctx.db.lock();
+    journal_event(
+        &conn,
+        ctx.app.as_ref(),
+        run_id,
+        event_type::RUN_CANCELED,
+        None,
+        &json!({}),
+    );
+    set_status(&conn, ctx.app.as_ref(), run_id, "canceled", None, None);
+}
+
+/// A kernel run found non-terminal at startup: there is no mid-run recovery yet,
+/// so say so on the timeline and fail rather than re-running steps whose commits
+/// are already in the workspace. Any exec the previous driver left open is
+/// abandoned (and its agent stopped) so nothing claims to still be live.
+async fn refuse_resume(ctx: &RunCtx, run_id: &str) {
+    let stale: Vec<(String, Option<String>)> = {
+        let conn = ctx.db.lock();
+        conn.prepare(
+            "SELECT id, agent_id FROM wf_step_exec
+             WHERE run_id = ?1 AND status IN ('spawning','running','gating')",
+        )
+        .and_then(|mut s| {
+            s.query_map([run_id], |r| {
+                Ok((r.get::<_, String>(0)?, r.get::<_, Option<String>>(1)?))
+            })?
+            .collect::<std::result::Result<Vec<_>, _>>()
+        })
+        .unwrap_or_default()
+    };
+    for (exec_id, agent_id) in stale {
+        if let Some(a) = &agent_id {
+            let _ = ctx.driver.stop(a).await;
+        }
+        let conn = ctx.db.lock();
+        abandon_exec(&conn, ctx.app.as_ref(), run_id, &exec_id, NO_RESUME);
+    }
+    let conn = ctx.db.lock();
+    fail_run(&conn, ctx.app.as_ref(), run_id, NO_RESUME);
+}
+
+/// Link the live agent to its exec row and mark the row `running` — what lets the
+/// monitor resolve and mount the step's chat mid-turn.
+fn stamp_spawned(conn: &Connection, exec_id: &str, agent_id: &str) {
+    let _ = conn.execute(
+        "UPDATE wf_step_exec SET agent_id = ?1, status = 'running', started_at = ?2
+         WHERE id = ?3",
+        rusqlite::params![agent_id, super::now_ms(), exec_id],
+    );
+}
+
+/// The agent stamped on an exec row, for the paths that lost the handle to the
+/// step future (timeout, cancel).
+fn agent_id_of(conn: &Connection, exec_id: &str) -> Option<String> {
+    conn.query_row(
+        "SELECT agent_id FROM wf_step_exec WHERE id = ?1",
+        [exec_id],
+        |r| r.get::<_, Option<String>>(0),
+    )
+    .ok()
+    .flatten()
+}
+
+fn journal(
+    ctx: &RunCtx,
+    run_id: &str,
+    exec_id: &str,
+    event_type: &str,
+    payload: serde_json::Value,
+) {
+    let conn = ctx.db.lock();
+    journal_event(
+        &conn,
+        ctx.app.as_ref(),
+        run_id,
+        event_type,
+        Some(exec_id),
+        &payload,
+    );
+}

--- a/src-tauri/src/workflow/runner/tests.rs
+++ b/src-tauri/src/workflow/runner/tests.rs
@@ -1,0 +1,778 @@
+use super::*;
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+use std::process::Command as Sh;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tokio::sync::broadcast;
+
+use crate::workflow::attempt::Deadlines;
+use crate::workflow::driver::{BoxFuture, SpawnedAgent, TurnUsage};
+use crate::workflow::spec::{AgentSpec, Finalize, Integrate, Join, Parallel};
+
+fn sh(dir: &Path, args: &[&str]) {
+    let out = Sh::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("git");
+    assert!(
+        out.status.success(),
+        "git {:?}: {}",
+        args,
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn git_out(dir: &Path, args: &[&str]) -> String {
+    let out = Sh::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("git");
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Whether `git <args>` exits zero — for the predicate commands whose answer is
+/// the exit status, not stdout.
+fn git_ok(dir: &Path, args: &[&str]) -> bool {
+    Sh::new("git")
+        .current_dir(dir)
+        .args(args)
+        .output()
+        .expect("git")
+        .status
+        .success()
+}
+
+/// How the stub "agent" behaves for one run. Everything the kernel's phases can
+/// hinge on is expressible here, so each test configures rather than defines a
+/// driver.
+#[derive(Default)]
+struct Behavior {
+    /// The agent commits work in the adopted workspace during its turn.
+    commit: bool,
+    fail_spawn: bool,
+    /// The turn never ends — models a wedged agent (the wall-timeout path).
+    hang: bool,
+    /// `verdict.json` body the nth agent writes into its step's blackboard dir.
+    verdicts: Vec<Option<String>>,
+    /// Raised when the prompt lands, then the turn hangs — models a cancel
+    /// arriving mid-step.
+    cancel_on_prompt: Option<Arc<AtomicBool>>,
+}
+
+/// A real-git stub driver for the kernel: it never clones. Every spawn adopts
+/// `SpawnReq::existing_workspace` (the supervisor-side contract this runner is
+/// written against) and the "agent" works directly in that tree.
+struct Stub {
+    behavior: Behavior,
+    blackboard: PathBuf,
+    /// Step ids in run order, so the nth agent knows which blackboard dir is its
+    /// own.
+    steps: Vec<String>,
+    tx: broadcast::Sender<StatusEvent>,
+    state: Mutex<StubState>,
+}
+
+#[derive(Default)]
+struct StubState {
+    statuses: HashMap<String, AgentStatus>,
+    /// agent id → (spawn ordinal, adopted workspace).
+    agents: HashMap<String, (usize, PathBuf)>,
+    /// Adopted workspaces in spawn order — the proof that steps share one tree.
+    adopted: Vec<PathBuf>,
+    stops: usize,
+    archives: usize,
+}
+
+impl Stub {
+    fn new(behavior: Behavior, blackboard: PathBuf, steps: Vec<String>) -> Arc<Self> {
+        Arc::new(Self {
+            behavior,
+            blackboard,
+            steps,
+            tx: broadcast::channel(256).0,
+            state: Mutex::new(StubState::default()),
+        })
+    }
+    fn set(&self, id: &str, s: AgentStatus) {
+        self.state.lock().statuses.insert(id.to_string(), s.clone());
+        let _ = self.tx.send(StatusEvent {
+            agent_id: id.to_string(),
+            status: s,
+        });
+    }
+    fn adopted(&self) -> Vec<PathBuf> {
+        self.state.lock().adopted.clone()
+    }
+    fn stops(&self) -> usize {
+        self.state.lock().stops
+    }
+    fn archives(&self) -> usize {
+        self.state.lock().archives
+    }
+}
+
+impl AgentDriver for Stub {
+    fn spawn(&self, req: SpawnReq) -> BoxFuture<'_, Result<SpawnedAgent>> {
+        Box::pin(async move {
+            if self.behavior.fail_spawn {
+                return Err(Error::Other("no agent binary".into()));
+            }
+            let workspace = req
+                .existing_workspace
+                .clone()
+                .expect("kernel spawns must adopt the run workspace");
+            let id = {
+                let mut st = self.state.lock();
+                st.adopted.push(workspace.clone());
+                let ordinal = st.adopted.len() - 1;
+                let id = format!("stub-{}", ordinal + 1);
+                st.agents.insert(id.clone(), (ordinal, workspace.clone()));
+                id
+            };
+            self.set(&id, AgentStatus::Idle);
+            Ok(SpawnedAgent {
+                agent_id: id,
+                worktree: workspace,
+            })
+        })
+    }
+
+    fn status(&self, id: &str) -> Option<AgentStatus> {
+        self.state.lock().statuses.get(id).cloned()
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<StatusEvent> {
+        self.tx.subscribe()
+    }
+
+    fn send_message<'a>(&'a self, id: &'a str, _text: String) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            let (ordinal, workspace) = self.state.lock().agents.get(id).cloned().unwrap();
+            if let Some(flag) = &self.behavior.cancel_on_prompt {
+                flag.store(true, Ordering::SeqCst);
+                return Ok(());
+            }
+            if self.behavior.hang {
+                return Ok(());
+            }
+            self.set(id, AgentStatus::Running);
+            if self.behavior.commit {
+                std::fs::write(workspace.join(format!("{id}.txt")), "work").unwrap();
+                sh(&workspace, &["add", "-A"]);
+                sh(&workspace, &["commit", "-qm", "agent work"]);
+            }
+            if let Some(Some(body)) = self.behavior.verdicts.get(ordinal) {
+                let dir = self.blackboard.join(&self.steps[ordinal]);
+                std::fs::create_dir_all(&dir).unwrap();
+                std::fs::write(dir.join("verdict.json"), body).unwrap();
+            }
+            self.set(id, AgentStatus::Idle);
+            Ok(())
+        })
+    }
+
+    fn stop<'a>(&'a self, _id: &'a str) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            self.state.lock().stops += 1;
+            Ok(())
+        })
+    }
+
+    fn archive<'a>(&'a self, _id: &'a str) -> BoxFuture<'a, Result<()>> {
+        Box::pin(async move {
+            self.state.lock().archives += 1;
+            Ok(())
+        })
+    }
+
+    fn last_activity(&self, _id: &str) -> Option<i64> {
+        None
+    }
+
+    fn turn_usage(&self, _id: &str) -> Option<TurnUsage> {
+        None
+    }
+}
+
+fn step(id: &str, gate: Gate) -> Step {
+    Step {
+        id: id.to_string(),
+        agent: "coder".to_string(),
+        goal: format!("do {id}"),
+        gate,
+        budgets: None,
+        comms: vec![],
+    }
+}
+
+fn spec_of(blocks: Vec<Block>, finalize: Option<Finalize>) -> Spec {
+    let mut agents = BTreeMap::new();
+    agents.insert(
+        "coder".to_string(),
+        AgentSpec {
+            base: "codex".to_string(),
+            model: None,
+            effort: None,
+            instructions: None,
+            skills: vec![],
+            mcp_servers: vec![],
+            custom_agent: None,
+        },
+    );
+    Spec {
+        version: 1,
+        name: "demo".to_string(),
+        description: None,
+        budgets: None,
+        agents,
+        workflow: blocks,
+        finalize,
+    }
+}
+
+/// A source repo with a bare `origin`, so a finalize push has somewhere to land.
+/// Returns `(source, bare, base_sha)`.
+fn fixture_repo(tmp: &Path) -> (PathBuf, PathBuf, String) {
+    let bare = tmp.join("origin.git");
+    std::fs::create_dir_all(&bare).unwrap();
+    sh(&bare, &["init", "-q", "--bare", "-b", "main"]);
+    let source = tmp.join("source");
+    std::fs::create_dir_all(&source).unwrap();
+    sh(&source, &["init", "-q", "-b", "main"]);
+    sh(&source, &["config", "user.email", "t@t.t"]);
+    sh(&source, &["config", "user.name", "t"]);
+    std::fs::write(source.join("README"), "base").unwrap();
+    sh(&source, &["add", "-A"]);
+    sh(&source, &["commit", "-qm", "base"]);
+    sh(
+        &source,
+        &["remote", "add", "origin", bare.to_str().unwrap()],
+    );
+    let base_sha = git_out(&source, &["rev-parse", "HEAD"]);
+    (source, bare, base_sha)
+}
+
+struct Fixture {
+    db: super::super::Db,
+    run_dir: PathBuf,
+    bare: PathBuf,
+    cancel: Arc<AtomicBool>,
+}
+
+fn scaffold(tmp: &Path, run_id: &str, branch: &str, spec: &Spec) -> Fixture {
+    let (source, bare, base_sha) = fixture_repo(tmp);
+    let run_dir = tmp.join("rundir");
+    std::fs::create_dir_all(blackboard::blackboard_dir(&run_dir)).unwrap();
+    let db = crate::database::init(tmp).unwrap();
+    db.lock()
+        .execute(
+            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                    base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES (?1,'demo',?2,'the task','p',?3,?4,?5,?6,'pending','{}','{}',0,0)",
+            rusqlite::params![
+                run_id,
+                serde_json::to_string(spec).unwrap(),
+                source.to_string_lossy(),
+                run_dir.to_string_lossy(),
+                branch,
+                base_sha,
+            ],
+        )
+        .unwrap();
+    Fixture {
+        db,
+        run_dir,
+        bare,
+        cancel: Arc::new(AtomicBool::new(false)),
+    }
+}
+
+fn ctx_with(fx: &Fixture, driver: Arc<dyn AgentDriver>) -> RunCtx {
+    RunCtx {
+        db: fx.db.clone(),
+        driver,
+        app: None,
+        cancel: fx.cancel.clone(),
+        pending_ask: Arc::new(AtomicBool::new(false)),
+        deadlines: Deadlines::default(),
+        runs: None,
+    }
+}
+
+fn run_status(db: &super::super::Db, run_id: &str) -> (String, Option<String>) {
+    db.lock()
+        .query_row(
+            "SELECT status, error FROM wf_run WHERE id = ?1",
+            [run_id],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap()
+}
+
+fn exec_rows(db: &super::super::Db, run_id: &str) -> Vec<(String, String, Option<String>)> {
+    let conn = db.lock();
+    let mut stmt = conn
+        .prepare("SELECT id, status, agent_id FROM wf_step_exec WHERE run_id = ?1 ORDER BY rowid")
+        .unwrap();
+    let rows = stmt
+        .query_map([run_id], |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)))
+        .unwrap();
+    rows.collect::<rusqlite::Result<Vec<_>>>().unwrap()
+}
+
+fn event_types(db: &super::super::Db, run_id: &str) -> Vec<String> {
+    let conn = db.lock();
+    let mut stmt = conn
+        .prepare("SELECT type FROM wf_event WHERE run_id = ?1 ORDER BY seq")
+        .unwrap();
+    let rows = stmt.query_map([run_id], |r| r.get::<_, String>(0)).unwrap();
+    rows.collect::<rusqlite::Result<Vec<_>>>().unwrap()
+}
+
+// ─────────────────────────────── the happy path ──────────────────────────────
+
+#[tokio::test]
+async fn two_steps_share_one_workspace_and_land_on_one_line() {
+    let tmp = tempfile::tempdir().unwrap();
+    let branch = "wf/demo-abcdef12";
+    let spec = spec_of(
+        vec![
+            Block::Step(step("plan", Gate::Commit)),
+            Block::Step(step("build", Gate::Commit)),
+        ],
+        Some(Finalize {
+            push: true,
+            open_pr: false,
+            pr_base: Some("main".to_string()),
+        }),
+    );
+    let fx = scaffold(tmp.path(), "run-kernel", branch, &spec);
+    let driver = Stub::new(
+        Behavior {
+            commit: true,
+            ..Default::default()
+        },
+        blackboard::blackboard_dir(&fx.run_dir),
+        vec!["plan".into(), "build".into()],
+    );
+    let ctx = ctx_with(&fx, driver.clone());
+
+    run_kernel(&ctx, "run-kernel").await;
+
+    assert_eq!(run_status(&fx.db, "run-kernel").0, "done");
+
+    // Both steps ran in the *same* checkout — the whole point of the kernel.
+    let workspace = gitops::run_repo_path(&fx.run_dir);
+    assert_eq!(driver.adopted(), vec![workspace.clone(), workspace.clone()]);
+
+    // Two done execs, each with its agent stamped and its ref pinned in the
+    // shared workspace.
+    let execs = exec_rows(&fx.db, "run-kernel");
+    assert_eq!(execs.len(), 2);
+    for (exec_id, status, agent_id) in &execs {
+        assert_eq!(status, "done");
+        assert!(agent_id.is_some(), "agent stamped on {exec_id}");
+        let pinned = git_out(&workspace, &["rev-parse", &gitops::step_ref(exec_id)]);
+        assert!(!pinned.is_empty(), "refs/wf/steps/{exec_id} pinned");
+    }
+    // One line: the second step's ref is a descendant of the first's, and the
+    // whole run is base + two commits.
+    let (first, second) = (&execs[0].0, &execs[1].0);
+    assert!(
+        git_ok(
+            &workspace,
+            &[
+                "merge-base",
+                "--is-ancestor",
+                &gitops::step_ref(first),
+                &gitops::step_ref(second),
+            ]
+        ),
+        "step 2 builds on step 1"
+    );
+    assert_eq!(git_out(&workspace, &["rev-list", "--count", "HEAD"]), "3");
+
+    // Pushed, and every phase is on the timeline.
+    assert_eq!(
+        git_out(
+            &fx.bare,
+            &["rev-list", "--count", &format!("refs/heads/{branch}")]
+        ),
+        "3"
+    );
+    let events = event_types(&fx.db, "run-kernel");
+    for expected in [
+        event_type::RUN_LAUNCHED,
+        event_type::ATTEMPT_SPAWNED,
+        event_type::ATTEMPT_READY,
+        event_type::PROMPT_SENT,
+        event_type::TURN_ENDED,
+        event_type::GATE_EVALUATED,
+        event_type::BOUNDARY_COMMIT,
+        event_type::FINALIZE_PUSHED,
+        event_type::RUN_DONE,
+    ] {
+        assert!(
+            events.iter().any(|e| e == expected),
+            "{expected} journaled: {events:?}"
+        );
+    }
+    // Both chats stay replayable.
+    assert_eq!(driver.archives(), 2);
+}
+
+// ──────────────────────────────── verdict gate ───────────────────────────────
+
+#[tokio::test]
+async fn verdict_done_advances_the_run() {
+    let tmp = tempfile::tempdir().unwrap();
+    let spec = spec_of(
+        vec![
+            Block::Step(step("plan", Gate::Verdict)),
+            Block::Step(step("build", Gate::Verdict)),
+        ],
+        None,
+    );
+    let fx = scaffold(tmp.path(), "run-v", "wf/demo-1", &spec);
+    let driver = Stub::new(
+        Behavior {
+            commit: true,
+            verdicts: vec![
+                Some(r#"{"result":"done","summary":"planned"}"#.into()),
+                Some(r#"{"result":"done","summary":"built"}"#.into()),
+            ],
+            ..Default::default()
+        },
+        blackboard::blackboard_dir(&fx.run_dir),
+        vec!["plan".into(), "build".into()],
+    );
+    let ctx = ctx_with(&fx, driver.clone());
+
+    run_kernel(&ctx, "run-v").await;
+
+    assert_eq!(run_status(&fx.db, "run-v").0, "done");
+    assert_eq!(exec_rows(&fx.db, "run-v").len(), 2);
+}
+
+#[tokio::test]
+async fn verdict_revise_fails_the_run_with_the_reason() {
+    let tmp = tempfile::tempdir().unwrap();
+    let spec = spec_of(
+        vec![
+            Block::Step(step("plan", Gate::Verdict)),
+            Block::Step(step("build", Gate::Verdict)),
+        ],
+        None,
+    );
+    let fx = scaffold(tmp.path(), "run-v2", "wf/demo-2", &spec);
+    let driver = Stub::new(
+        Behavior {
+            commit: true,
+            verdicts: vec![Some(
+                r#"{"result":"revise","summary":"needs another pass"}"#.into(),
+            )],
+            ..Default::default()
+        },
+        blackboard::blackboard_dir(&fx.run_dir),
+        vec!["plan".into(), "build".into()],
+    );
+    let ctx = ctx_with(&fx, driver.clone());
+
+    run_kernel(&ctx, "run-v2").await;
+
+    let (status, error) = run_status(&fx.db, "run-v2");
+    assert_eq!(status, "failed");
+    let error = error.unwrap();
+    assert!(error.contains("revise"), "{error}");
+    assert!(error.contains("needs another pass"), "{error}");
+
+    // The first step is `blocked` and the second never spawned — no silent
+    // advance past an unmet gate.
+    let execs = exec_rows(&fx.db, "run-v2");
+    assert_eq!(execs.len(), 1);
+    assert_eq!(execs[0].1, "blocked");
+    assert_eq!(driver.adopted().len(), 1);
+    // Pausing/failing stops processes.
+    assert_eq!(driver.stops(), 1);
+}
+
+#[tokio::test]
+async fn a_missing_verdict_fails_the_run() {
+    let tmp = tempfile::tempdir().unwrap();
+    let spec = spec_of(vec![Block::Step(step("plan", Gate::Verdict))], None);
+    let fx = scaffold(tmp.path(), "run-v3", "wf/demo-3", &spec);
+    let driver = Stub::new(
+        Behavior {
+            commit: true,
+            ..Default::default()
+        },
+        blackboard::blackboard_dir(&fx.run_dir),
+        vec!["plan".into()],
+    );
+    let ctx = ctx_with(&fx, driver.clone());
+
+    run_kernel(&ctx, "run-v3").await;
+
+    let (status, error) = run_status(&fx.db, "run-v3");
+    assert_eq!(status, "failed");
+    assert!(error.unwrap().contains("no verdict.json"));
+}
+
+// ─────────────────────────── errors, timeout, cancel ─────────────────────────
+
+#[tokio::test]
+async fn a_spawn_failure_fails_the_run() {
+    let tmp = tempfile::tempdir().unwrap();
+    let spec = spec_of(vec![Block::Step(step("plan", Gate::Commit))], None);
+    let fx = scaffold(tmp.path(), "run-e", "wf/demo-e", &spec);
+    let driver = Stub::new(
+        Behavior {
+            fail_spawn: true,
+            ..Default::default()
+        },
+        blackboard::blackboard_dir(&fx.run_dir),
+        vec!["plan".into()],
+    );
+    let ctx = ctx_with(&fx, driver.clone());
+
+    run_kernel(&ctx, "run-e").await;
+
+    let (status, error) = run_status(&fx.db, "run-e");
+    assert_eq!(status, "failed");
+    assert!(error.unwrap().contains("spawn failed"));
+    let execs = exec_rows(&fx.db, "run-e");
+    assert_eq!(execs[0].1, "error");
+    assert!(
+        event_types(&fx.db, "run-e")
+            .iter()
+            .any(|e| e == event_type::ATTEMPT_ERROR),
+        "the cause is on the timeline"
+    );
+}
+
+#[tokio::test]
+async fn a_wedged_step_hits_the_wall_timeout_and_fails_the_run() {
+    let tmp = tempfile::tempdir().unwrap();
+    let spec = spec_of(vec![Block::Step(step("plan", Gate::Commit))], None);
+    let fx = scaffold(tmp.path(), "run-t", "wf/demo-t", &spec);
+    let driver = Stub::new(
+        Behavior {
+            hang: true,
+            ..Default::default()
+        },
+        blackboard::blackboard_dir(&fx.run_dir),
+        vec!["plan".into()],
+    );
+    let ctx = ctx_with(&fx, driver.clone());
+
+    run_kernel(&ctx, "run-t").await;
+
+    let (status, error) = run_status(&fx.db, "run-t");
+    assert_eq!(status, "failed");
+    assert!(error.unwrap().contains("timed out"));
+    // The wedged agent is not left running.
+    assert_eq!(driver.stops(), 1);
+    assert_eq!(exec_rows(&fx.db, "run-t")[0].1, "error");
+}
+
+#[tokio::test]
+async fn a_cancel_mid_step_stops_the_agent_and_marks_the_run_canceled() {
+    let tmp = tempfile::tempdir().unwrap();
+    let spec = spec_of(
+        vec![
+            Block::Step(step("plan", Gate::Commit)),
+            Block::Step(step("build", Gate::Commit)),
+        ],
+        None,
+    );
+    let fx = scaffold(tmp.path(), "run-c", "wf/demo-c", &spec);
+    let driver = Stub::new(
+        Behavior {
+            cancel_on_prompt: Some(fx.cancel.clone()),
+            ..Default::default()
+        },
+        blackboard::blackboard_dir(&fx.run_dir),
+        vec!["plan".into(), "build".into()],
+    );
+    let ctx = ctx_with(&fx, driver.clone());
+
+    run_kernel(&ctx, "run-c").await;
+
+    assert_eq!(run_status(&fx.db, "run-c").0, "canceled");
+    assert_eq!(driver.stops(), 1, "the live agent is stopped");
+    assert_eq!(driver.archives(), 1, "its chat stays replayable");
+    let execs = exec_rows(&fx.db, "run-c");
+    assert_eq!(execs.len(), 1, "the second step never spawned");
+    assert_eq!(execs[0].1, "abandoned");
+    assert!(event_types(&fx.db, "run-c")
+        .iter()
+        .any(|e| e == event_type::RUN_CANCELED));
+}
+
+#[tokio::test]
+async fn a_pre_canceled_run_spawns_nothing() {
+    let tmp = tempfile::tempdir().unwrap();
+    let spec = spec_of(vec![Block::Step(step("plan", Gate::Commit))], None);
+    let fx = scaffold(tmp.path(), "run-c0", "wf/demo-c0", &spec);
+    fx.cancel.store(true, Ordering::SeqCst);
+    let driver = Stub::new(
+        Behavior::default(),
+        blackboard::blackboard_dir(&fx.run_dir),
+        vec!["plan".into()],
+    );
+    let ctx = ctx_with(&fx, driver.clone());
+
+    run_kernel(&ctx, "run-c0").await;
+
+    assert_eq!(run_status(&fx.db, "run-c0").0, "canceled");
+    assert!(driver.adopted().is_empty());
+}
+
+// ────────────────────────────── resume & routing ─────────────────────────────
+
+#[tokio::test]
+async fn a_non_terminal_kernel_run_is_failed_rather_than_resumed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let spec = spec_of(vec![Block::Step(step("plan", Gate::Commit))], None);
+    let fx = scaffold(tmp.path(), "run-r", "wf/demo-r", &spec);
+    // The state a crash leaves behind: a `running` run with a live-looking exec.
+    {
+        let conn = fx.db.lock();
+        conn.execute(
+            "UPDATE wf_run SET status = 'running' WHERE id = 'run-r'",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO wf_step_exec (id, run_id, step_id, attempt, iteration, status,
+                    gate_mode, agent_id)
+             VALUES ('exec-old','run-r','plan',1,0,'running','commit','stub-old')",
+            [],
+        )
+        .unwrap();
+    }
+    let driver = Stub::new(
+        Behavior::default(),
+        blackboard::blackboard_dir(&fx.run_dir),
+        vec!["plan".into()],
+    );
+    let ctx = ctx_with(&fx, driver.clone());
+
+    run_kernel(&ctx, "run-r").await;
+
+    let (status, error) = run_status(&fx.db, "run-r");
+    assert_eq!(status, "failed");
+    assert!(error.unwrap().contains("do not resume yet"));
+    // Nothing was re-run, and the stale exec no longer claims to be live.
+    assert!(driver.adopted().is_empty());
+    assert_eq!(exec_rows(&fx.db, "run-r")[0].1, "abandoned");
+    assert_eq!(driver.stops(), 1);
+}
+
+#[tokio::test]
+async fn a_terminal_run_is_not_redriven() {
+    let tmp = tempfile::tempdir().unwrap();
+    let spec = spec_of(vec![Block::Step(step("plan", Gate::Commit))], None);
+    let fx = scaffold(tmp.path(), "run-d", "wf/demo-d", &spec);
+    fx.db
+        .lock()
+        .execute("UPDATE wf_run SET status = 'done' WHERE id = 'run-d'", [])
+        .unwrap();
+    let driver = Stub::new(
+        Behavior::default(),
+        blackboard::blackboard_dir(&fx.run_dir),
+        vec!["plan".into()],
+    );
+    let ctx = ctx_with(&fx, driver.clone());
+
+    run_kernel(&ctx, "run-d").await;
+
+    assert_eq!(run_status(&fx.db, "run-d").0, "done");
+    assert!(driver.adopted().is_empty());
+    assert!(event_types(&fx.db, "run-d").is_empty());
+}
+
+#[test]
+fn eligibility_admits_plain_steps_with_commit_or_verdict_gates_only() {
+    let commit_and_verdict = spec_of(
+        vec![
+            Block::Step(step("a", Gate::Commit)),
+            Block::Step(step("b", Gate::Verdict)),
+        ],
+        None,
+    );
+    assert!(kernel_eligible(&commit_and_verdict));
+
+    // A gate the kernel can't decide by itself.
+    for gate in [
+        Gate::Artifact {
+            path: "PLAN.md".into(),
+        },
+        Gate::Tests,
+        Gate::Approval {
+            require: vec![],
+            artifact: None,
+        },
+    ] {
+        let spec = spec_of(vec![Block::Step(step("a", gate))], None);
+        assert!(!kernel_eligible(&spec));
+    }
+
+    // A block kind the kernel doesn't execute.
+    let parallel = spec_of(
+        vec![Block::Parallel(Parallel {
+            join: Join::All,
+            integrate: Integrate::None,
+            max_concurrent: None,
+            steps: vec![step("a", Gate::Commit)],
+        })],
+        None,
+    );
+    assert!(!kernel_eligible(&parallel));
+
+    // Nothing to run is not the kernel's business either.
+    assert!(!kernel_eligible(&spec_of(vec![], None)));
+}
+
+#[test]
+fn routing_reads_the_runs_frozen_spec() {
+    let tmp = tempfile::tempdir().unwrap();
+    let eligible = spec_of(vec![Block::Step(step("a", Gate::Commit))], None);
+    let ineligible = spec_of(vec![Block::Step(step("a", Gate::Tests))], None);
+    let db = crate::database::init(tmp.path()).unwrap();
+    let insert = |conn: &rusqlite::Connection, id: &str, spec: &Spec| {
+        conn.execute(
+            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                    base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES (?1,'demo',?2,'t','p','/tmp/r','/tmp/d','wf/x','sha','pending','{}','{}',0,0)",
+            rusqlite::params![id, serde_json::to_string(spec).unwrap()],
+        )
+        .unwrap();
+    };
+    {
+        let conn = db.lock();
+        insert(&conn, "kernel", &eligible);
+        insert(&conn, "legacy", &ineligible);
+        conn.execute(
+            "INSERT INTO wf_run (id,name,spec_json,task,project_id,repo_path,run_dir,branch,
+                    base_sha,status,budgets_json,spent_json,created_at,updated_at)
+             VALUES ('broken','demo','not json','t','p','/tmp/r','/tmp/d','wf/x','sha',
+                     'pending','{}','{}',0,0)",
+            [],
+        )
+        .unwrap();
+    }
+
+    assert!(routes_to_kernel(&db, "kernel"));
+    assert!(!routes_to_kernel(&db, "legacy"));
+    // An unreadable spec and a missing run both belong to the old engine, which
+    // owns reporting that failure.
+    assert!(!routes_to_kernel(&db, "broken"));
+    assert!(!routes_to_kernel(&db, "nope"));
+}

--- a/src-tauri/src/workflow/scheduler/drive.rs
+++ b/src-tauri/src/workflow/scheduler/drive.rs
@@ -80,7 +80,16 @@ pub(crate) fn spawn_drive_task(
     };
     let id = run_id.clone();
     let join = tauri::async_runtime::spawn(async move {
-        drive_run(&ctx, &id).await;
+        // The one routing site (see `docs/workflow-kernel-layers.md`): a flat
+        // sequence of steps with only commit/verdict gates runs on the
+        // sequential kernel; every richer spec stays on this engine. The
+        // decision comes from the run's frozen spec, so a re-drive of the same
+        // run always lands in the same runner.
+        if crate::workflow::runner::routes_to_kernel(&ctx.db, &id) {
+            crate::workflow::runner::run_kernel(&ctx, &id).await;
+        } else {
+            drive_run(&ctx, &id).await;
+        }
     });
     // Panic containment (§6.1): a panicked/aborted drive task marks its run
     // failed so it is never left `running` with no live driver.
@@ -487,7 +496,9 @@ pub(crate) async fn pause_question(
     );
 }
 
-async fn finalize_run(
+/// Push the run's final ref and (optionally) open its PR. `pub(crate)` because
+/// the kernel runner finalizes the same way from the same run repo.
+pub(crate) async fn finalize_run(
     ctx: &RunCtx,
     run_id: &str,
     run: &RunEssentials,

--- a/src-tauri/src/workflow/scheduler/parallel.rs
+++ b/src-tauri/src/workflow/scheduler/parallel.rs
@@ -1315,6 +1315,9 @@ pub(crate) fn build_spawn_req(
         fork_base: Some(fork_base.to_string()),
         run_repo: Some(run_repo.to_path_buf()),
         owner_run_id: run_id.to_string(),
+        // The clone-per-step engine never shares a workspace; only the kernel
+        // runner sets this.
+        existing_workspace: None,
     }
 }
 

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -500,11 +500,16 @@ impl WorkspaceManager {
         )?;
 
         // Update checkout records with new branch info and clear snapshot fields.
+        // `adopted_checkout` is dropped with them: restore always provisions an
+        // agent-owned clone at the derived path (see `restore_agent` in
+        // `supervisor::disposition`), so a row still naming the adopted tree
+        // would point every reader away from the checkout that was just built.
         for repo in &repos {
             conn.execute(
                 "UPDATE worktrees SET branch = ?1, parent_branch = ?2,
                         branch_tip_sha = NULL, parent_branch_sha = NULL,
-                        diff_additions = 0, diff_deletions = 0
+                        diff_additions = 0, diff_deletions = 0,
+                        adopted_checkout = NULL
                  WHERE workspace_id = ?3 AND subdir = ?4",
                 rusqlite::params![repo.branch, repo.parent_branch, id, repo.subdir],
             )?;

--- a/src-tauri/src/workspace/mod.rs
+++ b/src-tauri/src/workspace/mod.rs
@@ -105,6 +105,39 @@ pub struct TrackedRepo {
     /// back to the folder basename in the UI and in agent-facing notes.
     #[serde(default)]
     pub label: Option<String>,
+    /// A pre-provisioned working tree this entry *adopted* instead of the
+    /// agent-owned `~/.fletch/workspaces/<agent-id>/<subdir>/` — today only the
+    /// workflow kernel's shared run workspace (`~/.fletch/runs/<id>/repo`),
+    /// which every step of the run works in.
+    ///
+    /// Adoption inverts ownership: the agent is a tenant of a directory whose
+    /// lifetime belongs to something else. Nothing on the agent's disposal path
+    /// (archive, discard, project delete) may remove it — see
+    /// `disposition::teardown_agent_checkouts` — and nothing provisions it: the
+    /// tree already exists at spawn, with its own HEAD.
+    ///
+    /// `None` for every ordinary checkout, which the agent owns outright.
+    #[serde(default)]
+    pub adopted_checkout: Option<PathBuf>,
+}
+
+impl TrackedRepo {
+    /// Absolute path to this checkout's working tree — the single answer every
+    /// consumer (the CLI's cwd, git facts, the shell, the file tree, teardown)
+    /// must resolve through, so an adopted tree can't be reached by one caller
+    /// and missed by the next.
+    pub fn checkout_path(&self, agent_id: &str) -> Result<PathBuf> {
+        match &self.adopted_checkout {
+            Some(path) => Ok(path.clone()),
+            None => repo_checkout_path(agent_id, &self.subdir),
+        }
+    }
+
+    /// Whether this checkout is owned by something other than the agent, and so
+    /// survives the agent's disposal.
+    pub fn is_adopted(&self) -> bool {
+        self.adopted_checkout.is_some()
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/src-tauri/src/workspace/query.rs
+++ b/src-tauri/src/workspace/query.rs
@@ -195,7 +195,7 @@ impl WorkspaceManager {
     fn query_tracked_repos(conn: &Connection, agent_id: &str) -> Vec<TrackedRepo> {
         let mut stmt = match conn.prepare(
             "SELECT r.path, w.subdir, w.branch, w.parent_branch, w.base_sha, w.pr_number,
-                    w.pr_url, w.pr_title, w.pr_state, r.label
+                    w.pr_url, w.pr_title, w.pr_state, r.label, w.adopted_checkout
              FROM worktrees w
              JOIN repos r ON r.id = w.repo_id
              WHERE w.workspace_id = ?1
@@ -216,6 +216,7 @@ impl WorkspaceManager {
             let pr_title: Option<String> = row.get(7)?;
             let pr_state: Option<String> = row.get(8)?;
             let label: Option<String> = row.get(9)?;
+            let adopted: Option<String> = row.get(10)?;
             Ok(TrackedRepo {
                 repo_path: PathBuf::from(path),
                 subdir,
@@ -227,6 +228,7 @@ impl WorkspaceManager {
                 pr_title,
                 pr_state,
                 label,
+                adopted_checkout: adopted.map(PathBuf::from),
             })
         })
         .ok()
@@ -369,8 +371,8 @@ impl WorkspaceManager {
 
         let wt_id = uuid::Uuid::new_v4().to_string();
         conn.execute(
-            "INSERT INTO worktrees (id, workspace_id, repo_id, subdir, branch, parent_branch, base_sha, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            "INSERT INTO worktrees (id, workspace_id, repo_id, subdir, branch, parent_branch, base_sha, adopted_checkout, created_at)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             rusqlite::params![
                 wt_id,
                 agent_id,
@@ -379,6 +381,9 @@ impl WorkspaceManager {
                 repo.branch,
                 repo.parent_branch,
                 repo.base_sha,
+                repo.adopted_checkout
+                    .as_ref()
+                    .map(|p| p.to_string_lossy().into_owned()),
                 now_millis(),
             ],
         )?;

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -106,7 +106,71 @@ fn mk_repo(path: &str) -> TrackedRepo {
         pr_title: None,
         pr_state: None,
         label: None,
+        adopted_checkout: None,
     }
+}
+
+/// An adopted checkout is the authoritative path for that repo entry, while an
+/// ordinary entry still derives one from the agent id + subdir. Every consumer
+/// resolves through this, so the two must not be confusable.
+#[test]
+fn checkout_path_prefers_an_adopted_tree_over_the_derived_layout() {
+    let derived = mk_repo("/r").checkout_path("yosemite").unwrap();
+    assert_eq!(derived, repo_checkout_path("yosemite", "repo").unwrap());
+
+    let run_tree = PathBuf::from("/runs/run-7/repo");
+    let adopted = TrackedRepo {
+        adopted_checkout: Some(run_tree.clone()),
+        ..mk_repo("/r")
+    };
+    assert_eq!(adopted.checkout_path("yosemite").unwrap(), run_tree);
+    assert!(adopted.is_adopted());
+    assert!(!mk_repo("/r").is_adopted());
+}
+
+/// The adopted path has to survive the DB, not just the spawn call: every later
+/// launch, gate and teardown reads the record back rather than the spawn request.
+#[test]
+fn adopted_checkout_round_trips_and_is_cleared_by_restore() {
+    let db = test_db();
+    seed_repo(&db, "/r");
+    let wm = WorkspaceManager::new(db);
+    let run_tree = PathBuf::from("/runs/run-7/repo");
+
+    let mut record = new_agent_record(
+        "yosemite".into(),
+        "a".into(),
+        "claude".into(),
+        TrackedRepo {
+            adopted_checkout: Some(run_tree.clone()),
+            ..mk_repo("/r")
+        },
+        "task".into(),
+        AgentView::Custom,
+    );
+    wm.add_agent(&mut record).unwrap();
+
+    let loaded = wm.agent("yosemite").unwrap();
+    assert_eq!(loaded.repos[0].adopted_checkout, Some(run_tree));
+    assert_eq!(
+        loaded.repos[0].checkout_path("yosemite").unwrap(),
+        PathBuf::from("/runs/run-7/repo")
+    );
+
+    // Restore provisions an agent-owned clone at the derived path, so the row
+    // must stop naming the run's tree.
+    wm.archive_agent(
+        "yosemite",
+        ArchiveMetadata {
+            archived_at: chrono::Utc::now().to_rfc3339(),
+            repos: Vec::new(),
+            diff_stats: DiffStats::default(),
+        },
+    )
+    .unwrap();
+    wm.restore_agent("yosemite", vec![mk_repo("/r")]).unwrap();
+    let restored = wm.agent("yosemite").unwrap();
+    assert_eq!(restored.repos[0].adopted_checkout, None);
 }
 
 /// Helper: ensure the repo path exists in the repos table so add_agent can find it.
@@ -1643,6 +1707,7 @@ fn archive_then_restore_roundtrip() {
         pr_title: None,
         pr_state: None,
         label: None,
+        adopted_checkout: None,
     }];
     wm.restore_agent(&id, restored).unwrap();
     let a = wm.agent(&id).unwrap();
@@ -1712,6 +1777,7 @@ fn make_workspace_with_session(db: &Arc<Mutex<Connection>>) -> (String, Workspac
             pr_title: None,
             pr_state: None,
             label: None,
+            adopted_checkout: None,
         },
         "task".into(),
         AgentView::Custom,

--- a/src/components/Workspace/ChatComposer.tsx
+++ b/src/components/Workspace/ChatComposer.tsx
@@ -1,0 +1,168 @@
+// The composer docked under a chat log, bound to one agent: the working strip
+// that slides up from behind it, the model/effort controls, the mention and
+// issue pickers, and the send/stop wiring.
+//
+// Extracted from ChatView so the run monitor's thread — one continuous log over
+// several step agents — routes its single composer to whichever agent is live
+// through the identical send machinery instead of a second copy of it.
+
+import { useCallback, useEffect, useState } from "react";
+import { type AgentRecord, api } from "@/api";
+import { Composer } from "@/components/Composer";
+import { providerLabel } from "@/data/providers";
+import { getLinearTeamId } from "@/storage/projectSettings";
+import { useAppStore } from "@/store";
+import { ChatWorkingStatus } from "./ChatWorkingStatus";
+
+export function ChatComposer({
+  agent,
+  activeModel,
+  liveBusy,
+  liveStartedAt,
+  onSend,
+}: {
+  agent: AgentRecord;
+  /** Model the agent actually used most recently (from its transcript). */
+  activeModel: string | undefined;
+  /** Debounced "is working" — drives the working strip above the composer. */
+  liveBusy: boolean;
+  /** Epoch millis the open turn started; when set, the strip's timer ticks. */
+  liveStartedAt: number | undefined;
+  /** Fired just before the message is dispatched — the owner of the scroll
+   *  container re-pins its log to the bottom here. */
+  onSend?: () => void;
+}) {
+  const transcriptLoading = useAppStore((s) => s.transcriptLoading[agent.id] ?? false);
+  const busy = useAppStore((s) => s.managedBusy[agent.id] ?? false);
+  const busyLabel = useAppStore((s) => s.managedBusyLabel[agent.id]);
+  const switchInFlight = useAppStore((s) => s.switchInFlight[agent.id] ?? false);
+  const send = useAppStore((s) => s.sendUserMessage);
+  const setAgentEffort = useAppStore((s) => s.setAgentEffort);
+  const setAgentModel = useAppStore((s) => s.setAgentModel);
+  const stop = useAppStore((s) => s.stop);
+  const runLocalCommand = useAppStore((s) => s.runLocalCommand);
+  const usage = useAppStore((s) => s.usage[agent.id]);
+  // The custom agent this session was spawned from (if any, and still present),
+  // so the chat surfaces the agent's name rather than its base provider.
+  const customAgent = useAppStore((s) =>
+    agent.custom_agent_id ? s.customAgents.find((a) => a.id === agent.custom_agent_id) : undefined,
+  );
+  const composerSeed = useAppStore((s) => s.composerSeeds[agent.id]);
+  const consumeComposerSeed = useAppStore((s) => s.consumeComposerSeed);
+  // Stable identity: the Composer's seed effect lists this in its deps, so an
+  // inline arrow would re-fire it on every render (and double-append under
+  // StrictMode's double-invoked effects).
+  const onSeedConsumed = useCallback(
+    () => consumeComposerSeed(agent.id),
+    [agent.id, consumeComposerSeed],
+  );
+
+  // The project's configured Linear team, scoping the composer's issue
+  // picker to the agent's primary repo. Undefined while loading or unset —
+  // the picker then serves GitHub issues only.
+  const repoPath = agent.repos[0]?.repo_path;
+  const projectId = useAppStore((s) =>
+    repoPath ? (s.workspace?.projects.find((p) => p.path === repoPath)?.project_id ?? "") : "",
+  );
+  const [linearTeamId, setLinearTeamId] = useState<string | undefined>();
+  useEffect(() => {
+    let cancelled = false;
+    setLinearTeamId(undefined);
+    getLinearTeamId(projectId)
+      .then((teamId) => {
+        if (!cancelled) setLinearTeamId(teamId);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  // Mid-turn follow-ups are allowed: a busy (running) agent still accepts a
+  // message — delivered live (claude) or queued for the next turn boundary
+  // (per-turn agents). So `canSend` no longer gates on `busy`; the Composer
+  // shows Stop when empty and Send once the user types (see Composer).
+  const canSend =
+    !transcriptLoading &&
+    !switchInFlight &&
+    (agent.status === "running" || agent.status === "idle");
+
+  return (
+    <div className="composer-wrap">
+      <div className="composer-stack">
+        <div className="composer-anchor">
+          <ChatWorkingStatus
+            visible={liveBusy}
+            label={busyLabel ?? `${customAgent?.name ?? providerLabel(agent.provider)} is working`}
+            startedAt={liveStartedAt}
+          />
+          <Composer
+            existingSession
+            activeModel={activeModel}
+            usage={usage}
+            defaultProvider={agent.provider}
+            projectDir={agent.repos[0]?.repo_path}
+            onLocalCommand={(action) => runLocalCommand(action, agent.id)}
+            defaultModel={agent.model ?? undefined}
+            defaultCustomAgentId={agent.custom_agent_id ?? undefined}
+            initialThinking={agent.effort ?? undefined}
+            onChangeEffort={(value) => {
+              // Go through the store so the change is serialized per agent and
+              // a subsequent send waits for it to land (see queueConfigOp).
+              // claude restarts to re-apply --effort; per-turn agents read the
+              // new value from the record on their next turn.
+              setAgentEffort(agent.id, value).catch((e) => {
+                console.error("set_agent_effort failed", e);
+              });
+            }}
+            onChangeModel={(model) => {
+              setAgentModel(agent.id, model ?? null).catch((e) => {
+                console.error("set_agent_model failed", e);
+              });
+            }}
+            disabled={!canSend}
+            placeholder={
+              canSend
+                ? undefined
+                : transcriptLoading
+                  ? "Loading transcript…"
+                  : switchInFlight
+                    ? "Switching view…"
+                    : "Agent is not ready"
+            }
+            stopping={busy}
+            mentionSource={() =>
+              api.listCheckoutTree(agent.id).then((files) => files.map((f) => f.path))
+            }
+            listDir={api.listDir}
+            listPrs={() => api.listPrs(agent.id)}
+            listIssues={repoPath ? () => api.listTrackerIssues(repoPath, linearTeamId) : undefined}
+            listIssueComments={
+              repoPath ? (issue) => api.issueComments(repoPath, issue.source, issue.key) : undefined
+            }
+            onPickIssue={(issue) => {
+              // Persist the pick so the agent's eventual PR closes this
+              // issue — the brief insert alone wouldn't survive to the
+              // trailer. Best-effort: a failure only loses the trailer.
+              api.setAgentIssueRef(agent.id, issue.key).catch((e) => {
+                console.error("set_agent_issue_ref failed", e);
+              });
+            }}
+            seed={composerSeed}
+            onSeedConsumed={onSeedConsumed}
+            draftKey={agent.id}
+            onSend={({ text, attachments }) => {
+              // Effort is session-level now (persisted via onChangeEffort and
+              // read from the record each turn), so sends carry no per-message
+              // effort — the composer's `thinking` in the payload is only used
+              // by the new-agent spawn path.
+              onSend?.();
+              send(agent.id, text, attachments);
+            }}
+            onStop={() => stop(agent.id)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Workspace/ChatView.tsx
+++ b/src/components/Workspace/ChatView.tsx
@@ -1,11 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { type AgentRecord, api } from "@/api";
-import { Composer } from "@/components/Composer";
-import { providerLabel } from "@/data/providers";
-import { getLinearTeamId } from "@/storage/projectSettings";
+import type { AgentRecord } from "@/api";
 import { useAppStore } from "@/store";
+import { ChatComposer } from "./ChatComposer";
 import { ChatSearch } from "./ChatSearch";
-import { ChatWorkingStatus } from "./ChatWorkingStatus";
 import { TranscriptList } from "./messages/TranscriptList";
 import { isTurnPending } from "./messages/turnPending";
 import { useTranscript } from "./messages/useTranscript";
@@ -15,52 +12,7 @@ import { useLiveBusy } from "./useLiveBusy";
  *  The composer here dispatches the user's message via the store; it
  *  doesn't care about provider routing yet. */
 export function ChatView({ agent }: { agent: AgentRecord }) {
-  const transcriptLoading = useAppStore((s) => s.transcriptLoading[agent.id] ?? false);
-  const busy = useAppStore((s) => s.managedBusy[agent.id] ?? false);
-  const busyLabel = useAppStore((s) => s.managedBusyLabel[agent.id]);
   const turnStartedAt = useAppStore((s) => s.turnStartedAt[agent.id]);
-  const switchInFlight = useAppStore((s) => s.switchInFlight[agent.id] ?? false);
-  const send = useAppStore((s) => s.sendUserMessage);
-  const setAgentEffort = useAppStore((s) => s.setAgentEffort);
-  const setAgentModel = useAppStore((s) => s.setAgentModel);
-  const stop = useAppStore((s) => s.stop);
-  const runLocalCommand = useAppStore((s) => s.runLocalCommand);
-  const usage = useAppStore((s) => s.usage[agent.id]);
-  // The custom agent this session was spawned from (if any, and still present),
-  // so the chat surfaces the agent's name rather than its base provider.
-  const customAgent = useAppStore((s) =>
-    agent.custom_agent_id ? s.customAgents.find((a) => a.id === agent.custom_agent_id) : undefined,
-  );
-  const composerSeed = useAppStore((s) => s.composerSeeds[agent.id]);
-  const consumeComposerSeed = useAppStore((s) => s.consumeComposerSeed);
-  // Stable identity: the Composer's seed effect lists this in its deps, so an
-  // inline arrow would re-fire it on every ChatView render (and double-append
-  // under StrictMode's double-invoked effects).
-  const onSeedConsumed = useCallback(
-    () => consumeComposerSeed(agent.id),
-    [agent.id, consumeComposerSeed],
-  );
-
-  // The project's configured Linear team, scoping the composer's issue
-  // picker to the agent's primary repo. Undefined while loading or unset —
-  // the picker then serves GitHub issues only.
-  const repoPath = agent.repos[0]?.repo_path;
-  const projectId = useAppStore((s) =>
-    repoPath ? (s.workspace?.projects.find((p) => p.path === repoPath)?.project_id ?? "") : "",
-  );
-  const [linearTeamId, setLinearTeamId] = useState<string | undefined>();
-  useEffect(() => {
-    let cancelled = false;
-    setLinearTeamId(undefined);
-    getLinearTeamId(projectId)
-      .then((teamId) => {
-        if (!cancelled) setLinearTeamId(teamId);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [projectId]);
 
   const scrollRef = useRef<HTMLDivElement | null>(null);
   // Owned here so sending a message can re-pin the log to the bottom.
@@ -124,15 +76,6 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
   // persisted start. Absent during spawn → strip shows, timer waits.
   const liveStartedAt = liveBusy ? (turnStartedAt ?? openTurnStartedAt) : undefined;
 
-  // Mid-turn follow-ups are allowed: a busy (running) agent still accepts a
-  // message — delivered live (claude) or queued for the next turn boundary
-  // (per-turn agents). So `canSend` no longer gates on `busy`; the Composer
-  // shows Stop when empty and Send once the user types (see Composer).
-  const canSend =
-    !transcriptLoading &&
-    !switchInFlight &&
-    (agent.status === "running" || agent.status === "idle");
-
   return (
     <div className="chat">
       {searchOpen && (
@@ -153,88 +96,15 @@ export function ChatView({ agent }: { agent: AgentRecord }) {
         pinRef={pinnedToBottom}
         hideNav={searchOpen}
       />
-      <div className="composer-wrap">
-        <div className="composer-stack">
-          <div className="composer-anchor">
-            <ChatWorkingStatus
-              visible={liveBusy}
-              label={
-                busyLabel ?? `${customAgent?.name ?? providerLabel(agent.provider)} is working`
-              }
-              startedAt={liveStartedAt}
-            />
-            <Composer
-              existingSession
-              activeModel={activeModel}
-              usage={usage}
-              defaultProvider={agent.provider}
-              projectDir={agent.repos[0]?.repo_path}
-              onLocalCommand={(action) => runLocalCommand(action, agent.id)}
-              defaultModel={agent.model ?? undefined}
-              defaultCustomAgentId={agent.custom_agent_id ?? undefined}
-              initialThinking={agent.effort ?? undefined}
-              onChangeEffort={(value) => {
-                // Go through the store so the change is serialized per agent and
-                // a subsequent send waits for it to land (see queueConfigOp).
-                // claude restarts to re-apply --effort; per-turn agents read the
-                // new value from the record on their next turn.
-                setAgentEffort(agent.id, value).catch((e) => {
-                  console.error("set_agent_effort failed", e);
-                });
-              }}
-              onChangeModel={(model) => {
-                setAgentModel(agent.id, model ?? null).catch((e) => {
-                  console.error("set_agent_model failed", e);
-                });
-              }}
-              disabled={!canSend}
-              placeholder={
-                canSend
-                  ? undefined
-                  : transcriptLoading
-                    ? "Loading transcript…"
-                    : switchInFlight
-                      ? "Switching view…"
-                      : "Agent is not ready"
-              }
-              stopping={busy}
-              mentionSource={() =>
-                api.listCheckoutTree(agent.id).then((files) => files.map((f) => f.path))
-              }
-              listDir={api.listDir}
-              listPrs={() => api.listPrs(agent.id)}
-              listIssues={
-                repoPath ? () => api.listTrackerIssues(repoPath, linearTeamId) : undefined
-              }
-              listIssueComments={
-                repoPath
-                  ? (issue) => api.issueComments(repoPath, issue.source, issue.key)
-                  : undefined
-              }
-              onPickIssue={(issue) => {
-                // Persist the pick so the agent's eventual PR closes this
-                // issue — the brief insert alone wouldn't survive to the
-                // trailer. Best-effort: a failure only loses the trailer.
-                api.setAgentIssueRef(agent.id, issue.key).catch((e) => {
-                  console.error("set_agent_issue_ref failed", e);
-                });
-              }}
-              seed={composerSeed}
-              onSeedConsumed={onSeedConsumed}
-              draftKey={agent.id}
-              onSend={({ text, attachments }) => {
-                // Effort is session-level now (persisted via onChangeEffort and
-                // read from the record each turn), so sends carry no per-message
-                // effort — the composer's `thinking` in the payload is only used
-                // by the new-agent spawn path.
-                pinnedToBottom.current = true;
-                send(agent.id, text, attachments);
-              }}
-              onStop={() => stop(agent.id)}
-            />
-          </div>
-        </div>
-      </div>
+      <ChatComposer
+        agent={agent}
+        activeModel={activeModel}
+        liveBusy={liveBusy}
+        liveStartedAt={liveStartedAt}
+        onSend={() => {
+          pinnedToBottom.current = true;
+        }}
+      />
     </div>
   );
 }

--- a/src/components/Workspace/messages/TranscriptList.tsx
+++ b/src/components/Workspace/messages/TranscriptList.tsx
@@ -1,14 +1,11 @@
-// The scrolling transcript itself: rows, turn footers, bottom-pinning, and the
-// turn navigator. Shared by the custom view's ChatView (which stacks a composer
-// under it) and the native view's rail (which sits beside the terminal).
-import { Fragment, type MutableRefObject, useEffect, useRef } from "react";
+// The scrolling transcript itself: bottom-pinning and the turn navigator around
+// one agent's rows (TranscriptRows). Shared by the custom view's ChatView (which
+// stacks a composer under it) and the native view's rail (which sits beside the
+// terminal).
+import { type MutableRefObject, useEffect, useRef } from "react";
 import type { AgentRecord } from "@/api";
-import { Loader } from "@/components/ui/Loader";
-import { providerLabel } from "@/data/providers";
 import { ChatNav } from "../ChatNav";
-import { TurnFooter } from "../RunTimer";
-import { MessageItem } from "./MessageItem";
-import { rowKey } from "./pair";
+import { TranscriptRows } from "./TranscriptRows";
 import type { Transcript } from "./useTranscript";
 
 interface Props {
@@ -38,7 +35,7 @@ export function TranscriptList({
   pinRef,
   hideNav,
 }: Props) {
-  const { items, turns, turnIds, turnFooters, openTurnStart, transcriptLoading, log } = transcript;
+  const { turns, transcriptLoading, log } = transcript;
 
   const ownRef = useRef<HTMLDivElement | null>(null);
   const ref = scrollRef ?? ownRef;
@@ -78,40 +75,12 @@ export function TranscriptList({
     <div className="chat-scroll-wrap">
       <div className="chat-scroll" ref={ref} onScroll={handleScroll}>
         <div className="chat-inner fade-in" key={agent.id}>
-          {transcriptLoading && items.length === 0 ? (
-            <div className="writing flex-center">
-              <Loader variant="accent" />
-              <span>Loading transcript…</span>
-            </div>
-          ) : items.length === 0 && transcript.hasPriorConversation && !liveBusy ? (
-            <div className="empty-msg" style={{ margin: "40px auto", maxWidth: 360 }}>
-              <div className="et">No transcript available</div>
-              <div>
-                {providerLabel(agent.provider)}'s session file is not on disk for this agent.
-              </div>
-            </div>
-          ) : (
-            items.map((item, i) => {
-              const footer = turnFooters[i];
-              return (
-                <Fragment key={rowKey(item, i)}>
-                  <MessageItem
-                    item={item}
-                    provider={agent.provider}
-                    agentId={agent.id}
-                    busy={liveBusy && i >= openTurnStart}
-                    turnId={turnIds[i]}
-                  />
-                  {footer != null && <TurnFooter {...footer} agentId={agent.id} />}
-                </Fragment>
-              );
-            })
-          )}
-          {pending && (
-            <div className="chat-pending" aria-hidden="true">
-              <Loader variant="muted" size="md" />
-            </div>
-          )}
+          <TranscriptRows
+            agent={agent}
+            transcript={transcript}
+            liveBusy={liveBusy}
+            pending={pending}
+          />
         </div>
       </div>
       {!hideNav && <ChatNav scrollRef={ref} turns={turns} />}

--- a/src/components/Workspace/messages/TranscriptRows.tsx
+++ b/src/components/Workspace/messages/TranscriptRows.tsx
@@ -1,0 +1,73 @@
+// The rows of one agent's transcript — nothing else. No scroll container, no
+// bottom-pinning, no navigator: those belong to whoever owns the scroll.
+//
+// Extracted from TranscriptList so a surface that stacks several agents' logs in
+// one scroll container (the run monitor's thread) renders identical rows from the
+// identical derivation instead of a second copy of this mapping.
+import { Fragment } from "react";
+import type { AgentRecord } from "@/api";
+import { Loader } from "@/components/ui/Loader";
+import { providerLabel } from "@/data/providers";
+import { TurnFooter } from "../RunTimer";
+import { MessageItem } from "./MessageItem";
+import { rowKey } from "./pair";
+import type { Transcript } from "./useTranscript";
+
+export function TranscriptRows({
+  agent,
+  transcript,
+  liveBusy,
+  pending,
+}: {
+  agent: AgentRecord;
+  transcript: Transcript;
+  /** The agent is mid-turn: rows in the open turn may show a live spinner. */
+  liveBusy: boolean;
+  /** Quiet inline anchor for a just-sent first prompt with nothing back yet. */
+  pending?: boolean;
+}) {
+  const { items, turnIds, turnFooters, openTurnStart, transcriptLoading } = transcript;
+
+  if (transcriptLoading && items.length === 0) {
+    return (
+      <div className="writing flex-center">
+        <Loader variant="accent" />
+        <span>Loading transcript…</span>
+      </div>
+    );
+  }
+
+  if (items.length === 0 && transcript.hasPriorConversation && !liveBusy) {
+    return (
+      <div className="empty-msg" style={{ margin: "40px auto", maxWidth: 360 }}>
+        <div className="et">No transcript available</div>
+        <div>{providerLabel(agent.provider)}'s session file is not on disk for this agent.</div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {items.map((item, i) => {
+        const footer = turnFooters[i];
+        return (
+          <Fragment key={rowKey(item, i)}>
+            <MessageItem
+              item={item}
+              provider={agent.provider}
+              agentId={agent.id}
+              busy={liveBusy && i >= openTurnStart}
+              turnId={turnIds[i]}
+            />
+            {footer != null && <TurnFooter {...footer} agentId={agent.id} />}
+          </Fragment>
+        );
+      })}
+      {pending && (
+        <div className="chat-pending" aria-hidden="true">
+          <Loader variant="muted" size="md" />
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/workflows/run/RunView/PausedBanner/index.tsx
+++ b/src/workflows/run/RunView/PausedBanner/index.tsx
@@ -22,11 +22,15 @@ export function PausedBanner({
   question,
   evidence,
   evidencePending,
+  hideAnswer,
 }: {
   run: WfRun;
   detail?: string;
   /** The pending human `ask` message when `paused_reason === "question"`. */
   question?: WfMessage;
+  /** Drop the inline answer form — the caller renders it somewhere the user is
+   *  already typing (the thread's composer). The banner still names the cause. */
+  hideAnswer?: boolean;
   /** The review evidence for a `paused(approval)` run (its `gate_evidence`
    *  event), or `null` when none has arrived. */
   evidence?: GateEvidence | null;
@@ -75,7 +79,9 @@ export function PausedBanner({
       <div className="wf-banner-text">
         <div className="wf-banner-title">{spec.title}</div>
         <div className="wf-banner-body">{spec.body}</div>
-        {isQuestion && <AnswerForm run={run} question={question} onError={setLastError} />}
+        {isQuestion && !hideAnswer && (
+          <AnswerForm run={run} question={question} onError={setLastError} />
+        )}
         {isBudget && <ResumeBudgetForm run={run} onError={setLastError} />}
       </div>
       <div className="wf-banner-actions">

--- a/src/workflows/run/RunView/ThreadView/HandoffMarker.tsx
+++ b/src/workflows/run/RunView/ThreadView/HandoffMarker.tsx
@@ -1,0 +1,64 @@
+// ThreadView/HandoffMarker — the seam where one agent hands the work to the
+// next. The thread reads as one conversation, so the only thing that must never
+// be implicit is *who* is speaking from here on: name, identity chip, and the
+// step's place in the sequence.
+
+import { Icon } from "../../../../components/Icon";
+import { fmtDur } from "../../../../components/Workspace/RunTimer";
+import { AgentAvatar } from "../../../builder/AgentAvatar";
+import type { ResolvedAgent } from "../../../shared";
+import { attemptChip } from "../../status";
+import type { Segment } from "./segments";
+
+export function HandoffMarker({
+  segment,
+  stepCount,
+  agent,
+}: {
+  segment: Segment;
+  stepCount: number;
+  /** The step's resolved identity, or null when its alias no longer resolves. */
+  agent: ResolvedAgent | null;
+}) {
+  const { exec, step, stepIndex, retryIndex } = segment;
+  const chip = attemptChip(exec.status);
+  const ran =
+    exec.started_at != null && exec.ended_at != null
+      ? fmtDur((exec.ended_at - exec.started_at) / 1000)
+      : null;
+
+  return (
+    <div className="wf-handoff" data-step-id={exec.step_id}>
+      <span className="wf-handoff-line" aria-hidden="true" />
+      <span className="wf-handoff-body">
+        {agent ? (
+          <AgentAvatar
+            custom={agent.custom}
+            slug={agent.providerId}
+            short={agent.short}
+            hue={agent.hue}
+            size={16}
+          />
+        ) : (
+          <Icon name="bot" size={13} />
+        )}
+        <span className="wf-handoff-name">{agent?.name ?? "Unknown agent"}</span>
+        <span className="wf-handoff-sep">·</span>
+        <span className="wf-handoff-step">{step?.id ?? exec.step_id}</span>
+        {stepIndex >= 0 && (
+          <span className="wf-handoff-idx">
+            step {stepIndex + 1} of {stepCount}
+          </span>
+        )}
+        {retryIndex > 0 && <span className="wf-handoff-retry">retry {retryIndex}</span>}
+        {ran && <span className="wf-handoff-dur">{ran}</span>}
+        {exec.status !== "done" && (
+          <span className="wf-handoff-state" style={{ color: chip.tone }}>
+            {chip.label}
+          </span>
+        )}
+      </span>
+      <span className="wf-handoff-line" aria-hidden="true" />
+    </div>
+  );
+}

--- a/src/workflows/run/RunView/ThreadView/PhaseRow.tsx
+++ b/src/workflows/run/RunView/ThreadView/PhaseRow.tsx
@@ -1,0 +1,90 @@
+// ThreadView/PhaseRow — the named gap. Whenever no agent is streaming, this row
+// says what the run is doing and how long it has been doing it. Quiet by design:
+// a pulse, a label and a clock, not a banner (the banner is for states that need
+// the human).
+
+import { open as openExternal } from "@tauri-apps/plugin-shell";
+import { type CSSProperties, useEffect, useState } from "react";
+import { Icon, type IconName } from "../../../../components/Icon";
+import { Loader } from "../../../../components/ui/Loader";
+import { LiveTimer } from "../../../../components/Workspace/RunTimer";
+import { GREEN } from "../../status";
+import { isTerminalPhase, type Phase, type PhaseKind, phaseLabel } from "./phases";
+
+/** Phases that are normally instant — the boundary commit usually lands in
+ *  milliseconds. A row that flashes and vanishes is noise, so these only get
+ *  announced once they have actually persisted. */
+const TRANSIENT: ReadonlySet<PhaseKind> = new Set(["committing"]);
+const TRANSIENT_DELAY_MS = 600;
+
+export function PhaseRow({ phase, agentName }: { phase: Phase; agentName?: string }) {
+  const persisted = usePersisted(
+    `${phase.kind}:${phase.startedAt}`,
+    TRANSIENT.has(phase.kind) ? TRANSIENT_DELAY_MS : 0,
+  );
+  if (isTerminalPhase(phase)) return <TerminalRow phase={phase} />;
+  if (!persisted) return null;
+  return (
+    <div className="wf-phase" role="status" aria-live="polite">
+      <Loader variant="accent" />
+      <span className="wf-phase-label">{phaseLabel(phase, agentName)}</span>
+      <span className="wf-phase-sep">·</span>
+      <Icon name="clock" size={11} className="turn-clock-i" />
+      <LiveTimer startedAt={phase.startedAt} />
+    </div>
+  );
+}
+
+/** Whether `delay` ms have passed since `key` last changed. `delay: 0` is
+ *  immediate — the common case, so it never costs a render. */
+function usePersisted(key: string, delay: number): boolean {
+  const [persisted, setPersisted] = useState(delay === 0);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: `key` is the change
+  // signal rather than a value the body reads — a new phase restarts the wait.
+  useEffect(() => {
+    if (delay === 0) {
+      setPersisted(true);
+      return;
+    }
+    setPersisted(false);
+    const t = window.setTimeout(() => setPersisted(true), delay);
+    return () => window.clearTimeout(t);
+  }, [key, delay]);
+  return persisted;
+}
+
+/** The run's last word: what happened, and the one link that follows from it. */
+function TerminalRow({ phase }: { phase: Phase }) {
+  const url = phase.url;
+  const tone =
+    phase.kind === "done" ? GREEN : phase.kind === "failed" ? "var(--danger)" : "var(--fg-3)";
+  const icon: IconName =
+    phase.kind === "done" ? "check" : phase.kind === "failed" ? "close" : "stop";
+  return (
+    <div className={`wf-phase term ${phase.kind}`} style={{ "--term-tone": tone } as CSSProperties}>
+      <span className="wf-phase-mark" aria-hidden="true">
+        <Icon name={icon} size={12} />
+      </span>
+      <div className="wf-phase-term-body">
+        <div className="wf-phase-term-title">{phaseLabel(phase)}</div>
+        {phase.kind !== "done" && phase.detail && (
+          <div className="wf-phase-term-detail">{phase.detail}</div>
+        )}
+        {phase.kind === "done" && phase.detail && (
+          <div className="wf-phase-term-detail mono">{phase.detail}</div>
+        )}
+        {url && (
+          <button
+            type="button"
+            className="btn-t outline wf-phase-pr"
+            onClick={() => {
+              void openExternal(url).catch(() => {});
+            }}
+          >
+            <Icon name="pr" size={12} /> View pull request
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/workflows/run/RunView/ThreadView/ThreadComposer.tsx
+++ b/src/workflows/run/RunView/ThreadView/ThreadComposer.tsx
@@ -1,0 +1,76 @@
+// ThreadView/ThreadComposer — one composer for the whole thread, routed by what
+// the run can accept right now:
+//
+//   live      → the step agent that is working: the normal chat composer, same
+//               send machinery as any other agent (ChatComposer).
+//   question  → the run is paused on an ask: the existing wf_answer form, docked
+//               where the user is already typing.
+//   otherwise → disabled with a short reason. Never a live-looking box that
+//               silently drops what the user types.
+
+import type { AgentRecord, WfMessage, WfRun } from "../../../../api";
+import { ChatComposer } from "../../../../components/Workspace/ChatComposer";
+import { useTranscript } from "../../../../components/Workspace/messages/useTranscript";
+import { useLiveBusy } from "../../../../components/Workspace/useLiveBusy";
+import { useAppStore } from "../../../../store";
+import { AnswerForm } from "../PausedBanner/AnswerForm";
+import { composerRoute, disabledHint } from "./composer";
+
+export function ThreadComposer({
+  run,
+  question,
+  live,
+  onSend,
+}: {
+  run: WfRun;
+  /** The pending human `ask` when the run is paused on a question. */
+  question?: WfMessage;
+  /** The step agent currently working, when there is one. */
+  live: AgentRecord | undefined;
+  /** Re-pin the thread to the bottom — a send should scroll like a chat send. */
+  onSend: () => void;
+}) {
+  const setLastError = useAppStore((s) => s.setLastError);
+  const route = composerRoute(run, live);
+
+  if (route === "question") {
+    return (
+      <div className="composer-wrap">
+        <div className="wf-thread-answer">
+          <AnswerForm run={run} question={question} onError={setLastError} />
+        </div>
+      </div>
+    );
+  }
+
+  if (route === "live" && live) {
+    return <LiveComposer agent={live} onSend={onSend} />;
+  }
+
+  return (
+    <div className="composer-wrap">
+      <div className="wf-thread-hint">{disabledHint(run)}</div>
+    </div>
+  );
+}
+
+/** The live step agent's composer. Mounted only while such an agent exists, so
+ *  its transcript hooks can be unconditional; the derivation is the same
+ *  memoized pass the agent's own segment runs, and the composer sits outside the
+ *  scroll container, so it reads it here rather than threading it through. */
+function LiveComposer({ agent, onSend }: { agent: AgentRecord; onSend: () => void }) {
+  const turnStartedAt = useAppStore((s) => s.turnStartedAt[agent.id]);
+  const transcript = useTranscript(agent);
+  const liveBusy = useLiveBusy(agent.id, transcript.awaitingInput);
+  const liveStartedAt = liveBusy ? (turnStartedAt ?? transcript.openTurnStartedAt) : undefined;
+
+  return (
+    <ChatComposer
+      agent={agent}
+      activeModel={transcript.activeModel}
+      liveBusy={liveBusy}
+      liveStartedAt={liveStartedAt}
+      onSend={onSend}
+    />
+  );
+}

--- a/src/workflows/run/RunView/ThreadView/ThreadSegment.tsx
+++ b/src/workflows/run/RunView/ThreadView/ThreadSegment.tsx
@@ -1,0 +1,57 @@
+// ThreadView/ThreadSegment — one step agent's stretch of the thread: its
+// hand-off marker plus its transcript rows, rendered into the *thread's* scroll
+// container rather than one of its own.
+//
+// The rows and the derivation behind them are the chat's, not a copy: the
+// segment calls the same useTranscript (lazy history load, display policy, tool
+// pairing, turn footers) and renders the same TranscriptRows. Only the live
+// segment gets the live behaviors — a settled step must never show a spinner.
+
+import type { AgentRecord } from "../../../../api";
+import { TranscriptRows } from "../../../../components/Workspace/messages/TranscriptRows";
+import { isTurnPending } from "../../../../components/Workspace/messages/turnPending";
+import { useTranscript } from "../../../../components/Workspace/messages/useTranscript";
+import { useLiveBusy } from "../../../../components/Workspace/useLiveBusy";
+import type { ResolvedAgent } from "../../../shared";
+import { HandoffMarker } from "./HandoffMarker";
+import type { Segment } from "./segments";
+
+export function ThreadSegment({
+  segment,
+  stepCount,
+  resolved,
+}: {
+  segment: Segment;
+  stepCount: number;
+  resolved: ResolvedAgent | null;
+}) {
+  return (
+    <div className="wf-thread-seg">
+      <HandoffMarker segment={segment} stepCount={stepCount} agent={resolved} />
+      {segment.agent ? (
+        <SegmentBody agent={segment.agent} live={segment.live} />
+      ) : (
+        <div className="wf-thread-gap">
+          {segment.exec.agent_id
+            ? "This step's chat is no longer loaded."
+            : "This step hasn't started its agent yet."}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Split out so the transcript hooks only ever run for a segment that has an
+ *  agent record to hook onto. */
+function SegmentBody({ agent, live }: { agent: AgentRecord; live: boolean }) {
+  const transcript = useTranscript(agent);
+  const busy = useLiveBusy(agent.id, transcript.awaitingInput);
+  // An archived agent can still read `busy` from a stale store entry; only the
+  // attempt the run is actually working may render as live.
+  const liveBusy = live && busy;
+  const pending = liveBusy && isTurnPending(transcript.items) && transcript.turns.length <= 1;
+
+  return (
+    <TranscriptRows agent={agent} transcript={transcript} liveBusy={liveBusy} pending={pending} />
+  );
+}

--- a/src/workflows/run/RunView/ThreadView/composer.ts
+++ b/src/workflows/run/RunView/ThreadView/composer.ts
@@ -1,0 +1,38 @@
+// ThreadView/composer.ts — where the thread's one composer sends what the user
+// types. Pure, so the routing is asserted rather than eyeballed: a composer that
+// looks enabled and drops the message is worse than a disabled one.
+
+import type { AgentRecord, WfRun } from "../../../../api";
+
+export type ComposerRoute =
+  /** A step agent is working — the normal chat composer talks to it. */
+  | "live"
+  /** The run is paused on an ask — the answer form resumes it. */
+  | "question"
+  /** Nothing can accept a message right now. */
+  | "disabled";
+
+type RunState = Pick<WfRun, "status" | "paused_reason">;
+
+export function composerRoute(run: RunState, live: AgentRecord | undefined): ComposerRoute {
+  // The question outranks a live agent: the run is waiting on the answer, and a
+  // message to the step agent wouldn't resume it.
+  if (run.status === "paused" && run.paused_reason === "question") return "question";
+  return live ? "live" : "disabled";
+}
+
+/** The reason the composer is inert — always names what the user is waiting for. */
+export function disabledHint(run: RunState): string {
+  switch (run.status) {
+    case "done":
+      return "This run has finished.";
+    case "failed":
+      return "This run stopped. Its reason is above.";
+    case "canceled":
+      return "This run was canceled.";
+    case "paused":
+      return "Resolve the pause above to continue.";
+    default:
+      return "The next step starts automatically — you can talk to its agent once it's up.";
+  }
+}

--- a/src/workflows/run/RunView/ThreadView/index.tsx
+++ b/src/workflows/run/RunView/ThreadView/index.tsx
@@ -60,10 +60,11 @@ export function ThreadView({
 
   // Whether the live agent's chat is putting anything on screen this moment. It
   // decides whether the thread owes the user a phase row: a streaming turn
-  // already speaks for itself.
-  const streaming = useAppStore((s) =>
-    live ? (s.managedBusy[live.id] ?? false) || (s.managedLogs[live.id]?.length ?? 0) > 0 : false,
-  );
+  // already speaks for itself. This must be a *now* signal — `managedBusy`
+  // flips at turn start/end. Anything cumulative (e.g. a nonempty log) reads as
+  // "has ever streamed" and would suppress the working row for every quiet
+  // interval after the step's first output.
+  const streaming = useAppStore((s) => (live ? (s.managedBusy[live.id] ?? false) : false));
 
   const phase = useMemo(
     () => derivePhase({ run, events, steps, attempts, streaming }),

--- a/src/workflows/run/RunView/ThreadView/index.tsx
+++ b/src/workflows/run/RunView/ThreadView/index.tsx
@@ -1,0 +1,107 @@
+// ThreadView — the run as one continuous conversation.
+//
+// A sequential run is one agent's worth of work split across several agents, so
+// the monitor renders it that way: every step's transcript concatenated in
+// execution order, a hand-off marker at each seam, and one composer at the
+// bottom. The pane is never blank — whatever the run is doing between two
+// streaming turns gets a named phase row with a live timer (see phases.ts).
+//
+// Only sequential runs get this treatment (see `isSequentialSpec`); parallel,
+// loop and orchestrate runs keep the per-step chat, which is the only honest
+// rendering of work that isn't a line.
+
+import { useEffect, useMemo } from "react";
+import type { AgentRecord, WfEvent, WfMessage, WfRun, WfStepExec } from "../../../../api";
+import { useAppStore } from "../../../../store";
+import type { ResolvedAgent } from "../../../shared";
+import type { StepDesc } from "../flatten";
+import { PhaseRow } from "./PhaseRow";
+import { derivePhase } from "./phases";
+import { deriveSegments, liveAgent } from "./segments";
+import { ThreadComposer } from "./ThreadComposer";
+import { ThreadSegment } from "./ThreadSegment";
+import { useThreadScroll } from "./useThreadScroll";
+
+/** A step the user asked to see. Carries a nonce so re-picking the same step
+ *  scrolls again, and so the thread never yanks the view on its own when the
+ *  run's selection advances. */
+export interface FocusRequest {
+  stepId: string;
+  nonce: number;
+}
+
+export function ThreadView({
+  run,
+  steps,
+  attempts,
+  agents,
+  events,
+  resolve,
+  question,
+  focus,
+}: {
+  run: WfRun;
+  steps: StepDesc[];
+  attempts: WfStepExec[];
+  /** The run's step agents, live and archived. */
+  agents: AgentRecord[];
+  events: WfEvent[];
+  resolve: (alias: string) => ResolvedAgent | null;
+  question?: WfMessage;
+  focus: FocusRequest | null;
+}) {
+  const { scrollRef, innerRef, onScroll, toBottom } = useThreadScroll(run.id);
+
+  const segments = useMemo(
+    () => deriveSegments(steps, attempts, agents),
+    [steps, attempts, agents],
+  );
+  const live = useMemo(() => liveAgent(segments), [segments]);
+
+  // Whether the live agent's chat is putting anything on screen this moment. It
+  // decides whether the thread owes the user a phase row: a streaming turn
+  // already speaks for itself.
+  const streaming = useAppStore((s) =>
+    live ? (s.managedBusy[live.id] ?? false) || (s.managedLogs[live.id]?.length ?? 0) > 0 : false,
+  );
+
+  const phase = useMemo(
+    () => derivePhase({ run, events, steps, attempts, streaming }),
+    [run, events, steps, attempts, streaming],
+  );
+
+  // The phase's agent, when it names one — resolved from the spec, because a
+  // step that hasn't spawned yet has no agent record to read a name from.
+  const phaseAgent =
+    phase?.stepIndex != null ? resolve(steps[phase.stepIndex]?.agentAlias ?? "") : null;
+
+  // A step picked in the stepper (or the sidebar) scrolls its segment into view.
+  // Only on an explicit request — following the selection would fight the user's
+  // own scrolling as the run advances.
+  useEffect(() => {
+    if (!focus) return;
+    const el = innerRef.current?.querySelector(`[data-step-id="${CSS.escape(focus.stepId)}"]`);
+    el?.scrollIntoView({ block: "start" });
+  }, [focus, innerRef]);
+
+  return (
+    <div className="chat wf-thread">
+      <div className="chat-scroll-wrap">
+        <div className="chat-scroll" ref={scrollRef} onScroll={onScroll}>
+          <div className="chat-inner fade-in" ref={innerRef}>
+            {segments.map((segment) => (
+              <ThreadSegment
+                key={segment.exec.id}
+                segment={segment}
+                stepCount={steps.length}
+                resolved={segment.step ? resolve(segment.step.agentAlias) : null}
+              />
+            ))}
+            {phase && <PhaseRow phase={phase} agentName={phaseAgent?.name} />}
+          </div>
+        </div>
+      </div>
+      <ThreadComposer run={run} question={question} live={live} onSend={toBottom} />
+    </div>
+  );
+}

--- a/src/workflows/run/RunView/ThreadView/phases.test.ts
+++ b/src/workflows/run/RunView/ThreadView/phases.test.ts
@@ -1,0 +1,241 @@
+// The "no silent second" contract, asserted against the kernel runner's actual
+// event sequence (src-tauri/src/workflow/runner/mod.rs): every point in a run
+// either has an agent streaming or resolves to a named phase. A null phase with
+// nothing streaming is the bug these tests exist to catch.
+
+import { describe, expect, it } from "vitest";
+import type { WfEvent, WfRun, WfStepExec } from "../../../../api";
+import type { StepDesc } from "../flatten";
+import { composerRoute, disabledHint } from "./composer";
+import { derivePhase, type PhaseInput, phaseLabel } from "./phases";
+
+const steps: StepDesc[] = [
+  { id: "plan", agentAlias: "planner", goal: "" },
+  { id: "code", agentAlias: "coder", goal: "" },
+];
+
+const attempts: WfStepExec[] = [stepExec("exec-plan", "plan"), stepExec("exec-code", "code")];
+
+function stepExec(id: string, step_id: string): WfStepExec {
+  return {
+    id,
+    run_id: "r1",
+    step_id,
+    attempt: 0,
+    iteration: 0,
+    agent_id: null,
+    status: "done",
+    gate_mode: "commit",
+    head_start: null,
+    head_end: null,
+    verdict: null,
+    error: null,
+    started_at: 0,
+    ended_at: 0,
+  };
+}
+
+let seq = 0;
+function ev(type: string, execId: string | null = null, payload: unknown = {}): WfEvent {
+  seq += 1;
+  return { run_id: "r1", seq, ts: seq * 1000, step_exec_id: execId, type, payload };
+}
+
+function run(over: Partial<WfRun> = {}): WfRun {
+  return {
+    status: "running",
+    created_at: 500,
+    updated_at: 9000,
+    error: null,
+    paused_reason: null,
+    ...over,
+  } as WfRun;
+}
+
+function phase(events: WfEvent[], over: Partial<PhaseInput> = {}) {
+  return derivePhase({ run: run(), events, steps, attempts, streaming: false, ...over });
+}
+
+describe("derivePhase — the kernel's sequence", () => {
+  it("names the pre-launch gap from the run row's own timestamp", () => {
+    expect(phase([])).toEqual({ kind: "preparing", startedAt: 500 });
+  });
+
+  it("names the first step's agent between run_launched and its spawn", () => {
+    const p = phase([ev("run_launched", null, { runner: "kernel" })]);
+    expect(p?.kind).toBe("starting");
+    expect(p?.stepIndex).toBe(0);
+  });
+
+  it("keeps naming the step while it spawns and comes up", () => {
+    const spawned = phase([ev("run_launched"), ev("attempt_spawned", "exec-plan")]);
+    expect(spawned).toMatchObject({ kind: "starting", stepIndex: 0 });
+    const ready = phase([
+      ev("run_launched"),
+      ev("attempt_spawned", "exec-plan"),
+      ev("attempt_ready", "exec-plan"),
+    ]);
+    expect(ready).toMatchObject({ kind: "starting", stepIndex: 0 });
+  });
+
+  it("yields to the chat once the brief is sent and something is streaming", () => {
+    const events = [
+      ev("run_launched"),
+      ev("attempt_spawned", "exec-plan"),
+      ev("prompt_sent", "exec-plan"),
+    ];
+    expect(phase(events, { streaming: true })).toBeNull();
+  });
+
+  it("still names the moment after prompt_sent when nothing is streaming", () => {
+    const events = [ev("prompt_sent", "exec-plan")];
+    expect(phase(events)).toMatchObject({ kind: "working", stepIndex: 0 });
+  });
+
+  it("names the commit window between turn_ended and boundary_commit", () => {
+    expect(phase([ev("turn_ended", "exec-plan")])).toMatchObject({
+      kind: "committing",
+      stepIndex: 0,
+    });
+    expect(phase([ev("turn_ended", "exec-plan"), ev("gate_evaluated", "exec-plan")])).toMatchObject(
+      {
+        kind: "committing",
+        stepIndex: 0,
+      },
+    );
+  });
+
+  it("hands off to the next step after a boundary commit", () => {
+    const p = phase([ev("boundary_commit", "exec-plan")]);
+    expect(p).toMatchObject({ kind: "starting", stepIndex: 1 });
+  });
+
+  it("moves to finalize after the last step's boundary commit", () => {
+    expect(phase([ev("boundary_commit", "exec-code")])).toMatchObject({ kind: "pushing" });
+  });
+
+  it("names the finalize events", () => {
+    expect(phase([ev("finalize_pushed", null, { branch: "wf/x" })])).toMatchObject({
+      kind: "publishing",
+      detail: "wf/x",
+    });
+    expect(phase([ev("finalize_pr", null, { url: "u" })])).toMatchObject({ kind: "finishing" });
+  });
+
+  it("ignores bookkeeping events between phases", () => {
+    // A budget tick or a missing-skill warning must not reset the phase clock or
+    // rename the phase.
+    const events = [
+      ev("attempt_spawned", "exec-plan"),
+      ev("skills_missing", "exec-plan", { skills: ["x"] }),
+      ev("budget_tick", null),
+    ];
+    const p = phase(events);
+    expect(p?.kind).toBe("starting");
+    expect(p?.startedAt).toBe(events[0].ts);
+  });
+
+  it("goes quiet while paused — the banner owns that moment", () => {
+    const events = [ev("run_paused", null, { reason: "question" })];
+    expect(phase(events, { run: run({ status: "paused", paused_reason: "question" }) })).toBeNull();
+  });
+
+  it("names the failure from the journal before the run row catches up", () => {
+    const events = [ev("attempt_error", "exec-code", { error: 'verdict.json result is "revise"' })];
+    expect(phase(events)).toMatchObject({
+      kind: "failed",
+      detail: 'verdict.json result is "revise"',
+    });
+  });
+});
+
+describe("derivePhase — terminal runs", () => {
+  it("reports the run's own error, prominently, over the journal's", () => {
+    const events = [ev("attempt_error", "exec-code", { error: "journaled" })];
+    const p = derivePhase({
+      run: run({ status: "failed", error: "step timed out after 1800s" }),
+      events,
+      steps,
+      attempts,
+      streaming: false,
+    });
+    expect(p).toMatchObject({ kind: "failed", detail: "step timed out after 1800s" });
+  });
+
+  it("falls back to the journaled reason when the row carries none", () => {
+    const events = [ev("run_failed", null, { error: "no verdict.json was written" })];
+    const p = derivePhase({
+      run: run({ status: "failed" }),
+      events,
+      steps,
+      attempts,
+      streaming: false,
+    });
+    expect(p?.detail).toBe("no verdict.json was written");
+  });
+
+  it("carries the finalize branch and PR onto the done row", () => {
+    const events = [
+      ev("finalize_pushed", null, { branch: "wf/thing" }),
+      ev("finalize_pr", null, { url: "https://example.test/pr/1" }),
+      ev("run_done"),
+    ];
+    const p = derivePhase({
+      run: run({ status: "done" }),
+      events,
+      steps,
+      attempts,
+      streaming: false,
+    });
+    expect(p).toMatchObject({
+      kind: "done",
+      detail: "wf/thing",
+      url: "https://example.test/pr/1",
+    });
+  });
+
+  it("reports a cancel even mid-turn", () => {
+    const p = derivePhase({
+      run: run({ status: "canceled" }),
+      events: [ev("prompt_sent", "exec-code")],
+      steps,
+      attempts,
+      streaming: true,
+    });
+    expect(p?.kind).toBe("canceled");
+  });
+});
+
+describe("phaseLabel", () => {
+  it("names the agent when one was resolved, and stays honest when not", () => {
+    const p = { kind: "starting", startedAt: 0, stepIndex: 1 } as const;
+    expect(phaseLabel(p, "Reviewer")).toBe("Starting Reviewer…");
+    expect(phaseLabel(p)).toBe("Starting the next step…");
+  });
+
+  it("puts the pushed branch on the completion line", () => {
+    expect(phaseLabel({ kind: "done", startedAt: 0, detail: "wf/x" })).toBe(
+      "Run complete — pushed wf/x",
+    );
+  });
+});
+
+describe("composerRoute", () => {
+  const agent = { id: "ag-1" } as never;
+
+  it("talks to the live step agent", () => {
+    expect(composerRoute(run(), agent)).toBe("live");
+  });
+
+  it("answers the run's question even when a step agent is still up", () => {
+    expect(composerRoute(run({ status: "paused", paused_reason: "question" }), agent)).toBe(
+      "question",
+    );
+  });
+
+  it("disables itself between steps rather than dropping a message", () => {
+    expect(composerRoute(run(), undefined)).toBe("disabled");
+    expect(disabledHint(run())).toMatch(/starts automatically/);
+    expect(disabledHint(run({ status: "done" }))).toMatch(/finished/);
+  });
+});

--- a/src/workflows/run/RunView/ThreadView/phases.ts
+++ b/src/workflows/run/RunView/ThreadView/phases.ts
@@ -1,0 +1,217 @@
+// ThreadView/phases.ts — what the run is doing right now, named, from the
+// journal alone.
+//
+// Governing rule: no silent second. Every moment where no agent is streaming
+// must resolve to a named phase with a start timestamp, so the thread can show a
+// label and a live timer instead of a blank pane. The kernel journals each
+// transition as it happens (runner/mod.rs), so the phase is a pure function of
+// the run row plus the event tail — the last *phase-bearing* event decides it,
+// and bookkeeping events in between (budget ticks, missing-skill warnings,
+// routed messages) are skipped rather than mistaken for progress.
+
+import type { WfEvent, WfRun, WfStepExec } from "../../../../api";
+import type { StepDesc } from "../flatten";
+
+export type PhaseKind =
+  | "preparing"
+  | "starting"
+  | "working"
+  | "resuming"
+  | "committing"
+  | "pushing"
+  | "publishing"
+  | "finishing"
+  | "done"
+  | "failed"
+  | "canceled";
+
+export interface Phase {
+  kind: PhaseKind;
+  /** Epoch millis the phase began — the live timer's anchor. */
+  startedAt: number;
+  /** The step whose agent this phase is about, when it is about one. */
+  stepIndex?: number;
+  /** Journaled specifics: the failure reason, the pushed branch. */
+  detail?: string;
+  /** The pull request the finished run opened. */
+  url?: string;
+}
+
+export interface PhaseInput {
+  run: Pick<WfRun, "status" | "created_at" | "updated_at" | "error">;
+  /** The journal in seq order (as `useRunDetail` keeps it). */
+  events: WfEvent[];
+  steps: StepDesc[];
+  attempts: WfStepExec[];
+  /** A step agent's chat is rendering the current turn — that segment owns this
+   *  moment, so no phase row is needed for it. */
+  streaming: boolean;
+}
+
+/** Event types that move the run from one nameable phase to the next. Anything
+ *  else is bookkeeping and must not reset the phase clock. */
+const PHASE_EVENTS: ReadonlySet<string> = new Set([
+  "run_launched",
+  "run_resumed",
+  "run_paused",
+  "attempt_spawned",
+  "attempt_ready",
+  "prompt_sent",
+  "turn_ended",
+  "gate_evaluated",
+  "boundary_commit",
+  "attempt_error",
+  "finalize_pushed",
+  "finalize_pr",
+]);
+
+/** Read a string field from an untyped journal payload. */
+function str(payload: unknown, key: string): string | undefined {
+  if (payload && typeof payload === "object" && key in payload) {
+    const v = (payload as Record<string, unknown>)[key];
+    if (typeof v === "string") return v;
+  }
+  return undefined;
+}
+
+/** The last event of `type`, or undefined. */
+function lastOf(events: WfEvent[], type: string): WfEvent | undefined {
+  for (let i = events.length - 1; i >= 0; i -= 1) {
+    if (events[i].type === type) return events[i];
+  }
+  return undefined;
+}
+
+export function derivePhase({ run, events, steps, attempts, streaming }: PhaseInput): Phase | null {
+  if (run.status === "done" || run.status === "canceled") {
+    return terminalPhase(run, events);
+  }
+  if (run.status === "failed") return terminalPhase(run, events);
+  // A paused run's cause and its one action live in the banner; a second
+  // "waiting" row under the thread would only say it again.
+  if (run.status === "paused") return null;
+
+  const tail = (() => {
+    for (let i = events.length - 1; i >= 0; i -= 1) {
+      if (PHASE_EVENTS.has(events[i].type)) return events[i];
+    }
+    return undefined;
+  })();
+
+  // Nothing journaled yet: the run row exists, the workspace does not.
+  if (!tail) return { kind: "preparing", startedAt: run.created_at };
+
+  const at = tail.ts;
+  const stepIndex = stepIndexOf(tail.step_exec_id, steps, attempts);
+
+  switch (tail.type) {
+    case "run_launched":
+      // The workspace is provisioned; the first step's agent is coming up. Its
+      // exec row may not exist yet, so name the first step directly.
+      return { kind: "starting", startedAt: at, stepIndex: steps.length > 0 ? 0 : undefined };
+    case "run_resumed":
+      return { kind: "resuming", startedAt: at };
+    case "run_paused":
+      return null;
+    case "attempt_spawned":
+    case "attempt_ready":
+      return { kind: "starting", startedAt: at, stepIndex };
+    case "prompt_sent":
+      // The brief is in; the step's chat is the surface. Only when nothing is
+      // rendering there does the thread owe the user a row.
+      return streaming ? null : { kind: "working", startedAt: at, stepIndex };
+    case "turn_ended":
+    case "gate_evaluated":
+      return { kind: "committing", startedAt: at, stepIndex };
+    case "boundary_commit": {
+      // The step is durable. Either the next step is coming up, or this was the
+      // last one and finalize is running.
+      const next = stepIndex == null ? undefined : stepIndex + 1;
+      if (next != null && next < steps.length) {
+        return { kind: "starting", startedAt: at, stepIndex: next };
+      }
+      return { kind: "pushing", startedAt: at };
+    }
+    case "finalize_pushed":
+      return { kind: "publishing", startedAt: at, detail: str(tail.payload, "branch") };
+    case "finalize_pr":
+      return { kind: "finishing", startedAt: at };
+    case "attempt_error":
+      // The run's terminal write lands a beat later; name the failure now rather
+      // than showing a phase that has already stopped advancing.
+      return { kind: "failed", startedAt: at, detail: str(tail.payload, "error") };
+    default:
+      return { kind: "working", startedAt: at, stepIndex };
+  }
+}
+
+function terminalPhase(run: PhaseInput["run"], events: WfEvent[]): Phase {
+  const pushed = lastOf(events, "finalize_pushed");
+  const pr = lastOf(events, "finalize_pr");
+  if (run.status === "done") {
+    return {
+      kind: "done",
+      startedAt: run.updated_at,
+      detail: pushed ? str(pushed.payload, "branch") : undefined,
+      url: pr ? str(pr.payload, "url") : undefined,
+    };
+  }
+  if (run.status === "canceled") return { kind: "canceled", startedAt: run.updated_at };
+  // The row's error is the authoritative reason; the journal's is the fallback
+  // for a row written before the column existed.
+  const journaled =
+    str(lastOf(events, "run_failed")?.payload, "error") ??
+    str(lastOf(events, "attempt_error")?.payload, "error");
+  return {
+    kind: "failed",
+    startedAt: run.updated_at,
+    detail: run.error ?? journaled,
+  };
+}
+
+/** The flat-step position of the exec an event is keyed to. */
+function stepIndexOf(
+  execId: string | null,
+  steps: StepDesc[],
+  attempts: WfStepExec[],
+): number | undefined {
+  if (!execId) return undefined;
+  const stepId = attempts.find((a) => a.id === execId)?.step_id;
+  if (!stepId) return undefined;
+  const i = steps.findIndex((s) => s.id === stepId);
+  return i >= 0 ? i : undefined;
+}
+
+/** The phase's one line of product copy. `agentName` is the resolved identity of
+ *  `phase.stepIndex`'s agent, when the caller could resolve one. */
+export function phaseLabel(phase: Phase, agentName?: string): string {
+  switch (phase.kind) {
+    case "preparing":
+      return "Preparing the workspace…";
+    case "starting":
+      return agentName ? `Starting ${agentName}…` : "Starting the next step…";
+    case "working":
+      return agentName ? `${agentName} is working…` : "Working…";
+    case "resuming":
+      return "Resuming the run…";
+    case "committing":
+      return "Committing work…";
+    case "pushing":
+      return "Pushing the branch…";
+    case "publishing":
+      return "Opening the pull request…";
+    case "finishing":
+      return "Wrapping up…";
+    case "done":
+      return phase.detail ? `Run complete — pushed ${phase.detail}` : "Run complete";
+    case "failed":
+      return "Run failed";
+    case "canceled":
+      return "Run canceled";
+  }
+}
+
+/** Terminal phases are a record, not an activity: no spinner, no live timer. */
+export function isTerminalPhase(phase: Phase): boolean {
+  return phase.kind === "done" || phase.kind === "failed" || phase.kind === "canceled";
+}

--- a/src/workflows/run/RunView/ThreadView/segments.test.ts
+++ b/src/workflows/run/RunView/ThreadView/segments.test.ts
@@ -1,0 +1,131 @@
+// The thread is a concatenation in execution order. These guard the two ways
+// that can go wrong: ordering by timestamp (which reshuffles rows that share a
+// millisecond, and splits a step's retries apart), and letting a settled attempt
+// claim the live behaviors.
+
+import { describe, expect, it } from "vitest";
+import type { AgentRecord, WfStepExec } from "../../../../api";
+import type { StepDesc } from "../flatten";
+import { deriveSegments, liveAgent } from "./segments";
+
+const steps: StepDesc[] = [
+  { id: "plan", agentAlias: "a", goal: "" },
+  { id: "code", agentAlias: "b", goal: "" },
+  { id: "review", agentAlias: "c", goal: "" },
+];
+
+function exec(over: Partial<WfStepExec> & { id: string; step_id: string }): WfStepExec {
+  return {
+    run_id: "r1",
+    attempt: 0,
+    iteration: 0,
+    agent_id: null,
+    status: "done",
+    gate_mode: "commit",
+    head_start: null,
+    head_end: null,
+    verdict: null,
+    error: null,
+    started_at: 0,
+    ended_at: 0,
+    ...over,
+  };
+}
+
+function agent(id: string): AgentRecord {
+  return { id, provider: "claude", task: "t", status: "idle", repos: [] } as unknown as AgentRecord;
+}
+
+describe("deriveSegments", () => {
+  it("orders by step position, not by the order rows arrive", () => {
+    const rows = [
+      exec({ id: "e3", step_id: "review" }),
+      exec({ id: "e1", step_id: "plan" }),
+      exec({ id: "e2", step_id: "code" }),
+    ];
+    expect(deriveSegments(steps, rows, []).map((s) => s.exec.id)).toEqual(["e1", "e2", "e3"]);
+  });
+
+  it("keeps a step's retries adjacent and numbered", () => {
+    const rows = [
+      exec({ id: "code-2", step_id: "code", attempt: 1 }),
+      exec({ id: "plan-1", step_id: "plan" }),
+      exec({ id: "code-1", step_id: "code", attempt: 0 }),
+    ];
+    const segments = deriveSegments(steps, rows, []);
+    expect(segments.map((s) => s.exec.id)).toEqual(["plan-1", "code-1", "code-2"]);
+    expect(segments.map((s) => s.retryIndex)).toEqual([0, 0, 1]);
+  });
+
+  it("sorts loop iterations before retries within a step", () => {
+    const rows = [
+      exec({ id: "i1-a1", step_id: "code", iteration: 1, attempt: 0 }),
+      exec({ id: "i0-a1", step_id: "code", iteration: 0, attempt: 1 }),
+      exec({ id: "i0-a0", step_id: "code", iteration: 0, attempt: 0 }),
+    ];
+    expect(deriveSegments(steps, rows, []).map((s) => s.exec.id)).toEqual([
+      "i0-a0",
+      "i0-a1",
+      "i1-a1",
+    ]);
+  });
+
+  it("puts a row whose step left the spec last rather than first", () => {
+    const rows = [exec({ id: "ghost", step_id: "gone" }), exec({ id: "e1", step_id: "plan" })];
+    const segments = deriveSegments(steps, rows, []);
+    expect(segments.map((s) => s.exec.id)).toEqual(["e1", "ghost"]);
+    expect(segments[1].step).toBeUndefined();
+    expect(segments[1].stepIndex).toBe(-1);
+  });
+
+  it("skips a step whose exec row exists but whose agent hasn't spawned", () => {
+    // The phase row already names that moment; a marker would announce the step
+    // twice, once with nothing under it.
+    const rows = [
+      exec({ id: "e1", step_id: "plan" }),
+      exec({ id: "e2", step_id: "code", status: "spawning", agent_id: null }),
+    ];
+    expect(deriveSegments(steps, rows, []).map((s) => s.exec.id)).toEqual(["e1"]);
+  });
+
+  it("keeps an attempt that ended without ever getting an agent", () => {
+    const rows = [exec({ id: "e1", step_id: "plan", status: "error", agent_id: null })];
+    expect(deriveSegments(steps, rows, []).map((s) => s.exec.id)).toEqual(["e1"]);
+  });
+
+  it("attaches the run's agent record, live or archived", () => {
+    const rows = [exec({ id: "e1", step_id: "plan", agent_id: "ag-1" })];
+    const segments = deriveSegments(steps, rows, [agent("ag-1")]);
+    expect(segments[0].agent?.id).toBe("ag-1");
+  });
+
+  it("marks only in-flight attempts live", () => {
+    const rows = [
+      exec({ id: "e1", step_id: "plan", status: "done" }),
+      exec({ id: "e2", step_id: "code", status: "running" }),
+    ];
+    expect(deriveSegments(steps, rows, []).map((s) => s.live)).toEqual([false, true]);
+  });
+});
+
+describe("liveAgent", () => {
+  it("returns the newest live attempt's agent", () => {
+    const rows = [
+      exec({ id: "e1", step_id: "plan", status: "done", agent_id: "ag-1" }),
+      exec({ id: "e2", step_id: "code", status: "running", agent_id: "ag-2" }),
+    ];
+    const segments = deriveSegments(steps, rows, [agent("ag-1"), agent("ag-2")]);
+    expect(liveAgent(segments)?.id).toBe("ag-2");
+  });
+
+  it("returns nothing between steps — the composer must not talk to a dead agent", () => {
+    const rows = [exec({ id: "e1", step_id: "plan", status: "done", agent_id: "ag-1" })];
+    const segments = deriveSegments(steps, rows, [agent("ag-1")]);
+    expect(liveAgent(segments)).toBeUndefined();
+  });
+
+  it("returns nothing while a live attempt has no agent record yet", () => {
+    const rows = [exec({ id: "e1", step_id: "plan", status: "spawning", agent_id: null })];
+    expect(liveAgent(deriveSegments(steps, rows, []))).toBeUndefined();
+  });
+});

--- a/src/workflows/run/RunView/ThreadView/segments.ts
+++ b/src/workflows/run/RunView/ThreadView/segments.ts
@@ -1,0 +1,77 @@
+// ThreadView/segments.ts — the thread's spine: one transcript segment per step
+// attempt, in execution order.
+//
+// Execution order, never timestamps. A sequential run's steps run in spec order,
+// so the step's position in the flattened spec is the primary key and the
+// attempt's (iteration, retry) its tie-break. Interleaving by `started_at` would
+// reorder the thread whenever two rows share a millisecond, and a step's rows
+// must stay adjacent regardless.
+
+import type { AgentRecord, WfStepExec } from "../../../../api";
+import type { StepDesc } from "../flatten";
+
+export interface Segment {
+  /** The attempt this segment renders. */
+  exec: WfStepExec;
+  /** The spec step it belongs to; undefined for a row whose step left the spec. */
+  step: StepDesc | undefined;
+  /** 0-based position in the flattened step list. */
+  stepIndex: number;
+  /** Which retry of the step this is, 0-based — a marker shows it when > 0. */
+  retryIndex: number;
+  /** The step agent's record, when the run still owns it (live or archived). */
+  agent: AgentRecord | undefined;
+  /** The run is still working this attempt: its chat keeps the live behaviors. */
+  live: boolean;
+}
+
+/** Attempt statuses that mean the kernel has not moved past this step yet. */
+const LIVE_STATUSES: ReadonlySet<WfStepExec["status"]> = new Set(["spawning", "running", "gating"]);
+
+/** Statuses an attempt holds before it has an agent to show. */
+const UNSTARTED_STATUSES: ReadonlySet<WfStepExec["status"]> = new Set(["pending", "spawning"]);
+
+export function deriveSegments(
+  steps: StepDesc[],
+  attempts: WfStepExec[],
+  agents: AgentRecord[],
+): Segment[] {
+  const order = new Map(steps.map((s, i) => [s.id, i]));
+  // A row whose step_id is absent from the spec (hand-edited spec, renamed step)
+  // sorts after every known step rather than to the front.
+  const rank = (exec: WfStepExec) => order.get(exec.step_id) ?? steps.length;
+
+  const rows = attempts
+    .slice()
+    // The exec row is created before the agent is spawned, so a step about to
+    // start already has one. It has nothing to render, and the phase row already
+    // names that moment — a marker here would announce the step twice. A row that
+    // ended without an agent (spawn failed, abandoned) is real history and stays.
+    .filter((a) => a.agent_id != null || !UNSTARTED_STATUSES.has(a.status))
+    .sort((a, b) => rank(a) - rank(b) || a.iteration - b.iteration || a.attempt - b.attempt);
+
+  const seenPerStep = new Map<string, number>();
+  return rows.map((exec) => {
+    const retryIndex = seenPerStep.get(exec.step_id) ?? 0;
+    seenPerStep.set(exec.step_id, retryIndex + 1);
+    const stepIndex = order.get(exec.step_id) ?? -1;
+    return {
+      exec,
+      step: stepIndex >= 0 ? steps[stepIndex] : undefined,
+      stepIndex,
+      retryIndex,
+      agent: exec.agent_id ? agents.find((a) => a.id === exec.agent_id) : undefined,
+      live: LIVE_STATUSES.has(exec.status),
+    };
+  });
+}
+
+/** The agent the thread's one composer talks to: the live attempt's, if any.
+ *  Later segments win, so a fresh step takes over the composer the moment it
+ *  spawns. */
+export function liveAgent(segments: Segment[]): AgentRecord | undefined {
+  for (let i = segments.length - 1; i >= 0; i -= 1) {
+    if (segments[i].live && segments[i].agent) return segments[i].agent;
+  }
+  return undefined;
+}

--- a/src/workflows/run/RunView/ThreadView/useThreadScroll.ts
+++ b/src/workflows/run/RunView/ThreadView/useThreadScroll.ts
@@ -1,0 +1,62 @@
+// ThreadView/useThreadScroll.ts — bottom-pinning for a scroll container whose
+// content comes from several sources at once.
+//
+// TranscriptList can follow one agent's log by watching that log's identity. The
+// thread has no single such signal: segments append, a lazily-loaded history
+// lands under an older segment, and a phase row swaps for a taller one. So it
+// follows the rendered height instead — one ResizeObserver on the inner column
+// covers every one of those cases with the same rule.
+
+import { type MutableRefObject, useEffect, useRef } from "react";
+
+/** Slop that still counts as "at the bottom" — sub-pixel rounding otherwise
+ *  makes exact equality flaky. Matches TranscriptList. */
+const BOTTOM_SLOP = 40;
+
+export interface ThreadScroll {
+  scrollRef: MutableRefObject<HTMLDivElement | null>;
+  innerRef: MutableRefObject<HTMLDivElement | null>;
+  /** True while the thread follows new content; false once the user scrolls up. */
+  pinned: MutableRefObject<boolean>;
+  onScroll: () => void;
+  /** Re-pin and jump to the bottom (used when the user sends a message). */
+  toBottom: () => void;
+}
+
+export function useThreadScroll(runId: string): ThreadScroll {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const innerRef = useRef<HTMLDivElement | null>(null);
+  const pinned = useRef(true);
+
+  // Each run opens at its latest.
+  useEffect(() => {
+    pinned.current = true;
+  }, [runId]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    const inner = innerRef.current;
+    if (!el || !inner) return;
+    const follow = () => {
+      if (pinned.current) el.scrollTop = el.scrollHeight;
+    };
+    follow();
+    const ro = new ResizeObserver(follow);
+    ro.observe(inner);
+    return () => ro.disconnect();
+  }, []);
+
+  const onScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    pinned.current = el.scrollHeight - el.scrollTop - el.clientHeight <= BOTTOM_SLOP;
+  };
+
+  const toBottom = () => {
+    pinned.current = true;
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  };
+
+  return { scrollRef, innerRef, pinned, onScroll, toBottom };
+}

--- a/src/workflows/run/RunView/flatten.test.ts
+++ b/src/workflows/run/RunView/flatten.test.ts
@@ -1,0 +1,53 @@
+// isSequentialSpec mirrors the kernel runner's `kernel_eligible`
+// (src-tauri/src/workflow/runner/mod.rs). If the two drift, the monitor renders
+// a thread for a run that isn't one — or hides the thread from one that is.
+
+import { describe, expect, it } from "vitest";
+import type { Block, Gate, Spec } from "../../spec";
+import { isSequentialSpec } from "./flatten";
+
+function spec(workflow: Block[]): Spec {
+  return { version: 1, name: "s", agents: { a: { base: "claude" } }, workflow };
+}
+
+function step(id: string, gate?: Gate): Block {
+  return { step: { id, agent: "a", goal: "g", ...(gate ? { gate } : {}) } };
+}
+
+describe("isSequentialSpec", () => {
+  it("accepts a flat sequence of commit/verdict steps", () => {
+    expect(
+      isSequentialSpec(spec([step("plan", { type: "verdict" }), step("code", { type: "commit" })])),
+    ).toBe(true);
+  });
+
+  it("accepts a step with no gate — serde defaults it to verdict", () => {
+    expect(isSequentialSpec(spec([step("plan")]))).toBe(true);
+  });
+
+  it("rejects an empty workflow", () => {
+    expect(isSequentialSpec(spec([]))).toBe(false);
+    expect(isSequentialSpec(null)).toBe(false);
+  });
+
+  it("rejects gates that suspend the run or need external verification", () => {
+    for (const gate of [
+      { type: "approval" },
+      { type: "tests" },
+      { type: "artifact", path: "out.md" },
+    ] as Gate[]) {
+      expect(isSequentialSpec(spec([step("plan"), step("check", gate)]))).toBe(false);
+    }
+  });
+
+  it("rejects parallel, loop and orchestrate blocks", () => {
+    const parallel: Block = { parallel: { join: "all", integrate: "merge", steps: [] } };
+    const loop: Block = { loop: { max: 2, until: { step: "plan" }, body: [step("plan")] } };
+    const orchestrate: Block = {
+      orchestrate: { agent: "a", goal: "g", join: "all", integrate: "none" },
+    };
+    for (const block of [parallel, loop, orchestrate]) {
+      expect(isSequentialSpec(spec([step("plan"), block]))).toBe(false);
+    }
+  });
+});

--- a/src/workflows/run/RunView/flatten.ts
+++ b/src/workflows/run/RunView/flatten.ts
@@ -50,3 +50,20 @@ export function flattenSteps(spec: Spec | null): StepDesc[] {
   walk(spec.workflow, out);
   return out;
 }
+
+/** Whether the run reads as one continuous conversation: a non-empty flat
+ *  sequence of top-level steps, each gated on something a step decides by
+ *  itself. Mirrors the kernel runner's `kernel_eligible` (runner/mod.rs) — the
+ *  shapes it accepts are exactly the ones that hand one step off to the next in
+ *  a single workspace. Anything else (parallel, loop, orchestrate, or a gate
+ *  that suspends the run) keeps the per-step chat.
+ *
+ *  A step with no `gate` defaults to `verdict`, matching serde on the Rust side. */
+export function isSequentialSpec(spec: Spec | null): boolean {
+  if (!spec?.workflow || spec.workflow.length === 0) return false;
+  return spec.workflow.every((block) => {
+    if (!("step" in block)) return false;
+    const gate = block.step.gate?.type ?? "verdict";
+    return gate === "commit" || gate === "verdict";
+  });
+}

--- a/src/workflows/run/RunView/index.tsx
+++ b/src/workflows/run/RunView/index.tsx
@@ -22,11 +22,12 @@ import { resolveAlias } from "../../shared";
 import type { Spec } from "../../spec";
 import { runChip } from "../status";
 import { BudgetMeter, hasBudgets } from "./BudgetMeter";
-import { flattenSteps, type StepDesc } from "./flatten";
+import { flattenSteps, isSequentialSpec, type StepDesc } from "./flatten";
 import { PausedBanner } from "./PausedBanner";
 import { selectPendingQuestion } from "./pendingQuestion";
 import { RoadmapChip } from "./RoadmapChip";
 import { AttemptStrip, latestAttempt, Stepper, stepAttempts } from "./Stepper";
+import { type FocusRequest, ThreadView } from "./ThreadView";
 import { useRunDetail } from "./useRunDetail";
 
 export function RunView({ id }: { id: string }) {
@@ -43,11 +44,17 @@ export function RunView({ id }: { id: string }) {
   // A step the user focused before it has any attempt — shows the "hasn't
   // started" state; cleared the moment the step spawns its first attempt.
   const [pickedStepId, setPickedStepId] = useState<string | null>(null);
+  // An explicit "show me this step" — the thread scrolls to its segment. Carries
+  // a nonce so re-picking the same step scrolls again.
+  const [focus, setFocus] = useState<FocusRequest | null>(null);
 
   const run = detail?.run ?? null;
   const spec = (run?.spec ?? null) as Spec | null;
   const attempts = detail?.attempts ?? [];
   const steps = useMemo(() => flattenSteps(spec), [spec]);
+  // A flat sequence of steps reads as one conversation; anything else keeps the
+  // per-step chat (see ThreadView).
+  const sequential = useMemo(() => isSequentialSpec(spec), [spec]);
 
   // The most recent `run_paused` event — the source of both the paused-reason
   // detail and the exec whose question the human must answer.
@@ -122,6 +129,7 @@ export function RunView({ id }: { id: string }) {
       });
       setPickedAttemptId(latest.id);
       setPickedStepId(null);
+      setFocus((prev) => ({ stepId: latest.step_id, nonce: (prev?.nonce ?? 0) + 1 }));
     }
     clearFocusedStepAgent();
   }, [focusedStepAgentId, attempts, loading, clearFocusedStepAgent]);
@@ -183,6 +191,7 @@ export function RunView({ id }: { id: string }) {
   const selectedStepRows = selected ? stepAttempts(attempts, selected.step_id) : [];
 
   const onSelectStep = (step: StepDesc) => {
+    setFocus((prev) => ({ stepId: step.id, nonce: (prev?.nonce ?? 0) + 1 }));
     const latest = latestAttempt(stepAttempts(attempts, step.id));
     if (latest) {
       setPickedAttemptId(latest.id);
@@ -258,35 +267,53 @@ export function RunView({ id }: { id: string }) {
         question={pendingQuestion}
         evidence={gateEvidence}
         evidencePending={loading}
+        // In thread mode the answer belongs at the bottom, where the user is
+        // already typing — the banner keeps the cause and its other actions.
+        hideAnswer={sequential}
       />
 
-      {/* Attempt history for the focused step — only when there is history. */}
-      {selected && selectedStepRows.length > 1 && (
-        <AttemptStrip
-          stepId={selected.step_id}
-          rows={selectedStepRows}
-          selectedId={selected.id}
-          onSelect={(a) => {
-            setPickedAttemptId(a.id);
-            setPickedStepId(null);
-          }}
+      {sequential ? (
+        <ThreadView
+          run={run}
+          steps={steps}
+          attempts={attempts}
+          agents={agents}
+          events={events}
+          resolve={resolve}
+          question={pendingQuestion}
+          focus={focus}
         />
-      )}
+      ) : (
+        <>
+          {/* Attempt history for the focused step — only when there is history. */}
+          {selected && selectedStepRows.length > 1 && (
+            <AttemptStrip
+              stepId={selected.step_id}
+              rows={selectedStepRows}
+              selectedId={selected.id}
+              onSelect={(a) => {
+                setPickedAttemptId(a.id);
+                setPickedStepId(null);
+              }}
+            />
+          )}
 
-      <div className="wf-run-chat">
-        {selAgent ? (
-          <ChatView agent={selAgent} key={selAgent.id} />
-        ) : (
-          <div className="empty-msg" style={{ margin: "auto", maxWidth: 320 }}>
-            <div className="et">{selected ? "Chat unavailable" : "Step hasn't started"}</div>
-            <div>
-              {selected
-                ? "This attempt's agent is no longer loaded."
-                : "This step begins once the previous one hands off."}
-            </div>
+          <div className="wf-run-chat">
+            {selAgent ? (
+              <ChatView agent={selAgent} key={selAgent.id} />
+            ) : (
+              <div className="empty-msg" style={{ margin: "auto", maxWidth: 320 }}>
+                <div className="et">{selected ? "Chat unavailable" : "Step hasn't started"}</div>
+                <div>
+                  {selected
+                    ? "This attempt's agent is no longer loaded."
+                    : "This step begins once the previous one hands off."}
+                </div>
+              </div>
+            )}
           </div>
-        )}
-      </div>
+        </>
+      )}
     </div>
   );
 }

--- a/src/workflows/workflows.css
+++ b/src/workflows/workflows.css
@@ -2199,3 +2199,181 @@ button.wf-run-rm:hover {
   line-height: 1.4;
   color: var(--fg-2);
 }
+
+/* ── thread view: the run as one continuous conversation ───────────────────
+   Reuses the chat's own layout (.chat / .chat-scroll / .chat-inner) so rows,
+   composer and spacing are identical to a normal agent chat. Only the seams
+   between agents and the named gaps between turns are new — both deliberately
+   quiet, so the conversation stays the loudest thing on screen. */
+.wf-thread {
+  min-width: 0;
+}
+.wf-thread-seg {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+}
+
+/* Hand-off marker — a centered caption on a hairline: who is speaking from
+   here, and where that step sits in the sequence. */
+.wf-handoff {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 18px 0 10px;
+}
+.wf-thread-seg:first-child .wf-handoff {
+  margin-top: 2px;
+}
+.wf-handoff-line {
+  flex: 1;
+  height: 1px;
+  background: color-mix(in oklch, var(--bd-soft) 70%, transparent);
+}
+.wf-handoff-body {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  flex-shrink: 0;
+  max-width: 100%;
+  font-size: var(--fs-xs);
+  color: var(--fg-3);
+}
+.wf-handoff-name {
+  font-weight: 600;
+  color: var(--fg-1);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wf-handoff-sep {
+  opacity: 0.5;
+}
+.wf-handoff-step {
+  font-family: var(--font-mono);
+  color: var(--fg-2);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wf-handoff-idx,
+.wf-handoff-retry,
+.wf-handoff-dur,
+.wf-handoff-state {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--bd-soft);
+  font-size: 10.5px;
+  line-height: 1.5;
+  white-space: nowrap;
+}
+.wf-handoff-dur {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  border-color: transparent;
+  color: var(--fg-3);
+}
+.wf-handoff-retry {
+  border-color: transparent;
+  background: var(--bg-3);
+  color: var(--fg-2);
+}
+/* A segment with no agent record to render — still named, never blank. */
+.wf-thread-gap {
+  padding: 6px 0 10px;
+  font-size: var(--fs-xs);
+  color: var(--fg-3);
+}
+
+/* Phase row — the named gap. Pulse + label + live clock, on the thread's own
+   left edge so it reads as part of the conversation rather than a banner. */
+.wf-phase {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 26px;
+  margin: 10px 0 4px;
+  font-size: 12px;
+  line-height: 1.2;
+  color: var(--fg-2);
+}
+.wf-phase-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.wf-phase-sep {
+  flex-shrink: 0;
+  opacity: 0.4;
+}
+.wf-phase .turn-clock {
+  flex-shrink: 0;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  font-size: 11.5px;
+  letter-spacing: 0.02em;
+  color: var(--accent);
+}
+
+/* The run's last word. Tinted by outcome via --term-tone (set inline from the
+   same tone table the status pill and timeline use). */
+.wf-phase.term {
+  align-items: flex-start;
+  gap: 9px;
+  margin: 16px 0 4px;
+  padding: 10px 12px;
+  border: 1px solid color-mix(in oklch, var(--term-tone) 32%, transparent);
+  border-radius: var(--r-md);
+  background: color-mix(in oklch, var(--term-tone) 7%, transparent);
+}
+.wf-phase-mark {
+  display: inline-flex;
+  margin-top: 1px;
+  color: var(--term-tone);
+}
+.wf-phase-term-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.wf-phase-term-title {
+  font-weight: 600;
+  color: var(--fg-1);
+}
+.wf-phase-term-detail {
+  font-size: var(--fs-xs);
+  line-height: 1.45;
+  color: var(--fg-2);
+  overflow-wrap: anywhere;
+}
+.wf-phase-term-detail.mono {
+  font-family: var(--font-mono);
+}
+.wf-phase-pr {
+  align-self: flex-start;
+  margin-top: 2px;
+}
+
+/* Composer slot when the thread has nobody to talk to, and when it has an
+   answer to collect instead. Both sit in the composer's own padding. */
+.wf-thread-hint {
+  padding: 10px 12px;
+  border: 1px dashed var(--bd-soft);
+  border-radius: var(--r-md);
+  font-size: var(--fs-xs);
+  color: var(--fg-3);
+  text-align: center;
+}
+.wf-thread-answer {
+  padding: 10px 12px;
+  border: 1px solid var(--bd-soft);
+  border-radius: var(--r-md);
+  background: var(--bg-1);
+}
+.wf-thread-answer .wf-answer {
+  margin-top: 0;
+}


### PR DESCRIPTION
Third slice of the workflow kernel rework. **Stacked on #632** (`feat/wf-kernel-runner`) — review only the top commit here. Frontend only; no `src-tauri/` changes.

## Why

The kernel (#632) removed the between-step machinery; this makes the result *visible*. A sequential run now reads like one agent working plan → code → review in a single conversation, instead of per-step chats with blank gaps. Governing rule: **no silent second** — every moment where nothing streams shows a named phase with a live timer.

## What

- **`ThreadView/`** (new, under `RunView/`): step-agent transcripts concatenated in execution order (exec rows, never timestamps) in one scroll; a hand-off marker (step, agent identity, duration) at each switch; retries would appear adjacent and numbered.
- **Phase rows** derived purely from the journal (`phases.ts`): Preparing the workspace… → Starting <agent>… → <agent> is working… → Committing work… (withheld 600 ms so the usually-instant commit doesn't flash) → Pushing the branch… → Opening the pull request…, plus honest terminal rows (done carries branch + PR link; failed shows the journaled reason). Timers anchor to event timestamps, not component mount.
- **One composer**, routed by run state: a paused question outranks the live agent (answers via the existing `wf_answer` flow), a live step agent receives messages through the normal send path, otherwise a quiet hint names the wait.
- **Reuse, not forks**: the transcript row mapping was extracted from `TranscriptList` (`TranscriptRows`) and the composer block from `ChatView` (`ChatComposer`) — both with unchanged behavior for existing surfaces. `useTranscript`/`useLiveBusy` are reused per segment; only the live segment gets live behaviors.
- **Gating** mirrors the kernel's eligibility client-side (`isSequentialSpec`): parallel/loop/orchestrate runs keep the existing per-step UI unchanged. Stepper and PausedBanner render in both modes; clicking a step scrolls to its segment.
- Auto-scroll follows rendered height via one ResizeObserver (segments appending, lazy history landing, phase swaps) with the same bottom-slop behavior as the existing chat. All styling uses existing CSS variables — light and dark both covered.

## Deferred

Turn navigator + ⌘F in thread mode (both assume a single agent's turn list); historic gaps are summarized by the hand-off marker rather than retained phase rows.

## Tests

New pure-logic suites: `flatten.test.ts` (eligibility), `segments.test.ts` (ordering, retries, live selection), `phases.test.ts` (the kernel's full event sequence → phase timeline, terminal states, composer routing). `bun run check`, `bun run lint`, `bun run test`: 98 files / 1049 tests green.