### PR TITLE
fix(dictation): settle every start/stop outcome, and document the feature

### DIFF
--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -1,0 +1,73 @@
+# Voice dictation
+
+The mic button in the agent composer (beside the paperclip) streams the
+platform's native speech recognizer into the prompt box. This document is the
+part that isn't obvious from the code: which platforms have it, what the OS
+demands before it works, and where your audio goes.
+
+## Platform support
+
+**Apple only.** The implementation is Apple's Speech framework
+(`SFSpeechRecognizer` fed by an `AVAudioEngine` mic tap), reached through the
+`objc2` bindings — the same code compiles for macOS and iOS, with no Swift
+toolchain step. Linux and Windows get a stub that reports `supported: false`,
+and the composer hides the button entirely rather than offer one that can only
+fail.
+
+The flow, end to end:
+
+| Layer | File |
+| --- | --- |
+| Button | `src/components/Composer/dictation/DictationButton.tsx` |
+| Session state | `src/components/Composer/dictation/useDictation.ts` |
+| IPC | `src/api/domains/dictation.ts` → `dictation_availability` / `dictation_start` / `dictation_stop` |
+| Events | `src/api/events.ts` — `dictation:transcript`, `dictation:state` |
+| Commands + contract | `src-tauri/src/dictation/mod.rs` |
+| Recognizer | `src-tauri/src/dictation/apple.rs` |
+
+## Permissions
+
+Dictation needs **two** separate TCC grants, prompted on the first
+`dictation_start` (speech first, then the microphone, one dialog at a time):
+
+- `NSSpeechRecognitionUsageDescription`
+- `NSMicrophoneUsageDescription`
+
+Both strings live in `src-tauri/Info.plist`, which the Tauri CLI picks up by
+filename and `tauri-codegen` also embeds into the dev binary — so the prompts
+work under `tauri dev`, not just in a bundle. The speech string is load-bearing
+rather than cosmetic: `requestAuthorization:` crashes the process outright if
+it is missing.
+
+A denied grant can only be undone in System Settings › Privacy & Security, so
+the button shows a slashed mic and says so. To get the first-run prompts back
+while testing:
+
+```sh
+tccutil reset Microphone com.fletch.desktop
+tccutil reset SpeechRecognition com.fletch.desktop
+```
+
+## The audio-input entitlement
+
+Release builds are signed with the hardened runtime, which denies microphone
+access to the process regardless of the user's TCC answer unless
+`com.apple.security.device.audio-input` is granted. It is set in
+`src-tauri/Entitlements.plist` and wired through `bundle.macOS.entitlements` in
+`tauri.conf.json` — entitlements, unlike `Info.plist`, are never discovered by
+filename.
+
+The failure mode when this doesn't reach `codesign` is quiet: dev builds work,
+the notarized app lights the mic and transcribes silence. If dictation returns
+an empty transcript only in a released build, check the entitlement first.
+
+## On-device vs Apple's servers
+
+The request sets `requiresOnDeviceRecognition` to whatever the recognizer
+reports as `supportsOnDeviceRecognition()`. Where that is true (a supported
+locale on Apple Silicon, with the assets downloaded) **no audio leaves the
+machine**. Where it is false, recognition is server-backed and Apple caps a
+session at roughly a minute, after which the recognizer ends it itself — the
+composer sees the ordinary final transcript and `stopped`, so a long dictation
+simply stops rather than breaking. `dictation_availability` reports which mode
+this machine is in as `on_device`.

--- a/src-tauri/src/dictation/apple.rs
+++ b/src-tauri/src/dictation/apple.rs
@@ -58,12 +58,14 @@ thread_local! {
     /// The one live session, main-thread only. See the module's threading note.
     static SESSION: RefCell<Option<Session>> = const { RefCell::new(None) };
 
-    /// A `dictation_stop` that found no session to stop. `start` sits on the
-    /// permission prompts with `ACTIVE` claimed but `SESSION` still empty, so
-    /// without this a stop issued in that window would be swallowed and the
-    /// mic would open anyway once the user granted access. `start` clears the
-    /// flag before prompting and consumes it after; both ends run on the main
-    /// thread, which is what orders a stop against a concurrent start.
+    /// A `dictation_stop` that arrived while a start was in flight — `ACTIVE`
+    /// claimed but `SESSION` still empty, which is exactly the span of the
+    /// permission prompts. Without this the stop would be swallowed and the
+    /// mic would open anyway once the user granted access. Set only in that
+    /// window (an idle stop leaves nothing behind), consumed by `begin`, and
+    /// cleared on the one path that abandons a claim without reaching `begin`.
+    /// Both ends run on the main thread, which is what orders a stop against a
+    /// concurrent start.
     static STOP_PENDING: Cell<bool> = const { Cell::new(false) };
 }
 
@@ -274,18 +276,14 @@ pub fn availability() -> Availability {
     }
 }
 
-pub async fn start(app: AppHandle) -> Result<()> {
+/// `Ok(true)` once a session is live and `listening` has been emitted;
+/// `Ok(false)` when nothing was started, so no terminal event will follow.
+pub async fn start(app: AppHandle) -> Result<bool> {
     // Claiming ACTIVE up front is what makes a second start a no-op, and it
     // has to happen before the permission prompts, which can sit on screen
     // for a long time.
     if ACTIVE.swap(true, Ordering::SeqCst) {
-        return Ok(());
-    }
-    // Discard a stop that predates this start; only one that lands while the
-    // prompts are up should cancel us.
-    if let Err(e) = on_main(&app, || STOP_PENDING.set(false)).await {
-        ACTIVE.store(false, Ordering::SeqCst);
-        return Err(e);
+        return Ok(false);
     }
     // The claim is released by exactly one owner: `start` while `begin` still
     // hasn't run, then `begin` itself on failure, then `teardown` once the
@@ -294,6 +292,10 @@ pub async fn start(app: AppHandle) -> Result<()> {
     // live recognizer behind a cleared flag.
     if let Err(e) = ensure_authorized().await {
         ACTIVE.store(false, Ordering::SeqCst);
+        // The only path that drops the claim without `begin` consuming a stop
+        // that landed during the prompts — clear it, or it would cancel an
+        // unrelated later start.
+        let _ = on_main(&app, || STOP_PENDING.set(false)).await;
         return Err(e);
     }
     let handle = app.clone();
@@ -307,22 +309,23 @@ pub async fn start(app: AppHandle) -> Result<()> {
     }
 }
 
-fn begin(app: AppHandle) -> Result<()> {
+fn begin(app: AppHandle) -> Result<bool> {
     // The user asked to stop while the permission prompts were up. Honour it
     // instead of opening the mic behind their back. No state event: the
-    // session never came up, so there is nothing to close out.
+    // session never came up, so there is nothing to close out — the `false`
+    // is what tells the caller not to wait for one.
     if STOP_PENDING.replace(false) {
         ACTIVE.store(false, Ordering::SeqCst);
-        return Ok(());
+        return Ok(false);
     }
-    let started = build_session(app);
-    if started.is_err() {
+    if let Err(e) = build_session(app) {
         // `build_session` unwinds whatever it installed, so releasing the
         // claim here is what lets the user retry. No state event — the
         // command's `Err` is the frontend's signal.
         ACTIVE.store(false, Ordering::SeqCst);
+        return Err(e);
     }
-    started
+    Ok(true)
 }
 
 /// Build and start the session. Main thread; permissions are already granted,
@@ -474,10 +477,13 @@ pub async fn stop(app: AppHandle) -> Result<()> {
             ))
         });
         let Some((generation, engine, input, request)) = live else {
-            // Either genuinely idle, or a `start` is still sitting on the
-            // permission prompts. Leave the request for `begin` to consume; a
-            // stale flag from the idle case is cleared by the next `start`.
-            STOP_PENDING.set(true);
+            // No session — but a claimed `ACTIVE` with an empty `SESSION` means
+            // a `start` is still sitting on the permission prompts, so leave
+            // the request for `begin` to consume. Genuinely idle, record
+            // nothing: a flag left behind here would cancel a later start.
+            if ACTIVE.load(Ordering::SeqCst) {
+                STOP_PENDING.set(true);
+            }
             return None;
         };
         unsafe {

--- a/src-tauri/src/dictation/apple.rs
+++ b/src-tauri/src/dictation/apple.rs
@@ -276,14 +276,15 @@ pub fn availability() -> Availability {
     }
 }
 
-/// `Ok(true)` once a session is live and `listening` has been emitted;
-/// `Ok(false)` when nothing was started, so no terminal event will follow.
-pub async fn start(app: AppHandle) -> Result<bool> {
+/// `Ok(Some(id))` once a session is live and `listening` has been emitted —
+/// the id every event of that session carries; `Ok(None)` when nothing was
+/// started, so no terminal event will follow.
+pub async fn start(app: AppHandle) -> Result<Option<u64>> {
     // Claiming ACTIVE up front is what makes a second start a no-op, and it
     // has to happen before the permission prompts, which can sit on screen
     // for a long time.
     if ACTIVE.swap(true, Ordering::SeqCst) {
-        return Ok(false);
+        return Ok(None);
     }
     // The claim is released by exactly one owner: `start` while `begin` still
     // hasn't run, then `begin` itself on failure, then `teardown` once the
@@ -309,29 +310,32 @@ pub async fn start(app: AppHandle) -> Result<bool> {
     }
 }
 
-fn begin(app: AppHandle) -> Result<bool> {
+fn begin(app: AppHandle) -> Result<Option<u64>> {
     // The user asked to stop while the permission prompts were up. Honour it
     // instead of opening the mic behind their back. No state event: the
-    // session never came up, so there is nothing to close out — the `false`
+    // session never came up, so there is nothing to close out — the `None`
     // is what tells the caller not to wait for one.
     if STOP_PENDING.replace(false) {
         ACTIVE.store(false, Ordering::SeqCst);
-        return Ok(false);
+        return Ok(None);
     }
-    if let Err(e) = build_session(app) {
-        // `build_session` unwinds whatever it installed, so releasing the
-        // claim here is what lets the user retry. No state event — the
-        // command's `Err` is the frontend's signal.
-        ACTIVE.store(false, Ordering::SeqCst);
-        return Err(e);
+    match build_session(app) {
+        Ok(generation) => Ok(Some(generation)),
+        Err(e) => {
+            // `build_session` unwinds whatever it installed, so releasing the
+            // claim here is what lets the user retry. No state event — the
+            // command's `Err` is the frontend's signal.
+            ACTIVE.store(false, Ordering::SeqCst);
+            Err(e)
+        }
     }
-    Ok(true)
 }
 
-/// Build and start the session. Main thread; permissions are already granted,
-/// which matters because reading `inputNode`'s format before that yields a
-/// zero-rate format and installing a tap with it throws in ObjC.
-fn build_session(app: AppHandle) -> Result<()> {
+/// Build and start the session, returning its generation — the id the frontend
+/// keys events on. Main thread; permissions are already granted, which matters
+/// because reading `inputNode`'s format before that yields a zero-rate format
+/// and installing a tap with it throws in ObjC.
+fn build_session(app: AppHandle) -> Result<u64> {
     let recognizer = unsafe { SFSpeechRecognizer::init(SFSpeechRecognizer::alloc()) }
         .ok_or_else(|| Error::Other("Dictation doesn't support this Mac's language.".into()))?;
     if !unsafe { recognizer.isAvailable() } {
@@ -410,8 +414,8 @@ fn build_session(app: AppHandle) -> Result<()> {
         stopping: false,
     }));
     // Audio is flowing. Only now can the frontend show a live mic.
-    emit_state(&app, State::Listening, None);
-    Ok(())
+    emit_state(&app, generation, State::Listening, None);
+    Ok(generation)
 }
 
 /// The recognizer's result handler. Runs on the recognizer's queue — the main
@@ -431,11 +435,11 @@ fn result_handler(
                 if !is_live(generation) {
                     return;
                 }
-                emit_transcript(&app, text, is_final);
+                emit_transcript(&app, generation, text, is_final);
                 if is_final {
                     if let Some(session) = claim(generation) {
                         teardown(session);
-                        emit_state(&app, State::Stopped, None);
+                        emit_state(&app, generation, State::Stopped, None);
                     }
                 }
                 return;
@@ -450,10 +454,10 @@ fn result_handler(
                 if stopping {
                     // The expected end of a user-requested stop, not a failure.
                     tracing::debug!(error = %message, "dictation stream ended");
-                    emit_state(&app, State::Stopped, None);
+                    emit_state(&app, generation, State::Stopped, None);
                 } else {
                     tracing::warn!(error = %message, "dictation failed");
-                    emit_state(&app, State::Error, Some(message));
+                    emit_state(&app, generation, State::Error, Some(message));
                 }
             }
         },
@@ -515,7 +519,7 @@ pub async fn stop(app: AppHandle) -> Result<()> {
                     "dictation: no final result before the flush deadline; forcing stop"
                 );
                 teardown(session);
-                emit_state(&emit_to, State::Stopped, None);
+                emit_state(&emit_to, generation, State::Stopped, None);
             }
         })
         .await;

--- a/src-tauri/src/dictation/mod.rs
+++ b/src-tauri/src/dictation/mod.rs
@@ -137,10 +137,16 @@ pub async fn dictation_availability() -> Availability {
 
 /// Start listening. Requests microphone and speech permission on first use
 /// (so the first call can block on two TCC prompts), and resolves once audio
-/// is actually flowing — by which point `dictation:state` `listening` has
-/// been emitted. A second call while a session is live is a no-op.
+/// is actually flowing.
+///
+/// `true` means a session is now live and `dictation:state` `listening` has
+/// been emitted, so a terminal state will follow. `false` means nothing was
+/// started and no event will arrive: either a session was already active (a
+/// second start is a no-op) or a `dictation_stop` issued while the prompts
+/// were up cancelled this one. The caller needs the distinction because a
+/// `false` leaves nothing to wait for.
 #[tauri::command]
-pub async fn dictation_start(app: AppHandle) -> Result<()> {
+pub async fn dictation_start(app: AppHandle) -> Result<bool> {
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     {
         apple::start(app).await

--- a/src-tauri/src/dictation/mod.rs
+++ b/src-tauri/src/dictation/mod.rs
@@ -66,9 +66,15 @@ pub struct Availability {
 /// A revision of the session's transcript. `text` is the entire utterance so
 /// far, not an increment. At most one event per session has `is_final`: a
 /// recognizer that never flushes gets torn down on the deadline instead.
+///
+/// `session` is the id `dictation_start` returned for this session. Events are
+/// app-wide, and a session outlives the composer that started it (a stop is
+/// followed by a flush), so a composer that starts the next one needs the id to
+/// tell the old session's stragglers from its own.
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[derive(Clone, Serialize)]
 struct TranscriptPayload {
+    session: u64,
     text: String,
     is_final: bool,
 }
@@ -88,6 +94,8 @@ enum State {
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[derive(Clone, Serialize)]
 struct StatePayload {
+    /// Same id as on [`TranscriptPayload`].
+    session: u64,
     state: State,
     /// Set only for `Error` — the recognizer's own message, shown as-is.
     error: Option<String>,
@@ -103,17 +111,29 @@ fn emit<T: Serialize + Clone>(app: &AppHandle, event: &str, payload: T) {
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-fn emit_transcript(app: &AppHandle, text: String, is_final: bool) {
+fn emit_transcript(app: &AppHandle, session: u64, text: String, is_final: bool) {
     emit(
         app,
         "dictation:transcript",
-        TranscriptPayload { text, is_final },
+        TranscriptPayload {
+            session,
+            text,
+            is_final,
+        },
     );
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
-fn emit_state(app: &AppHandle, state: State, error: Option<String>) {
-    emit(app, "dictation:state", StatePayload { state, error });
+fn emit_state(app: &AppHandle, session: u64, state: State, error: Option<String>) {
+    emit(
+        app,
+        "dictation:state",
+        StatePayload {
+            session,
+            state,
+            error,
+        },
+    );
 }
 
 /// Whether dictation works here, and what permissions stand in the way. Cheap
@@ -139,14 +159,16 @@ pub async fn dictation_availability() -> Availability {
 /// (so the first call can block on two TCC prompts), and resolves once audio
 /// is actually flowing.
 ///
-/// `true` means a session is now live and `dictation:state` `listening` has
-/// been emitted, so a terminal state will follow. `false` means nothing was
-/// started and no event will arrive: either a session was already active (a
-/// second start is a no-op) or a `dictation_stop` issued while the prompts
-/// were up cancelled this one. The caller needs the distinction because a
-/// `false` leaves nothing to wait for.
+/// `Some(id)` means a session is now live and `dictation:state` `listening` has
+/// been emitted, so a terminal state will follow; every event of that session
+/// carries the same `id`, which is how a caller tells its own session from a
+/// previous one still flushing. `None` means nothing was started and no event
+/// will arrive: either a session was already active (a second start is a
+/// no-op) or a `dictation_stop` issued while the prompts were up cancelled
+/// this one. The caller needs the distinction because `None` leaves nothing
+/// to wait for.
 #[tauri::command]
-pub async fn dictation_start(app: AppHandle) -> Result<bool> {
+pub async fn dictation_start(app: AppHandle) -> Result<Option<u64>> {
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     {
         apple::start(app).await

--- a/src/api/domains/dictation.ts
+++ b/src/api/domains/dictation.ts
@@ -5,14 +5,16 @@ export const dictationApi = {
   /** Whether native dictation exists on this platform and what the user has
    *  authorized so far. Cheap; safe to call on every composer mount. */
   dictationAvailability: () => invoke<DictationAvailability>("dictation_availability"),
-  /** Start listening. Requests mic + speech permission on first use. Resolves
-   *  once audio is flowing; transcripts then arrive via `onDictationTranscript`.
-   *  Rejects with a message if permission is denied or the recognizer can't
-   *  start. Only one session runs at a time — a second start while listening
-   *  is a no-op, and a `dictationStop` issued while a permission prompt is
-   *  still up cancels the pending session, so this resolves with no
-   *  `listening` state ever arriving. */
-  dictationStart: () => invoke<void>("dictation_start"),
+  /** Start listening. Requests mic + speech permission on first use. Rejects
+   *  with a message if permission is denied or the recognizer can't start.
+   *
+   *  Resolves `true` once audio is flowing: `dictation:state` `listening` has
+   *  been emitted, transcripts follow via `onDictationTranscript`, and a
+   *  terminal state is guaranteed. Resolves `false` when nothing was started
+   *  and no event will arrive — either a session was already active (only one
+   *  runs at a time) or a `dictationStop` issued while a permission prompt was
+   *  up cancelled this one. Callers must not wait for an event on `false`. */
+  dictationStart: () => invoke<boolean>("dictation_start"),
   /** Stop listening and let the recognizer flush its final result: normally
    *  one last `dictation:transcript` with `is_final: true`, then
    *  `dictation:state` `stopped`. The final transcript is best-effort — a

--- a/src/api/domains/dictation.ts
+++ b/src/api/domains/dictation.ts
@@ -1,5 +1,5 @@
 import { invoke } from "../invoke";
-import type { DictationAvailability } from "../types/dictation";
+import type { DictationAvailability, DictationSessionId } from "../types/dictation";
 
 export const dictationApi = {
   /** Whether native dictation exists on this platform and what the user has
@@ -8,13 +8,15 @@ export const dictationApi = {
   /** Start listening. Requests mic + speech permission on first use. Rejects
    *  with a message if permission is denied or the recognizer can't start.
    *
-   *  Resolves `true` once audio is flowing: `dictation:state` `listening` has
-   *  been emitted, transcripts follow via `onDictationTranscript`, and a
-   *  terminal state is guaranteed. Resolves `false` when nothing was started
-   *  and no event will arrive — either a session was already active (only one
-   *  runs at a time) or a `dictationStop` issued while a permission prompt was
-   *  up cancelled this one. Callers must not wait for an event on `false`. */
-  dictationStart: () => invoke<boolean>("dictation_start"),
+   *  Resolves with the session id once audio is flowing: `dictation:state`
+   *  `listening` has been emitted, transcripts follow via
+   *  `onDictationTranscript`, and a terminal state is guaranteed — all stamped
+   *  with that id, which the caller must match against (see
+   *  `DictationSessionId`). Resolves `null` when nothing was started and no
+   *  event will arrive — either a session was already active (only one runs at
+   *  a time) or a `dictationStop` issued while a permission prompt was up
+   *  cancelled this one. Callers must not wait for an event on `null`. */
+  dictationStart: () => invoke<DictationSessionId | null>("dictation_start"),
   /** Stop listening and let the recognizer flush its final result: normally
    *  one last `dictation:transcript` with `is_final: true`, then
    *  `dictation:state` `stopped`. The final transcript is best-effort — a

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -182,7 +182,10 @@ export function onDictationTranscript(
   return listen<DictationTranscriptEvent>("dictation:transcript", (event) => cb(event.payload));
 }
 
-/** Dictation session lifecycle: listening → stopped, or error with a reason. */
+/** Dictation session lifecycle: listening → stopped, or error with a reason.
+ *  App-wide, like the session itself — every subscriber sees every session's
+ *  events, so a consumer that owns one has to ignore the rest (a composer that
+ *  unmounted mid-session leaves its terminal event to land on the next one). */
 export function onDictationState(cb: (e: DictationStateEvent) => void): Promise<UnlistenFn> {
   return listen<DictationStateEvent>("dictation:state", (event) => cb(event.payload));
 }

--- a/src/api/types/dictation.ts
+++ b/src/api/types/dictation.ts
@@ -20,12 +20,20 @@ export interface DictationAvailability {
   on_device: boolean;
 }
 
+/** Identifies one dictation session: the value `dictationStart` resolved with,
+ *  stamped on every event of that session. Events are app-wide and a session
+ *  outlives the composer that started it (a stop is followed by a flush), so a
+ *  consumer must drop events whose `session` isn't the one it owns — otherwise
+ *  the previous session's final transcript lands in the next composer's box. */
+export type DictationSessionId = number;
+
 /** Payload of the `dictation:transcript` event. `text` is the whole running
- *  transcript for the current session (Apple revises earlier words as it hears
- *  more), not a delta — the UI replaces the in-progress segment with it.
- *  `is_final` marks the last result of a session, after which no more
- *  transcript events arrive until the next `dictation_start`. */
+ *  transcript for that session (Apple revises earlier words as it hears more),
+ *  not a delta — the UI replaces the in-progress segment with it. `is_final`
+ *  marks the last result of a session, after which no more transcript events
+ *  arrive for it. */
 export interface DictationTranscriptEvent {
+  session: DictationSessionId;
   text: string;
   is_final: boolean;
 }
@@ -39,6 +47,7 @@ export type DictationState = "listening" | "stopped" | "error";
  *  `dictationStart` and emit no event, so the rejected promise — not this
  *  state — is what tells the UI a start didn't take. */
 export interface DictationStateEvent {
+  session: DictationSessionId;
   state: DictationState;
   error: string | null;
 }

--- a/src/components/Composer/dictation/DictationButton.tsx
+++ b/src/components/Composer/dictation/DictationButton.tsx
@@ -16,8 +16,8 @@ interface Props {
   /** null while the platform probe is in flight. */
   availability: DictationAvailability | null;
   listening: boolean;
-  /** The previous session is still tearing down. A start now would be a backend
-   *  no-op, so the control is held for the (sub-second) flush. */
+  /** The previous session is still tearing down. The backend starts nothing in
+   *  that window, so the control is held for the (sub-second) flush. */
   stopping: boolean;
   /** Reason the last start failed, or null. */
   error: string | null;

--- a/src/components/Composer/dictation/useDictation.ts
+++ b/src/components/Composer/dictation/useDictation.ts
@@ -1,5 +1,11 @@
 import { useEffect, useRef, useState } from "react";
-import { api, type DictationAvailability, onDictationState, onDictationTranscript } from "@/api";
+import {
+  api,
+  type DictationAvailability,
+  type DictationSessionId,
+  onDictationState,
+  onDictationTranscript,
+} from "@/api";
 import { type ComposerInput, grow } from "../useComposerInput";
 import { spliceTranscript } from "./spliceTranscript";
 
@@ -58,11 +64,19 @@ export function useDictation(input: ComposerInput) {
   // with whatever it gets back: never adopt it.
   const abortStartRef = useRef(false);
   const stoppingRef = useRef(false);
-  // Set while this hook owns the one app-wide session, from the moment it asks
-  // for a start until that session ends. `dictation:state` is a global event,
-  // so without this a straggler from the session a previously mounted composer
-  // left flushing would reset the one this hook just started.
-  const ownsRef = useRef(false);
+  // The id of the session this hook owns, or null. Both dictation events are
+  // app-wide and a session outlives the composer that started it (a stop is
+  // followed by a flush), so a composer that starts the next one would otherwise
+  // take the old session's final transcript into its box and let the old
+  // `stopped` reset it. Every event is matched against this before it counts.
+  // Set from the `listening` event while a start is in flight (so an early
+  // event of our own is recognised), then authoritatively from what
+  // `dictationStart` resolves with.
+  const sessionRef = useRef<DictationSessionId | null>(null);
+  // The last session of ours that ended. A terminal event can beat the start's
+  // own reply (an instant recognizer failure); the reply must not re-adopt a
+  // session the event already closed out.
+  const endedRef = useRef<DictationSessionId | null>(null);
   // False once unmounted, so a probe (or a start) that settles late doesn't set
   // state on a gone component.
   const mountedRef = useRef(true);
@@ -113,6 +127,10 @@ export function useDictation(input: ComposerInput) {
 
     (async () => {
       const unTranscript = await onDictationTranscript((e) => {
+        // A previous session's flush, or one we've since disowned — not ours to
+        // write. A partial of our own arriving before the id is known is safe
+        // to drop: the next one carries the whole transcript again.
+        if (e.session !== sessionRef.current) return;
         if (!acceptingRef.current) return;
         if (e.is_final) acceptingRef.current = false;
         const ip = inputRef.current;
@@ -136,17 +154,24 @@ export function useDictation(input: ComposerInput) {
       offTranscript = unTranscript;
 
       const unState = await onDictationState((e) => {
-        // Someone else's session (see `ownsRef`) — the event is app-wide, but
-        // the state it reports isn't ours to act on.
-        if (!ownsRef.current) return;
         if (e.state === "listening") {
-          setListeningState(true);
+          // Only one session can come up at a time, so the `listening` that
+          // lands while our start is in flight is ours: adopt its id here, so
+          // a terminal event that beats the start's own reply is still matched.
+          if (startingRef.current && sessionRef.current === null) {
+            sessionRef.current = e.session;
+          }
+          if (e.session === sessionRef.current) setListeningState(true);
           return;
         }
+        // Someone else's session (see `sessionRef`) — the event is app-wide,
+        // but the state it reports isn't ours to act on.
+        if (e.session !== sessionRef.current) return;
         // `stopped` and `error` both end the session; only `error` has a reason
         // worth showing (the backend's message doubles as the fix instruction).
         // Either one means teardown is done, so the mic is startable again.
-        ownsRef.current = false;
+        endedRef.current = e.session;
+        sessionRef.current = null;
         setListeningState(false);
         setStoppingState(false);
         acceptingRef.current = false;
@@ -219,7 +244,7 @@ export function useDictation(input: ComposerInput) {
     setStoppingState(true);
     void api.dictationStop().catch(() => {
       // A failed stop emits no `stopped`, so nothing else would release the mic.
-      ownsRef.current = false;
+      sessionRef.current = null;
       setStoppingState(false);
     });
   }
@@ -239,21 +264,28 @@ export function useDictation(input: ComposerInput) {
     acceptingRef.current = true;
     startingRef.current = true;
     abortStartRef.current = false;
-    ownsRef.current = true;
+    sessionRef.current = null;
     try {
       // Resolves once audio is flowing; on first use this is where the OS
       // permission prompts appear, so it can sit pending for a while.
-      const started = await api.dictationStart();
-      if (!started) {
+      const id = await api.dictationStart();
+      if (id === null) {
         // Nothing came up — a stop of ours landed while the prompts were up, or
         // the backend was already busy. No terminal event is coming, so this is
         // the only place the control can be released.
-        ownsRef.current = false;
         acceptingRef.current = false;
         setListeningState(false);
         setStoppingState(false);
         return;
       }
+      if (endedRef.current === id) {
+        // Came up and ended before this reply arrived; the terminal event has
+        // already released the control, and adopting the id now would hold it
+        // for an event that isn't coming.
+        return;
+      }
+      // Authoritative, whatever the `listening` handler adopted meanwhile.
+      sessionRef.current = id;
       if (abortStartRef.current) {
         // A stop was requested while this start was in flight, and it reached
         // the backend after the session came up — so it stopped that session for
@@ -266,7 +298,7 @@ export function useDictation(input: ComposerInput) {
       setListeningState(true);
     } catch (e) {
       // Nothing was started, so no event will release the control from here.
-      ownsRef.current = false;
+      sessionRef.current = null;
       acceptingRef.current = false;
       setListeningState(false);
       setStoppingState(false);

--- a/src/components/Composer/dictation/useDictation.ts
+++ b/src/components/Composer/dictation/useDictation.ts
@@ -26,10 +26,9 @@ export function useDictation(input: ComposerInput) {
   const [availability, setAvailability] = useState<DictationAvailability | null>(null);
   const [listening, setListening] = useState(false);
   // The backend keeps the recognizer claimed after a stop until its final
-  // result lands (or the flush deadline passes), and answers a start in that
-  // window with a successful no-op. Holding the control until the session
-  // actually ends is what keeps a quick second click from lighting the mic with
-  // nothing behind it.
+  // result lands (or the flush deadline passes), and starts nothing in that
+  // window. Holding the control until the session actually ends is what keeps a
+  // quick second click from lighting the mic with nothing behind it.
   const [stopping, setStopping] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -54,10 +53,19 @@ export function useDictation(input: ComposerInput) {
   // session instead of closing it.
   const startingRef = useRef(false);
   // Set when a pending start is no longer wanted — the composer unmounted, or
-  // the message went out from under it. `dictationStop` can't cancel a session
-  // that hasn't come up yet, so the start closes it on arrival instead.
+  // the message went out from under it. Every path that sets it also sends the
+  // backend a stop, so this only decides what the start's continuation does
+  // with whatever it gets back: never adopt it.
   const abortStartRef = useRef(false);
   const stoppingRef = useRef(false);
+  // Set while this hook owns the one app-wide session, from the moment it asks
+  // for a start until that session ends. `dictation:state` is a global event,
+  // so without this a straggler from the session a previously mounted composer
+  // left flushing would reset the one this hook just started.
+  const ownsRef = useRef(false);
+  // False once unmounted, so a probe (or a start) that settles late doesn't set
+  // state on a gone component.
+  const mountedRef = useRef(true);
   const inputRef = useRef(input);
   inputRef.current = input;
 
@@ -71,20 +79,26 @@ export function useDictation(input: ComposerInput) {
     setStopping(next);
   }
 
-  // Probe once per mount: cheap, and the answer can change between mounts (the
-  // user grants permission in System Settings while the app runs).
-  useEffect(() => {
-    let cancelled = false;
+  function probe() {
     api
       .dictationAvailability()
       .then((a) => {
-        if (!cancelled) setAvailability(a);
+        if (mountedRef.current) setAvailability(a);
       })
       .catch(() => {
-        if (!cancelled) setAvailability(UNAVAILABLE);
+        if (mountedRef.current) setAvailability(UNAVAILABLE);
       });
+  }
+
+  // Probe on mount, and again after every start attempt settles (see `toggle`):
+  // the first-run prompt and a trip to System Settings both move the answer, and
+  // a stale one leaves the wrong icon and tooltip until the composer remounts.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: probe on mount only; it reads nothing from render scope
+  useEffect(() => {
+    mountedRef.current = true;
+    probe();
     return () => {
-      cancelled = true;
+      mountedRef.current = false;
     };
   }, []);
 
@@ -122,6 +136,9 @@ export function useDictation(input: ComposerInput) {
       offTranscript = unTranscript;
 
       const unState = await onDictationState((e) => {
+        // Someone else's session (see `ownsRef`) — the event is app-wide, but
+        // the state it reports isn't ours to act on.
+        if (!ownsRef.current) return;
         if (e.state === "listening") {
           setListeningState(true);
           return;
@@ -129,6 +146,7 @@ export function useDictation(input: ComposerInput) {
         // `stopped` and `error` both end the session; only `error` has a reason
         // worth showing (the backend's message doubles as the fix instruction).
         // Either one means teardown is done, so the mic is startable again.
+        ownsRef.current = false;
         setListeningState(false);
         setStoppingState(false);
         acceptingRef.current = false;
@@ -148,10 +166,10 @@ export function useDictation(input: ComposerInput) {
       acceptingRef.current = false;
       // Unmounting mid-session (a view switch) must not leave the mic open —
       // nothing is left to receive its transcript. A start still sitting on the
-      // permission prompt has no session to stop yet, so it is marked unwanted
-      // and shuts itself down the moment it comes up.
+      // permission prompt is stopped too: the backend cancels it before the mic
+      // ever opens, or stops the session if it came up first (see `stop`).
       if (startingRef.current) abortStartRef.current = true;
-      if (listeningRef.current) {
+      if (startingRef.current || listeningRef.current) {
         listeningRef.current = false;
         void api.dictationStop().catch(() => {});
       }
@@ -178,23 +196,30 @@ export function useDictation(input: ComposerInput) {
     }
   }, [input.text]);
 
-  /** End the session, whatever stage it's at. A no-op when the mic is idle, so
-   *  callers that just want it quiet (send) don't have to check first.
+  /** End the session, whatever stage it's at — including a start still waiting
+   *  on the OS permission prompt, which the backend cancels before the mic
+   *  opens. A no-op when the mic is idle, so callers that just want it quiet
+   *  (send) don't have to check first.
    *
    *  Optimistic about `listening`: the mic shouldn't stay lit while the final
    *  result is flushed — `dictation:state` `stopped` confirms the end. */
   function stop() {
+    if (!listeningRef.current && !startingRef.current) return;
     if (startingRef.current) {
-      // Still on the permission prompt, so there's no session to stop and no
-      // transcript worth keeping once it does come up.
+      // The start hasn't resolved yet, so send the stop anyway: the backend
+      // honours one issued while a permission prompt is up and the mic never
+      // opens. Both ends run on its main thread, so the request lands either
+      // before the session is built (cancelled, the start resolves `false`) or
+      // after (a real stop, terminal event to follow) — never in between. The
+      // flag tells the start's continuation not to adopt what it opened.
       abortStartRef.current = true;
       acceptingRef.current = false;
     }
-    if (!listeningRef.current) return;
     setListeningState(false);
     setStoppingState(true);
     void api.dictationStop().catch(() => {
       // A failed stop emits no `stopped`, so nothing else would release the mic.
+      ownsRef.current = false;
       setStoppingState(false);
     });
   }
@@ -205,38 +230,53 @@ export function useDictation(input: ComposerInput) {
       return;
     }
     // A start still on the permission prompt, or a session still tearing down.
-    // The backend answers a start in either window with a successful no-op,
-    // which would light the button with nothing recording behind it. (The
-    // control is disabled while stopping; this also catches a raced click.)
+    // The backend starts nothing in either window, and a second attempt would
+    // take over the refs the one in flight still needs. (The control is disabled
+    // while stopping; this also catches a raced click.)
     if (startingRef.current || stoppingRef.current) return;
     baseRef.current = input.text;
     lastWrittenRef.current = input.text;
     acceptingRef.current = true;
     startingRef.current = true;
     abortStartRef.current = false;
+    ownsRef.current = true;
     try {
       // Resolves once audio is flowing; on first use this is where the OS
       // permission prompts appear, so it can sit pending for a while.
-      await api.dictationStart();
+      const started = await api.dictationStart();
+      if (!started) {
+        // Nothing came up — a stop of ours landed while the prompts were up, or
+        // the backend was already busy. No terminal event is coming, so this is
+        // the only place the control can be released.
+        ownsRef.current = false;
+        acceptingRef.current = false;
+        setListeningState(false);
+        setStoppingState(false);
+        return;
+      }
       if (abortStartRef.current) {
-        // Nobody is left to dictate into — close the session that just opened
-        // rather than leaving the mic live behind an idle button. Held until
-        // the backend confirms, like any other stop: its teardown would
-        // otherwise land on a session started in the meantime.
-        setStoppingState(true);
-        void api.dictationStop().catch(() => setStoppingState(false));
+        // A stop was requested while this start was in flight, and it reached
+        // the backend after the session came up — so it stopped that session for
+        // real and the terminal event is on its way. Don't adopt what we're
+        // about to be told is over; just leave the control held until it lands.
+        setListeningState(false);
         return;
       }
       setError(null);
       setListeningState(true);
     } catch (e) {
-      // The start's owner is gone; there's nothing to report the failure to.
-      if (abortStartRef.current) return;
-      setListeningState(false);
+      // Nothing was started, so no event will release the control from here.
+      ownsRef.current = false;
       acceptingRef.current = false;
-      setError(String(e));
+      setListeningState(false);
+      setStoppingState(false);
+      // The start's owner is gone; there's nothing to report the failure to.
+      if (!abortStartRef.current) setError(String(e));
     } finally {
       startingRef.current = false;
+      // The attempt may have settled a permission (the first-run prompt), which
+      // decides the icon and its tooltip.
+      probe();
     }
   }
 


### PR DESCRIPTION
Post-merge review pass over #640 and #641, which were written by parallel agents against a fixed contract and never run against a real microphone. Nine leads checked; four needed code, one needed docs, four were already right.

## Findings

| # | Lead | Verdict | What changed |
| --- | --- | --- | --- |
| 1 | Session ownership across mounted composers | Partly real | No two `Composer`s can be mounted at once today (all four call sites are mutually exclusive branches: `Workspace` early-returns between `EmptyWorkspace`/`ChatView`/`RunView`, `App` swaps `ProjectScreen` for `Workspace`, and `Roadmap/Thread` picks `NewChatScreen` **or** `ChatPane`). But `dictation:state` is app-wide, so a composer that unmounts mid-session leaves its `stopped` to land on the *next* composer's listener — where it cleared `accepting` and killed a transcript the user had just started. Gated all state handling on an `ownsRef` the starting hook sets. |
| 2 | Ambiguous `dictation_start` result | Real | `dictation_start` now returns `bool`: `true` = a session is live and a terminal state will follow, `false` = nothing started, no event coming. TS wrapper + docs updated; the hook adopts or releases on it. Audited every `stopping = true`: `stop()` (live) → terminal event or the stop's own rejection handler; `stop()` (pending start) → the start's continuation, which always runs; rejected start → synchronous reset (this path previously returned early while aborting and left `listening` set). |
| 3 | Frontend never used the backend's stop-during-prompt path | Real | `stop()` and the unmount cleanup now call `dictationStop()` during a pending start, so the mic never opens. Safe because both ends run on the backend's main thread: the request either cancels the start (resolves `false`) or stops the session that beat it (terminal event follows) — never in between. That also let the start's abort path drop its own `dictationStop()`, so no double-stop on a fast double-click. |
| 4 | `STOP_PENDING` hygiene | Real | Set only when `ACTIVE` is claimed, i.e. a start really is in flight. An idle stop no longer leaves a flag behind, and the pre-clear at the top of `start` (which could itself discard a stop racing the claim) moves to the one path that abandons a claim without reaching `begin`: the `ensure_authorized` error. |
| 5 | Stale `availability` after permission changes | Real | Re-probed in `toggle`'s `finally`, so answering the first-run prompt or flipping the permission in System Settings updates the slashed-mic icon and tooltip without a remount. |
| 6 | Disabled button + tooltips | Fine, no change | `IconButton` emits `data-tip` and the `tip` class regardless of `disabled`, so the tooltip is in the DOM; a disabled `<button>` does swallow hover in the WebView, but the only window where the mic is disabled is the sub-second flush, and the tip there is the plain affordance label. Nothing informative is lost, so no wrapper span. Listening and stopping can no longer both read true — the abort path now clears `listening`. |
| 7 | Release and dev packaging | Fine, no change | `release.yml` runs `tauri-action@v0` with `args: --target universal-apple-darwin` and no `--config` override, and `src-tauri/tauri.conf.json` is the only Tauri config in the tree, so `bundle.macOS.entitlements` is honoured. `tauri-codegen` 2.6.2 (`context.rs:302`) emits `embed_plist::embed_info_plist!` from `<config dir>/Info.plist` when `target == MacOS && dev`, so the usage strings are in the dev binary and the TCC prompts work under `tauri dev`. |
| 8 | Docs convention | Real | `docs/` carries per-feature write-ups (`feedback.md`, `isolation.md`), so added `docs/dictation.md`: platform support, the two TCC strings, the hardened-runtime entitlement, on-device vs server-backed, and the `tccutil reset` lines for re-testing first-run prompts. |
| 9 | Anything else | Mixed | Fixed stale comments that outlived their code ("the backend answers a start in that window with a successful no-op" in three places). Judged fine and left alone: the ~1-minute cap on server-backed recognition (the recognizer's own final result drives `stopped`, so the button returns to idle by itself — now documented); `error` mid-sentence (text received so far stays in the box); unmount while `stopping` (the backend's flush deadline tears the session down); the `stopped`-then-typing path that drops the final punctuated result (deliberate — it's what stops a sent message from being refilled). |

## Verified

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` (1482 passed, 19 ignored) — clean on macOS.
- Non-Apple stub re-verified by inverting the `cfg` predicates in `dictation/mod.rs` and running the same clippy gate: clean, then restored.
- `bun run check` (tsc), `biome check` on all touched files, `bun run test` (101 files, 1096 tests) — clean.

## Not verifiable here (no microphone)

Nothing in this PR was exercised at runtime. Worth walking through once:

1. Click the mic, grant both prompts, speak — the button tints and the transcript lands. Then check the tooltip: after granting, it must no longer read the System Settings hint (lead 5).
2. Click the mic and click it again *while the permission dialog is still up*: the dialog stays, but after answering it the menu-bar mic indicator must never appear, and the button must return to idle rather than stay disabled (leads 2 + 3).
3. Same, but press Enter to send while the dialog is up: message goes, box stays clear, no mic.
4. Fast double-click the mic on an already-granted machine (start still resolving when the second click lands): one stop, button settles idle.
5. Switch agents while listening, then immediately start dictating in the new composer: the old session's `stopped` must not blank the new one's transcript (lead 1).
6. Deny in System Settings mid-session and start again: the button shows the backend's message and is clickable again.
7. Signed release build: transcript is non-empty (the entitlement reached `codesign`).
