### PR TITLE
feat(drafts): remember the new-agent base branch per project

### DIFF
--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -6,7 +6,6 @@ import { type ProjectOption, ProjectPicker } from "@/components/Composer/Project
 import { Icon, LandmarkGlyph } from "@/components/Icon";
 import { PanelToggle } from "@/components/PanelToggle";
 import { IconButton } from "@/components/ui/IconButton";
-import { resolveBaseBranch } from "@/helpers";
 import { getLinearTeamId } from "@/storage/projectSettings";
 import type { DraftAgent } from "@/store";
 import { useAppStore } from "@/store";
@@ -27,6 +26,8 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
   const updateDraft = useAppStore((s) => s.updateDraft);
   const setNewDraftSelection = useAppStore((s) => s.setNewDraftSelection);
   const setLastRepoPath = useAppStore((s) => s.setLastRepoPath);
+  const rememberDraftBase = useAppStore((s) => s.rememberDraftBase);
+  const resolveDraftBase = useAppStore((s) => s.resolveDraftBase);
   const projectRefs = useAppStore((s) => s.workspace?.projects ?? []);
   // One picker entry per project: a multi-repo project shows once, valued at
   // its primary (first) repo, which is where the agent spawns.
@@ -236,8 +237,9 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
                 value={draft.repoPath}
                 projects={projectOptions}
                 onChange={async (repoPath) => {
-                  // Switching projects: the previously chosen base branch may not
-                  // exist in the new repo, so reset to the new repo's *default*
+                  // Switching projects: the previously chosen base branch belongs
+                  // to the old repo and may not exist here, so re-resolve against
+                  // the new one — its own remembered pick, else its *default*
                   // (not a hardcoded "main") — and drop any issue tag, which
                   // belongs to the previous project's tracker (its key would
                   // close the wrong issue, or a dead one, from the new repo's
@@ -248,7 +250,7 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
                   // momentarily pointing at a base from the previous repo — a
                   // spawn in that window would fork from a branch this repo may
                   // not even have. It's a local ref read, not a network call.
-                  const base = await resolveBaseBranch(repoPath);
+                  const base = await resolveDraftBase(repoPath);
                   updateDraft(draft.id, { repoPath, base, issueRef: undefined });
                   setLastRepoPath(repoPath);
                 }}
@@ -256,7 +258,14 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
               <BranchPicker
                 repoPath={draft.repoPath}
                 value={draft.base}
-                onChange={(branch) => updateDraft(draft.id, { base: branch })}
+                onChange={(branch) => {
+                  updateDraft(draft.id, { base: branch });
+                  // Sticky per project: the next new agent here starts on this
+                  // branch. Remembered on pick rather than on spawn, matching
+                  // the provider/model selection above — a draft the user
+                  // abandons still says what they meant to fork from.
+                  rememberDraftBase(draft.repoPath, branch);
+                }}
               />
               <span className="pill is-action" onClick={() => rerollDraftName(draft.id)}>
                 <Icon name="refresh" />

--- a/src/components/Workspace/EmptyWorkspace.tsx
+++ b/src/components/Workspace/EmptyWorkspace.tsx
@@ -28,6 +28,10 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
   const setLastRepoPath = useAppStore((s) => s.setLastRepoPath);
   const rememberDraftBase = useAppStore((s) => s.rememberDraftBase);
   const resolveDraftBase = useAppStore((s) => s.resolveDraftBase);
+  // The project the user picked most recently, so an in-flight base resolve for
+  // a project they've since switched away from can be discarded rather than
+  // applied out of order (see the ProjectPicker's onChange).
+  const pickedRepoPath = useRef<string | null>(null);
   const projectRefs = useAppStore((s) => s.workspace?.projects ?? []);
   // One picker entry per project: a multi-repo project shows once, valued at
   // its primary (first) repo, which is where the agent spawns.
@@ -249,8 +253,15 @@ export function EmptyWorkspace({ draft }: { draft: DraftAgent }) {
                   // Resolved before the switch is applied, so the draft is never
                   // momentarily pointing at a base from the previous repo — a
                   // spawn in that window would fork from a branch this repo may
-                  // not even have. It's a local ref read, not a network call.
+                  // not even have. These are local ref reads, not network calls,
+                  // but they're still subprocesses: switching again while one is
+                  // in flight leaves two resolves racing, and the *earlier* one
+                  // finishing last would strand the draft — and the spawn that
+                  // follows — on the project the user just navigated away from.
+                  // Only the newest selection may commit.
+                  pickedRepoPath.current = repoPath;
                   const base = await resolveDraftBase(repoPath);
+                  if (pickedRepoPath.current !== repoPath) return;
                   updateDraft(draft.id, { repoPath, base, issueRef: undefined });
                   setLastRepoPath(repoPath);
                 }}

--- a/src/helpers/spawn.ts
+++ b/src/helpers/spawn.ts
@@ -17,10 +17,25 @@ import type { AppState } from "../store";
  *  backend then fell back to whatever branch the source repo happened to have
  *  checked out. Every spawn path must pass a base.
  *
+ *  `preferred` is the branch this project's picker last settled on (see the
+ *  drafts slice's sticky base). It wins over the repo default, but only after
+ *  it's confirmed to still exist — a remembered branch that has since been
+ *  deleted or renamed must not become a fork base, and the repo default is the
+ *  right thing to land on when it's gone. A failure to list branches is treated
+ *  the same way: fall back rather than fork from something unverified.
+ *
  *  The backend already degrades to "main" internally, so the catch here only
  *  covers the IPC call itself failing; a base must always come back, because
  *  spawning without one is the bug we're closing. */
-export async function resolveBaseBranch(repoPath: string): Promise<string> {
+export async function resolveBaseBranch(repoPath: string, preferred?: string): Promise<string> {
+  if (preferred) {
+    try {
+      const branches = await api.listRepoBranches(repoPath);
+      if (branches.includes(preferred)) return preferred;
+    } catch {
+      // fall through to the repo default
+    }
+  }
   try {
     return await api.repoDefaultBranch(repoPath);
   } catch {

--- a/src/storage/preferences.ts
+++ b/src/storage/preferences.ts
@@ -142,6 +142,27 @@ export function parseNewDraftSelection(raw: string | undefined): NewDraftSelecti
   }
 }
 
+/** The base branch the new-agent screen's picker last selected, per project
+ *  (keyed by the project's primary repo path — the same value the draft's
+ *  `repoPath` carries). Stored as one JSON object; a corrupt or missing blob
+ *  reads as "nothing remembered", which falls back to each repo's default
+ *  branch. A remembered branch is re-validated against the repo's live branch
+ *  list on use, so one deleted since it was picked never becomes a fork base. */
+export function parseDraftBaseBranches(raw: string | undefined): Record<string, string> {
+  if (!raw) return {};
+  try {
+    const saved = JSON.parse(raw) as unknown;
+    if (!saved || typeof saved !== "object") return {};
+    const out: Record<string, string> = {};
+    for (const [repoPath, branch] of Object.entries(saved as Record<string, unknown>)) {
+      if (typeof branch === "string" && branch.trim()) out[repoPath] = branch;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
 // ---- Mission Control dismissals ----------------------------------------------
 
 /** Mission Control's "dismissed" marks: a review-queue item id → the signature

--- a/src/store/draftBase.test.ts
+++ b/src/store/draftBase.test.ts
@@ -1,0 +1,107 @@
+// The new-agent screen's base-branch picker is sticky per project: once the
+// user picks a branch there, the next agent they start in that project defaults
+// to it instead of the repo's default branch. These pin the store side of that
+// — the remembering, the per-project scoping, and the fallback when the
+// remembered branch no longer exists.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+
+const { allocateDraftName, repoDefaultBranch, listRepoBranches, setSetting } = vi.hoisted(() => ({
+  allocateDraftName: vi.fn(),
+  repoDefaultBranch: vi.fn(),
+  listRepoBranches: vi.fn(),
+  setSetting: vi.fn(),
+}));
+vi.mock("@/api", () => ({ api: { allocateDraftName, repoDefaultBranch, listRepoBranches } }));
+vi.mock("@/storage/settings", () => ({ setSetting }));
+
+import { createDraftsSlice } from "./drafts";
+import type { AppState } from "./types";
+
+const makeStore = () => {
+  const store = create<AppState>()((...a) => ({ ...createDraftsSlice(...a) }) as AppState);
+  store.setState({
+    customAgents: [],
+    modelsByAgent: {},
+    composerDrafts: {},
+    // biome-ignore lint/suspicious/noExplicitAny: partial store seed
+  } as any);
+  return store;
+};
+
+/** The base of the draft `createDraft` just pushed to the front of the list. */
+const newestBase = (store: ReturnType<typeof makeStore>) => store.getState().drafts[0]?.base;
+
+describe("sticky draft base branch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    allocateDraftName.mockResolvedValue("everest");
+    repoDefaultBranch.mockResolvedValue("main");
+    listRepoBranches.mockResolvedValue(["main", "develop"]);
+  });
+
+  it("starts a new draft on the repo default when nothing is remembered", async () => {
+    const store = makeStore();
+    await store.getState().createDraft("/repos/app");
+    expect(newestBase(store)).toBe("main");
+  });
+
+  it("seeds the next draft with the branch last picked for that project", async () => {
+    const store = makeStore();
+    store.getState().rememberDraftBase("/repos/app", "develop");
+
+    await store.getState().createDraft("/repos/app");
+
+    expect(newestBase(store)).toBe("develop");
+    expect(setSetting).toHaveBeenCalledWith("draftBaseBranches", { "/repos/app": "develop" });
+  });
+
+  it("scopes the pick to its project — another project keeps its own default", async () => {
+    const store = makeStore();
+    store.getState().rememberDraftBase("/repos/app", "develop");
+
+    await store.getState().createDraft("/repos/other");
+
+    expect(newestBase(store)).toBe("main");
+  });
+
+  it("falls back to the repo default once the remembered branch is deleted", async () => {
+    const store = makeStore();
+    store.getState().rememberDraftBase("/repos/app", "develop");
+    // "develop" has since been deleted from the repo.
+    listRepoBranches.mockResolvedValue(["main"]);
+
+    await store.getState().createDraft("/repos/app");
+
+    expect(newestBase(store)).toBe("main");
+  });
+
+  it("keeps the remembered pick when a branch is deleted, so a re-created branch resticks", async () => {
+    // Deletion is not a reason to forget the intent — the pick is only ignored
+    // while the branch is missing.
+    const store = makeStore();
+    store.getState().rememberDraftBase("/repos/app", "develop");
+    listRepoBranches.mockResolvedValue(["main"]);
+    await store.getState().createDraft("/repos/app");
+
+    listRepoBranches.mockResolvedValue(["main", "develop"]);
+    await store.getState().createDraft("/repos/app");
+
+    expect(newestBase(store)).toBe("develop");
+  });
+
+  it("re-picking a project's branch replaces the previous pick", async () => {
+    const store = makeStore();
+    store.getState().rememberDraftBase("/repos/app", "develop");
+    store.getState().rememberDraftBase("/repos/app", "release/1.x");
+    expect(store.getState().draftBaseByRepo).toEqual({ "/repos/app": "release/1.x" });
+  });
+
+  it("doesn't re-persist an unchanged pick", () => {
+    const store = makeStore();
+    store.getState().rememberDraftBase("/repos/app", "develop");
+    store.getState().rememberDraftBase("/repos/app", "develop");
+    expect(setSetting).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -56,6 +56,12 @@ export interface DraftsSlice {
   /** The project a new agent was last started in (persisted). Seeds ⌘N's
    *  default project; validated against the live repo list on use. */
   lastRepoPath?: string;
+  /** Sticky base branch per project, keyed by its primary repo path
+   *  (persisted). A project whose agents always fork from `develop` shouldn't
+   *  make the user re-pick it on every new agent. Seeds the new-agent screen's
+   *  branch picker; validated against the repo's live branches on use, so a
+   *  branch deleted since it was picked falls back to the repo default. */
+  draftBaseByRepo: Record<string, string>;
 
   // drafts
   /** Open a new draft on `repoPath`. `seedPrompt` prefills its composer (read
@@ -78,6 +84,14 @@ export interface DraftsSlice {
   startWorkFromIssue: (repoPath: string, issue: import("@/api").TrackerIssue) => Promise<void>;
   /** Remember the last project an agent was started in and persist it. */
   setLastRepoPath: (repoPath: string) => void;
+  /** Remember the base branch picked for a project and persist it, so the next
+   *  new agent there starts on the same branch. */
+  rememberDraftBase: (repoPath: string, branch: string) => void;
+  /** The base branch a new draft on `repoPath` should start on: the project's
+   *  remembered pick when it still exists, else the repo's default branch.
+   *  The single home for that policy — every path that opens or re-targets a
+   *  draft goes through it, so none of them can quietly skip the sticky pick. */
+  resolveDraftBase: (repoPath: string) => Promise<string>;
   updateDraft: (id: string, patch: Partial<DraftAgent>) => void;
   removeDraft: (id: string) => void;
   selectDraft: (id: string | null) => void;
@@ -97,6 +111,7 @@ export interface DraftsSlice {
 
 const NEW_DRAFT_SELECTION_SETTING = "newDraftSelection";
 const LAST_REPO_PATH_SETTING = "lastRepoPath";
+const DRAFT_BASE_BRANCHES_SETTING = "draftBaseBranches";
 
 function normalizeDraftSelection(
   provider: string,
@@ -125,12 +140,23 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
   newDraftModel: undefined,
   newDraftCustomAgentId: undefined,
   lastRepoPath: undefined,
+  draftBaseByRepo: {},
 
   setLastRepoPath: (repoPath) => {
     if (get().lastRepoPath === repoPath) return;
     set({ lastRepoPath: repoPath });
     void setSetting(LAST_REPO_PATH_SETTING, repoPath);
   },
+
+  rememberDraftBase: (repoPath, branch) => {
+    if (!repoPath || !branch) return;
+    if (get().draftBaseByRepo[repoPath] === branch) return;
+    const next = { ...get().draftBaseByRepo, [repoPath]: branch };
+    set({ draftBaseByRepo: next });
+    void setSetting(DRAFT_BASE_BRANCHES_SETTING, next);
+  },
+
+  resolveDraftBase: (repoPath) => resolveBaseBranch(repoPath, get().draftBaseByRepo[repoPath]),
 
   // ── drafts ─────────────────────────────────────────────────────────────────
   createDraft: async (repoPath, seedPrompt, roadmapItemId) => {
@@ -159,7 +185,7 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
       provider: selection.provider,
       model: selection.model,
       customAgentId,
-      base: await resolveBaseBranch(repoPath),
+      base: await get().resolveDraftBase(repoPath),
       roadmapItemId,
     };
     // Seed before the draft is visible, so the composer reads it on mount
@@ -188,7 +214,7 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
       provider: selection.provider,
       model: selection.model,
       customAgentId,
-      base: await resolveBaseBranch(repoPath),
+      base: await get().resolveDraftBase(repoPath),
       issueRef: issue.key,
     };
     // Seed the composer for this draft (read as its initial text on mount) with

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -48,6 +48,7 @@ import { getOrCreateAccount, toProfile } from "@/storage/accounts";
 import {
   DEFAULT_LEFT_WIDTH,
   DEFAULT_RIGHT_WIDTH,
+  parseDraftBaseBranches,
   parseFeatures,
   parseNewDraftSelection,
   parsePaneWidth,
@@ -133,6 +134,7 @@ export const hydrateSettings = async (set: AppSet) => {
       newDraftModel,
       newDraftCustomAgentId,
       lastRepoPath: s.lastRepoPath || undefined,
+      draftBaseByRepo: parseDraftBaseBranches(s.draftBaseBranches),
       // Opt-out: only an explicit "false" hides the native view's rail.
       transcriptRailOpen: s.transcriptRailOpen !== "false",
       gitCommitAction: isCommitAction(s.gitCommitAction) ? s.gitCommitAction : "agent-commit-pr",

--- a/src/store/spawnBase.test.ts
+++ b/src/store/spawnBase.test.ts
@@ -10,12 +10,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "zustand";
 
-const { spawnAgent, getWorkspace, repoDefaultBranch } = vi.hoisted(() => ({
+const { spawnAgent, getWorkspace, repoDefaultBranch, listRepoBranches } = vi.hoisted(() => ({
   spawnAgent: vi.fn(),
   getWorkspace: vi.fn(),
   repoDefaultBranch: vi.fn(),
+  listRepoBranches: vi.fn(),
 }));
-vi.mock("@/api", () => ({ api: { spawnAgent, getWorkspace, repoDefaultBranch } }));
+vi.mock("@/api", () => ({
+  api: { spawnAgent, getWorkspace, repoDefaultBranch, listRepoBranches },
+}));
 vi.mock("@/pty/buffers", () => ({ clearOutputBuffer: vi.fn(), dropAgentPty: vi.fn() }));
 
 import { resolveBaseBranch } from "@/helpers";
@@ -63,5 +66,37 @@ describe("spawn base branch", () => {
   it("resolves the default branch rather than assuming main", async () => {
     repoDefaultBranch.mockResolvedValue("master");
     await expect(resolveBaseBranch("/repos/legacy")).resolves.toBe("master");
+  });
+});
+
+// The new-agent screen's branch picker is sticky per project: a remembered pick
+// seeds the next draft there. It must never outlive the branch itself, so the
+// resolver re-validates it against the repo's live branches before honoring it.
+describe("sticky base branch", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    repoDefaultBranch.mockResolvedValue("main");
+  });
+
+  it("honors a remembered branch that still exists", async () => {
+    listRepoBranches.mockResolvedValue(["main", "develop", "release/1.x"]);
+    await expect(resolveBaseBranch("/repos/app", "develop")).resolves.toBe("develop");
+    expect(repoDefaultBranch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the repo default when the remembered branch was deleted", async () => {
+    listRepoBranches.mockResolvedValue(["main", "release/1.x"]);
+    await expect(resolveBaseBranch("/repos/app", "develop")).resolves.toBe("main");
+  });
+
+  it("falls back rather than forking from an unverified branch", async () => {
+    // Listing branches failed, so "develop" can't be confirmed to exist.
+    listRepoBranches.mockRejectedValue(new Error("not a repo"));
+    await expect(resolveBaseBranch("/repos/app", "develop")).resolves.toBe("main");
+  });
+
+  it("skips the branch listing entirely when nothing is remembered", async () => {
+    await expect(resolveBaseBranch("/repos/app")).resolves.toBe("main");
+    expect(listRepoBranches).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## What

The base branch picker on the new-agent screen is now sticky per project. Once you pick a branch there, the next agent you start in that project defaults to it instead of resetting to the repo's default branch.

## How

- The pick persists under a `draftBaseBranches` setting — a `{ repoPath: branch }` map keyed by the project's primary repo path — hydrated into the store on launch alongside the other sticky new-draft prefs (`newDraftSelection`, `lastRepoPath`).
- `resolveBaseBranch` (`src/helpers/spawn.ts`) gains an optional preferred branch. It only honors it after confirming the branch is still in `listRepoBranches`; if it's gone — or listing fails, so it can't be confirmed — it falls back to the repo default rather than forking from something unverified. The remembered pick is kept either way, so a re-created branch stickies again.
- The policy lives in one store action, `resolveDraftBase(repoPath)`, used by all three paths that set a draft's base: `createDraft` (⌘N, sidebar `+`, Home), `startWorkFromIssue`, and the project switcher on the new-agent screen — so switching projects picks up *that* project's remembered branch, not the previous one's. Pipeline mode inherits it too, since `WorkflowComposer` reads `draft.base`.
- Remembered on pick rather than on spawn, matching how the provider/model selection above it already behaves.

## Scope

Two spawn paths deliberately keep resolving the plain repo default: `spawn()` (`src/store/workspace.ts`) and the Roadmap PM chats (`usePmChats.ts`). Neither has a branch picker, so there is no user pick to be sticky to.

Since the key is the repo path, a project moved to a new path on disk starts fresh rather than carrying its pick over — matching how `lastRepoPath` already behaves.

## Tests

- 4 resolver cases added to `src/store/spawnBase.test.ts`: honoring a live remembered branch, falling back when it was deleted, falling back when listing fails, and skipping the branch listing entirely when nothing is remembered.
- New `src/store/draftBase.test.ts` covering remember-then-seed, per-project scoping, the deleted-branch fallback, that deletion doesn't forget the pick, re-picking, and no redundant persist on an unchanged pick.
- Full suite: 1060 tests across 99 files pass. `tsc --noEmit` and biome clean on the changed files.