### PR TITLE
chore(workflow): dedup kernel helpers into their shared homes

### DIFF
--- a/docs/workflow-kernel-handoff.md
+++ b/docs/workflow-kernel-handoff.md
@@ -1,0 +1,88 @@
+# Workflow kernel — implementer hand-off
+
+Contract for implementing the layers in [workflow-kernel-layers.md](workflow-kernel-layers.md). Read both before writing code.
+
+## Problem
+
+The original engine (`src-tauri/src/workflow/scheduler/` + `workflow/attempt.rs`) spawns a complete fresh agent per step: new agent record, new git clone, new sandbox container, cold CLI boot, plus a git ferry through an intermediate run repo between steps. Cost: 15–60 s of silent dead air per step boundary, in a UI that shows one step-chat at a time with blank gaps.
+
+## End goal
+
+Deterministic multi-agent workflows with the surface feel of a single agent:
+
+- One shared workspace per run. Hand-off via commits + blackboard files. Step boundary costs one CLI boot.
+- One continuous thread; marker at each agent hand-off.
+- **No silent second**: any moment with nothing streaming shows a named phase + live timer, derived from the journal. A silent gap is a bug, severity = crash.
+- Failures are loud, named, visible in the thread. No state the UI cannot explain.
+
+Robustness lives in the journal, gates, and pinned refs — not in per-step isolation.
+
+## Rules for every layer
+
+1. Success path first; edge cases as later layers. Never build the complicated robust version up front.
+2. Mechanism and user-visible narrative ship in the same PR. A retry the thread doesn't show is a regression with extra code.
+3. One unconditional invariant beats case-by-case handling. Writing a match over failure modes = missing invariant.
+4. Reuse/simplify/rewrite decided per layer: reuse what is simple (comms, budget accounting, gate mechanics, prompt composition), rewrite what exists only to serve removed complexity. Never reuse because it exists; never rewrite because it is old.
+5. Exit checks per layer: (a) step-boundary dead time did not regress; (b) no new state the UI cannot explain. Fail either → simplify or revert before merge.
+6. Cannot handle a case yet → explicit, journaled, visible refusal (pattern: `"kernel runs do not resume yet"`). Never silent or best-effort.
+
+## Existing architecture
+
+Landed as stack: #631 (workspace adoption) → #632 (kernel runner) → #633 (thread UI).
+
+### Kernel — `src-tauri/src/workflow/runner/`
+
+Per run: `gitops::provision_run_repo` (its working tree IS the workspace) → detach at `base_sha`. Per step: create `wf_step_exec` row → spawn agent adopting the workspace (`SpawnReq::existing_workspace`) → stamp `agent_id` on the row before the first event (mounts the chat) → wait idle → `prompts::step_prompt` → wait turn end → gate (`commit` = turn ended; `verdict` = `verdict.json` result `done`, else fail run) → `gitops::boundary_commit` + `pin_step_ref` (no ferry) → mark done → archive → next step. Finalize reused from old engine (workspace is already the repo it pushes from). One guard: 30-min per-step wall timeout. Emits the same event types / exec statuses as the old engine.
+
+Routing: one block in `scheduler/drive.rs::spawn_drive_task`, pure function of the launch-frozen spec — kernel iff every top-level block is `step` and every gate is `commit`/`verdict`. Everything else → old engine, untouched. Old engine is deleted when the parallel layer lands (no remaining tenant).
+
+### Adoption — supervisor/sandbox
+
+`SpawnReq::existing_workspace` → `TrackedRepo::adopted_checkout` (migration 0038). All checkout-path reads go through `TrackedRepo::checkout_path`; no symlinks. Teardown (archive, discard, failed-spawn) spares adopted trees; run-dir removal is the only deleter. Sandbox grants derive from cwd escaping the writable root (seatbelt: writable subpath + `.git/config` deny; containers: RW bind at host path). `git::hardening::refuse_steerable_config` covers `runs_root()` and `checkouts_root()`.
+
+### Thread UI — `src/workflows/run/RunView/ThreadView/`
+
+Gated by `isSequentialSpec` (client mirror of kernel eligibility). Segments = step transcripts in exec-row order — never timestamp-merged. Phase rows derived purely from journal events (`phases.ts`; timers anchored to event `ts`; transient phases withheld 600 ms). Composer routing: paused question > live agent > disabled hint. `TranscriptRows` and `ChatComposer` are extracted seams from the normal chat — extend them, never duplicate transcript reduction. Non-sequential runs keep the per-step UI.
+
+Indicator contract: turn in flight → `ChatWorkingStatus` strip owns the signal; between turns / engine work → phase row owns it. Exactly one indicator at a time. Signals feeding this must be instantaneous ("happening now"), never cumulative ("has ever happened") — cumulative signals kill coverage after the first output.
+
+## Invariants
+
+- **I1** Durable work = pinned refs (`refs/wf/steps/<exec>`) + blackboard files. Nothing else in the workspace is durable.
+- **I2** Every step attempt starts at exactly the predecessor's pinned ref. Retries: `git reset --hard <last-pinned-ref> && git clean -fd` unconditionally before every attempt — no reasoning about how the previous attempt ended.
+- **I3** One live step agent per kernel workspace. Parallelism = git worktrees off the run workspace, never two writers in one tree.
+- **I4** Routing is a pure function of the frozen spec; a run reaches the same runner on every drive (launch/resume/retry/revive).
+- **I5** The journal is the UI's only truth. Mechanisms emit events (reuse existing event types where they fit); UI derives phases/segments from journal + exec rows, never component-local state.
+- **I6** Agents never own the run tree. Agent teardown spares adopted checkouts; only run-dir removal deletes the workspace.
+- **I7** Host-side git in agent-writable trees goes through `git::hardening` (both roots).
+- **I8** The kernel stays readable top-to-bottom. A layer that bloats `runner/` is wrong, not the kernel.
+
+## Layer protocol
+
+Order: retries → tests gate → ask/approval → resume → loops → parallel → budgets → latency polish. One PR each. Before layer 1: dogfood a real plan→code→review run, measure step-boundary dead time, file every unexplained gap; findings outrank ledger order.
+
+Definition of done per layer:
+
+1. Mechanism in its simplest honest form (ledger "Plan" column = intended shape).
+2. Every new run state has a journaled, visible narrative + tests for the pure derivation logic.
+3. Old engine unchanged; routing stays pure. Widening eligibility (e.g. loops) → update `kernel_eligible` and `isSequentialSpec` in the same PR.
+4. `cargo test`, clippy (0 warnings), `bun run check && bun run lint && bun run test` all green.
+5. Ledger updated: layer row plan → fact; new limitations listed honestly.
+
+Layer-specific notes:
+
+- **Retries**: I2 is the mechanism. Narrative: marker "retry N — workspace reset" + journaled cause. Blackboard artifacts survive resets by design.
+- **Tests gate**: stream the run into the timeline (label + elapsed + output tail). Red-run re-prompt must be visible — the old engine's silent second turn is the anti-pattern.
+- **Ask/approval**: reuse `workflow/comms/` (mailbox, routing, pause reasons are execution-agnostic). Thread question routing already exists.
+- **Resume**: relaunch sandbox, `git worktree prune` (once worktrees exist), reset per I2, continue from first step without a `done` exec. Delete the no-resume refusal in the same PR.
+- **Loops**: iterate the body in the same workspace; reuse spec types (`Loop`, `Until`) unchanged.
+- **Parallel**: worktrees share object DB + refs → integration = local merges of pinned refs. Set `gc.auto=0` in the run workspace; `git worktree prune` on resume/cleanup; test with submodules before trusting. Children share the run's single sandbox (worktrees need the main `.git` visible). Then delete the old engine's clone+ferry machinery.
+- **Latency polish**: only with dogfood numbers. Candidates (independently droppable): pre-spawn next CLI for unambiguous straight-line successors only (no prediction, no orphan tracking), session reuse across loop iterations, async archive, run-owned container pooling — read `sandbox/docker/engine/mod.rs` header first (container-per-process-launch is an explicit design decision).
+
+## Hazards
+
+- `provision_codegraph_index` is the only host-side writer into the run tree (idempotent, commit-excluded). Keep it the only one, or remove it.
+- Restore-after-archive clears adoption (restored agent gets its own clone). Preserve when touching restore.
+- Thread mode lacks ⌘F / turn navigator (both assume one agent's turn list). Additive; not load-bearing.
+- Turn-boundary indicator overlap (~100s ms) is a debounce artifact. Cosmetic. Do not fix with cumulative signals (I8's UI counterpart).
+- Global `agent_lifecycle` lock: adoption spawns are light; if parallel children queue visibly on it, narrow the lock — do not pre-spawn around it.

--- a/src-tauri/src/workflow/attempt.rs
+++ b/src-tauri/src/workflow/attempt.rs
@@ -169,16 +169,10 @@ impl AttemptJournal {
         );
     }
 
-    /// Link the live agent to its attempt row and mark the row `running`. This is
-    /// what lets the monitor mount the step's chat (it resolves the agent through
-    /// `wf_step_exec.agent_id`) while the turn is still in flight.
+    /// Link the live agent to its attempt row and mark the row `running` — see
+    /// `scheduler::stamp_spawned` for why.
     fn stamp_spawned(&self, exec_id: &str, agent_id: &str) {
-        let conn = self.db.lock();
-        let _ = conn.execute(
-            "UPDATE wf_step_exec SET agent_id = ?1, status = 'running', started_at = ?2
-             WHERE id = ?3",
-            rusqlite::params![agent_id, super::now_ms(), exec_id],
-        );
+        super::scheduler::stamp_spawned(&self.db.lock(), exec_id, agent_id);
     }
 }
 

--- a/src-tauri/src/workflow/runner/mod.rs
+++ b/src-tauri/src/workflow/runner/mod.rs
@@ -31,13 +31,15 @@ use crate::error::{Error, Result};
 use crate::supervisor::StatusEvent;
 use crate::workspace::AgentStatus;
 
-use super::blackboard::{self, VerdictError, VerdictResult};
+use super::blackboard::{self, VerdictError};
 use super::driver::{AgentDriver, SpawnReq};
+use super::gates::{self, GateInputs, GateOutcome};
 use super::gitops;
 use super::prompts::{self, Position, StepPromptCtx};
 use super::scheduler::{
     abandon_exec, build_spawn_req, cancel_run, create_step_exec, fail_run, finalize_run,
-    finish_step_exec, gate_mode, journal_event, load_run, resolve_agent, set_status, RunCtx,
+    finish_step_exec, gate_mode, journal_event, load_run, resolve_agent, set_status, stamp_spawned,
+    RunCtx,
 };
 use super::spec::{Block, Gate, Spec, Step};
 use super::types::event_type;
@@ -481,38 +483,40 @@ async fn await_turn_end(
     }
 }
 
-/// The gate verdict as `Ok(())` (advance) or `Err(reason)` (fail the run). Pure:
-/// a `commit` gate is decided by the turn having ended, a `verdict` gate by the
-/// file the step wrote.
+/// The gate verdict as `Ok(())` (advance) or `Err(reason)` (fail the run).
+/// The kernel does the I/O (reading the verdict file) and `gates::evaluate`
+/// decides — one source for verdict semantics and reason wording across both
+/// engines. `commit` is the kernel's own semantics: the boundary commit records
+/// whatever the turn produced, including nothing, so the turn ending satisfies
+/// it — unlike the old engine's HEAD-moved predicate.
 fn evaluate_gate(
     gate: &Gate,
     blackboard: &std::path::Path,
     step_id: &str,
 ) -> std::result::Result<(), String> {
     match gate {
-        // The boundary commit records whatever the turn produced, including
-        // nothing; the kernel does not second-guess an agent that says it's done.
         Gate::Commit => Ok(()),
         Gate::Verdict => {
             let dir = blackboard::step_dir(blackboard, step_id)
                 .map_err(|e| format!("blackboard error: {e}"))?;
-            match blackboard::read_verdict(&dir) {
-                Ok(v) if v.result == VerdictResult::Done => Ok(()),
-                Ok(v) => Err(format!(
-                    "verdict.json result is \"{}\"{}",
-                    match v.result {
-                        VerdictResult::Done => "done",
-                        VerdictResult::Revise => "revise",
-                        VerdictResult::Blocked => "blocked",
-                    },
-                    if v.summary.trim().is_empty() {
-                        String::new()
-                    } else {
-                        format!(": {}", v.summary.trim())
-                    }
-                )),
-                Err(VerdictError::Missing) => Err("no verdict.json was written".into()),
-                Err(VerdictError::Malformed(e)) => Err(e),
+            let (verdict, error) = match blackboard::read_verdict(&dir) {
+                Ok(v) => (Some(v), None),
+                Err(VerdictError::Missing) => (None, None),
+                Err(VerdictError::Malformed(e)) => (None, Some(e)),
+            };
+            let result = gates::evaluate(
+                gate,
+                &GateInputs {
+                    verdict: verdict.as_ref(),
+                    verdict_error: error.as_deref(),
+                    ..Default::default()
+                },
+            );
+            match result.outcome {
+                GateOutcome::Done => Ok(()),
+                // A verdict gate never awaits approval; anything unmet fails the
+                // run (the kernel has no retry to spend the reason on yet).
+                _ => Err(result.reason),
             }
         }
         // `kernel_eligible` rejects every other gate before a run starts.
@@ -613,16 +617,6 @@ async fn refuse_resume(ctx: &RunCtx, run_id: &str) {
     }
     let conn = ctx.db.lock();
     fail_run(&conn, ctx.app.as_ref(), run_id, NO_RESUME);
-}
-
-/// Link the live agent to its exec row and mark the row `running` — what lets the
-/// monitor resolve and mount the step's chat mid-turn.
-fn stamp_spawned(conn: &Connection, exec_id: &str, agent_id: &str) {
-    let _ = conn.execute(
-        "UPDATE wf_step_exec SET agent_id = ?1, status = 'running', started_at = ?2
-         WHERE id = ?3",
-        rusqlite::params![agent_id, super::now_ms(), exec_id],
-    );
 }
 
 /// The agent stamped on an exec row, for the paths that lost the handle to the

--- a/src-tauri/src/workflow/runner/tests.rs
+++ b/src-tauri/src/workflow/runner/tests.rs
@@ -521,7 +521,7 @@ async fn a_missing_verdict_fails_the_run() {
 
     let (status, error) = run_status(&fx.db, "run-v3");
     assert_eq!(status, "failed");
-    assert!(error.unwrap().contains("no verdict.json"));
+    assert!(error.unwrap().contains("verdict.json not written"));
 }
 
 // ─────────────────────────── errors, timeout, cancel ─────────────────────────

--- a/src-tauri/src/workflow/scheduler/persistence.rs
+++ b/src-tauri/src/workflow/scheduler/persistence.rs
@@ -159,6 +159,17 @@ pub(crate) fn create_step_exec(
     );
 }
 
+/// Link the live agent to its exec row and mark the row `running`. This is what
+/// lets the monitor mount the step's chat (it resolves the agent through
+/// `wf_step_exec.agent_id`) while the turn is still in flight.
+pub(crate) fn stamp_spawned(conn: &Connection, exec_id: &str, agent_id: &str) {
+    let _ = conn.execute(
+        "UPDATE wf_step_exec SET agent_id = ?1, status = 'running', started_at = ?2
+         WHERE id = ?3",
+        rusqlite::params![agent_id, crate::workflow::now_ms(), exec_id],
+    );
+}
+
 pub(crate) fn finish_step_exec(conn: &Connection, id: &str, status: &str, head_end: Option<&str>) {
     let _ = conn.execute(
         "UPDATE wf_step_exec SET status = ?1, head_end = ?2, ended_at = ?3 WHERE id = ?4",

--- a/src/workflows/run/RunView/Stepper.tsx
+++ b/src/workflows/run/RunView/Stepper.tsx
@@ -232,7 +232,9 @@ function StepCard({
           </div>
         )}
       </div>
-      <div className="wf-nc-foot">Click to open this step's chat</div>
+      {/* Neutral across both run modes: a click opens the step's chat in the
+          per-step view, and scrolls to its segment in the thread view. */}
+      <div className="wf-nc-foot">Click to view this step</div>
     </div>
   );
 }

--- a/src/workflows/run/RunView/ThreadView/useThreadScroll.ts
+++ b/src/workflows/run/RunView/ThreadView/useThreadScroll.ts
@@ -16,8 +16,6 @@ const BOTTOM_SLOP = 40;
 export interface ThreadScroll {
   scrollRef: MutableRefObject<HTMLDivElement | null>;
   innerRef: MutableRefObject<HTMLDivElement | null>;
-  /** True while the thread follows new content; false once the user scrolls up. */
-  pinned: MutableRefObject<boolean>;
   onScroll: () => void;
   /** Re-pin and jump to the bottom (used when the user sends a message). */
   toBottom: () => void;
@@ -58,5 +56,5 @@ export function useThreadScroll(runId: string): ThreadScroll {
     if (el) el.scrollTop = el.scrollHeight;
   };
 
-  return { scrollRef, innerRef, pinned, onScroll, toBottom };
+  return { scrollRef, innerRef, onScroll, toBottom };
 }

--- a/src/workflows/run/RunView/flatten.ts
+++ b/src/workflows/run/RunView/flatten.ts
@@ -6,7 +6,7 @@
 
 import type { Block, Spec, Step } from "../../spec";
 
-export type ContainerKind = "parallel" | "loop" | "orchestrate";
+type ContainerKind = "parallel" | "loop" | "orchestrate";
 
 export interface StepDesc {
   id: string;


### PR DESCRIPTION
## What

Post-kernel cleanup, scoped by an audit of what the kernel stack (#631–#633) actually orphaned. Answer: no dead code yet — the old engine still serves every spec the kernel doesn't claim (mixed blocks, tests/artifact/approval gates, loops, parallel), so nothing old-engine is deleted here. What the kernel *did* introduce is two private copies of logic that already had a shared home; this PR removes the duplication before the layer work builds on it.

## Rust

- **`stamp_spawned`** — the kernel carried a byte-identical copy of `AttemptJournal::stamp_spawned`. Now one definition in `scheduler/persistence.rs` (next to `create_step_exec`/`finish_step_exec`); both engines delegate.
- **Verdict gate** — the kernel's `evaluate_gate` re-implemented verdict semantics that `gates::evaluate` already defines as a pure, tested function. The kernel now does only the I/O (reading `verdict.json`) and hands `gates::evaluate` the facts, so both engines share one source of gate truth and identical failure wording. This also pre-paves the tests-gate layer, which will feed the same module. The `commit` arm is deliberately **not** unified: the kernel's commit gate is satisfied by turn end (the boundary commit captures everything), unlike the old engine's HEAD-moved predicate — the comment now says so.
- One reason string changes user-visibly: a missing verdict now fails with `verdict.json not written yet` (the shared wording) instead of `no verdict.json was written`; test updated.

## Frontend trivia (from the same audit)

- `useThreadScroll` no longer exposes the never-read `pinned` field (still used internally).
- `ContainerKind` in `flatten.ts` un-exported — no external importers.
- Stepper hover-card footer now says "Click to view this step" — the old "open this step's chat" copy was wrong in thread mode, where a click scrolls the thread.

## Explicitly not touched

`gitops::ferry` and the clone-per-step machinery (live for all non-kernel specs), the per-step run UI (only rendering for non-sequential runs), `await_turn_end` (intentionally divergent from `drive_turn` — no watchdogs is the kernel design), and the intentional bottom-pin/live-state duplications documented in-file. The old engine and its UI go away together when the parallel layer lands, per the ledger.

## Verification

`cargo test` 1476 passed, clippy clean (`-D warnings`), fmt clean; `bun run check`/`lint`/`test` green (1049 tests).