### PR TITLE
feat(autopilot): project-level switch, on by default

### DIFF
--- a/src/autopilot.ts
+++ b/src/autopilot.ts
@@ -135,9 +135,11 @@ export type StuckReason =
   /** No evidence arrived within `EVIDENCE_TIMEOUT_MS`. */
   | "no-evidence";
 
-/** Per-checkout autopilot state, keyed by `checkoutKey`. Absent = never enrolled. */
+/** Per-checkout autopilot state, keyed by `checkoutKey`. Absent = the driver has
+ *  not ticked this checkout yet (or its project has autopilot switched off). */
 export interface AutopilotState {
-  /** The user turned it on for this checkout. Off by default, everywhere. */
+  /** Autopilot is tracking this checkout. On by default: the driver enrolls
+   *  every live checkout of a project whose switch is on. */
   enrolled: boolean;
   /** Paused by the user; enrollment is kept so resuming is one click. */
   paused: boolean;

--- a/src/components/ProjectScreen/AutopilotSection.tsx
+++ b/src/components/ProjectScreen/AutopilotSection.tsx
@@ -1,0 +1,32 @@
+import { Toggle } from "@/components/Settings/Toggle";
+import { useAppStore } from "@/store";
+
+/** Project-level autopilot switch. ON by default: every checkout in the project
+ *  gets its PR nursed to mergeable (failing checks, conflicts, review comments)
+ *  without being asked. Reads and writes the store's mirror of
+ *  `project_settings` (`AUTOPILOT_ENABLED_KEY`) so the driver reacts on its next
+ *  tick, with no reload. */
+export function AutopilotSection({ projectId }: { projectId: string }) {
+  const on = useAppStore((s) => !s.autopilotDisabledProjects.includes(projectId));
+  const setProjectAutopilot = useAppStore((s) => s.setProjectAutopilot);
+
+  return (
+    <section className="ps-section">
+      <header className="ps-section-h">
+        <h2 className="ps-section-t text-lg">Autopilot</h2>
+        <p className="ps-section-lead text-sm">
+          When on, every agent in this project keeps its own PR moving: it fixes failing checks,
+          resolves conflicts, updates the branch and answers review comments without being asked,
+          and hands back when it gets stuck. On by default. Pause a single PR from its Git panel.
+        </p>
+      </header>
+
+      <div className="ps-field ps-name-row">
+        <label className="ps-label text-sm" htmlFor="ps-autopilot">
+          Get PRs to mergeable automatically
+        </label>
+        <Toggle value={on} onChange={(next) => setProjectAutopilot(projectId, next)} />
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProjectScreen/AutopilotSection.tsx
+++ b/src/components/ProjectScreen/AutopilotSection.tsx
@@ -7,7 +7,11 @@ import { useAppStore } from "@/store";
  *  `project_settings` (`AUTOPILOT_ENABLED_KEY`) so the driver reacts on its next
  *  tick, with no reload. */
 export function AutopilotSection({ projectId }: { projectId: string }) {
-  const on = useAppStore((s) => !s.autopilotDisabledProjects.includes(projectId));
+  // A null list means the opt-outs never loaded and the driver is off; showing
+  // the toggle as on would misreport that.
+  const on = useAppStore(
+    (s) => s.autopilotDisabledProjects !== null && !s.autopilotDisabledProjects.includes(projectId),
+  );
   const setProjectAutopilot = useAppStore((s) => s.setProjectAutopilot);
 
   return (

--- a/src/components/ProjectScreen/AutopilotSection.tsx
+++ b/src/components/ProjectScreen/AutopilotSection.tsx
@@ -1,18 +1,23 @@
 import { Toggle } from "@/components/Settings/Toggle";
+import { Button } from "@/components/ui/Button";
 import { useAppStore } from "@/store";
+import { autopilotProjectOn } from "@/store/autopilot";
 
 /** Project-level autopilot switch. ON by default: every checkout in the project
  *  gets its PR nursed to mergeable (failing checks, conflicts, review comments)
  *  without being asked. Reads and writes the store's mirror of
  *  `project_settings` (`AUTOPILOT_ENABLED_KEY`) so the driver reacts on its next
- *  tick, with no reload. */
+ *  tick, with no reload.
+ *
+ *  While the opt-outs are unknown (the launch load failed) the switch is
+ *  unavailable rather than shown as something clickable: a click would have
+ *  nothing sound to flip from, and the store refuses it anyway. Retry reloads. */
 export function AutopilotSection({ projectId }: { projectId: string }) {
-  // A null list means the opt-outs never loaded and the driver is off; showing
-  // the toggle as on would misreport that.
-  const on = useAppStore(
-    (s) => s.autopilotDisabledProjects !== null && !s.autopilotDisabledProjects.includes(projectId),
-  );
+  const disabled = useAppStore((s) => s.autopilotDisabledProjects);
   const setProjectAutopilot = useAppStore((s) => s.setProjectAutopilot);
+  const reload = useAppStore((s) => s.loadAutopilotProjects);
+  const unknown = disabled === null;
+  const on = autopilotProjectOn(disabled, projectId);
 
   return (
     <section className="ps-section">
@@ -29,8 +34,25 @@ export function AutopilotSection({ projectId }: { projectId: string }) {
         <label className="ps-label text-sm" htmlFor="ps-autopilot">
           Get PRs to mergeable automatically
         </label>
-        <Toggle value={on} onChange={(next) => setProjectAutopilot(projectId, next)} />
+        <Toggle
+          value={on}
+          disabled={unknown}
+          title={unknown ? "Autopilot settings couldn't be loaded" : undefined}
+          onChange={(next) => setProjectAutopilot(projectId, next)}
+        />
       </div>
+
+      {unknown && (
+        <div className="ps-error text-sm flex-center" style={{ justifyContent: "space-between" }}>
+          <span>
+            Autopilot settings couldn&rsquo;t be loaded, so autopilot is off for every project until
+            they are.
+          </span>
+          <Button variant="outline" size="sm" onClick={() => void reload()}>
+            Retry
+          </Button>
+        </div>
+      )}
     </section>
   );
 }

--- a/src/components/ProjectScreen/index.tsx
+++ b/src/components/ProjectScreen/index.tsx
@@ -5,6 +5,7 @@ import { Loader } from "@/components/ui/Loader";
 import { useAppStore } from "@/store";
 import { basename } from "@/util/format";
 import { Activity } from "./Activity";
+import { AutopilotSection } from "./AutopilotSection";
 import { DeleteSection } from "./DeleteSection";
 import { EnvVarsSection } from "./EnvVarsSection";
 import { GeneralSection } from "./GeneralSection";
@@ -110,6 +111,7 @@ export function ProjectScreen({ repoPath }: { repoPath: string }) {
                 <EnvVarsSection projectId={loaded.projectId} repoPath={repoPath} />
                 <LinearSection projectId={loaded.projectId} />
                 <RoadmapSection projectId={loaded.projectId} />
+                <AutopilotSection projectId={loaded.projectId} />
                 <VerifySection projectId={loaded.projectId} />
                 <DeleteSection projectId={loaded.projectId} projectName={name} />
               </>

--- a/src/components/RightPanel/GitPanel/AutopilotChip.tsx
+++ b/src/components/RightPanel/GitPanel/AutopilotChip.tsx
@@ -1,6 +1,7 @@
 import type { AutopilotState, StuckReason } from "@/autopilot";
 import { Icon } from "@/components/Icon";
 import { useAppStore } from "@/store";
+import { autopilotProjectOn } from "@/store/autopilot";
 import { checkoutKey } from "@/store/git";
 
 // ── Autopilot control + status, per checkout ──────────────────────────────────
@@ -54,10 +55,9 @@ export function AutopilotChip({ agentId, subdir }: { agentId: string; subdir?: s
   const agent = useAppStore((s) => s.workspace?.agents.find((a) => a.id === agentId));
   // Off when the project switched it off — or when the opt-outs never loaded,
   // in which case the driver is not running and the chip must not claim it is.
+  // Same predicate the driver uses, so the two can't disagree.
   const projectOff = useAppStore(
-    (s) =>
-      s.autopilotDisabledProjects === null ||
-      (agent != null && s.autopilotDisabledProjects.includes(agent.project_id)),
+    (s) => agent == null || !autopilotProjectOn(s.autopilotDisabledProjects, agent.project_id),
   );
   const enroll = useAppStore((s) => s.enrollAutopilot);
   const pause = useAppStore((s) => s.pauseAutopilot);

--- a/src/components/RightPanel/GitPanel/AutopilotChip.tsx
+++ b/src/components/RightPanel/GitPanel/AutopilotChip.tsx
@@ -52,8 +52,12 @@ export function AutopilotChip({ agentId, subdir }: { agentId: string; subdir?: s
   const key = checkoutKey(agentId, subdir);
   const state = useAppStore((s) => s.autopilot[key]);
   const agent = useAppStore((s) => s.workspace?.agents.find((a) => a.id === agentId));
+  // Off when the project switched it off — or when the opt-outs never loaded,
+  // in which case the driver is not running and the chip must not claim it is.
   const projectOff = useAppStore(
-    (s) => agent != null && s.autopilotDisabledProjects.includes(agent.project_id),
+    (s) =>
+      s.autopilotDisabledProjects === null ||
+      (agent != null && s.autopilotDisabledProjects.includes(agent.project_id)),
   );
   const enroll = useAppStore((s) => s.enrollAutopilot);
   const pause = useAppStore((s) => s.pauseAutopilot);

--- a/src/components/RightPanel/GitPanel/AutopilotChip.tsx
+++ b/src/components/RightPanel/GitPanel/AutopilotChip.tsx
@@ -5,8 +5,10 @@ import { checkoutKey } from "@/store/git";
 
 // ── Autopilot control + status, per checkout ──────────────────────────────────
 // An unattended loop that spends agent turns has to be visible and stoppable
-// from the surface it acts on, so this is both the switch and the readout. Off is
-// the default everywhere; nothing here starts on its own.
+// from the surface it acts on, so this is both the readout and the pause switch.
+// Autopilot is on by default, per project: turning it OFF is a project-settings
+// decision, so the chip only pauses and resumes this one checkout, and when the
+// project has it off the chip says so and leads to the switch.
 
 /** What the chip says, derived from the stored state. Kept separate from the
  *  component so the phrasing is testable and the render stays dumb. */
@@ -39,7 +41,7 @@ export function stuckLabel(reason: StuckReason): string {
 }
 
 const LABEL: Record<ChipMode, string> = {
-  off: "Autopilot",
+  off: "Autopilot off",
   idle: "Autopilot on",
   working: "Autopilot working…",
   paused: "Autopilot paused",
@@ -49,30 +51,43 @@ const LABEL: Record<ChipMode, string> = {
 export function AutopilotChip({ agentId, subdir }: { agentId: string; subdir?: string }) {
   const key = checkoutKey(agentId, subdir);
   const state = useAppStore((s) => s.autopilot[key]);
+  const agent = useAppStore((s) => s.workspace?.agents.find((a) => a.id === agentId));
+  const projectOff = useAppStore(
+    (s) => agent != null && s.autopilotDisabledProjects.includes(agent.project_id),
+  );
   const enroll = useAppStore((s) => s.enrollAutopilot);
-  const unenroll = useAppStore((s) => s.unenrollAutopilot);
   const pause = useAppStore((s) => s.pauseAutopilot);
   const resume = useAppStore((s) => s.resumeAutopilot);
+  const openProjectScreen = useAppStore((s) => s.openProjectScreen);
 
-  const mode = chipMode(state);
+  // The driver enrolls a checkout on its first tick, so an absent entry for an
+  // enabled project is just "not ticked yet" — read it as on, which it is.
+  const mode: ChipMode = projectOff ? "off" : state ? chipMode(state) : "idle";
   const attempt = state?.cycle?.attempt;
 
-  // Primary click: the least surprising thing for the current mode. Enrolling is
-  // the only action that starts work, and it takes an explicit click every time.
+  // Primary click: the least surprising thing for the current mode. Off is a
+  // project decision, so that click goes to where the switch lives.
   const onClick = () => {
-    if (mode === "off") return enroll(key);
+    if (mode === "off") {
+      const repoPath = agent?.repos[0]?.repo_path;
+      if (repoPath) openProjectScreen(repoPath, "settings");
+      return;
+    }
     if (mode === "stuck" || mode === "paused") return resume(key);
-    return pause(key);
+    // Pausing before the first tick: create the entry so the pause has somewhere
+    // to land (the store ignores transitions on an absent checkout).
+    if (!state) enroll(key);
+    pause(key);
   };
 
   const title =
     mode === "stuck" && state?.stuck
       ? `${stuckLabel(state.stuck.reason)}. Click to let it try again.`
       : mode === "off"
-        ? "Let Fletch fix failing checks on this PR without being asked"
+        ? "Autopilot is off for this project. Click to open project settings."
         : mode === "paused"
           ? "Click to resume"
-          : "Click to pause";
+          : "Fletch fixes failing checks, conflicts and review comments on this PR without being asked. Click to pause.";
 
   return (
     <div className="git-autopilot flex-center">
@@ -85,18 +100,6 @@ export function AutopilotChip({ agentId, subdir }: { agentId: string; subdir?: s
           <span className="ap-attempt">#{attempt}</span>
         )}
       </button>
-      {/* Turning it off entirely is deliberately separate from pausing, so
-       *  "stop for now" can't be mistaken for "forget this checkout". */}
-      {mode !== "off" && (
-        <button
-          type="button"
-          className="ap-off text-xs"
-          onClick={() => unenroll(key)}
-          title="Turn autopilot off for this checkout"
-        >
-          Off
-        </button>
-      )}
     </div>
   );
 }

--- a/src/components/RightPanel/GitPanel/GitPanel.css
+++ b/src/components/RightPanel/GitPanel/GitPanel.css
@@ -1080,8 +1080,9 @@
 
 /* ── Autopilot chip ────────────────────────────────────────────────────────
    Sits in the footer above the action bar, next to the action it automates.
-   Quiet by default (off is the norm) and only takes on colour once it is
-   actually doing something or has stopped needing you. */
+   On is the norm (a project-level default), so idle is stated rather than
+   shouted; the chip only takes on real colour once it is doing something or has
+   stopped needing you. Off means the project switched it off. */
 .git-autopilot {
   gap: 6px;
   padding: 10px 18px 0;
@@ -1135,16 +1136,6 @@
 }
 .ap-attempt {
   opacity: 0.7;
-}
-.ap-off {
-  padding: 3px 6px;
-  border: 0;
-  background: transparent;
-  color: var(--fg-3);
-  cursor: pointer;
-}
-.ap-off:hover {
-  color: var(--fg-1);
 }
 
 /* ── Autopilot history ─────────────────────────────────────────────────────

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -66,6 +66,10 @@
 .sp-toggle[data-on="1"] {
   background: var(--accent);
 }
+.sp-toggle:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
 .sp-toggle i {
   position: absolute;
   top: 2px;

--- a/src/components/Settings/Toggle.tsx
+++ b/src/components/Settings/Toggle.tsx
@@ -1,6 +1,18 @@
 /** Pill switch used by feature/provider rows. CSS-driven — the
- *  `data-on` attribute selects the active state. */
-export function Toggle({ value, onChange }: { value: boolean; onChange: (v: boolean) => void }) {
+ *  `data-on` attribute selects the active state. `disabled` is for a switch
+ *  whose backing value is unknown or read-only right now: it still shows a
+ *  position, but a click must not invent a value. */
+export function Toggle({
+  value,
+  onChange,
+  disabled = false,
+  title,
+}: {
+  value: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+  title?: string;
+}) {
   return (
     <button
       type="button"
@@ -9,6 +21,8 @@ export function Toggle({ value, onChange }: { value: boolean; onChange: (v: bool
       onClick={() => onChange(!value)}
       aria-checked={value}
       role="switch"
+      disabled={disabled}
+      title={title}
     >
       <i />
     </button>

--- a/src/components/Sidebar/autopilotSignal.ts
+++ b/src/components/Sidebar/autopilotSignal.ts
@@ -22,8 +22,9 @@ import {
  *  shown": `stuck` outranks everything because it's the only mode waiting on a
  *  person — a working sibling will resolve itself, an abandoned one won't.
  *  `working` next: it explains motion the user didn't start. `paused` and `idle`
- *  are states the user chose or expects, and `off` is the default everywhere, so
- *  they rank low and (see the sidebar row) render nothing at all. */
+ *  are states the user chose or expects (on is the default, so `idle` is the
+ *  norm), and `off` means the project switched it off — so they rank low and
+ *  (see the sidebar row) render nothing at all. */
 const ATTENTION: Record<ChipMode, number> = {
   off: 0,
   idle: 1,

--- a/src/storage/projectSettings.ts
+++ b/src/storage/projectSettings.ts
@@ -29,6 +29,27 @@ export async function deleteProjectSetting(projectId: string, key: string): Prom
   await dbDelete("project_settings", { project_id: projectId, key });
 }
 
+/** Per-project switch for autopilot (set in Project Settings). Autopilot is ON
+ *  by default for every project, so the row exists only when it has been turned
+ *  off: `"0"` = off, absent = on. Turning it back on deletes the row. */
+export const AUTOPILOT_ENABLED_KEY = "autopilot.enabled";
+
+/** Whether a stored `autopilot.enabled` value means off. Anything other than an
+ *  explicit off reads as on — a loop that is on by default must not switch off
+ *  on a typo. */
+export function autopilotDisabledValue(value: string | undefined): boolean {
+  return value === "0" || value === "false";
+}
+
+/** Ids of every project whose autopilot has been switched off, in one query
+ *  over the settings table (there is one row per project, keyed by project id). */
+export async function loadAutopilotDisabledProjects(): Promise<string[]> {
+  const rows = await dbSelect<ProjectSettingRow>("project_settings", {
+    where: { key: AUTOPILOT_ENABLED_KEY },
+  });
+  return rows.filter((r) => autopilotDisabledValue(r.value)).map((r) => r.project_id);
+}
+
 /** Per-project keys for the Linear integration (set in Project Settings).
  *  The id scopes which team's issues feed the inbox + composer picker; the
  *  name is display-only so the picker renders without a network round-trip. */

--- a/src/store/app.ts
+++ b/src/store/app.ts
@@ -49,7 +49,7 @@ export const createAppSlice: SliceCreator<AppSlice> = (set, get) => ({
     if (get().initialized) return;
     set({ initialized: true });
 
-    await hydrateSettings(set);
+    await hydrateSettings(set, get);
     await hydrateAccount(set);
 
     // Probe installed provider CLIs for real versions + paths (async,

--- a/src/store/autopilot.test.ts
+++ b/src/store/autopilot.test.ts
@@ -5,9 +5,18 @@
 import { describe, expect, it, vi } from "vitest";
 import { create } from "zustand";
 
-// `vi.mock` is hoisted above the module body, so the spy has to be too.
-const { setSetting } = vi.hoisted(() => ({ setSetting: vi.fn() }));
+// `vi.mock` is hoisted above the module body, so the spies have to be too.
+const { setSetting, setProjectSetting, deleteProjectSetting } = vi.hoisted(() => ({
+  setSetting: vi.fn(),
+  setProjectSetting: vi.fn(() => Promise.resolve()),
+  deleteProjectSetting: vi.fn(() => Promise.resolve()),
+}));
 vi.mock("@/storage/settings", () => ({ setSetting }));
+vi.mock("@/storage/projectSettings", () => ({
+  AUTOPILOT_ENABLED_KEY: "autopilot.enabled",
+  setProjectSetting,
+  deleteProjectSetting,
+}));
 
 import { AUTOPILOT_SETTING, createAutopilotSlice, parseAutopilotEnrollment } from "./autopilot";
 import type { AppState } from "./types";
@@ -18,8 +27,34 @@ const report = (outcome: "passed" | "failed") => ({
   checks: [{ name: "test", command: "t", outcome, duration_ms: 1, tail: [] }],
 });
 
+describe("project switch", () => {
+  it("has every project on by default — the disabled list starts empty", () => {
+    expect(makeStore().getState().autopilotDisabledProjects).toEqual([]);
+  });
+
+  it("turning a project off writes the one row that exists; turning it on deletes it", () => {
+    // On is the default, so "on" is the ABSENCE of a row — a project never
+    // touched and a project switched back on look identical in the table.
+    const store = makeStore();
+    store.getState().setProjectAutopilot("p1", false);
+    expect(store.getState().autopilotDisabledProjects).toEqual(["p1"]);
+    expect(setProjectSetting).toHaveBeenLastCalledWith("p1", "autopilot.enabled", "0");
+
+    store.getState().setProjectAutopilot("p1", true);
+    expect(store.getState().autopilotDisabledProjects).toEqual([]);
+    expect(deleteProjectSetting).toHaveBeenLastCalledWith("p1", "autopilot.enabled");
+  });
+
+  it("switching a project off twice records it once", () => {
+    const store = makeStore();
+    store.getState().setProjectAutopilot("p1", false);
+    store.getState().setProjectAutopilot("p1", false);
+    expect(store.getState().autopilotDisabledProjects).toEqual(["p1"]);
+  });
+});
+
 describe("enrollment", () => {
-  it("starts absent — nothing is enrolled by default", () => {
+  it("starts absent — the driver enrolls live checkouts on its first tick", () => {
     expect(makeStore().getState().autopilot).toEqual({});
   });
 
@@ -42,10 +77,23 @@ describe("enrollment", () => {
     store.getState().openAutopilotCycle("a1", "fix-checks", "sig");
     store.getState().pauseAutopilot("a1");
 
-    // The last write is what a reload would read: enrolled + paused, no cycle.
+    // The last write is what a reload would read: paused, no cycle.
     const [key, value] = setSetting.mock.calls.at(-1) ?? [];
     expect(key).toBe(AUTOPILOT_SETTING);
     expect(value).toEqual({ a1: { paused: true } });
+  });
+
+  it("does not persist a checkout that is merely enrolled", () => {
+    // Enrollment is the default and re-derived from live agents every tick, so a
+    // row per checkout would only grow; the paused flag is the one intent worth
+    // keeping. Resuming therefore removes the entry again.
+    const store = makeStore();
+    store.getState().enrollAutopilot("a1");
+    expect(setSetting.mock.calls.at(-1)?.[1]).toEqual({});
+
+    store.getState().pauseAutopilot("a1");
+    store.getState().resumeAutopilot("a1");
+    expect(setSetting.mock.calls.at(-1)?.[1]).toEqual({});
   });
 
   it("pausing drops the in-flight cycle but keeps enrollment", () => {
@@ -101,14 +149,16 @@ describe("enrollment", () => {
     expect(store.getState().autopilot.a1.barren).toEqual([]);
   });
 
-  it("unenrolling forgets the checkout entirely", () => {
+  it("unenrolling forgets the checkout entirely, including its paused flag", () => {
     const store = makeStore();
     store.getState().enrollAutopilot("a1");
     store.getState().enrollAutopilot("a1::web");
+    store.getState().pauseAutopilot("a1");
+    store.getState().pauseAutopilot("a1::web");
     store.getState().unenrollAutopilot("a1");
 
     expect(Object.keys(store.getState().autopilot)).toEqual(["a1::web"]);
-    expect(setSetting.mock.calls.at(-1)?.[1]).toEqual({ "a1::web": { paused: false } });
+    expect(setSetting.mock.calls.at(-1)?.[1]).toEqual({ "a1::web": { paused: true } });
   });
 
   it("ignores transitions for a checkout that was never enrolled", () => {
@@ -215,9 +265,9 @@ describe("parseAutopilotEnrollment", () => {
     });
   });
 
-  it("fails closed on junk or absence — nothing enrolled", () => {
-    // The wrong way to fail is "enroll everything"; a loop that spends agent
-    // turns must default to off.
+  it("yields nothing on junk or absence — the driver re-enrolls live checkouts itself", () => {
+    // A corrupt row must not be able to pause (or un-pause) anything the user
+    // didn't; the only thing lost is the paused set, which the user can redo.
     expect(parseAutopilotEnrollment(undefined)).toEqual({});
     expect(parseAutopilotEnrollment("")).toEqual({});
     expect(parseAutopilotEnrollment("{oops")).toEqual({});

--- a/src/store/autopilot.test.ts
+++ b/src/store/autopilot.test.ts
@@ -28,8 +28,23 @@ const report = (outcome: "passed" | "failed") => ({
 });
 
 describe("project switch", () => {
-  it("has every project on by default — the disabled list starts empty", () => {
-    expect(makeStore().getState().autopilotDisabledProjects).toEqual([]);
+  it("starts with the opt-outs unknown (null), not with everything on", () => {
+    // Until hydration fills the list, the driver must run nothing: on-by-default
+    // without knowing who opted out would act on exactly the wrong projects.
+    expect(makeStore().getState().autopilotDisabledProjects).toBeNull();
+  });
+
+  it("reverts the switch when the durable write fails", async () => {
+    // The row is the truth: a session that shows "off" while the table still
+    // says "on" would quietly resume autopilot on the next launch. Better to
+    // snap the toggle back so the user sees the change didn't take.
+    setProjectSetting.mockRejectedValueOnce(new Error("db locked"));
+    const store = makeStore();
+    store.setState({ autopilotDisabledProjects: [] });
+
+    store.getState().setProjectAutopilot("p1", false);
+    expect(store.getState().autopilotDisabledProjects).toEqual(["p1"]);
+    await vi.waitFor(() => expect(store.getState().autopilotDisabledProjects).toEqual([]));
   });
 
   it("turning a project off writes the one row that exists; turning it on deletes it", () => {

--- a/src/store/autopilot.test.ts
+++ b/src/store/autopilot.test.ts
@@ -2,23 +2,31 @@
 // transitions the driver applies. The pure policy is tested in autopilot.test.ts
 // at the root; this covers the state it reads.
 
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { create } from "zustand";
 
 // `vi.mock` is hoisted above the module body, so the spies have to be too.
-const { setSetting, setProjectSetting, deleteProjectSetting } = vi.hoisted(() => ({
-  setSetting: vi.fn(),
-  setProjectSetting: vi.fn(() => Promise.resolve()),
-  deleteProjectSetting: vi.fn(() => Promise.resolve()),
-}));
+const { setSetting, setProjectSetting, deleteProjectSetting, loadAutopilotDisabledProjects } =
+  vi.hoisted(() => ({
+    setSetting: vi.fn(),
+    setProjectSetting: vi.fn(() => Promise.resolve()),
+    deleteProjectSetting: vi.fn(() => Promise.resolve()),
+    loadAutopilotDisabledProjects: vi.fn(() => Promise.resolve([] as string[])),
+  }));
 vi.mock("@/storage/settings", () => ({ setSetting }));
 vi.mock("@/storage/projectSettings", () => ({
   AUTOPILOT_ENABLED_KEY: "autopilot.enabled",
   setProjectSetting,
   deleteProjectSetting,
+  loadAutopilotDisabledProjects,
 }));
 
-import { AUTOPILOT_SETTING, createAutopilotSlice, parseAutopilotEnrollment } from "./autopilot";
+import {
+  AUTOPILOT_SETTING,
+  autopilotProjectOn,
+  createAutopilotSlice,
+  parseAutopilotEnrollment,
+} from "./autopilot";
 import type { AppState } from "./types";
 
 const makeStore = () =>
@@ -27,11 +35,106 @@ const report = (outcome: "passed" | "failed") => ({
   checks: [{ name: "test", command: "t", outcome, duration_ms: 1, tail: [] }],
 });
 
-describe("project switch", () => {
+/** A write the test releases by hand, to order completions deliberately. */
+const deferred = () => {
+  let resolve!: () => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+// Every test that writes uses its own project id: the per-project write queue
+// and sequence live at module scope, like the writes they order, so a queued
+// write from one test must not be able to trail into the next one's expectations.
+let n = 0;
+const fresh = () => `p${++n}`;
+
+beforeEach(() => {
+  setProjectSetting.mockReset().mockImplementation(() => Promise.resolve());
+  deleteProjectSetting.mockReset().mockImplementation(() => Promise.resolve());
+  loadAutopilotDisabledProjects.mockReset().mockImplementation(() => Promise.resolve([]));
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("autopilotProjectOn", () => {
+  it("is on for every project not listed, and off for a listed one", () => {
+    expect(autopilotProjectOn([], "p1")).toBe(true);
+    expect(autopilotProjectOn(["p1"], "p1")).toBe(false);
+    expect(autopilotProjectOn(["p1"], "p2")).toBe(true);
+  });
+
+  it("is off for EVERY project while the opt-outs are unknown", () => {
+    // The one predicate the driver, the chip and the toggle all share, so
+    // "unknown" fails closed everywhere at once rather than in three places.
+    expect(autopilotProjectOn(null, "p1")).toBe(false);
+  });
+});
+
+describe("project switch: loading", () => {
   it("starts with the opt-outs unknown (null), not with everything on", () => {
     // Until hydration fills the list, the driver must run nothing: on-by-default
     // without knowing who opted out would act on exactly the wrong projects.
     expect(makeStore().getState().autopilotDisabledProjects).toBeNull();
+  });
+
+  it("loads the list, and a failed load leaves it unknown rather than empty", async () => {
+    const store = makeStore();
+    loadAutopilotDisabledProjects.mockRejectedValueOnce(new Error("db not ready"));
+    await store.getState().loadAutopilotProjects();
+    expect(store.getState().autopilotDisabledProjects).toBeNull();
+
+    // The same action is the retry: the settings section calls it again.
+    loadAutopilotDisabledProjects.mockResolvedValueOnce(["p9"]);
+    await store.getState().loadAutopilotProjects();
+    expect(store.getState().autopilotDisabledProjects).toEqual(["p9"]);
+  });
+
+  it("refuses to flip a switch while the opt-outs are unknown", () => {
+    // Applying a click on top of null would invent an empty list and switch
+    // every project on — the exact failure null exists to prevent. The store
+    // enforces it, so no caller (not just the disabled toggle) can do it.
+    const store = makeStore();
+    store.getState().setProjectAutopilot(fresh(), true);
+    expect(store.getState().autopilotDisabledProjects).toBeNull();
+    expect(deleteProjectSetting).not.toHaveBeenCalled();
+    expect(setProjectSetting).not.toHaveBeenCalled();
+  });
+});
+
+describe("project switch: writing", () => {
+  const loaded = () => {
+    const store = makeStore();
+    store.setState({ autopilotDisabledProjects: [] });
+    return store;
+  };
+
+  it("turning a project off writes the one row that exists; turning it on deletes it", async () => {
+    // On is the default, so "on" is the ABSENCE of a row — a project never
+    // touched and a project switched back on look identical in the table.
+    const store = loaded();
+    const p = fresh();
+    store.getState().setProjectAutopilot(p, false);
+    expect(store.getState().autopilotDisabledProjects).toEqual([p]);
+    await vi.waitFor(() =>
+      expect(setProjectSetting).toHaveBeenLastCalledWith(p, "autopilot.enabled", "0"),
+    );
+
+    store.getState().setProjectAutopilot(p, true);
+    expect(store.getState().autopilotDisabledProjects).toEqual([]);
+    await vi.waitFor(() =>
+      expect(deleteProjectSetting).toHaveBeenLastCalledWith(p, "autopilot.enabled"),
+    );
+  });
+
+  it("switching a project off twice records it once", () => {
+    const store = loaded();
+    const p = fresh();
+    store.getState().setProjectAutopilot(p, false);
+    store.getState().setProjectAutopilot(p, false);
+    expect(store.getState().autopilotDisabledProjects).toEqual([p]);
   });
 
   it("reverts the switch when the durable write fails", async () => {
@@ -39,32 +142,75 @@ describe("project switch", () => {
     // says "on" would quietly resume autopilot on the next launch. Better to
     // snap the toggle back so the user sees the change didn't take.
     setProjectSetting.mockRejectedValueOnce(new Error("db locked"));
-    const store = makeStore();
-    store.setState({ autopilotDisabledProjects: [] });
+    const store = loaded();
+    const p = fresh();
 
-    store.getState().setProjectAutopilot("p1", false);
-    expect(store.getState().autopilotDisabledProjects).toEqual(["p1"]);
+    store.getState().setProjectAutopilot(p, false);
+    expect(store.getState().autopilotDisabledProjects).toEqual([p]);
     await vi.waitFor(() => expect(store.getState().autopilotDisabledProjects).toEqual([]));
   });
 
-  it("turning a project off writes the one row that exists; turning it on deletes it", () => {
-    // On is the default, so "on" is the ABSENCE of a row — a project never
-    // touched and a project switched back on look identical in the table.
-    const store = makeStore();
-    store.getState().setProjectAutopilot("p1", false);
-    expect(store.getState().autopilotDisabledProjects).toEqual(["p1"]);
-    expect(setProjectSetting).toHaveBeenLastCalledWith("p1", "autopilot.enabled", "0");
+  it("runs one project's writes in click order, even when the first is slow", async () => {
+    // off (slow) then on (fast): without ordering the delete lands first and the
+    // slow upsert then persists "off" — the opposite of the last click.
+    const slow = deferred();
+    setProjectSetting.mockReturnValueOnce(slow.promise);
+    const store = loaded();
+    const p = fresh();
 
-    store.getState().setProjectAutopilot("p1", true);
+    store.getState().setProjectAutopilot(p, false);
+    store.getState().setProjectAutopilot(p, true);
+    await vi.waitFor(() => expect(setProjectSetting).toHaveBeenCalledTimes(1));
+    expect(deleteProjectSetting).not.toHaveBeenCalled();
+
+    slow.resolve();
+    await vi.waitFor(() => expect(deleteProjectSetting).toHaveBeenCalledTimes(1));
     expect(store.getState().autopilotDisabledProjects).toEqual([]);
-    expect(deleteProjectSetting).toHaveBeenLastCalledWith("p1", "autopilot.enabled");
   });
 
-  it("switching a project off twice records it once", () => {
-    const store = makeStore();
-    store.getState().setProjectAutopilot("p1", false);
-    store.getState().setProjectAutopilot("p1", false);
-    expect(store.getState().autopilotDisabledProjects).toEqual(["p1"]);
+  it("a stale failure does not roll back a later choice", async () => {
+    // off fails slowly while on has already been requested: the user's latest
+    // choice is "on", and the earlier failure must not be allowed to touch it.
+    // Only the latest request for a project may roll back.
+    const slow = deferred();
+    setProjectSetting.mockReturnValueOnce(slow.promise);
+    const store = loaded();
+    const p = fresh();
+
+    store.getState().setProjectAutopilot(p, false); // slow, will fail
+    store.getState().setProjectAutopilot(p, true); // queued behind it
+    expect(store.getState().autopilotDisabledProjects).toEqual([]);
+
+    slow.reject(new Error("db locked"));
+    await vi.waitFor(() => expect(deleteProjectSetting).toHaveBeenCalledTimes(1));
+    expect(store.getState().autopilotDisabledProjects).toEqual([]);
+  });
+
+  it("a failure of the LATEST request does roll back, even behind an earlier success", async () => {
+    // Mirror image: the earlier write succeeds, the latest one fails, so the
+    // store must return to what the earlier write persisted.
+    deleteProjectSetting.mockRejectedValueOnce(new Error("db locked"));
+    const store = loaded();
+    const p = fresh();
+
+    store.getState().setProjectAutopilot(p, false); // succeeds
+    store.getState().setProjectAutopilot(p, true); // fails
+    await vi.waitFor(() => expect(store.getState().autopilotDisabledProjects).toEqual([p]));
+  });
+
+  it("keeps different projects' writes independent", async () => {
+    // Serialization is per project: a slow write for one must not hold up
+    // another's.
+    const slow = deferred();
+    setProjectSetting.mockReturnValueOnce(slow.promise);
+    const store = loaded();
+    const a = fresh();
+    const b = fresh();
+
+    store.getState().setProjectAutopilot(a, false); // slow
+    store.getState().setProjectAutopilot(b, false);
+    await vi.waitFor(() => expect(setProjectSetting).toHaveBeenCalledTimes(2));
+    slow.resolve();
   });
 });
 

--- a/src/store/autopilot.test.ts
+++ b/src/store/autopilot.test.ts
@@ -198,6 +198,48 @@ describe("project switch: writing", () => {
     await vi.waitFor(() => expect(store.getState().autopilotDisabledProjects).toEqual([p]));
   });
 
+  it("rolls back to what the row is KNOWN to hold, not to the click before", async () => {
+    // off fails, then on fails. The inverse of the latest click would be "off",
+    // but neither write changed the row — it still holds the default (on). A
+    // store showing off here would have autopilot resume at the next launch
+    // behind a switch that says otherwise.
+    setProjectSetting.mockRejectedValueOnce(new Error("db locked"));
+    deleteProjectSetting.mockRejectedValueOnce(new Error("db locked"));
+    const store = loaded();
+    const p = fresh();
+
+    store.getState().setProjectAutopilot(p, false); // fails
+    store.getState().setProjectAutopilot(p, true); // fails
+    await vi.waitFor(() => expect(deleteProjectSetting).toHaveBeenCalledTimes(1));
+    await vi.waitFor(() => expect(store.getState().autopilotDisabledProjects).toEqual([]));
+    // And the mirror: on fails, then off fails, from a row that holds off.
+    const q = fresh();
+    store.setState({ autopilotDisabledProjects: [q] });
+    loadAutopilotDisabledProjects.mockResolvedValueOnce([q]);
+    await store.getState().loadAutopilotProjects();
+    deleteProjectSetting.mockRejectedValueOnce(new Error("db locked"));
+    setProjectSetting.mockRejectedValueOnce(new Error("db locked"));
+
+    store.getState().setProjectAutopilot(q, true); // fails
+    store.getState().setProjectAutopilot(q, false); // fails
+    await vi.waitFor(() => expect(setProjectSetting).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() => expect(store.getState().autopilotDisabledProjects).toEqual([q]));
+  });
+
+  it("a load seeds what the row holds, so the first failed write reverts to it", async () => {
+    // The loaded list is the truth as of launch: a project the table says is off
+    // must revert to off when its very first write of the session fails.
+    const store = makeStore();
+    const p = fresh();
+    loadAutopilotDisabledProjects.mockResolvedValueOnce([p]);
+    await store.getState().loadAutopilotProjects();
+    deleteProjectSetting.mockRejectedValueOnce(new Error("db locked"));
+
+    store.getState().setProjectAutopilot(p, true);
+    expect(store.getState().autopilotDisabledProjects).toEqual([]);
+    await vi.waitFor(() => expect(store.getState().autopilotDisabledProjects).toEqual([p]));
+  });
+
   it("keeps different projects' writes independent", async () => {
     // Serialization is per project: a slow write for one must not hold up
     // another's.

--- a/src/store/autopilot.test.ts
+++ b/src/store/autopilot.test.ts
@@ -35,11 +35,11 @@ const report = (outcome: "passed" | "failed") => ({
   checks: [{ name: "test", command: "t", outcome, duration_ms: 1, tail: [] }],
 });
 
-/** A write the test releases by hand, to order completions deliberately. */
-const deferred = () => {
-  let resolve!: () => void;
+/** An async op the test releases by hand, to order completions deliberately. */
+const deferred = <T = void>() => {
+  let resolve!: (v: T) => void;
   let reject!: (e: unknown) => void;
-  const promise = new Promise<void>((res, rej) => {
+  const promise = new Promise<T>((res, rej) => {
     resolve = res;
     reject = rej;
   });
@@ -90,6 +90,50 @@ describe("project switch: loading", () => {
     loadAutopilotDisabledProjects.mockResolvedValueOnce(["p9"]);
     await store.getState().loadAutopilotProjects();
     expect(store.getState().autopilotDisabledProjects).toEqual(["p9"]);
+  });
+
+  it("ignores a load that a later load overtook", async () => {
+    // Startup load is slow; the user hits Retry, which finishes first. The
+    // startup load then completes with an older snapshot and must not replace
+    // the fresher one — or a project the retry saw as off would flip back on.
+    const store = makeStore();
+    const slow = deferred<string[]>();
+    loadAutopilotDisabledProjects.mockReturnValueOnce(slow.promise);
+    const first = store.getState().loadAutopilotProjects();
+
+    loadAutopilotDisabledProjects.mockResolvedValueOnce(["p-off"]);
+    await store.getState().loadAutopilotProjects();
+    expect(store.getState().autopilotDisabledProjects).toEqual(["p-off"]);
+
+    slow.resolve([]);
+    await first;
+    expect(store.getState().autopilotDisabledProjects).toEqual(["p-off"]);
+  });
+
+  it("ignores a load that a click overtook, in the store AND in the known row values", async () => {
+    // Loaded, then a load is in flight (Retry) when the user opts a project out
+    // and the write succeeds. The load's snapshot predates that opt-out: landing
+    // it would show the project on, run autopilot on it, and make a later failed
+    // write roll back to "on" — the wrong row value.
+    const store = makeStore();
+    const p = fresh();
+    loadAutopilotDisabledProjects.mockResolvedValueOnce([]);
+    await store.getState().loadAutopilotProjects();
+
+    const slow = deferred<string[]>();
+    loadAutopilotDisabledProjects.mockReturnValueOnce(slow.promise);
+    const stale = store.getState().loadAutopilotProjects();
+
+    store.getState().setProjectAutopilot(p, false);
+    await vi.waitFor(() => expect(setProjectSetting).toHaveBeenCalledTimes(1));
+    slow.resolve([]); // snapshot from before the opt-out
+    await stale;
+    expect(store.getState().autopilotDisabledProjects).toEqual([p]);
+
+    // The known row value survived too: a failed "on" now reverts to off.
+    deleteProjectSetting.mockRejectedValueOnce(new Error("db locked"));
+    store.getState().setProjectAutopilot(p, true);
+    await vi.waitFor(() => expect(store.getState().autopilotDisabledProjects).toEqual([p]));
   });
 
   it("refuses to flip a switch while the opt-outs are unknown", () => {

--- a/src/store/autopilot.ts
+++ b/src/store/autopilot.ts
@@ -20,9 +20,11 @@ import type { DelegationKind } from "@/delegation";
 import {
   AUTOPILOT_ENABLED_KEY,
   deleteProjectSetting,
+  loadAutopilotDisabledProjects,
   setProjectSetting,
 } from "@/storage/projectSettings";
 import { setSetting } from "@/storage/settings";
+import { createKeyedQueue } from "@/util/keyedQueue";
 import type { SliceCreator } from "./types";
 
 /** Settings key holding the persisted per-checkout intent (paused checkouts). */
@@ -32,6 +34,26 @@ export const AUTOPILOT_SETTING = "autopilotEnrollment";
 interface PersistedEnrollment {
   paused: boolean;
 }
+
+/** The one answer to "is autopilot on for this project?", shared by the driver,
+ *  the Git panel chip and the settings toggle so they can never disagree.
+ *
+ *  `disabled === null` means the opt-outs are unknown (not loaded, or the load
+ *  failed) and the answer is NO for every project: a loop that is on by default
+ *  must fail closed when it cannot tell who opted out. */
+export function autopilotProjectOn(disabled: readonly string[] | null, projectId: string): boolean {
+  return disabled !== null && !disabled.includes(projectId);
+}
+
+/** Project-switch writes, serialized per project. Two quick clicks on one toggle
+ *  are two writes to the same row; without ordering, the slower first write can
+ *  land after the faster second and persist the opposite of the last click. */
+const switchWrites = createKeyedQueue();
+
+/** The newest switch request per project. A failed write may only roll the
+ *  store back if it is still the latest request for its project — a stale
+ *  rollback would otherwise replace a later choice that succeeded. */
+const switchSeq = new Map<string, number>();
 
 export interface AutopilotSlice {
   /** Per-checkout autopilot state, keyed by `checkoutKey`. Absent = the driver
@@ -56,7 +78,15 @@ export interface AutopilotSlice {
    *  be judged by a report produced for it. */
   autopilotVerdicts: Record<string, VerificationReport>;
 
-  /** Flip a project's autopilot switch and persist it to `project_settings`. */
+  /** Load (or reload) the opt-out list from `project_settings`. Called at
+   *  launch by `hydrateSettings`, and again by the settings section's retry when
+   *  the launch load failed. Leaves the list untouched on failure, so a failed
+   *  reload can never turn "unknown" into "everything on". */
+  loadAutopilotProjects: () => Promise<void>;
+  /** Flip a project's autopilot switch and persist it to `project_settings`.
+   *  Optimistic, serialized per project, and rolled back if the write fails
+   *  while it is still the latest request. A no-op while the opt-outs are
+   *  unknown: there is nothing sound to flip from. */
   setProjectAutopilot: (projectId: string, enabled: boolean) => void;
 
   /** Start tracking a checkout (the driver does this for every live checkout of
@@ -156,29 +186,54 @@ const clearVerdict = (verdicts: Record<string, VerificationReport>, key: string)
   return rest;
 };
 
-export const createAutopilotSlice: SliceCreator<AutopilotSlice> = (set) => ({
+export const createAutopilotSlice: SliceCreator<AutopilotSlice> = (set, get) => ({
   autopilot: {},
   autopilotVerdicts: {},
   autopilotDisabledProjects: null,
 
+  loadAutopilotProjects: async () => {
+    try {
+      set({ autopilotDisabledProjects: await loadAutopilotDisabledProjects() });
+    } catch (e) {
+      // Stay (or become) unknown rather than defaulting to "all on" — see
+      // `autopilotProjectOn`. Loud, since it silences a whole feature.
+      console.error("load autopilot opt-outs failed — autopilot stays off until it loads", e);
+    }
+  },
+
   setProjectAutopilot: (projectId, enabled) => {
+    // Unknown opt-outs: refuse. Applying a click on top of null would invent an
+    // empty list and switch every project on — the exact failure the null exists
+    // to prevent. The section disables its toggle for the same reason; this is
+    // the store making sure no other caller can do it either.
+    if (get().autopilotDisabledProjects === null) return;
+
     const apply = (on: boolean) =>
       set((s) => {
-        const rest = (s.autopilotDisabledProjects ?? []).filter((id) => id !== projectId);
+        // Guarded above, but a reload could race in between; never fabricate.
+        if (s.autopilotDisabledProjects === null) return s;
+        const rest = s.autopilotDisabledProjects.filter((id) => id !== projectId);
         return { autopilotDisabledProjects: on ? rest : [...rest, projectId] };
       });
+    const seq = (switchSeq.get(projectId) ?? 0) + 1;
+    switchSeq.set(projectId, seq);
+
     // Optimistic, so the toggle answers immediately — but the durable row is the
-    // truth. If the write fails, revert, or the session would run with a switch
-    // the next launch has never heard of (an "off" that comes back on).
+    // truth. Writes for one project run in click order (`switchWrites`), so the
+    // last click is what the row ends up saying; and a failure rolls back only
+    // if no later click has superseded it.
     apply(enabled);
-    // On is the default, so "on" means no row at all.
-    const write = enabled
-      ? deleteProjectSetting(projectId, AUTOPILOT_ENABLED_KEY)
-      : setProjectSetting(projectId, AUTOPILOT_ENABLED_KEY, "0");
-    write.catch((e) => {
-      console.error("save autopilot.enabled failed", e);
-      apply(!enabled);
-    });
+    switchWrites
+      .run(projectId, () =>
+        // On is the default, so "on" means no row at all.
+        enabled
+          ? deleteProjectSetting(projectId, AUTOPILOT_ENABLED_KEY)
+          : setProjectSetting(projectId, AUTOPILOT_ENABLED_KEY, "0"),
+      )
+      .catch((e) => {
+        console.error("save autopilot.enabled failed", e);
+        if (switchSeq.get(projectId) === seq) apply(!enabled);
+      });
   },
 
   enrollAutopilot: (key) => {

--- a/src/store/autopilot.ts
+++ b/src/store/autopilot.ts
@@ -65,6 +65,14 @@ const switchSeq = new Map<string, number>();
  *  behind a switch that says otherwise. */
 const durableOff = new Set<string>();
 
+/** Generation of the opt-out state. Bumped by every load START and every
+ *  switch click; a load applies its snapshot only if the generation is still
+ *  the one it began in. That drops a load that a later load (Retry during a slow
+ *  startup load) or a click (an opt-out persisted while a load was in flight)
+ *  has overtaken — either would otherwise replace the newer truth with an older
+ *  snapshot, in both the store and `durableOff`. */
+let optOutsGen = 0;
+
 export interface AutopilotSlice {
   /** Per-checkout autopilot state, keyed by `checkoutKey`. Absent = the driver
    *  hasn't ticked this checkout yet (or its project has autopilot off). */
@@ -202,8 +210,12 @@ export const createAutopilotSlice: SliceCreator<AutopilotSlice> = (set, get) => 
   autopilotDisabledProjects: null,
 
   loadAutopilotProjects: async () => {
+    const gen = ++optOutsGen;
     try {
       const disabled = await loadAutopilotDisabledProjects();
+      // Overtaken while in flight — this snapshot is already stale. Whatever
+      // overtook it (a newer load, a click) owns the state now.
+      if (gen !== optOutsGen) return;
       // A load is the truth as of now: it resets what we believe the table holds.
       durableOff.clear();
       for (const id of disabled) durableOff.add(id);
@@ -221,6 +233,9 @@ export const createAutopilotSlice: SliceCreator<AutopilotSlice> = (set, get) => 
     // to prevent. The section disables its toggle for the same reason; this is
     // the store making sure no other caller can do it either.
     if (get().autopilotDisabledProjects === null) return;
+    // A click is newer than any load still in flight; that load must not land
+    // on top of it (see `optOutsGen`).
+    optOutsGen++;
 
     const apply = (on: boolean) =>
       set((s) => {

--- a/src/store/autopilot.ts
+++ b/src/store/autopilot.ts
@@ -39,8 +39,13 @@ export interface AutopilotSlice {
   autopilot: Record<string, AutopilotState>;
   /** Projects whose autopilot switch is off (`project_id`s). Every other project
    *  is on — that is the default. Hydrated from `project_settings` at launch and
-   *  kept in sync by `setProjectAutopilot`. */
-  autopilotDisabledProjects: string[];
+   *  kept in sync by `setProjectAutopilot`.
+   *
+   *  `null` until that load succeeds. The driver treats null as "run nothing":
+   *  a loop that is on by default must fail CLOSED when it cannot tell which
+   *  projects opted out, or a startup hiccup would spend agent turns on exactly
+   *  the projects the user switched off. */
+  autopilotDisabledProjects: string[] | null;
   /** Local verification autopilot ran to judge the CURRENT cycle, keyed by
    *  `checkoutKey`.
    *
@@ -154,18 +159,26 @@ const clearVerdict = (verdicts: Record<string, VerificationReport>, key: string)
 export const createAutopilotSlice: SliceCreator<AutopilotSlice> = (set) => ({
   autopilot: {},
   autopilotVerdicts: {},
-  autopilotDisabledProjects: [],
+  autopilotDisabledProjects: null,
 
   setProjectAutopilot: (projectId, enabled) => {
-    set((s) => {
-      const rest = s.autopilotDisabledProjects.filter((id) => id !== projectId);
-      return { autopilotDisabledProjects: enabled ? rest : [...rest, projectId] };
-    });
+    const apply = (on: boolean) =>
+      set((s) => {
+        const rest = (s.autopilotDisabledProjects ?? []).filter((id) => id !== projectId);
+        return { autopilotDisabledProjects: on ? rest : [...rest, projectId] };
+      });
+    // Optimistic, so the toggle answers immediately — but the durable row is the
+    // truth. If the write fails, revert, or the session would run with a switch
+    // the next launch has never heard of (an "off" that comes back on).
+    apply(enabled);
     // On is the default, so "on" means no row at all.
     const write = enabled
       ? deleteProjectSetting(projectId, AUTOPILOT_ENABLED_KEY)
       : setProjectSetting(projectId, AUTOPILOT_ENABLED_KEY, "0");
-    write.catch((e) => console.error("save autopilot.enabled failed", e));
+    write.catch((e) => {
+      console.error("save autopilot.enabled failed", e);
+      apply(!enabled);
+    });
   },
 
   enrollAutopilot: (key) => {

--- a/src/store/autopilot.ts
+++ b/src/store/autopilot.ts
@@ -55,6 +55,16 @@ const switchWrites = createKeyedQueue();
  *  rollback would otherwise replace a later choice that succeeded. */
 const switchSeq = new Map<string, number>();
 
+/** Projects whose row is KNOWN to say off — what the table holds as last
+ *  confirmed, seeded by a load and advanced only by a write that succeeded.
+ *
+ *  This, not the inverse of the failed click, is what a rollback restores. The
+ *  inverse would assume the click before it persisted; if two clicks in a row
+ *  fail (off, then on), the inverse of "on" would show off while the row still
+ *  holds the default — and autopilot would come back on at the next launch
+ *  behind a switch that says otherwise. */
+const durableOff = new Set<string>();
+
 export interface AutopilotSlice {
   /** Per-checkout autopilot state, keyed by `checkoutKey`. Absent = the driver
    *  hasn't ticked this checkout yet (or its project has autopilot off). */
@@ -193,7 +203,11 @@ export const createAutopilotSlice: SliceCreator<AutopilotSlice> = (set, get) => 
 
   loadAutopilotProjects: async () => {
     try {
-      set({ autopilotDisabledProjects: await loadAutopilotDisabledProjects() });
+      const disabled = await loadAutopilotDisabledProjects();
+      // A load is the truth as of now: it resets what we believe the table holds.
+      durableOff.clear();
+      for (const id of disabled) durableOff.add(id);
+      set({ autopilotDisabledProjects: disabled });
     } catch (e) {
       // Stay (or become) unknown rather than defaulting to "all on" — see
       // `autopilotProjectOn`. Loud, since it silences a whole feature.
@@ -220,7 +234,8 @@ export const createAutopilotSlice: SliceCreator<AutopilotSlice> = (set, get) => 
 
     // Optimistic, so the toggle answers immediately — but the durable row is the
     // truth. Writes for one project run in click order (`switchWrites`), so the
-    // last click is what the row ends up saying; and a failure rolls back only
+    // last click is what the row ends up saying. A success advances what we know
+    // the row holds; a failure rolls the store back to exactly that — and only
     // if no later click has superseded it.
     apply(enabled);
     switchWrites
@@ -230,10 +245,16 @@ export const createAutopilotSlice: SliceCreator<AutopilotSlice> = (set, get) => 
           ? deleteProjectSetting(projectId, AUTOPILOT_ENABLED_KEY)
           : setProjectSetting(projectId, AUTOPILOT_ENABLED_KEY, "0"),
       )
-      .catch((e) => {
-        console.error("save autopilot.enabled failed", e);
-        if (switchSeq.get(projectId) === seq) apply(!enabled);
-      });
+      .then(
+        () => {
+          if (enabled) durableOff.delete(projectId);
+          else durableOff.add(projectId);
+        },
+        (e) => {
+          console.error("save autopilot.enabled failed", e);
+          if (switchSeq.get(projectId) === seq) apply(!durableOff.has(projectId));
+        },
+      );
   },
 
   enrollAutopilot: (key) => {

--- a/src/store/autopilot.ts
+++ b/src/store/autopilot.ts
@@ -2,20 +2,30 @@
 // (pure); this slice is the state it reads and the transitions the driver
 // (`autopilotSync`) applies to it.
 //
-// Enrollment is persisted, deliberately: a loop the user switched on should
-// survive a reload rather than quietly stopping. Cycles are NOT persisted —
-// an in-flight cycle's agent turn doesn't survive a restart either, so resuming
-// one would be judging a turn that never finished. A restart drops back to
-// "enrolled, no cycle", and the next tick re-derives from the live world.
+// Autopilot is ON by default, per project: the switch lives in `project_settings`
+// (`AUTOPILOT_ENABLED_KEY`) and is mirrored here as the list of projects that
+// turned it off. The driver enrolls every live checkout of an enabled project on
+// its own; the per-checkout entry below is runtime bookkeeping, not consent.
+//
+// The one per-checkout intent that persists is `paused`: a PR the user parked
+// should stay parked across a reload rather than quietly resuming. Cycles are NOT
+// persisted — an in-flight cycle's agent turn doesn't survive a restart either,
+// so resuming one would be judging a turn that never finished. A restart drops
+// back to "enrolled, no cycle", and the next tick re-derives from the live world.
 
 import type { VerificationReport } from "@/api";
 import type { AutopilotState, Cycle, CyclePhase, StuckReason } from "@/autopilot";
 import { newEnrollment } from "@/autopilot";
 import type { DelegationKind } from "@/delegation";
+import {
+  AUTOPILOT_ENABLED_KEY,
+  deleteProjectSetting,
+  setProjectSetting,
+} from "@/storage/projectSettings";
 import { setSetting } from "@/storage/settings";
 import type { SliceCreator } from "./types";
 
-/** Settings key holding the persisted enrollment set. */
+/** Settings key holding the persisted per-checkout intent (paused checkouts). */
 export const AUTOPILOT_SETTING = "autopilotEnrollment";
 
 /** The persisted shape: only the user's intent, never in-flight machinery. */
@@ -24,9 +34,13 @@ interface PersistedEnrollment {
 }
 
 export interface AutopilotSlice {
-  /** Per-checkout autopilot state, keyed by `checkoutKey`. Absent = never
-   *  enrolled, which is the default for every checkout. */
+  /** Per-checkout autopilot state, keyed by `checkoutKey`. Absent = the driver
+   *  hasn't ticked this checkout yet (or its project has autopilot off). */
   autopilot: Record<string, AutopilotState>;
+  /** Projects whose autopilot switch is off (`project_id`s). Every other project
+   *  is on — that is the default. Hydrated from `project_settings` at launch and
+   *  kept in sync by `setProjectAutopilot`. */
+  autopilotDisabledProjects: string[];
   /** Local verification autopilot ran to judge the CURRENT cycle, keyed by
    *  `checkoutKey`.
    *
@@ -37,9 +51,14 @@ export interface AutopilotSlice {
    *  be judged by a report produced for it. */
   autopilotVerdicts: Record<string, VerificationReport>;
 
-  /** Turn autopilot on for a checkout. */
+  /** Flip a project's autopilot switch and persist it to `project_settings`. */
+  setProjectAutopilot: (projectId: string, enabled: boolean) => void;
+
+  /** Start tracking a checkout (the driver does this for every live checkout of
+   *  an enabled project; the chip does it when the user acts before the first
+   *  tick). */
   enrollAutopilot: (key: string) => void;
-  /** Turn it off entirely and forget the checkout's history. */
+  /** Forget a checkout's state and history — used when its agent is gone. */
   unenrollAutopilot: (key: string) => void;
   /** Hold without losing enrollment; resuming is one click. */
   pauseAutopilot: (key: string) => void;
@@ -78,11 +97,12 @@ export interface AutopilotSlice {
   recordAutopilotVerdict: (key: string, report: VerificationReport) => void;
 }
 
-/** Parse the persisted enrollment set at launch (mirrors `parseReviewDismissed`
- *  in eventListeners). Rebuilds from a fresh enrollment so a hand-edited or
- *  corrupt row can never inject a cycle, a spent budget, or a `stuck` the user
- *  never saw — and an unparseable value yields nothing enrolled, which is the
- *  right way for a loop that spends agent turns to fail. */
+/** Parse the persisted per-checkout intent at launch (mirrors
+ *  `parseReviewDismissed` in eventListeners). Rebuilds from a fresh enrollment so
+ *  a hand-edited or corrupt row can never inject a cycle, a spent budget, or a
+ *  `stuck` the user never saw. An unparseable value yields nothing, which is
+ *  safe: the driver re-enrolls live checkouts on its first tick, and the only
+ *  thing lost is a paused flag. */
 export function parseAutopilotEnrollment(raw: string | undefined): Record<string, AutopilotState> {
   if (!raw) return {};
   try {
@@ -97,11 +117,13 @@ export function parseAutopilotEnrollment(raw: string | undefined): Record<string
   }
 }
 
-/** Persist just the enrollment intent for every enrolled checkout. */
+/** Persist just the user's intent: which checkouts are paused. Enrollment itself
+ *  is not worth a row — the driver re-derives it from live agents on every tick,
+ *  and writing every checkout ever seen would grow the row without bound. */
 function persist(map: Record<string, AutopilotState>) {
   const out: Record<string, PersistedEnrollment> = {};
   for (const [key, s] of Object.entries(map)) {
-    if (s.enrolled) out[key] = { paused: s.paused };
+    if (s.enrolled && s.paused) out[key] = { paused: true };
   }
   void setSetting(AUTOPILOT_SETTING, out);
 }
@@ -132,6 +154,19 @@ const clearVerdict = (verdicts: Record<string, VerificationReport>, key: string)
 export const createAutopilotSlice: SliceCreator<AutopilotSlice> = (set) => ({
   autopilot: {},
   autopilotVerdicts: {},
+  autopilotDisabledProjects: [],
+
+  setProjectAutopilot: (projectId, enabled) => {
+    set((s) => {
+      const rest = s.autopilotDisabledProjects.filter((id) => id !== projectId);
+      return { autopilotDisabledProjects: enabled ? rest : [...rest, projectId] };
+    });
+    // On is the default, so "on" means no row at all.
+    const write = enabled
+      ? deleteProjectSetting(projectId, AUTOPILOT_ENABLED_KEY)
+      : setProjectSetting(projectId, AUTOPILOT_ENABLED_KEY, "0");
+    write.catch((e) => console.error("save autopilot.enabled failed", e));
+  },
 
   enrollAutopilot: (key) => {
     set((s) => {

--- a/src/store/autopilotSync.test.ts
+++ b/src/store/autopilotSync.test.ts
@@ -25,6 +25,11 @@ import { newEnrollment } from "@/autopilot";
 const { runVerification } = vi.hoisted(() => ({ runVerification: vi.fn() }));
 vi.mock("@/api", () => ({ api: { runVerification } }));
 vi.mock("@/storage/settings", () => ({ setSetting: vi.fn() }));
+vi.mock("@/storage/projectSettings", () => ({
+  AUTOPILOT_ENABLED_KEY: "autopilot.enabled",
+  setProjectSetting: vi.fn(() => Promise.resolve()),
+  deleteProjectSetting: vi.fn(() => Promise.resolve()),
+}));
 
 // The pass reads `useAppStore.getState()` on every key, so the mock has to
 // forward to whatever store the current test built.
@@ -37,7 +42,7 @@ vi.mock("@/store", () => ({
 
 import { createAutopilotSlice } from "./autopilot";
 import { createAutopilotLogSlice } from "./autopilotLog";
-import { autopilotPass } from "./autopilotSync";
+import { autopilotKeys, autopilotPass } from "./autopilotSync";
 import { checkoutKey, createGitSlice } from "./git";
 import type { AppState } from "./types";
 
@@ -94,14 +99,21 @@ const cycle = (over: Partial<Cycle> = {}): Cycle => ({
 const TRIGGER = '[app-action] fix-checks failing="test"';
 
 interface Fixture {
-  /** Enrolled checkouts, by `checkoutKey`. Their readiness is seeded to the one
+  /** Tracked checkouts, by `checkoutKey`. Their readiness is seeded to the one
    *  world autopilot acts on: an open PR whose required check is failing. */
   autopilot: Record<string, AutopilotState>;
-  /** Live agents and their status. A key absent here is an agent that's gone. */
+  /** Live agents and their status. A key absent here is an agent that's gone.
+   *  Every fixture agent belongs to project `p1` unless `projectOf` says so. */
   agents: Record<string, AgentStatus>;
+  projectOf?: Record<string, string>;
+  /** Projects whose autopilot switch is off. */
+  disabled?: string[];
+  /** Checkouts (by key) to seed readiness for beyond the tracked ones — used
+   *  when the pass is expected to enroll a checkout it hasn't seen. */
+  readiness?: string[];
 }
 
-function makeStore({ autopilot, agents }: Fixture) {
+function makeStore({ autopilot, agents, projectOf = {}, disabled = [], readiness = [] }: Fixture) {
   const sendUserMessage = vi.fn();
   const store = create<AppState>()(
     (...a) =>
@@ -113,14 +125,21 @@ function makeStore({ autopilot, agents }: Fixture) {
         ...createAutopilotLogSlice(...a),
       }) as AppState,
   );
-  const per = <T>(value: T) => Object.fromEntries(Object.keys(autopilot).map((k) => [k, value]));
+  const seeded = [...new Set([...Object.keys(autopilot), ...readiness])];
+  const per = <T>(value: T) => Object.fromEntries(seeded.map((k) => [k, value]));
   store.setState({
     sendUserMessage,
     workspace: {
-      agents: Object.entries(agents).map(([id, status]) => ({ id, status })),
+      agents: Object.entries(agents).map(([id, status]) => ({
+        id,
+        status,
+        project_id: projectOf[id] ?? "p1",
+        repos: [{ repo_path: `/r/${id}`, subdir: "" }],
+      })),
       // biome-ignore lint/suspicious/noExplicitAny: minimal workspace fixture
     } as any,
     autopilot,
+    autopilotDisabledProjects: disabled,
     gitStates: per(git()),
     prStates: per(pr()),
     prChecks: per(checks()),
@@ -321,6 +340,87 @@ describe("autopilotPass drops an enrollment whose agent is gone", () => {
     await autopilotPass([key.primary, key.web], new Set());
 
     expect(store.getState().autopilot).toEqual({});
+    expect(sendUserMessage).not.toHaveBeenCalled();
+  });
+});
+
+// ── on by default, per project ───────────────────────────────────────────────
+// Nobody clicks "enroll" any more: the driver enrolls every live checkout of a
+// project that hasn't switched autopilot off, and the switch is the only opt-out.
+
+describe("autopilotKeys derives the sweep from live agents", () => {
+  const agent = (id: string, project_id: string, subdirs: string[] = [""]) =>
+    ({
+      id,
+      project_id,
+      repos: subdirs.map((subdir) => ({ repo_path: `/r/${id}/${subdir}`, subdir })),
+    }) as unknown as import("@/api").AgentRecord;
+
+  it("includes every checkout of every agent in an enabled project, keyed like the Git panel", () => {
+    // The primary repo is the plain agent id (index 0, whatever its subdir says);
+    // secondaries carry `::subdir` — the same keys every git/PR map uses.
+    const keys = autopilotKeys([agent("a1", "p1", ["", "web"]), agent("a2", "p2")], {}, []);
+    expect(keys).toEqual(["a1", "a1::web", "a2"]);
+  });
+
+  it("leaves out the agents of a project that switched autopilot off", () => {
+    const keys = autopilotKeys([agent("a1", "p1"), agent("a2", "p2")], {}, ["p2"]);
+    expect(keys).toEqual(["a1"]);
+  });
+
+  it("still visits a tracked checkout that is no longer live, so the pass can drop it", () => {
+    // Whether the agent is gone or its project was just switched off, the entry
+    // needs one more visit to be cleaned up rather than lingering forever.
+    const keys = autopilotKeys([agent("a1", "p1")], { gone: state(), a2: state() }, ["p2"]);
+    expect(keys).toEqual(["a1", "a2", "gone"]);
+  });
+});
+
+describe("autopilotPass enrolls on the first tick and honours the project switch", () => {
+  it("enrolls an unseen checkout of an enabled project and acts on it in the same pass", async () => {
+    // The whole point of on-by-default: a PR with failing checks gets a fix
+    // dispatched without anyone having clicked anything.
+    const { store, sendUserMessage } = makeStore({
+      autopilot: {},
+      agents: { a1: "idle" },
+      readiness: [key.primary],
+    });
+
+    await autopilotPass([key.primary], new Set());
+
+    expect(store.getState().autopilot[key.primary]).toMatchObject({ enrolled: true });
+    expect(store.getState().autopilot[key.primary].cycle?.rung).toBe("fix-checks");
+    expect(sendUserMessage).toHaveBeenCalledExactlyOnceWith("a1", TRIGGER);
+  });
+
+  it("does nothing for a checkout whose project has autopilot off, and forgets its state", async () => {
+    // Switching a project off mid-cycle: the agent's turn (if any) runs on, but
+    // autopilot stops judging it and drops the entry, so the chip stops claiming
+    // it is working. Coming back on starts fresh on the next tick.
+    const { store, sendUserMessage } = makeStore({
+      autopilot: { [key.primary]: state({ cycle: cycle() }) },
+      agents: { a1: "idle" },
+      disabled: ["p1"],
+    });
+
+    await autopilotPass([key.primary], new Set());
+
+    expect(store.getState().autopilot[key.primary]).toBeUndefined();
+    expect(sendUserMessage).not.toHaveBeenCalled();
+    expect(runVerification).not.toHaveBeenCalled();
+  });
+
+  it("a paused checkout stays paused across ticks — the first tick never un-pauses it", async () => {
+    // Paused is the one per-checkout intent that persists; enrolling on tick
+    // must not overwrite it with a fresh (un-paused) enrollment.
+    const { store, sendUserMessage } = makeStore({
+      autopilot: { [key.primary]: state({ paused: true }) },
+      agents: { a1: "idle" },
+    });
+
+    await autopilotPass([key.primary], new Set());
+
+    expect(store.getState().autopilot[key.primary].paused).toBe(true);
     expect(sendUserMessage).not.toHaveBeenCalled();
   });
 });

--- a/src/store/autopilotSync.test.ts
+++ b/src/store/autopilotSync.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/storage/projectSettings", () => ({
   AUTOPILOT_ENABLED_KEY: "autopilot.enabled",
   setProjectSetting: vi.fn(() => Promise.resolve()),
   deleteProjectSetting: vi.fn(() => Promise.resolve()),
+  loadAutopilotDisabledProjects: vi.fn(() => Promise.resolve([])),
 }));
 
 // The pass reads `useAppStore.getState()` on every key, so the mock has to

--- a/src/store/autopilotSync.test.ts
+++ b/src/store/autopilotSync.test.ts
@@ -363,6 +363,12 @@ describe("autopilotKeys derives the sweep from live agents", () => {
     expect(keys).toEqual(["a1", "a1::web", "a2"]);
   });
 
+  it("sweeps NOTHING while the opt-outs are unknown — fail closed, not open", () => {
+    // Hydration failed or hasn't finished: even a checkout already tracked from
+    // a paused flag is left alone, because we can't tell whose project said no.
+    expect(autopilotKeys([agent("a1", "p1")], { a1: state() }, null)).toEqual([]);
+  });
+
   it("leaves out the agents of a project that switched autopilot off", () => {
     const keys = autopilotKeys([agent("a1", "p1"), agent("a2", "p2")], {}, ["p2"]);
     expect(keys).toEqual(["a1"]);

--- a/src/store/autopilotSync.ts
+++ b/src/store/autopilotSync.ts
@@ -20,6 +20,7 @@ import { type AutopilotEffect, type AutopilotState, autopilotStep } from "@/auto
 import { appActionMessage } from "@/delegation";
 import { useAppStore } from "@/store";
 import { usePoll } from "@/util/hooks";
+import { autopilotProjectOn } from "./autopilot";
 import type { AutopilotLogEntry } from "./autopilotLog";
 import { checkoutKey, splitCheckoutKey } from "./git";
 
@@ -40,7 +41,7 @@ const AUTOPILOT_TICK_MS = 10_000;
  *
  *  `disabledProjects === null` means the opt-outs haven't loaded (or failed to):
  *  nothing is swept, because "on by default" without knowing who opted out would
- *  act on exactly the projects that said no. */
+ *  act on exactly the projects that said no (see `autopilotProjectOn`). */
 export function autopilotKeys(
   agents: readonly AgentRecord[],
   tracked: Record<string, AutopilotState>,
@@ -49,7 +50,7 @@ export function autopilotKeys(
   if (disabledProjects === null) return [];
   const keys = new Set(Object.keys(tracked));
   for (const agent of agents) {
-    if (disabledProjects.includes(agent.project_id)) continue;
+    if (!autopilotProjectOn(disabledProjects, agent.project_id)) continue;
     for (const [i, repo] of (agent.repos ?? []).entries()) {
       keys.add(checkoutKey(agent.id, i === 0 ? undefined : repo.subdir));
     }
@@ -105,9 +106,7 @@ export async function autopilotPass(keys: string[], verifying: Set<string>) {
     // The checkout's agent is gone (archived/discarded), or its project switched
     // autopilot off — drop the entry rather than ticking forever against nothing.
     // A project that comes back on starts its checkouts fresh on the next tick.
-    // (A null list — opt-outs not loaded — never reaches here: `autopilotKeys`
-    // hands the pass no keys at all; treating it as "off" is the same answer.)
-    if (!agent || (s.autopilotDisabledProjects ?? [agent.project_id]).includes(agent.project_id)) {
+    if (!agent || !autopilotProjectOn(s.autopilotDisabledProjects, agent.project_id)) {
       if (s.autopilot[key]) s.unenrollAutopilot(key);
       continue;
     }

--- a/src/store/autopilotSync.ts
+++ b/src/store/autopilotSync.ts
@@ -36,12 +36,17 @@ const AUTOPILOT_TICK_MS = 10_000;
  *
  *  The primary repo (index 0) keeps the plain agent id, exactly as the Git panel
  *  keys it (`checkoutScopes` in GitPanel/index.tsx); secondaries get `::subdir`.
- *  Sorted so the tick keeps a stable identity across unrelated store writes. */
+ *  Sorted so the tick keeps a stable identity across unrelated store writes.
+ *
+ *  `disabledProjects === null` means the opt-outs haven't loaded (or failed to):
+ *  nothing is swept, because "on by default" without knowing who opted out would
+ *  act on exactly the projects that said no. */
 export function autopilotKeys(
   agents: readonly AgentRecord[],
   tracked: Record<string, AutopilotState>,
-  disabledProjects: readonly string[],
+  disabledProjects: readonly string[] | null,
 ): string[] {
+  if (disabledProjects === null) return [];
   const keys = new Set(Object.keys(tracked));
   for (const agent of agents) {
     if (disabledProjects.includes(agent.project_id)) continue;
@@ -100,7 +105,9 @@ export async function autopilotPass(keys: string[], verifying: Set<string>) {
     // The checkout's agent is gone (archived/discarded), or its project switched
     // autopilot off — drop the entry rather than ticking forever against nothing.
     // A project that comes back on starts its checkouts fresh on the next tick.
-    if (!agent || s.autopilotDisabledProjects.includes(agent.project_id)) {
+    // (A null list — opt-outs not loaded — never reaches here: `autopilotKeys`
+    // hands the pass no keys at all; treating it as "off" is the same answer.)
+    if (!agent || (s.autopilotDisabledProjects ?? [agent.project_id]).includes(agent.project_id)) {
       if (s.autopilot[key]) s.unenrollAutopilot(key);
       continue;
     }

--- a/src/store/autopilotSync.ts
+++ b/src/store/autopilotSync.ts
@@ -1,4 +1,5 @@
-// The autopilot driver: one tick, every enrolled checkout.
+// The autopilot driver: one tick, every live checkout of every project that has
+// autopilot on (the default — see `autopilotDisabledProjects`).
 //
 // Mounted once at the app root, like `useGitSync` and `useDelegationSync`. The
 // decision for each checkout is pure (`autopilotStep`); this hook is the applier
@@ -14,13 +15,13 @@
 
 import { useCallback, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { api } from "@/api";
-import { type AutopilotEffect, autopilotStep } from "@/autopilot";
+import { type AgentRecord, api } from "@/api";
+import { type AutopilotEffect, type AutopilotState, autopilotStep } from "@/autopilot";
 import { appActionMessage } from "@/delegation";
 import { useAppStore } from "@/store";
 import { usePoll } from "@/util/hooks";
 import type { AutopilotLogEntry } from "./autopilotLog";
-import { splitCheckoutKey } from "./git";
+import { checkoutKey, splitCheckoutKey } from "./git";
 
 /** How often to evaluate enrolled checkouts. Slower than the git poll on
  *  purpose: every action this can take costs an agent turn, so there is nothing
@@ -28,16 +29,34 @@ import { splitCheckoutKey } from "./git";
  *  double-dispatch structurally unlikely. */
 const AUTOPILOT_TICK_MS = 10_000;
 
+/** The checkouts one pass should look at: every checkout of every live agent
+ *  whose project has autopilot on, plus anything still tracked in `autopilot` —
+ *  so an entry whose agent is gone, or whose project was just switched off, gets
+ *  visited once more and dropped rather than lingering.
+ *
+ *  The primary repo (index 0) keeps the plain agent id, exactly as the Git panel
+ *  keys it (`checkoutScopes` in GitPanel/index.tsx); secondaries get `::subdir`.
+ *  Sorted so the tick keeps a stable identity across unrelated store writes. */
+export function autopilotKeys(
+  agents: readonly AgentRecord[],
+  tracked: Record<string, AutopilotState>,
+  disabledProjects: readonly string[],
+): string[] {
+  const keys = new Set(Object.keys(tracked));
+  for (const agent of agents) {
+    if (disabledProjects.includes(agent.project_id)) continue;
+    for (const [i, repo] of (agent.repos ?? []).entries()) {
+      keys.add(checkoutKey(agent.id, i === 0 ? undefined : repo.subdir));
+    }
+  }
+  return [...keys].sort();
+}
+
 /** Mount once, at the app root. */
 export function useAutopilotSync() {
-  // Only enrolled checkouts are ever considered. Sorted + shallow-compared so the
-  // tick keeps a stable identity across unrelated store writes.
   const keys = useAppStore(
     useShallow((s) =>
-      Object.entries(s.autopilot)
-        .filter(([, a]) => a.enrolled)
-        .map(([key]) => key)
-        .sort(),
+      autopilotKeys(s.workspace?.agents ?? [], s.autopilot, s.autopilotDisabledProjects),
     ),
   );
 
@@ -50,7 +69,7 @@ export function useAutopilotSync() {
   usePoll(tick, AUTOPILOT_TICK_MS, [tick]);
 }
 
-/** One sweep over every enrolled checkout, applying what the policy decided.
+/** One sweep over the given checkouts, applying what the policy decided.
  *
  *  Exported so the WIRING is testable without a rendered hook: the decision is
  *  pure and covered by `autopilot.test.ts`, but the store transitions, the
@@ -78,12 +97,17 @@ export async function autopilotPass(keys: string[], verifying: Set<string>) {
     const s = useAppStore.getState();
     const { agentId, subdir } = splitCheckoutKey(key);
     const agent = s.workspace?.agents.find((a) => a.id === agentId);
-    // The checkout's agent is gone (archived/discarded) — drop the enrollment
-    // rather than ticking forever against nothing.
-    if (!agent) {
-      s.unenrollAutopilot(key);
+    // The checkout's agent is gone (archived/discarded), or its project switched
+    // autopilot off — drop the entry rather than ticking forever against nothing.
+    // A project that comes back on starts its checkouts fresh on the next tick.
+    if (!agent || s.autopilotDisabledProjects.includes(agent.project_id)) {
+      if (s.autopilot[key]) s.unenrollAutopilot(key);
       continue;
     }
+    // Autopilot is on by default: a checkout the driver hasn't seen yet is
+    // enrolled here, on its first tick, rather than by a click.
+    if (!s.autopilot[key]) s.enrollAutopilot(key);
+    const state = useAppStore.getState().autopilot[key];
     const git = s.gitStates[key] ?? null;
     const readiness = {
       git,
@@ -93,7 +117,7 @@ export async function autopilotPass(keys: string[], verifying: Set<string>) {
     };
     const now = Date.now();
     const effect = autopilotStep({
-      state: s.autopilot[key],
+      state,
       readiness,
       ladder: { base: git?.parent_branch || "main", commitMode: "commit-pr" },
       agentBusy:

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -59,7 +59,6 @@ import {
   parseSandboxEngine,
   type ThemeMode,
 } from "@/storage/preferences";
-import { loadAutopilotDisabledProjects } from "@/storage/projectSettings";
 import { getAllSettings } from "@/storage/settings";
 import { recordUsageSnapshot } from "@/storage/usageDaily";
 import { notify } from "@/util/notify";
@@ -112,7 +111,7 @@ const patchAgent = (get: AppGet, set: AppSet, agentId: string, patch: AgentPatch
 
 // Load persisted settings from the DB and hydrate the matching UI state.
 // First launch / DB-not-ready is non-fatal — defaults stand in.
-export const hydrateSettings = async (set: AppSet) => {
+export const hydrateSettings = async (set: AppSet, get: AppGet) => {
   try {
     const s = await getAllSettings();
     const {
@@ -193,17 +192,10 @@ export const hydrateSettings = async (set: AppSet) => {
   } catch {
     // First launch or DB not ready — defaults are fine.
   }
-  // Autopilot is on per project by default; only the projects that switched it
-  // off are stored (in `project_settings`, not the global table above). Loaded
-  // separately so a failure here can't undo the settings already applied.
-  try {
-    set({ autopilotDisabledProjects: await loadAutopilotDisabledProjects() });
-  } catch (e) {
-    // Fail CLOSED, unlike the defaults above: the list stays null and the
-    // driver runs nothing, because "everything on" is the one wrong answer when
-    // we can't tell who opted out. Loud, since it silences a whole feature.
-    console.error("load autopilot opt-outs failed — autopilot stays off this session", e);
-  }
+  // Autopilot's per-project opt-outs live in `project_settings`, not the global
+  // table above, and the slice owns their loading (it fails closed and is
+  // re-runnable from the settings section) — so just kick it off here.
+  await get().loadAutopilotProjects();
 };
 
 // Load (or lazily create) the single local account profile. Non-fatal — the

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -198,8 +198,11 @@ export const hydrateSettings = async (set: AppSet) => {
   // separately so a failure here can't undo the settings already applied.
   try {
     set({ autopilotDisabledProjects: await loadAutopilotDisabledProjects() });
-  } catch {
-    // Same as above — default (all on) stands.
+  } catch (e) {
+    // Fail CLOSED, unlike the defaults above: the list stays null and the
+    // driver runs nothing, because "everything on" is the one wrong answer when
+    // we can't tell who opted out. Loud, since it silences a whole feature.
+    console.error("load autopilot opt-outs failed — autopilot stays off this session", e);
   }
 };
 

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -59,6 +59,7 @@ import {
   parseSandboxEngine,
   type ThemeMode,
 } from "@/storage/preferences";
+import { loadAutopilotDisabledProjects } from "@/storage/projectSettings";
 import { getAllSettings } from "@/storage/settings";
 import { recordUsageSnapshot } from "@/storage/usageDaily";
 import { notify } from "@/util/notify";
@@ -183,14 +184,22 @@ export const hydrateSettings = async (set: AppSet) => {
       // Admin unlocks the Developer settings section in production. Opt-in:
       // only an explicit "true" in the `admin` settings row grants it.
       admin: s.admin === "true",
-      // Autopilot enrollment (checkout key → paused). Only the user's intent is
-      // persisted; cycles and budgets always start fresh — an in-flight cycle's
-      // agent turn doesn't survive a restart either, so resuming one would mean
-      // judging a turn that never finished.
+      // Autopilot's per-checkout intent (checkout key → paused). Only the user's
+      // intent is persisted; cycles and budgets always start fresh — an in-flight
+      // cycle's agent turn doesn't survive a restart either, so resuming one
+      // would mean judging a turn that never finished.
       autopilot: parseAutopilotEnrollment(s[AUTOPILOT_SETTING]),
     });
   } catch {
     // First launch or DB not ready — defaults are fine.
+  }
+  // Autopilot is on per project by default; only the projects that switched it
+  // off are stored (in `project_settings`, not the global table above). Loaded
+  // separately so a failure here can't undo the settings already applied.
+  try {
+    set({ autopilotDisabledProjects: await loadAutopilotDisabledProjects() });
+  } catch {
+    // Same as above — default (all on) stands.
   }
 };
 

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -25,6 +25,7 @@ import {
 } from "@/helpers";
 import { clearOutputBuffer, dropAgentPty } from "@/pty/buffers";
 import { recordUsageSnapshot } from "@/storage/usageDaily";
+import { createKeyedQueue } from "@/util/keyedQueue";
 import { forkContextDigest } from "./forkDigest";
 import { interruptedAgents } from "./interrupted";
 import { refreshWorkspace } from "./refreshWorkspace";
@@ -36,18 +37,7 @@ import type { AppState, SliceCreator } from "./types";
 // change was persisted — the turn would then read stale config from the record.
 // `sendUserMessage` awaits the agent's pending config op before dispatching, and
 // chaining also applies rapid config changes in call order.
-const configOps = new Map<string, Promise<void>>();
-
-function queueConfigOp(id: string, op: () => Promise<void>): Promise<void> {
-  const next = (configOps.get(id) ?? Promise.resolve()).catch(() => {}).then(op);
-  configOps.set(id, next);
-  void next
-    .catch(() => {})
-    .finally(() => {
-      if (configOps.get(id) === next) configOps.delete(id);
-    });
-  return next;
-}
+const configOps = createKeyedQueue();
 
 /** A degraded transcript-ingest state stored per agent (the `healthy` status is
  *  never stored — it deletes the key). `provider`/`version` are for the banner
@@ -459,14 +449,14 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
     }
   },
 
-  setAgentEffort: (id, effort) => queueConfigOp(id, () => api.setAgentEffort(id, effort)),
-  setAgentModel: (id, model) => queueConfigOp(id, () => api.setAgentModel(id, model)),
+  setAgentEffort: (id, effort) => configOps.run(id, () => api.setAgentEffort(id, effort)),
+  setAgentModel: (id, model) => configOps.run(id, () => api.setAgentModel(id, model)),
 
   sendUserMessage: async (id, text, attachments = []) => {
     // Wait for any in-flight effort/model change for this agent to land before
     // dispatching, so the turn reads the intended config from the record (the
-    // backend resolves per-turn config at dispatch). See `queueConfigOp`.
-    await configOps.get(id)?.catch(() => {});
+    // backend resolves per-turn config at dispatch). See `configOps`.
+    await configOps.pending(id)?.catch(() => {});
     // Guard: some Claude built-in control commands (e.g. /usage, /agents,
     // /login) only work in its interactive TUI and don't resolve over this
     // view's stream-json transport. Dispatched as a plain message they'd

--- a/src/util/keyedQueue.test.ts
+++ b/src/util/keyedQueue.test.ts
@@ -1,0 +1,94 @@
+// The per-key op chain behind session-config writes and project-switch writes.
+// What matters is the contract both rely on: same key runs in issue order, a
+// failure neither blocks the chain nor hides from its own caller, and different
+// keys don't wait on each other.
+
+import { describe, expect, it, vi } from "vitest";
+import { createKeyedQueue } from "./keyedQueue";
+
+const deferred = <T = void>() => {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe("createKeyedQueue", () => {
+  it("runs ops for one key in issue order, each starting after the previous settles", async () => {
+    const q = createKeyedQueue();
+    const first = deferred();
+    const started: string[] = [];
+
+    const a = q.run("k", () => {
+      started.push("a");
+      return first.promise;
+    });
+    const b = q.run("k", async () => {
+      started.push("b");
+    });
+    // `a` starts once the (empty) chain ahead of it settles; `b` must not start
+    // until `a` does, however long that takes.
+    await vi.waitFor(() => expect(started).toEqual(["a"]));
+
+    first.resolve();
+    await Promise.all([a, b]);
+    expect(started).toEqual(["a", "b"]);
+  });
+
+  it("does not let one key's op hold up another key's", async () => {
+    const q = createKeyedQueue();
+    const stuck = deferred();
+    const ran: string[] = [];
+
+    void q.run("slow", () => stuck.promise);
+    await q.run("fast", async () => {
+      ran.push("fast");
+    });
+    expect(ran).toEqual(["fast"]);
+    stuck.resolve();
+  });
+
+  it("surfaces a failure to its caller but lets the next op run", async () => {
+    const q = createKeyedQueue();
+    const failed = q.run("k", () => Promise.reject(new Error("boom")));
+    const next = q.run("k", async () => "ok");
+
+    await expect(failed).rejects.toThrow("boom");
+    await expect(next).resolves.toBe("ok");
+  });
+
+  it("exposes the pending tail for a key, and clears it once settled", async () => {
+    const q = createKeyedQueue();
+    expect(q.pending("k")).toBeUndefined();
+
+    const gate = deferred();
+    const op = q.run("k", () => gate.promise);
+    expect(q.pending("k")).toBeDefined();
+
+    gate.resolve();
+    await op;
+    // The finally that clears the tail runs a microtask after `op` resolves.
+    await Promise.resolve();
+    expect(q.pending("k")).toBeUndefined();
+  });
+
+  it("keeps the tail pointed at the newest op when an older one settles", async () => {
+    // Clearing on settle must only clear if nothing newer was queued since —
+    // otherwise a dependent action would see "nothing pending" while a later
+    // write is still in flight.
+    const q = createKeyedQueue();
+    const first = deferred();
+    const second = deferred();
+    const a = q.run("k", () => first.promise);
+    void q.run("k", () => second.promise);
+
+    first.resolve();
+    await a;
+    await Promise.resolve();
+    expect(q.pending("k")).toBeDefined();
+    second.resolve();
+  });
+});

--- a/src/util/keyedQueue.ts
+++ b/src/util/keyedQueue.ts
@@ -1,0 +1,39 @@
+/** Per-key serialization of async operations.
+ *
+ *  Two writers that target the same durable thing — an agent's session config, a
+ *  project's setting row — must land in the order they were issued, or a slower
+ *  earlier request can overwrite a faster later one and persist the opposite of
+ *  what the user last chose. A queue keyed by that thing chains each op behind
+ *  the previous one for the same key while leaving different keys independent.
+ *
+ *  Failures never block the chain: a rejected op is swallowed for the purpose
+ *  of sequencing (the *caller* still sees its own rejection), so one bad write
+ *  can't wedge every later one behind it. */
+export interface KeyedQueue {
+  /** Run `op` after every op already queued for `key`. Resolves/rejects with
+   *  `op`'s own outcome. */
+  run<T>(key: string, op: () => Promise<T>): Promise<T>;
+  /** The tail of `key`'s chain, or undefined when nothing is pending. Awaiting
+   *  it (with its rejection swallowed) is how a dependent action waits for a
+   *  key's writes to settle before it acts. */
+  pending(key: string): Promise<unknown> | undefined;
+}
+
+export function createKeyedQueue(): KeyedQueue {
+  const tails = new Map<string, Promise<unknown>>();
+  return {
+    run(key, op) {
+      const next = (tails.get(key) ?? Promise.resolve()).catch(() => {}).then(op);
+      tails.set(key, next);
+      void next
+        .catch(() => {})
+        .finally(() => {
+          if (tails.get(key) === next) tails.delete(key);
+        });
+      return next;
+    },
+    pending(key) {
+      return tails.get(key);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Autopilot was opt-in per checkout: clicking the Git panel chip enrolled one checkout, and the enrollment set lived in a single global `settings` row. This moves the switch to the **project level** and flips the default to **on**.

## Changes

- **Storage** — new `project_settings` key `autopilot.enabled`. On is the default, so a row exists only for projects that turned it off (`"0"`); turning it back on deletes the row. No migration needed.
- **Store** (`src/store/autopilot.ts`) — mirrors the disabled project ids (`autopilotDisabledProjects`) and adds `setProjectAutopilot`, which updates the store and persists to the DB. The old global `autopilotEnrollment` row now stores only paused checkouts, so it no longer grows with every checkout seen.
- **Driver** (`src/store/autopilotSync.ts`) — derives its sweep from live agents via `autopilotKeys`: every checkout of every agent in an enabled project is enrolled on its first tick. Entries whose agent is gone or whose project switched off are dropped.
- **Hydration** (`eventListeners.ts`) — disabled projects load at launch with one query, in their own try block so a failure cannot undo the other settings.
- **Git panel chip** — the enroll click and the Off button are gone. The chip reads on / working / paused / stopped and pauses or resumes that one checkout. When the project has autopilot off it says so and clicking opens that project's settings.
- **Project Settings** — new `AutopilotSection` with the toggle, above the Verify section.

## Behaviour notes

- Existing users will see autopilot start on every open PR with failing checks, conflicts, or unresolved comments — one agent turn at a time, within the existing per-rung budgets. Turning it off is one toggle per project.
- Old enrollment data is ignored rather than migrated. Paused checkouts stored under the old shape still load as paused; anything merely enrolled is now covered by the default.

## Testing

- `bun run check` passes.
- `bun run test`: 99 files, 1070 tests pass, including new tests for the project switch, first-tick enrollment, disabled-project cleanup, and paused-state persistence.
- Biome reports no new issues in touched files.