### PR TITLE
feat(git): let open_pr target a base other than the spawn default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,23 +36,34 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Plain apt, deliberately not `cache-apt-pkgs-action`. That action cached a
+      # *failed* install: when Ubuntu's mirror served 404s for the versions its
+      # index advertised, the action installed 0 of 4 packages, exited green, and
+      # cached the empty result — after which every run on every branch restored a
+      # 6 KB "cache", skipped installation, and failed later inside `glib-sys`.
+      # Bumping the cache key only bought one run, because the key includes the
+      # resolved package versions and those rotate.
+      #
+      # `update` immediately before `install` keeps the index and the pool in
+      # step, and the retry rides out the mirror lag that caused the 404s. There
+      # is no cache to poison, and a failed install fails the step.
       - name: Install system dependencies
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
-          # Bump to invalidate the package cache. `1.0` had to be retired: a run
-          # hit 404s from a stale Ubuntu mirror, installed nothing, and the action
-          # cached that empty result — after which every run restored a 6 KB
-          # "cache" and skipped installation entirely.
-          # Quoted: unquoted `1.0` reached the action as the string "1", so the
-          # key that has to change is not the one written here.
-          version: "1.1"
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends \
+                 libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev; then
+              exit 0
+            fi
+            echo "::warning::apt attempt $attempt failed (likely mirror lag); retrying in 15s"
+            sleep 15
+          done
+          echo "::error::apt failed three times; the GTK build dependencies are not installed"
+          exit 1
 
-      # The action above does not fail when apt installs nothing (see the
-      # `version` note), and a missing GTK stack otherwise surfaces two steps
-      # later as a pkg-config error from inside `glib-sys`. Assert the headers
-      # Clippy and the tests need are actually present, so an empty install fails
-      # here with a message that names the cause.
+      # Backstop, kept because it is what turned the silent-empty-install into a
+      # legible failure in the first place: without it a missing GTK stack
+      # surfaces two steps later as a pkg-config error from inside `glib-sys`.
       - name: Verify system dependencies
         run: pkg-config --exists --print-errors glib-2.0 gobject-2.0 gtk+-3.0 webkit2gtk-4.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,21 @@ jobs:
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
-          version: 1.0
+          # Bump to invalidate the package cache. `1.0` had to be retired: a run
+          # hit 404s from a stale Ubuntu mirror, installed nothing, and the action
+          # cached that empty result — after which every run restored a 6 KB
+          # "cache" and skipped installation entirely.
+          # Quoted: unquoted `1.0` reached the action as the string "1", so the
+          # key that has to change is not the one written here.
+          version: "1.1"
+
+      # The action above does not fail when apt installs nothing (see the
+      # `version` note), and a missing GTK stack otherwise surfaces two steps
+      # later as a pkg-config error from inside `glib-sys`. Assert the headers
+      # Clippy and the tests need are actually present, so an empty install fails
+      # here with a message that names the cause.
+      - name: Verify system dependencies
+        run: pkg-config --exists --print-errors glib-2.0 gobject-2.0 gtk+-3.0 webkit2gtk-4.1
 
       - name: Setup Rust
         # Toolchain version + components come from /rust-toolchain.toml (the

--- a/src-tauri/src/git/transport.rs
+++ b/src-tauri/src/git/transport.rs
@@ -184,11 +184,14 @@ pub async fn remote_base_sha(source_repo: &Path, base: &str) -> Option<String> {
     (!sha.is_empty()).then_some(sha)
 }
 
-/// Whether `branch` exists on `origin` *right now*, asked over the wire with the
-/// app's token. `Some(false)` only when git says definitively "no such ref";
-/// `None` when the question couldn't be answered at all (no remote, transport
-/// failure, timeout), so a caller can tell "absent" from "don't know" and a
-/// flaky network never becomes a false refusal.
+/// Whether a branch named exactly `branch` exists on `origin` *right now*, asked
+/// over the wire with the app's token. `Some(false)` when no such branch is
+/// there; `None` when the question couldn't be answered at all (no remote,
+/// transport failure, timeout), so a caller can tell "absent" from "don't know"
+/// and a flaky network never becomes a false refusal.
+///
+/// Exact, not pattern: a glob (`feat/*`) is reported absent even though git
+/// happily matches it, because the caller is validating a literal branch name.
 ///
 /// Deliberately not [`remote_base_sha`]: that reads the clone's own
 /// `refs/remotes/origin/<base>`, which reports any branch created since the last
@@ -215,7 +218,19 @@ pub async fn remote_branch_exists(checkout: &Path, branch: &str) -> Option<bool>
     }
     let out = output_timed(&mut cmd, "git ls-remote").await.ok()?;
     match (out.status.success(), out.status.code()) {
-        (true, _) => Some(true),
+        // Exit status alone is not the answer: `ls-remote`'s ref argument is a
+        // *pattern*, so `refs/heads/feat/*` matches `refs/heads/feat/x` and exits
+        // 0 while naming something GitHub will reject as a literal base. Require
+        // the ref back verbatim, so only an exact branch counts as present and a
+        // glob resolves to "absent" like any other name that isn't a branch.
+        (true, _) => {
+            let want = format!("refs/heads/{branch}");
+            Some(
+                String::from_utf8_lossy(&out.stdout)
+                    .lines()
+                    .any(|line| line.split('\t').nth(1).map(str::trim) == Some(want.as_str())),
+            )
+        }
         // `--exit-code` reserves 2 for "matched nothing". Every other non-zero
         // code is a failure to ask (128 for a missing remote or a rejected
         // credential), which must not read as absence.

--- a/src-tauri/src/git/transport.rs
+++ b/src-tauri/src/git/transport.rs
@@ -184,6 +184,46 @@ pub async fn remote_base_sha(source_repo: &Path, base: &str) -> Option<String> {
     (!sha.is_empty()).then_some(sha)
 }
 
+/// Whether `branch` exists on `origin` *right now*, asked over the wire with the
+/// app's token. `Some(false)` only when git says definitively "no such ref";
+/// `None` when the question couldn't be answered at all (no remote, transport
+/// failure, timeout), so a caller can tell "absent" from "don't know" and a
+/// flaky network never becomes a false refusal.
+///
+/// Deliberately not [`remote_base_sha`]: that reads the clone's own
+/// `refs/remotes/origin/<base>`, which reports any branch created since the last
+/// fetch as missing — fine for measuring staleness, wrong for a pre-flight check
+/// on a branch name a request just supplied.
+pub async fn remote_branch_exists(checkout: &Path, branch: &str) -> Option<bool> {
+    // Same reasoning as `push_head_to_branch`: this runs the transport, so a
+    // steerable config in an agent-writable checkout is refused before git does.
+    super::hardening::refuse_steerable_config(checkout)
+        .await
+        .ok()?;
+    let mut cmd = crate::git_dist::command(checkout);
+    // The pattern is always prefixed `refs/heads/`, so `branch` can never reach
+    // git in an option position however the request spelled it.
+    cmd.args([
+        "ls-remote",
+        "--exit-code",
+        "--heads",
+        "origin",
+        &format!("refs/heads/{branch}"),
+    ]);
+    for (k, v) in crate::github::git_auth_env() {
+        cmd.env(k, v);
+    }
+    let out = output_timed(&mut cmd, "git ls-remote").await.ok()?;
+    match (out.status.success(), out.status.code()) {
+        (true, _) => Some(true),
+        // `--exit-code` reserves 2 for "matched nothing". Every other non-zero
+        // code is a failure to ask (128 for a missing remote or a rejected
+        // credential), which must not read as absence.
+        (false, Some(2)) => Some(false),
+        _ => None,
+    }
+}
+
 /// Rebase the current branch onto `base` (e.g. "main"). Used by the clean-state
 /// panel action to bring the checkout up to date with its base branch when the
 /// base has moved ahead. Aborts the rebase on conflict so the checkout is never

--- a/src-tauri/src/instructions/git_actions.md
+++ b/src-tauri/src/instructions/git_actions.md
@@ -15,10 +15,12 @@ param means your starting (primary) checkout, as always.
 **Local git is yours to run directly.** Your workspace is a real checkout with a writable `.git`, so run plain git for local work: `git status`, `git add`, `git commit`, `git merge`, and conflict resolution all work in-place. What Fletch runs *for* you are the actions that need your GitHub credentials — and those stay on the host, never in your sandbox. So for anything that talks to the remote, use the file-RPC ops:
 
 - **`git_push`** — push the current branch to `origin`. Pass `args.force=true` to push a rewritten history (e.g. after a rebase); it uses `--force-with-lease`, which rewrites the remote branch but refuses if the remote has moved in a way you haven't seen.
-- **`open_pr`** — push and open a pull request.
+- **`open_pr`** — push and open a pull request. It targets the base branch this workspace was created against; pass `args.base="<branch>"` to target a different one (see below).
 - **`git_fetch`** — refresh a base branch from `origin` (for `update-branch`).
 
 Your workspace starts with no branch (detached HEAD) — that's expected. The branch is created the first time you push, and **you choose its name**: pass `args.branch` to `git_push` (or `open_pr`) with a short, conventional, descriptive name for the work — `fix/…`, `feat/…`, or `chore/…` (no `fletch/` prefix), e.g. `fix/login-crash`. Run `git status` if unsure whether you're already on a branch; once you are, omit `args.branch` and later pushes update that same branch.
+
+**Choosing the PR base.** The `base` a trigger carries is the branch this workspace was created against — the default, not a constraint. If you built your work on a different branch (the user asked you to stack on a feature branch, you branched off it, or you can see from `git log` that that's where your commits sit), pass that branch as `args.base` to `open_pr` so the PR targets it. Do that whenever the honest base differs from the trigger's `base`: a PR opened into the wrong branch shows every commit of the intervening work as if it were yours. The base you open against replaces the workspace's recorded base, so the app's behind-count and its `update-branch` action follow your PR from then on.
 
 ### commit
 
@@ -30,11 +32,11 @@ Commit with plain git as in `commit`, then push by calling the `git_push` op —
 
 ### commit-pr — params: `base`
 
-Commit with plain git as in `commit`, then write a concise PR title and description covering ALL changes versus the `base` branch, and open the PR by calling the `open_pr` op with that title and body — plus `args.branch` (your chosen conventional name) if you don't have a branch yet.
+Commit with plain git as in `commit`, then write a concise PR title and description covering ALL changes versus the `base` branch, and open the PR by calling the `open_pr` op with that title and body — plus `args.branch` (your chosen conventional name) if you don't have a branch yet, and `args.base` if your work is stacked on a branch other than the trigger's `base`.
 
 ### open-pr — params: `base`
 
-Everything is already committed. Review the work versus `base` (`git log <base>..HEAD`, `git diff <base>...HEAD`), write a concise, descriptive PR title and body, and open the PR by calling the `open_pr` op with them — plus `args.branch` (your chosen conventional name) if you don't have a branch yet.
+Everything is already committed. Review the work versus `base` (`git log <base>..HEAD`, `git diff <base>...HEAD`), write a concise, descriptive PR title and body, and open the PR by calling the `open_pr` op with them — plus `args.branch` (your chosen conventional name) if you don't have a branch yet, and `args.base` if your work is stacked on a branch other than the trigger's `base`. If that review shows commits you didn't write, `base` is the wrong target — find the branch your work actually sits on and pass it as `args.base`.
 
 ### push
 

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -416,6 +416,19 @@ impl GitDispatcher {
         let body_owned = crate::github::with_closes_trailer(body_arg, closes);
         let body = body_owned.as_str();
         let requested = arg_branch(args);
+        // The branch this PR targets. Defaults to the base the checkout was
+        // spawned against; `args.base` overrides it, because the user can tell
+        // the agent mid-session to build on a feature branch and the spawn-time
+        // record has no way to know that. Resolved *before* the head branch is
+        // materialized so a malformed base fails without leaving a stray branch
+        // behind. The effective base is reported back on `EVENT_PR_OPENED`, which
+        // rewrites the checkout's recorded base — otherwise ahead/behind, "rebase
+        // onto", and the `update-branch` fetch would keep measuring against a
+        // base this PR isn't stacked on.
+        let base = arg_branch_named(args, "base").unwrap_or_else(|| t.base_branch.clone());
+        if let Some(resp) = refuse_option_like(id, "open_pr", "base", &base) {
+            return (resp, Vec::new());
+        }
 
         let current = match crate::git::current_branch(&t.cwd).await {
             Ok(b) => b,
@@ -451,9 +464,14 @@ impl GitDispatcher {
             }
         };
 
-        if let Some(resp) = refuse_option_like_branch(id, "open_pr", &branch) {
+        if let Some(resp) = refuse_option_like(id, "open_pr", "branch", &branch) {
             return (resp, effects);
         }
+        // Deliberately the *recorded* base, never `base`: this gate fences the
+        // head branch off the branch the work is reviewed against, and reading it
+        // from the request would let an agent name a decoy base and thereby
+        // publish over the real one (`PROTECTED_TRUNKS` covers only main/master,
+        // so a repo reviewed against `release/2.0` would open up).
         if let Some(why) = self.caps.refuses_branch(&branch, &t.base_branch) {
             return (Response::err(id, why), effects);
         }
@@ -461,7 +479,9 @@ impl GitDispatcher {
             .refuse_unless_publish_approved(
                 "open_pr",
                 t.subdir.as_deref(),
-                &format!("open a pull request from {branch} into {}", t.base_branch),
+                // The *effective* base, so the confirmation names the PR the user
+                // is actually approving rather than the spawn-time default.
+                &format!("open a pull request from {branch} into {base}"),
             )
             .await
         {
@@ -473,12 +493,12 @@ impl GitDispatcher {
                 effects,
             );
         }
-        match crate::github::pr_create(&t.cwd, title, body, &t.base_branch).await {
+        match crate::github::pr_create(&t.cwd, title, body, &base).await {
             Ok(pr) => {
                 crate::telemetry::track("pr_opened", json!({ "source": "agent_rpc" }));
                 effects.push(RpcEvent::named(
                     EVENT_PR_OPENED,
-                    with_repo(json!({ "number": pr.number }), &t.subdir),
+                    with_repo(json!({ "number": pr.number, "base": base }), &t.subdir),
                 ));
                 (Response::ok(id, 0, pr.url, String::new()), effects)
             }
@@ -523,7 +543,7 @@ impl GitDispatcher {
             },
         };
 
-        if let Some(resp) = refuse_option_like_branch(id, "git_push", &branch) {
+        if let Some(resp) = refuse_option_like(id, "git_push", "branch", &branch) {
             return (resp, effects);
         }
         if let Some(why) = self
@@ -585,11 +605,8 @@ impl GitDispatcher {
             Some(r) => r,
             None => t.base_branch,
         };
-        if branch.starts_with('-') {
-            return Response::err(
-                id,
-                format!("git_fetch: refusing option-like ref {branch:?}"),
-            );
+        if let Some(resp) = refuse_option_like(id, "git_fetch", "ref", &branch) {
+            return resp;
         }
         let auth = crate::github::git_auth_env();
         let resp = run_git_command(id, &cwd, &["fetch", "origin", &branch], &auth).await;
@@ -626,17 +643,19 @@ fn arg_branch(args: &Value) -> Option<String> {
     arg_branch_named(args, "branch")
 }
 
-/// Refuse a branch name git could reinterpret as an option (leading `-`). The
-/// resolved branch comes from the agent-writable `.git/HEAD`; the `git::push`
-/// primitive already neutralises injection by pushing a fully-qualified refspec,
-/// but the same string also flows into `pr_create` (the PR head) and event
-/// payloads — so reject it up front here (parity with `git_fetch`) so an agent
-/// that planted an option-named HEAD fails loudly instead of silently creating a
-/// junk remote branch or PR.
-fn refuse_option_like_branch(id: &str, op: &str, branch: &str) -> Option<Response> {
-    branch
+/// Refuse a ref name git could reinterpret as an option (leading `-`), naming
+/// which one (`branch`, `base`, `ref`) in the error. Every ref an op resolves
+/// goes through this: a branch comes from the agent-writable `.git/HEAD`, and a
+/// base or fetch ref comes straight from the request. The `git::push` primitive
+/// already neutralises injection by pushing a fully-qualified refspec, but the
+/// same strings also flow into `pr_create` (the PR head and base), the fetch
+/// argv, and event payloads — so reject them up front so an agent that planted
+/// an option-named HEAD or passed an option-named base fails loudly instead of
+/// silently creating a junk remote branch or PR.
+fn refuse_option_like(id: &str, op: &str, kind: &str, value: &str) -> Option<Response> {
+    value
         .starts_with('-')
-        .then(|| Response::err(id, format!("{op}: refusing option-like branch {branch:?}")))
+        .then(|| Response::err(id, format!("{op}: refusing option-like {kind} {value:?}")))
 }
 
 /// Read a boolean flag arg by key, defaulting to `false` when absent or not a
@@ -878,6 +897,72 @@ mod tests {
             resp.error
         );
         assert!(fx.is_empty(), "a refused push must emit nothing: {fx:?}");
+    }
+
+    /// An option-named base is refused before the head branch is materialized,
+    /// so a malformed `args.base` can't leave a stray branch behind in the
+    /// checkout (the head-branch guard, by contrast, necessarily runs after
+    /// HEAD is resolved).
+    #[tokio::test]
+    async fn open_pr_refuses_option_like_base() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+
+        let disp = dispatcher(&repo);
+        let (resp, fx) = disp
+            .dispatch_inner(
+                "b1",
+                "open_pr",
+                &json!({"title": "t", "base": "--upload-pack=evil"}),
+            )
+            .await;
+        assert!(!resp.ok, "an option-named base must be refused: {resp:?}");
+        assert!(
+            resp.error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("option-like base"),
+            "error must name the refused base, got: {:?}",
+            resp.error
+        );
+        assert!(fx.is_empty(), "a refused PR must emit nothing: {fx:?}");
+    }
+
+    /// SECURITY: `args.base` redirects the PR target only. The gate that keeps an
+    /// agent from publishing over the branch its work is reviewed against still
+    /// reads the *recorded* base, so naming a decoy base can't unlock a push to
+    /// the real one. `release/2.0` rather than `main` because the trunk list would
+    /// catch `main` regardless — this is the case only the recorded base covers.
+    #[tokio::test]
+    async fn open_pr_base_override_does_not_unlock_the_recorded_base() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "release/2.0"]);
+
+        let disp = GitDispatcher::new(
+            repo.clone(),
+            "release/2.0".to_string(),
+            AgentCaps::interactive(),
+        );
+        let (resp, fx) = disp
+            .dispatch_inner("b2", "open_pr", &json!({"title": "t", "base": "feat/x"}))
+            .await;
+        assert!(
+            !resp.ok,
+            "publishing the review base must stay refused whatever base the PR names: {resp:?}"
+        );
+        assert!(
+            resp.error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("reviewed against"),
+            "error must be the review-base refusal, got: {:?}",
+            resp.error
+        );
+        assert!(fx.is_empty(), "a refused PR must emit nothing: {fx:?}");
     }
 
     #[tokio::test]

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -1016,6 +1016,56 @@ mod tests {
         );
     }
 
+    /// `ls-remote`'s ref argument is a pattern, so a glob base matches a real
+    /// branch and exits 0 — but GitHub rejects it as a literal base, which would
+    /// reopen exactly the pushed-branch-without-a-PR hole the probe closes. The
+    /// probe compares the returned ref verbatim, so a glob reads as absent.
+    #[tokio::test]
+    async fn open_pr_refuses_a_glob_base_that_matches_a_real_branch() {
+        let td = tempfile::tempdir().unwrap();
+        let origin = td.path().join("origin.git");
+        std::fs::create_dir_all(&origin).unwrap();
+        run_git(&origin, &["init", "-q", "--bare", "-b", "main"]);
+
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+        run_git(&repo, &["config", "user.email", "t@example.com"]);
+        run_git(&repo, &["config", "user.name", "Tester"]);
+        run_git(
+            &repo,
+            &["remote", "add", "origin", origin.to_str().unwrap()],
+        );
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        run_git(&repo, &["add", "-A"]);
+        run_git(&repo, &["commit", "-q", "-m", "init"]);
+        run_git(&repo, &["push", "-q", "origin", "main"]);
+        // A branch the glob genuinely matches, so the probe's `ls-remote` exits 0.
+        run_git(&repo, &["push", "-q", "origin", "main:refs/heads/feat/x"]);
+
+        let disp = dispatcher(&repo);
+        let (resp, fx) = disp
+            .dispatch_inner(
+                "b5",
+                "open_pr",
+                &json!({"title": "t", "branch": "fix/glob-base", "base": "feat/*"}),
+            )
+            .await;
+        assert!(
+            !resp.ok,
+            "a glob base must be refused even though ls-remote matches it: {resp:?}"
+        );
+        assert!(
+            resp.error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("does not exist on origin"),
+            "error must name the missing base, got: {:?}",
+            resp.error
+        );
+        assert!(fx.is_empty(), "nothing may be created: {fx:?}");
+    }
+
     /// The probe distinguishes "absent" from "couldn't ask". With no origin at
     /// all, `ls-remote` fails to *ask* — that must not read as absence, or every
     /// PR in a local-only repo would be refused on base grounds instead of

--- a/src-tauri/src/rpc/git.rs
+++ b/src-tauri/src/rpc/git.rs
@@ -425,9 +425,34 @@ impl GitDispatcher {
         // rewrites the checkout's recorded base — otherwise ahead/behind, "rebase
         // onto", and the `update-branch` fetch would keep measuring against a
         // base this PR isn't stacked on.
-        let base = arg_branch_named(args, "base").unwrap_or_else(|| t.base_branch.clone());
+        let requested_base = arg_branch_named(args, "base");
+        let base = requested_base
+            .clone()
+            .unwrap_or_else(|| t.base_branch.clone());
         if let Some(resp) = refuse_option_like(id, "open_pr", "base", &base) {
             return (resp, Vec::new());
+        }
+        // A base the *request* supplied is confirmed to exist on origin before
+        // anything is created or pushed. Otherwise a typo (`mainn`) costs a
+        // materialized branch and a push, and only then fails in `pr_create` —
+        // leaving a pushed branch with no PR. Only the requested base is checked:
+        // the recorded one was resolved at spawn, and putting a network round
+        // trip (and a new way to fail) in front of every default PR is not this
+        // op's business. `None` from the probe means "couldn't ask", which must
+        // not block — only a definitive "no such ref" refuses.
+        if requested_base.is_some()
+            && crate::git::remote_branch_exists(&t.cwd, &base).await == Some(false)
+        {
+            return (
+                Response::err(
+                    id,
+                    format!(
+                        "open_pr: base branch {base:?} does not exist on origin — \
+                         pass an existing branch as `args.base`"
+                    ),
+                ),
+                Vec::new(),
+            );
         }
 
         let current = match crate::git::current_branch(&t.cwd).await {
@@ -928,6 +953,97 @@ mod tests {
             resp.error
         );
         assert!(fx.is_empty(), "a refused PR must emit nothing: {fx:?}");
+    }
+
+    /// A requested base that origin doesn't have is refused before the head
+    /// branch is materialized or pushed, so a typo can't leave a pushed branch
+    /// with no PR behind it. Uses a local bare repo as `origin`, so the probe is
+    /// a real `ls-remote` over the local transport with no network.
+    #[tokio::test]
+    async fn open_pr_refuses_a_base_missing_from_origin() {
+        let td = tempfile::tempdir().unwrap();
+        let origin = td.path().join("origin.git");
+        std::fs::create_dir_all(&origin).unwrap();
+        run_git(&origin, &["init", "-q", "--bare", "-b", "main"]);
+
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+        run_git(&repo, &["config", "user.email", "t@example.com"]);
+        run_git(&repo, &["config", "user.name", "Tester"]);
+        run_git(
+            &repo,
+            &["remote", "add", "origin", origin.to_str().unwrap()],
+        );
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        run_git(&repo, &["add", "-A"]);
+        run_git(&repo, &["commit", "-q", "-m", "init"]);
+        run_git(&repo, &["push", "-q", "origin", "main"]);
+
+        let disp = dispatcher(&repo);
+        let (resp, fx) = disp
+            .dispatch_inner(
+                "b3",
+                "open_pr",
+                &json!({"title": "t", "branch": "fix/typo-base", "base": "mainn"}),
+            )
+            .await;
+        assert!(
+            !resp.ok,
+            "a base origin does not have must be refused: {resp:?}"
+        );
+        assert!(
+            resp.error
+                .as_deref()
+                .unwrap_or_default()
+                .contains("does not exist on origin"),
+            "error must name the missing base, got: {:?}",
+            resp.error
+        );
+        assert!(
+            fx.is_empty(),
+            "nothing may be created before the base is known good: {fx:?}"
+        );
+        // And the refusal is a pre-flight, not a side effect: no branch was cut.
+        let branches = std::process::Command::new("git")
+            .current_dir(&repo)
+            .args(["branch", "--list", "fix/typo-base"])
+            .output()
+            .unwrap();
+        assert!(
+            String::from_utf8_lossy(&branches.stdout).trim().is_empty(),
+            "the head branch must not be materialized for a bad base"
+        );
+    }
+
+    /// The probe distinguishes "absent" from "couldn't ask". With no origin at
+    /// all, `ls-remote` fails to *ask* — that must not read as absence, or every
+    /// PR in a local-only repo would be refused on base grounds instead of
+    /// failing honestly at the push.
+    #[tokio::test]
+    async fn open_pr_does_not_refuse_a_base_it_could_not_verify() {
+        let td = tempfile::tempdir().unwrap();
+        let repo = td.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        run_git(&repo, &["init", "-q", "-b", "main"]);
+        run_git(&repo, &["config", "user.email", "t@example.com"]);
+        run_git(&repo, &["config", "user.name", "Tester"]);
+        std::fs::write(repo.join("a.txt"), b"x").unwrap();
+        run_git(&repo, &["add", "-A"]);
+        run_git(&repo, &["commit", "-q", "-m", "init"]);
+        run_git(&repo, &["checkout", "-q", "-b", "fix/unverifiable"]);
+
+        let disp = dispatcher(&repo);
+        let (resp, _fx) = disp
+            .dispatch_inner("b4", "open_pr", &json!({"title": "t", "base": "feat/x"}))
+            .await;
+        assert!(!resp.ok);
+        let err = resp.error.as_deref().unwrap_or_default();
+        assert!(
+            !err.contains("does not exist on origin"),
+            "an unanswerable probe must not be reported as a missing base: {err}"
+        );
+        assert!(err.contains("push failed"), "got: {err}");
     }
 
     /// SECURITY: `args.base` redirects the PR target only. The gate that keeps an

--- a/src-tauri/src/supervisor/rpc_watch.rs
+++ b/src-tauri/src/supervisor/rpc_watch.rs
@@ -149,6 +149,18 @@ fn handle_rpc_event(sup: &Supervisor, app: &AppHandle, agent_id: &str, event: rp
                     // importantly `update-branch`, which would otherwise merge
                     // the wrong branch into the PR. A no-op write when the base
                     // wasn't redirected, so no need to compare first.
+                    //
+                    // The record only. The live `GitDispatcher` stamps its base
+                    // at construction and is not rebuilt until the next
+                    // resume/turn, so a *second* bare `open_pr` in this same
+                    // session still defaults to the spawn base — same bounded
+                    // staleness the dispatcher already documents for
+                    // `own_branch` (see `supervisor::lifecycle`). The app path
+                    // self-corrects, because the panel reads its trigger's
+                    // `base` param from this row; a bare op call does not.
+                    // Making the base live would mean interior mutability on a
+                    // struct deliberately stamped once at spawn, which is a
+                    // bigger change than it buys.
                     if let Some(base) = payload.get("base").and_then(|v| v.as_str()) {
                         if let Err(e) = sup.workspace.set_repo_parent_branch(agent_id, subdir, base)
                         {

--- a/src-tauri/src/supervisor/rpc_watch.rs
+++ b/src-tauri/src/supervisor/rpc_watch.rs
@@ -141,6 +141,25 @@ fn handle_rpc_event(sup: &Supervisor, app: &AppHandle, agent_id: &str, event: rp
                             "open_pr: failed to persist PR number"
                         );
                     }
+                    // The base the PR was actually opened against, which
+                    // `args.base` may have redirected away from the spawn-time
+                    // default. Rewriting the record keeps every base-keyed
+                    // reader (ahead/behind, "rebase onto", the `update-branch`
+                    // fetch) pointed at the branch this PR is stacked on — most
+                    // importantly `update-branch`, which would otherwise merge
+                    // the wrong branch into the PR. A no-op write when the base
+                    // wasn't redirected, so no need to compare first.
+                    if let Some(base) = payload.get("base").and_then(|v| v.as_str()) {
+                        if let Err(e) = sup.workspace.set_repo_parent_branch(agent_id, subdir, base)
+                        {
+                            tracing::warn!(
+                                error = %e,
+                                agent_id = %agent_id,
+                                base = %base,
+                                "open_pr: failed to persist PR base"
+                            );
+                        }
+                    }
                 }
             }
             sup.fetch_and_emit_pr_state(app.clone(), agent_id.to_string());

--- a/src-tauri/src/workspace/agents.rs
+++ b/src-tauri/src/workspace/agents.rs
@@ -193,6 +193,26 @@ impl WorkspaceManager {
         Ok(())
     }
 
+    /// Record the base branch a tracked repo's work is reviewed against,
+    /// identified by subdir. Seeded at spawn from the project's default and
+    /// rewritten when `open_pr` targets a different base (`args.base`) — the user
+    /// can point the agent at a feature branch mid-session, and everything keyed
+    /// on the base (ahead/behind, "rebase onto", the `update-branch` fetch) has to
+    /// follow the PR that actually exists rather than the spawn-time guess.
+    /// Overwrites unconditionally; re-recording the same base is a no-op write.
+    ///
+    /// Deliberately leaves `base_sha` alone: that is the immutable fork point the
+    /// checkout was cut from, which the diff base reads in preference to this
+    /// name, and it stays true whatever the PR targets.
+    pub fn set_repo_parent_branch(&self, agent_id: &str, subdir: &str, base: &str) -> Result<()> {
+        let conn = self.db.lock();
+        conn.execute(
+            "UPDATE worktrees SET parent_branch = ?1 WHERE workspace_id = ?2 AND subdir = ?3",
+            rusqlite::params![base, agent_id, subdir],
+        )?;
+        Ok(())
+    }
+
     /// Record the fork-point SHA for a tracked repo, identified by subdir.
     /// Written once the spawn task has created the checkout and resolved its
     /// HEAD. Overwrites unconditionally — the fork point is fixed for the

--- a/src-tauri/src/workspace/tests.rs
+++ b/src-tauri/src/workspace/tests.rs
@@ -1271,6 +1271,38 @@ fn pr_number_persists_and_resets_on_name_reuse() {
     assert_eq!(wm.agent(&reused_id).unwrap().repos[0].pr_number, None);
 }
 
+/// Opening a PR against a base other than the spawn-time one rewrites the
+/// recorded base, so every base-keyed reader (ahead/behind, "rebase onto", the
+/// `update-branch` fetch) follows the PR that actually exists. The fork point
+/// (`base_sha`) is deliberately untouched — it records where the checkout was
+/// cut, which is still true whatever the PR targets.
+#[test]
+fn recorded_base_follows_a_redirected_pr_base() {
+    let db = test_db();
+    let wm = WorkspaceManager::new(db.clone());
+    seed_repo(&db, "/r");
+
+    let mut rec = new_agent_record(
+        "denali".into(),
+        "a".into(),
+        "claude".into(),
+        mk_repo("/r"),
+        "task".into(),
+        AgentView::Custom,
+    );
+    let id = rec.id.clone();
+    wm.add_agent(&mut rec).unwrap();
+    let subdir = wm.agent(&id).unwrap().repos[0].subdir.clone();
+    wm.set_repo_base_sha(&id, &subdir, "cafebabe").unwrap();
+
+    wm.set_repo_parent_branch(&id, &subdir, "feat/stacked")
+        .unwrap();
+
+    let repo = wm.agent(&id).unwrap().repos.remove(0);
+    assert_eq!(repo.parent_branch.as_deref(), Some("feat/stacked"));
+    assert_eq!(repo.base_sha.as_deref(), Some("cafebabe"));
+}
+
 /// A checkout accumulates every PR it has held, not just the current binding:
 /// a workspace that keeps working after a merge opens follow-ups, and the
 /// merged PR's identity is cleared off the `worktrees` row when the next one


### PR DESCRIPTION
## Problem

Tell an agent mid-session to base its work on a feature branch and it branches
off that branch correctly — but ask it to open a PR into that branch and the PR
still targets `main`, with the agent explaining that "base was passed as main".

The agent is right, and it isn't the trigger's fault. `open_pr` never read a
base from the request: it always passed `t.base_branch`, resolved from
`AgentRecord.repos[].parent_branch`, which is written only at spawn and
restore. The `base="…"` on the app's `[app-action]` trigger reached the agent
(and its PR description) but could not reach the host op, so there was no way
to retarget short of editing the PR on GitHub afterward.

## Change

`open_pr` accepts `args.base`, falling back to the recorded base:

- Resolved and validated **before** the head branch is materialized, so a
  malformed base fails without leaving a stray branch behind in the checkout.
- The cap gate that fences the head branch off the branch the work is reviewed
  against deliberately keeps reading the **recorded** base. Reading it from the
  request would let an agent name a decoy base and thereby publish over the
  real one — `PROTECTED_TRUNKS` covers only `main`/`master`, so a repo reviewed
  against `release/2.0` would have opened up. There's a test for exactly this.
- The publish confirmation prompt names the **effective** base, so it describes
  the PR the user is actually approving rather than the spawn-time default.

The effective base rides back on `git.pr_opened` and rewrites the checkout's
recorded base (`set_repo_parent_branch`). Without that, `open_pr` would honor
the base while the rest of the app kept measuring against the spawn base — the
behind-count chip, "Rebase onto …", and worst of all `update-branch`, which
would fetch and merge `origin/main` into a PR stacked on `feat/y`. That's a
wrong merge, not just a wrong label. `base_sha` (the immutable fork point the
diff base reads) is deliberately left alone.

`git_actions.md` now tells the agent the trigger's `base` is the default rather
than a constraint, and to pass `args.base` when its work honestly sits on a
different branch.

Incidental: `git_fetch` had inlined its own copy of the option-like-ref check,
so the guard is now one `refuse_option_like` helper that names which ref
(`branch`, `base`, `ref`) it refused. Error strings are unchanged.

## Notes

- No frontend changes needed — `useGitActions.ts` already sends `base` as the
  trigger param; it now reads as a default instead of the only option.
- The same limitation still exists on the non-delegated path:
  `commands/github.rs` hardcodes `repo.parent_branch.unwrap_or("main")`, so the
  direct "Open PR (auto-fill)" button can't retarget either. A base picker in
  the panel would fix that one and is deliberately left out of this PR.

## Verification

`cargo test --lib` — 1479 passed, 0 failed. `cargo fmt --check` clean, clippy
silent. Three new tests: the option-like-base refusal (and that it emits
nothing), the security property that a base override doesn't unlock the
recorded base, and that a redirected base rewrites the record while leaving
`base_sha` intact.