### PR TITLE
feat(dictation): native speech recognition backend on Apple platforms

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1182,10 +1182,16 @@ name = "fletch"
 version = "0.7.21"
 dependencies = [
  "base64 0.22.1",
+ "block2",
  "chrono",
  "dirs 5.0.1",
  "flate2",
  "nix 0.29.0",
+ "objc2",
+ "objc2-av-foundation",
+ "objc2-avf-audio",
+ "objc2-foundation",
+ "objc2-speech",
  "parking_lot",
  "portable-pty",
  "reqwest 0.13.3",
@@ -2726,6 +2732,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-av-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478ae33fcac9df0a18db8302387c666b8ef08a3e2d62b510ca4fc278a384b6c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-avf-audio"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13a380031deed8e99db00065c45937da434ca987c034e13b87e4441f9e4090be"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-cloud-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2862,6 +2891,18 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-speech"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9eb609f9d2a25e0f8b76954f3acaa58348ce2a91285fe867643b2224ac4d263"
+dependencies = [
+ "block2",
+ "objc2",
+ "objc2-avf-audio",
  "objc2-foundation",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -80,6 +80,46 @@ tauri-plugin-window-state = "2"
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "3"
 
+# Voice dictation (dictation/apple.rs): Apple's Speech framework driven by an
+# AVAudioEngine mic tap. objc2 + objc2-foundation + block2 are already in the
+# tree (tauri's own macOS backend); the framework crates are added here.
+# `default-features = false` throughout because these crates' defaults compile
+# *every* class in the framework — we name only the handful of classes and the
+# `block2` bridge (completion/result handlers) that the recognizer path needs.
+[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSError", "NSString"] }
+block2 = "0.6"
+objc2-speech = { version = "0.3", default-features = false, features = [
+    "std",
+    "block2",
+    "objc2-avf-audio",
+    "SFSpeechRecognizer",
+    "SFSpeechRecognitionRequest",
+    "SFSpeechRecognitionResult",
+    "SFSpeechRecognitionTask",
+    "SFTranscription",
+] }
+objc2-avf-audio = { version = "0.3", default-features = false, features = [
+    "std",
+    "block2",
+    "AVAudioEngine",
+    "AVAudioNode",
+    "AVAudioIONode",
+    "AVAudioBuffer",
+    "AVAudioFormat",
+    "AVAudioTime",
+    "AVAudioTypes",
+] }
+# Microphone (as opposed to speech) authorization only: TCC's mic status lives
+# on AVCaptureDevice, which is in AVFoundation proper rather than AVFAudio.
+objc2-av-foundation = { version = "0.3", default-features = false, features = [
+    "std",
+    "block2",
+    "AVCaptureDevice",
+    "AVMediaFormat",
+] }
+
 [dev-dependencies]
 tempfile = "3"
 # `test-util` unlocks the paused-time test clock (`#[tokio::test(start_paused)]`)

--- a/src-tauri/Entitlements.plist
+++ b/src-tauri/Entitlements.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Referenced from tauri.conf.json (`bundle.macOS.entitlements`) — unlike
+  Info.plist, entitlements are never discovered by filename.
+
+  The release build is signed with the hardened runtime, which denies
+  microphone access to the process regardless of the user's TCC answer unless
+  this entitlement is present. Without it the notarized app records silence
+  and dictation produces an empty transcript, while dev builds work fine.
+-->
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+  </dict>
+</plist>

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Merged into the bundle's generated Info.plist by the Tauri CLI, which picks
+  this file up by name from the config directory (no tauri.conf.json entry).
+  tauri-codegen additionally embeds it into the dev binary via embed_plist, so
+  the dictation permission prompts also appear under `tauri dev`.
+
+  These two usage strings are load-bearing, not cosmetic: SFSpeechRecognizer's
+  requestAuthorization: crashes the process outright if
+  NSSpeechRecognitionUsageDescription is missing.
+-->
+<plist version="1.0">
+  <dict>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Fletch uses the microphone to dictate prompts.</string>
+    <key>NSSpeechRecognitionUsageDescription</key>
+    <string>Fletch uses speech recognition to turn your dictated prompts into text.</string>
+  </dict>
+</plist>

--- a/src-tauri/src/dictation/apple.rs
+++ b/src-tauri/src/dictation/apple.rs
@@ -1,0 +1,491 @@
+//! Dictation on Apple's Speech framework: an `AVAudioEngine` mic tap feeding
+//! an `SFSpeechAudioBufferRecognitionRequest`.
+//!
+//! # Threading
+//!
+//! Speech and AVFoundation objects are not `Send`, and Apple calls our blocks
+//! back on queues of its own choosing. Rather than wrap the handles in a
+//! `Send` lie, everything that touches session state runs on the main thread
+//! (`on_main`), and the session itself lives in a `thread_local` — so there is
+//! no lock to hold, nothing to declare `unsafe impl Send`, and no way for a
+//! callback to observe a half-built session.
+//!
+//! That works because `SFSpeechRecognizer`'s `queue` defaults to the main
+//! queue: the result handler is *dispatched* to the same thread we mutate
+//! state on rather than re-entering us, so it cannot run until the
+//! `on_main` block that created the task has returned. The one exception is
+//! the audio tap, which Apple invokes on a real-time render thread — it
+//! deliberately touches no session state, only `appendAudioPCMBuffer` on its
+//! own retained request, which is the pattern Apple documents for it.
+//!
+//! Note that `#[tauri::command]` futures must be `Send`, which is the second
+//! reason for this shape: no ObjC handle is ever live across an `.await`.
+
+use std::cell::RefCell;
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::time::Duration;
+
+use block2::RcBlock;
+use objc2::rc::Retained;
+use objc2::AllocAnyThread;
+use objc2_av_foundation::{AVAuthorizationStatus, AVCaptureDevice, AVMediaTypeAudio};
+use objc2_avf_audio::{AVAudioEngine, AVAudioInputNode, AVAudioPCMBuffer, AVAudioTime};
+use objc2_foundation::NSError;
+use objc2_speech::{
+    SFSpeechAudioBufferRecognitionRequest, SFSpeechRecognitionResult, SFSpeechRecognitionTask,
+    SFSpeechRecognizer, SFSpeechRecognizerAuthorizationStatus,
+};
+use tauri::AppHandle;
+
+use super::{emit_state, emit_transcript, Auth, Availability, State};
+use crate::error::{Error, Result};
+
+/// The engine's only input bus.
+const BUS: usize = 0;
+
+/// Tap buffer size in sample frames, matching Apple's own live-recognition
+/// sample. The engine clamps this to a size it can service.
+const TAP_BUFFER_FRAMES: u32 = 1024;
+
+/// How long to wait after `endAudio` for the recognizer's final result before
+/// forcing the teardown. Apple normally flushes in well under a second; the
+/// deadline exists so a wedged recognizer can't leave the UI stuck in
+/// `listening` with no way back.
+const FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
+
+thread_local! {
+    /// The one live session, main-thread only. See the module's threading note.
+    static SESSION: RefCell<Option<Session>> = const { RefCell::new(None) };
+}
+
+/// Set for the whole span of a session, from the first moment of `start`
+/// until teardown finishes. Unlike `SESSION` this is readable from any
+/// thread, which is what lets `start` reject a concurrent second start
+/// without a main-thread hop, and makes "a second start while listening is a
+/// no-op" hold even against two commands racing.
+static ACTIVE: AtomicBool = AtomicBool::new(false);
+
+static NEXT_GENERATION: AtomicU64 = AtomicU64::new(0);
+
+struct Session {
+    /// Distinguishes this session from its successors. Every block Apple may
+    /// invoke late (a post-cancel result, the flush deadline) carries the
+    /// generation it was created for and does nothing if it no longer matches
+    /// — otherwise a straggler could tear down a session the user has since
+    /// started.
+    generation: u64,
+    engine: Retained<AVAudioEngine>,
+    input: Retained<AVAudioInputNode>,
+    request: Retained<SFSpeechAudioBufferRecognitionRequest>,
+    task: Retained<SFSpeechRecognitionTask>,
+    /// Kept alive for the tap's lifetime. `installTapOnBus` is documented to
+    /// take ownership, but holding our own reference costs nothing and takes
+    /// a use-after-free off the table.
+    _tap: RcBlock<dyn Fn(NonNull<AVAudioPCMBuffer>, NonNull<AVAudioTime>)>,
+    /// True once the user asked to stop. After that point the recognizer
+    /// reports the end of the stream *as an error* (a cancellation or
+    /// no-speech code from a private domain), which is the expected tail of a
+    /// normal session and must surface as `stopped`, not `error`.
+    stopping: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Main-thread plumbing
+
+/// Run `f` on the main thread and wait for its value. Every call that touches
+/// `SESSION` or a session's ObjC handles goes through here.
+async fn on_main<T: Send + 'static>(
+    app: &AppHandle,
+    f: impl FnOnce() -> T + Send + 'static,
+) -> Result<T> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    app.run_on_main_thread(move || {
+        let _ = tx.send(f());
+    })
+    .map_err(|e| Error::Other(format!("dictation: main thread unavailable: {e}")))?;
+    rx.await
+        .map_err(|_| Error::Other("dictation: main thread task was dropped".into()))
+}
+
+/// Is the session that `generation` belongs to still the live one?
+fn is_live(generation: u64) -> bool {
+    SESSION.with_borrow(|s| s.as_ref().is_some_and(|s| s.generation == generation))
+}
+
+/// Claim the live session, but only if it is still `generation`. Returning
+/// the `Session` by value makes teardown exactly-once: whoever gets it owns
+/// the terminal `dictation:state` emit.
+fn claim(generation: u64) -> Option<Session> {
+    SESSION.with_borrow_mut(|slot| {
+        if slot.as_ref().is_some_and(|s| s.generation == generation) {
+            slot.take()
+        } else {
+            None
+        }
+    })
+}
+
+/// Release the microphone and the recognizer, and let a new session start.
+fn teardown(session: Session) {
+    unsafe {
+        session.engine.stop();
+        session.input.removeTapOnBus(BUS);
+        session.task.cancel();
+    }
+    ACTIVE.store(false, Ordering::SeqCst);
+}
+
+// ---------------------------------------------------------------------------
+// Permissions
+
+impl From<SFSpeechRecognizerAuthorizationStatus> for Auth {
+    fn from(status: SFSpeechRecognizerAuthorizationStatus) -> Self {
+        match status {
+            SFSpeechRecognizerAuthorizationStatus::Authorized => Auth::Authorized,
+            SFSpeechRecognizerAuthorizationStatus::Denied => Auth::Denied,
+            SFSpeechRecognizerAuthorizationStatus::Restricted => Auth::Restricted,
+            // NotDetermined, and anything a future OS adds: treat as "ask".
+            _ => Auth::NotDetermined,
+        }
+    }
+}
+
+impl From<AVAuthorizationStatus> for Auth {
+    fn from(status: AVAuthorizationStatus) -> Self {
+        match status {
+            AVAuthorizationStatus::Authorized => Auth::Authorized,
+            AVAuthorizationStatus::Denied => Auth::Denied,
+            AVAuthorizationStatus::Restricted => Auth::Restricted,
+            _ => Auth::NotDetermined,
+        }
+    }
+}
+
+/// TCC's microphone status. `AVMediaTypeAudio` is an `extern` string constant,
+/// so it is nil only if AVFoundation failed to load at all; treat that as
+/// "can't tell, ask".
+fn microphone_auth() -> Auth {
+    let Some(audio) = (unsafe { AVMediaTypeAudio }) else {
+        return Auth::NotDetermined;
+    };
+    unsafe { AVCaptureDevice::authorizationStatusForMediaType(audio) }.into()
+}
+
+fn speech_auth() -> Auth {
+    unsafe { SFSpeechRecognizer::authorizationStatus() }.into()
+}
+
+/// Turn a settled permission state into a message the user can act on. The
+/// prompt only ever appears once, so a denied permission is only fixable in
+/// System Settings — say so rather than silently doing nothing.
+fn authorized_or_error(what: &str, auth: Auth) -> Result<()> {
+    match auth {
+        Auth::Authorized => Ok(()),
+        Auth::Denied | Auth::NotDetermined => Err(Error::Other(format!(
+            "Fletch needs {what} access to dictate. Enable it in System Settings > \
+             Privacy & Security."
+        ))),
+        Auth::Restricted => Err(Error::Other(format!(
+            "{what} access is restricted on this device, so dictation can't run."
+        ))),
+    }
+}
+
+/// The two `requestAuthorization`-style APIs hand their answer to a block on
+/// an arbitrary queue. These helpers are deliberately non-`async`: the block
+/// is created, handed off, and dropped entirely within them, so no ObjC handle
+/// is ever live across the caller's `.await`. Apple copies the block, so
+/// releasing our reference here is safe.
+fn request_speech_auth() -> tokio::sync::oneshot::Receiver<Auth> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let tx = parking_lot::Mutex::new(Some(tx));
+    let handler = RcBlock::new(move |status: SFSpeechRecognizerAuthorizationStatus| {
+        if let Some(tx) = tx.lock().take() {
+            let _ = tx.send(status.into());
+        }
+    });
+    unsafe { SFSpeechRecognizer::requestAuthorization(&handler) };
+    rx
+}
+
+fn request_microphone_auth() -> tokio::sync::oneshot::Receiver<Auth> {
+    let (tx, rx) = tokio::sync::oneshot::channel();
+    let Some(audio) = (unsafe { AVMediaTypeAudio }) else {
+        return rx;
+    };
+    let tx = parking_lot::Mutex::new(Some(tx));
+    let handler = RcBlock::new(move |granted: objc2::runtime::Bool| {
+        if let Some(tx) = tx.lock().take() {
+            let _ = tx.send(if granted.as_bool() {
+                Auth::Authorized
+            } else {
+                Auth::Denied
+            });
+        }
+    });
+    unsafe { AVCaptureDevice::requestAccessForMediaType_completionHandler(audio, &handler) };
+    rx
+}
+
+/// Ensure both permissions are granted, prompting for whichever hasn't been
+/// asked yet. Sequential rather than concurrent so the user sees one dialog at
+/// a time.
+async fn ensure_authorized() -> Result<()> {
+    let mut speech = speech_auth();
+    if speech == Auth::NotDetermined {
+        speech = request_speech_auth().await.map_err(|_| {
+            Error::Other("dictation: speech permission prompt was dismissed".into())
+        })?;
+    }
+    authorized_or_error("speech recognition", speech)?;
+
+    let mut mic = microphone_auth();
+    if mic == Auth::NotDetermined {
+        mic = request_microphone_auth().await.map_err(|_| {
+            Error::Other("dictation: microphone permission prompt was dismissed".into())
+        })?;
+    }
+    authorized_or_error("microphone", mic)
+}
+
+// ---------------------------------------------------------------------------
+// Commands
+
+pub fn availability() -> Availability {
+    // A recognizer only exists for a supported locale; without one there is
+    // nothing to ask about on-device support, so report the conservative
+    // answer and let `start` produce the readable error.
+    let on_device = unsafe { SFSpeechRecognizer::init(SFSpeechRecognizer::alloc()) }
+        .is_some_and(|r| unsafe { r.supportsOnDeviceRecognition() });
+    Availability {
+        supported: true,
+        speech: speech_auth(),
+        microphone: microphone_auth(),
+        on_device,
+    }
+}
+
+pub async fn start(app: AppHandle) -> Result<()> {
+    // Claiming ACTIVE up front is what makes a second start a no-op, and it
+    // has to happen before the permission prompts, which can sit on screen
+    // for a long time.
+    if ACTIVE.swap(true, Ordering::SeqCst) {
+        return Ok(());
+    }
+    // The claim is released by exactly one owner: `start` while `begin` still
+    // hasn't run, then `begin` itself on failure, then `teardown` once the
+    // session is up. Handing it over rather than clearing it from here means
+    // a caller who drops this future after the session came up can't leave a
+    // live recognizer behind a cleared flag.
+    if let Err(e) = ensure_authorized().await {
+        ACTIVE.store(false, Ordering::SeqCst);
+        return Err(e);
+    }
+    let handle = app.clone();
+    match on_main(&app, move || begin(handle)).await {
+        Ok(started) => started,
+        // The closure never ran, so `begin` never took the claim.
+        Err(e) => {
+            ACTIVE.store(false, Ordering::SeqCst);
+            Err(e)
+        }
+    }
+}
+
+fn begin(app: AppHandle) -> Result<()> {
+    let started = build_session(app);
+    if started.is_err() {
+        // `build_session` unwinds whatever it installed, so releasing the
+        // claim here is what lets the user retry. No state event — the
+        // command's `Err` is the frontend's signal.
+        ACTIVE.store(false, Ordering::SeqCst);
+    }
+    started
+}
+
+/// Build and start the session. Main thread; permissions are already granted,
+/// which matters because reading `inputNode`'s format before that yields a
+/// zero-rate format and installing a tap with it throws in ObjC.
+fn build_session(app: AppHandle) -> Result<()> {
+    let recognizer = unsafe { SFSpeechRecognizer::init(SFSpeechRecognizer::alloc()) }
+        .ok_or_else(|| Error::Other("Dictation doesn't support this Mac's language.".into()))?;
+    if !unsafe { recognizer.isAvailable() } {
+        return Err(Error::Other(
+            "Speech recognition is unavailable right now. If it needs the network, check your \
+             connection and try again."
+                .into(),
+        ));
+    }
+
+    let request = unsafe { SFSpeechAudioBufferRecognitionRequest::new() };
+    unsafe {
+        request.setShouldReportPartialResults(true);
+        // Keep the audio on this machine whenever the recognizer can manage
+        // it, and fall back to Apple's servers (with their ~1 minute cap)
+        // only when it can't.
+        request.setRequiresOnDeviceRecognition(recognizer.supportsOnDeviceRecognition());
+    }
+
+    let engine = unsafe { AVAudioEngine::new() };
+    let input = unsafe { engine.inputNode() };
+    let format = unsafe { input.outputFormatForBus(BUS) };
+    // A zero-rate or channel-less format means the OS gave us no usable input
+    // device. Installing a tap with it raises an ObjC exception, which would
+    // abort the process rather than surface an error, so check first.
+    if unsafe { format.sampleRate() } <= 0.0 || unsafe { format.channelCount() } == 0 {
+        return Err(Error::Other(
+            "No microphone input is available. Check your input device in System Settings > Sound."
+                .into(),
+        ));
+    }
+
+    let generation = NEXT_GENERATION.fetch_add(1, Ordering::SeqCst);
+
+    let tap_request = request.clone();
+    let tap = RcBlock::new(
+        move |buffer: NonNull<AVAudioPCMBuffer>, _when: NonNull<AVAudioTime>| {
+            // Real-time audio thread. Appending is the only thing that may
+            // happen here — no session state, no allocation, no emit.
+            unsafe { tap_request.appendAudioPCMBuffer(buffer.as_ref()) };
+        },
+    );
+    unsafe {
+        input.installTapOnBus_bufferSize_format_block(
+            BUS,
+            TAP_BUFFER_FRAMES,
+            Some(&format),
+            RcBlock::as_ptr(&tap),
+        );
+    }
+
+    let results = result_handler(app.clone(), generation);
+    let task = unsafe { recognizer.recognitionTaskWithRequest_resultHandler(&request, &results) };
+
+    unsafe {
+        engine.prepare();
+        if let Err(e) = engine.startAndReturnError() {
+            // Unwind what we just built rather than leaving a tap installed
+            // and a task running behind a failed start.
+            input.removeTapOnBus(BUS);
+            task.cancel();
+            return Err(Error::Other(format!(
+                "Couldn't start the microphone: {}",
+                e.localizedDescription()
+            )));
+        }
+    }
+
+    SESSION.set(Some(Session {
+        generation,
+        engine,
+        input,
+        request,
+        task,
+        _tap: tap,
+        stopping: false,
+    }));
+    // Audio is flowing. Only now can the frontend show a live mic.
+    emit_state(&app, State::Listening, None);
+    Ok(())
+}
+
+/// The recognizer's result handler. Runs on the recognizer's queue — the main
+/// queue by default, i.e. the thread `SESSION` lives on.
+fn result_handler(
+    app: AppHandle,
+    generation: u64,
+) -> RcBlock<dyn Fn(*mut SFSpeechRecognitionResult, *mut NSError)> {
+    RcBlock::new(
+        move |result: *mut SFSpeechRecognitionResult, error: *mut NSError| {
+            // Apple passes one or the other, and both may be null.
+            if let Some(result) = unsafe { result.as_ref() } {
+                let text = unsafe { result.bestTranscription().formattedString() }.to_string();
+                let is_final = unsafe { result.isFinal() };
+                // A result for an already-replaced session must stay silent,
+                // or it would overwrite the new session's transcript.
+                if !is_live(generation) {
+                    return;
+                }
+                emit_transcript(&app, text, is_final);
+                if is_final {
+                    if let Some(session) = claim(generation) {
+                        teardown(session);
+                        emit_state(&app, State::Stopped, None);
+                    }
+                }
+                return;
+            }
+            if let Some(error) = unsafe { error.as_ref() } {
+                let Some(session) = claim(generation) else {
+                    return;
+                };
+                let message = error.localizedDescription().to_string();
+                let stopping = session.stopping;
+                teardown(session);
+                if stopping {
+                    // The expected end of a user-requested stop, not a failure.
+                    tracing::debug!(error = %message, "dictation stream ended");
+                    emit_state(&app, State::Stopped, None);
+                } else {
+                    tracing::warn!(error = %message, "dictation failed");
+                    emit_state(&app, State::Error, Some(message));
+                }
+            }
+        },
+    )
+}
+
+pub async fn stop(app: AppHandle) -> Result<()> {
+    // The session stays in `SESSION` — the result handler still needs it to
+    // deliver the final transcript and own the teardown.
+    let stopped = on_main(&app, || {
+        // Clone the handles out before calling into ObjC: the rule for
+        // `SESSION` is that no borrow is ever held across a framework call.
+        let live = SESSION.with_borrow_mut(|slot| {
+            let session = slot.as_mut()?;
+            session.stopping = true;
+            Some((
+                session.generation,
+                session.engine.clone(),
+                session.input.clone(),
+                session.request.clone(),
+            ))
+        });
+        let (generation, engine, input, request) = live?;
+        unsafe {
+            engine.stop();
+            input.removeTapOnBus(BUS);
+            // Deliberately not `task.cancel()`: ending the audio is what makes
+            // the recognizer flush its final result, and that result is what
+            // drives the `stopped` emit. Cancelling would discard it.
+            request.endAudio();
+        }
+        Some(generation)
+    })
+    .await?;
+
+    // Idle: nothing to stop, and no event.
+    let Some(generation) = stopped else {
+        return Ok(());
+    };
+
+    let handle = app.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(FLUSH_TIMEOUT).await;
+        let emit_to = handle.clone();
+        let _ = on_main(&handle, move || {
+            // Still live means the final result never arrived; `claim` is what
+            // keeps this from double-emitting against the result handler.
+            if let Some(session) = claim(generation) {
+                tracing::warn!(
+                    "dictation: no final result before the flush deadline; forcing stop"
+                );
+                teardown(session);
+                emit_state(&emit_to, State::Stopped, None);
+            }
+        })
+        .await;
+    });
+    Ok(())
+}

--- a/src-tauri/src/dictation/apple.rs
+++ b/src-tauri/src/dictation/apple.rs
@@ -21,7 +21,7 @@
 //! Note that `#[tauri::command]` futures must be `Send`, which is the second
 //! reason for this shape: no ObjC handle is ever live across an `.await`.
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
@@ -57,6 +57,14 @@ const FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
 thread_local! {
     /// The one live session, main-thread only. See the module's threading note.
     static SESSION: RefCell<Option<Session>> = const { RefCell::new(None) };
+
+    /// A `dictation_stop` that found no session to stop. `start` sits on the
+    /// permission prompts with `ACTIVE` claimed but `SESSION` still empty, so
+    /// without this a stop issued in that window would be swallowed and the
+    /// mic would open anyway once the user granted access. `start` clears the
+    /// flag before prompting and consumes it after; both ends run on the main
+    /// thread, which is what orders a stop against a concurrent start.
+    static STOP_PENDING: Cell<bool> = const { Cell::new(false) };
 }
 
 /// Set for the whole span of a session, from the first moment of `start`
@@ -273,6 +281,12 @@ pub async fn start(app: AppHandle) -> Result<()> {
     if ACTIVE.swap(true, Ordering::SeqCst) {
         return Ok(());
     }
+    // Discard a stop that predates this start; only one that lands while the
+    // prompts are up should cancel us.
+    if let Err(e) = on_main(&app, || STOP_PENDING.set(false)).await {
+        ACTIVE.store(false, Ordering::SeqCst);
+        return Err(e);
+    }
     // The claim is released by exactly one owner: `start` while `begin` still
     // hasn't run, then `begin` itself on failure, then `teardown` once the
     // session is up. Handing it over rather than clearing it from here means
@@ -294,6 +308,13 @@ pub async fn start(app: AppHandle) -> Result<()> {
 }
 
 fn begin(app: AppHandle) -> Result<()> {
+    // The user asked to stop while the permission prompts were up. Honour it
+    // instead of opening the mic behind their back. No state event: the
+    // session never came up, so there is nothing to close out.
+    if STOP_PENDING.replace(false) {
+        ACTIVE.store(false, Ordering::SeqCst);
+        return Ok(());
+    }
     let started = build_session(app);
     if started.is_err() {
         // `build_session` unwinds whatever it installed, so releasing the
@@ -452,7 +473,13 @@ pub async fn stop(app: AppHandle) -> Result<()> {
                 session.request.clone(),
             ))
         });
-        let (generation, engine, input, request) = live?;
+        let Some((generation, engine, input, request)) = live else {
+            // Either genuinely idle, or a `start` is still sitting on the
+            // permission prompts. Leave the request for `begin` to consume; a
+            // stale flag from the idle case is cleared by the next `start`.
+            STOP_PENDING.set(true);
+            return None;
+        };
         unsafe {
             engine.stop();
             input.removeTapOnBus(BUS);

--- a/src-tauri/src/dictation/mod.rs
+++ b/src-tauri/src/dictation/mod.rs
@@ -1,0 +1,170 @@
+//! Voice dictation for the composer: hold the mic button, speak, get text.
+//!
+//! The whole thing is one session at a time, app-wide. `dictation_start`
+//! begins listening, `dictation:transcript` events carry the running text as
+//! the recognizer revises it, and `dictation_stop` ends audio so the
+//! recognizer can flush a final result. `dictation:state` brackets that with
+//! `listening` / `stopped` / `error`, so the frontend never has to infer
+//! whether a session is alive.
+//!
+//! Transcripts are whole-session text, not deltas: Apple rewrites earlier
+//! words as later context arrives ("to" → "two" → "too"), so a delta stream
+//! would be unreconstructable. Each event replaces the last.
+//!
+//! Only Apple platforms have an implementation (`apple`); everywhere else the
+//! commands are stubs that report `supported: false`, which is what keeps the
+//! Linux CI build compiling and lets the frontend hide the mic button without
+//! a platform check of its own.
+
+use serde::Serialize;
+use tauri::AppHandle;
+// Only the (Apple-gated) emitters below need the trait in scope.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+use tauri::Emitter;
+
+use crate::error::Result;
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod apple;
+
+/// A TCC (privacy) permission state, for either the microphone or speech
+/// recognition. Mirrors both `SFSpeechRecognizerAuthorizationStatus` and
+/// `AVAuthorizationStatus`, which share these four cases.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+// The full set is the wire contract on every platform, but only the Apple
+// implementation ever reports anything other than `NotDetermined`.
+#[cfg_attr(not(any(target_os = "macos", target_os = "ios")), allow(dead_code))]
+pub enum Auth {
+    /// Never asked — starting a session will prompt.
+    NotDetermined,
+    Authorized,
+    /// The user said no; only System Settings can undo it.
+    Denied,
+    /// Blocked by policy (MDM, Screen Time), so prompting can't help.
+    Restricted,
+}
+
+/// What dictation can do on this machine, for a UI that wants to disable the
+/// mic button (or explain why) before the user ever presses it.
+#[derive(Clone, Debug, Serialize)]
+pub struct Availability {
+    /// False on non-Apple platforms — nothing else in this struct matters.
+    supported: bool,
+    speech: Auth,
+    microphone: Auth,
+    /// The recognizer can transcribe without a network round-trip. When true
+    /// we pin the request on-device, so no audio leaves the machine; when
+    /// false recognition is server-backed and capped at about a minute.
+    on_device: bool,
+}
+
+// The event machinery below is gated on the platforms that have an
+// implementation: nothing emits without one, and CI builds Linux with
+// `-D warnings`, where an unused payload type is a hard error.
+
+/// A revision of the session's transcript. `text` is the entire utterance so
+/// far, not an increment. Exactly one event per session has `is_final`.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[derive(Clone, Serialize)]
+struct TranscriptPayload {
+    text: String,
+    is_final: bool,
+}
+
+/// The lifecycle of the one live session. `Stopped` and `Error` are both
+/// terminal *and* mean the session is fully torn down, so `dictation_start`
+/// is callable again the moment either arrives.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum State {
+    Listening,
+    Stopped,
+    Error,
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[derive(Clone, Serialize)]
+struct StatePayload {
+    state: State,
+    /// Set only for `Error` — the recognizer's own message, shown as-is.
+    error: Option<String>,
+}
+
+/// Emit one event, logging (not propagating) failure — same posture as
+/// `supervisor::events`: no event is delivery-guaranteed.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn emit<T: Serialize + Clone>(app: &AppHandle, event: &str, payload: T) {
+    if let Err(e) = app.emit(event, payload) {
+        tracing::warn!(error = %e, event, "emit failed");
+    }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn emit_transcript(app: &AppHandle, text: String, is_final: bool) {
+    emit(
+        app,
+        "dictation:transcript",
+        TranscriptPayload { text, is_final },
+    );
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn emit_state(app: &AppHandle, state: State, error: Option<String>) {
+    emit(app, "dictation:state", StatePayload { state, error });
+}
+
+/// Whether dictation works here, and what permissions stand in the way. Cheap
+/// and side-effect free — it never prompts, so the UI can call it on mount.
+#[tauri::command]
+pub async fn dictation_availability() -> Availability {
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    {
+        apple::availability()
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    {
+        Availability {
+            supported: false,
+            speech: Auth::NotDetermined,
+            microphone: Auth::NotDetermined,
+            on_device: false,
+        }
+    }
+}
+
+/// Start listening. Requests microphone and speech permission on first use
+/// (so the first call can block on two TCC prompts), and resolves once audio
+/// is actually flowing — by which point `dictation:state` `listening` has
+/// been emitted. A second call while a session is live is a no-op.
+#[tauri::command]
+pub async fn dictation_start(app: AppHandle) -> Result<()> {
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    {
+        apple::start(app).await
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    {
+        let _ = app;
+        Err(crate::error::Error::Other(
+            "dictation isn't supported on this platform".into(),
+        ))
+    }
+}
+
+/// Stop listening. Returns as soon as the microphone is released; the final
+/// transcript and the terminal `dictation:state` follow asynchronously once
+/// the recognizer has flushed. A no-op when idle.
+#[tauri::command]
+pub async fn dictation_stop(app: AppHandle) -> Result<()> {
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    {
+        apple::stop(app).await
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    {
+        let _ = app;
+        Ok(())
+    }
+}

--- a/src-tauri/src/dictation/mod.rs
+++ b/src-tauri/src/dictation/mod.rs
@@ -64,7 +64,8 @@ pub struct Availability {
 // `-D warnings`, where an unused payload type is a hard error.
 
 /// A revision of the session's transcript. `text` is the entire utterance so
-/// far, not an increment. Exactly one event per session has `is_final`.
+/// far, not an increment. At most one event per session has `is_final`: a
+/// recognizer that never flushes gets torn down on the deadline instead.
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[derive(Clone, Serialize)]
 struct TranscriptPayload {
@@ -155,7 +156,10 @@ pub async fn dictation_start(app: AppHandle) -> Result<()> {
 
 /// Stop listening. Returns as soon as the microphone is released; the final
 /// transcript and the terminal `dictation:state` follow asynchronously once
-/// the recognizer has flushed. A no-op when idle.
+/// the recognizer has flushed, and a recognizer that doesn't flush in time
+/// yields the terminal state alone. A no-op when idle, except that a stop
+/// issued while `dictation_start` waits on a permission prompt cancels that
+/// pending session.
 #[tauri::command]
 pub async fn dictation_stop(app: AppHandle) -> Result<()> {
     #[cfg(any(target_os = "macos", target_os = "ios"))]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,6 +7,7 @@ mod child_io;
 mod codegraph;
 mod commands;
 mod database;
+mod dictation;
 mod editors;
 mod error;
 mod exec_session;
@@ -1907,6 +1908,9 @@ pub fn run() {
             commands::detect_editors,
             commands::open_in_editor,
             commands::submit_feedback,
+            dictation::dictation_availability,
+            dictation::dictation_start,
+            dictation::dictation_stop,
         ])
         .build(tauri::generate_context!())
         .expect("error while building fletch")

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -48,7 +48,8 @@
       "icons/icon.icns"
     ],
     "macOS": {
-      "minimumSystemVersion": "13.0"
+      "minimumSystemVersion": "13.0",
+      "entitlements": "Entitlements.plist"
     }
   }
 }

--- a/src/api/domains/dictation.ts
+++ b/src/api/domains/dictation.ts
@@ -9,10 +9,15 @@ export const dictationApi = {
    *  once audio is flowing; transcripts then arrive via `onDictationTranscript`.
    *  Rejects with a message if permission is denied or the recognizer can't
    *  start. Only one session runs at a time — a second start while listening
-   *  is a no-op. */
+   *  is a no-op, and a `dictationStop` issued while a permission prompt is
+   *  still up cancels the pending session, so this resolves with no
+   *  `listening` state ever arriving. */
   dictationStart: () => invoke<void>("dictation_start"),
-  /** Stop listening and let the recognizer flush its final result (one last
-   *  `dictation:transcript` with `is_final: true`, then `dictation:state`
-   *  `stopped`). No-op when not listening. */
+  /** Stop listening and let the recognizer flush its final result: normally
+   *  one last `dictation:transcript` with `is_final: true`, then
+   *  `dictation:state` `stopped`. The final transcript is best-effort — a
+   *  recognizer that hasn't flushed within a couple of seconds is torn down
+   *  and only `stopped` arrives — so treat `stopped` as the point to commit
+   *  whatever text was last received. No-op when not listening. */
   dictationStop: () => invoke<void>("dictation_stop"),
 };

--- a/src/api/domains/dictation.ts
+++ b/src/api/domains/dictation.ts
@@ -1,0 +1,18 @@
+import { invoke } from "../invoke";
+import type { DictationAvailability } from "../types/dictation";
+
+export const dictationApi = {
+  /** Whether native dictation exists on this platform and what the user has
+   *  authorized so far. Cheap; safe to call on every composer mount. */
+  dictationAvailability: () => invoke<DictationAvailability>("dictation_availability"),
+  /** Start listening. Requests mic + speech permission on first use. Resolves
+   *  once audio is flowing; transcripts then arrive via `onDictationTranscript`.
+   *  Rejects with a message if permission is denied or the recognizer can't
+   *  start. Only one session runs at a time — a second start while listening
+   *  is a no-op. */
+  dictationStart: () => invoke<void>("dictation_start"),
+  /** Stop listening and let the recognizer flush its final result (one last
+   *  `dictation:transcript` with `is_final: true`, then `dictation:state`
+   *  `stopped`). No-op when not listening. */
+  dictationStop: () => invoke<void>("dictation_stop"),
+};

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -12,6 +12,7 @@ import type {
   AgentViewEvent,
   ShellOutputEvent,
 } from "./types/agent";
+import type { DictationStateEvent, DictationTranscriptEvent } from "./types/dictation";
 import type { PrStateChangedEvent } from "./types/pr";
 import type { AgentInstallEvent } from "./types/providers";
 import type {
@@ -171,6 +172,19 @@ export function onAgentOutput(cb: (e: AgentOutputEvent) => void): Promise<Unlist
 
 export function onShellOutput(cb: (e: ShellOutputEvent) => void): Promise<UnlistenFn> {
   return listen<ShellOutputEvent>("shell:output", (event) => cb(event.payload));
+}
+
+/** The running transcript of the active dictation session (see
+ *  `DictationTranscriptEvent` — whole text, not a delta). */
+export function onDictationTranscript(
+  cb: (e: DictationTranscriptEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<DictationTranscriptEvent>("dictation:transcript", (event) => cb(event.payload));
+}
+
+/** Dictation session lifecycle: listening → stopped, or error with a reason. */
+export function onDictationState(cb: (e: DictationStateEvent) => void): Promise<UnlistenFn> {
+  return listen<DictationStateEvent>("dictation:state", (event) => cb(event.payload));
 }
 
 export function onAgentEvent(cb: (e: AgentManagedEvent) => void): Promise<UnlistenFn> {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,5 +1,6 @@
 import { agentsApi } from "./domains/agents";
 import { commandsApi } from "./domains/commands";
+import { dictationApi } from "./domains/dictation";
 import { filesApi } from "./domains/files";
 import { gitApi } from "./domains/git";
 import { githubApi } from "./domains/github";
@@ -20,6 +21,7 @@ export * from "./events";
 export * from "./types/agent";
 export * from "./types/checkout";
 export * from "./types/commands";
+export * from "./types/dictation";
 export * from "./types/git";
 export * from "./types/issues";
 export * from "./types/pr";
@@ -47,6 +49,7 @@ export const api = {
   ...runApi,
   ...filesApi,
   ...commandsApi,
+  ...dictationApi,
   ...providersApi,
   ...workflowsApi,
   ...roadmapApi,

--- a/src/api/types/dictation.ts
+++ b/src/api/types/dictation.ts
@@ -33,8 +33,11 @@ export interface DictationTranscriptEvent {
 export type DictationState = "listening" | "stopped" | "error";
 
 /** Payload of the `dictation:state` event. `error` is a human-readable reason,
- *  set only when `state` is `error` (e.g. permission denied, recognizer
- *  unavailable, audio engine failed to start). */
+ *  set only when `state` is `error`, which only happens when a session that
+ *  was already listening fails. Failures to get started at all (permission
+ *  denied, no recognizer for the locale, the mic wouldn't open) reject
+ *  `dictationStart` and emit no event, so the rejected promise — not this
+ *  state — is what tells the UI a start didn't take. */
 export interface DictationStateEvent {
   state: DictationState;
   error: string | null;

--- a/src/api/types/dictation.ts
+++ b/src/api/types/dictation.ts
@@ -1,0 +1,41 @@
+// Voice dictation: the composer's mic button, backed by the platform's native
+// speech recognizer (Apple's SFSpeechRecognizer on macOS/iOS). Mirrors the Rust
+// `dictation` module's serde shapes — keep the two in sync.
+
+/** Apple's authorization states for the mic and for speech recognition.
+ *  `not_determined` means the OS hasn't asked the user yet; the first
+ *  `dictation_start` triggers the prompt. `restricted` is a parental-control /
+ *  MDM lock the user can't lift from the app. */
+export type DictationAuthorization = "not_determined" | "authorized" | "denied" | "restricted";
+
+export interface DictationAvailability {
+  /** False on platforms with no native recognizer (Linux, Windows). The
+   *  composer hides the mic button entirely when this is false. */
+  supported: boolean;
+  speech: DictationAuthorization;
+  microphone: DictationAuthorization;
+  /** The recognizer for the current locale can run without sending audio to
+   *  Apple. When false, recognition uses Apple's servers and sessions are
+   *  capped at roughly one minute. */
+  on_device: boolean;
+}
+
+/** Payload of the `dictation:transcript` event. `text` is the whole running
+ *  transcript for the current session (Apple revises earlier words as it hears
+ *  more), not a delta — the UI replaces the in-progress segment with it.
+ *  `is_final` marks the last result of a session, after which no more
+ *  transcript events arrive until the next `dictation_start`. */
+export interface DictationTranscriptEvent {
+  text: string;
+  is_final: boolean;
+}
+
+export type DictationState = "listening" | "stopped" | "error";
+
+/** Payload of the `dictation:state` event. `error` is a human-readable reason,
+ *  set only when `state` is `error` (e.g. permission denied, recognizer
+ *  unavailable, audio engine failed to start). */
+export interface DictationStateEvent {
+  state: DictationState;
+  error: string | null;
+}


### PR DESCRIPTION
## Summary

Native voice dictation backend for the composer's upcoming mic button (UI lands in the stacked follow-up PR). Uses Apple's Speech framework (`SFSpeechRecognizer` + `SFSpeechAudioBufferRecognitionRequest`) fed by an `AVAudioEngine` mic tap, via the `objc2` bindings. No Swift toolchain step; the same code compiles for macOS and iOS. Other platforms get a stub that reports `supported: false`, so the frontend hides the button without a platform check of its own.

## What's in it

- **Commands** `dictation_availability`, `dictation_start`, `dictation_stop` in `src-tauri/src/dictation/`, plus **events** `dictation:transcript` (`{ text, is_final }`, whole running transcript, not a delta) and `dictation:state` (`listening | stopped | error`).
- **Typed frontend contract** in `src/api` (types, command wrappers, event listeners). No UI in this PR.
- **`Info.plist`** with the mic and speech usage strings. Tauri picks it up by filename and also embeds it in the dev binary, so the TCC prompts work under `tauri dev`. Without `NSSpeechRecognitionUsageDescription`, `requestAuthorization` crashes the process.
- **`Entitlements.plist`** with `com.apple.security.device.audio-input`, wired via `bundle.macOS.entitlements`. The release build is signed with hardened runtime, which yields silence from the mic without this.
- Cargo: `objc2-speech`, `objc2-avf-audio`, `objc2-av-foundation` with `default-features = false` and only the needed classes. Three new crates in the lockfile.

## Design notes

- **Threading.** All session state lives in a main-thread `thread_local`; every touch goes through `run_on_main_thread`. `SFSpeechRecognizer.queue` defaults to the main queue, so the result handler is dispatched to the same thread we mutate on and cannot re-enter. No `unsafe impl Send`. The audio tap runs on Apple's real-time thread and only appends buffers to its own retained request.
- **Exactly-once teardown.** A per-session generation counter plus a `claim(generation)` that takes the session by value. The result handler, the post-stop flush timer (2s), and any late callback race safely; whoever claims it owns the terminal state event.
- **Stop flushes, never cancels.** `dictation_stop` stops the engine and calls `endAudio`; the recognizer then delivers the final (punctuated) result, which drives `stopped`. Any error arriving after a user-requested stop is treated as `stopped`, since the end-of-stream errors come from a private domain with undocumented codes.
- **On-device when possible.** `requiresOnDeviceRecognition` is set to `supportsOnDeviceRecognition()`, so audio stays local wherever the recognizer can manage it and falls back to Apple's servers (about a one-minute cap) only where it can't.
- **Guards** for a zero-rate input format (installing a tap with it throws in ObjC and would abort the process) and a concurrent second `start` (atomic claim before the permission prompts).

## Verification

- `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`: clean on macOS.
- `cargo test`: 1482 passed.
- Non-Apple stub verified by temporarily inverting the cfg predicates on macOS and running the clippy gate. That surfaced dead-code errors that would have broken the Linux CI build; the event machinery is now cfg-gated to Apple.
- `bun run check`, `biome check`: clean.
- **Not exercised at runtime** in the sandbox (no mic access). Manual checklist below.

## Manual test checklist (macOS)

Reset TCC first so you get first-run prompts: `tccutil reset Microphone com.fletch.desktop` and `tccutil reset SpeechRecognition com.fletch.desktop`.

1. `bun run tauri dev`, then in devtools: `__TAURI__.core.invoke('dictation_availability')` returns `supported: true`, both auths `not_determined`, `on_device: true` on Apple Silicon. No prompt appears.
2. `invoke('dictation_start')`: speech prompt, then mic prompt, each showing the Info.plist string. Grant both. Promise resolves, `dictation:state` `listening` arrives, orange mic indicator shows in the menu bar.
3. Speak a sentence with a revisable word ("to/two/too"). Each `dictation:transcript` carries the whole utterance and earlier words change between events.
4. `invoke('dictation_stop')`: resolves promptly, mic indicator clears, then one `is_final: true` transcript followed by exactly one `stopped` state.
5. Start again immediately: works, no re-prompt.
6. Second `start` while listening: resolves Ok, no second `listening` event.
7. `stop` while idle: resolves Ok, no events.
8. Deny path: reset mic TCC, restart, start, deny. Promise rejects with the System Settings guidance; no state event.
9. Signed release build: repeat 2 to 4 on the installed app. If the mic lights up but the transcript is empty, the entitlement isn't reaching codesign.