### PR TITLE
feat(dictation): download the Whisper model behind a Settings opt-in

### DIFF
--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -61,6 +61,59 @@ The failure mode when this doesn't reach `codesign` is quiet: dev builds work,
 the notarized app lights the mic and transcribes silence. If dictation returns
 an empty transcript only in a released build, check the entitlement first.
 
+## Local Whisper engine (opt-in)
+
+Settings › General › Dictation offers a second engine: whisper.cpp running
+locally, for people who want transcription that never depends on Apple's
+locale support or its servers. Apple's recognizer stays the default — the
+local engine costs a one-time model download, so it can only be a choice the
+user makes.
+
+The opt-in is the `dictation_engine` settings row (`whisper` or `apple`),
+written by the backend `set_dictation_engine` command. Enabling it starts the
+download in a background task and returns immediately; progress arrives as
+`dictation:model_progress` events, and `dictation_model_status` is what a
+freshly opened Settings screen reads instead. Weights only reach their final
+path after their SHA-256 matched, so "the file is there, at the pinned size"
+is the same statement as "it was verified" — that is what
+`models::installed_path` checks.
+
+### Where the weights live
+
+`<app data>/whisper-models/`, seeded by `whisper::init` from `setup` — so
+`~/Library/Application Support/com.fletch.desktop/whisper-models` in a bundle,
+and `…/com.fletch.desktop/dev/whisper-models` in a debug build (`tauri dev`
+gets its own data dir, weights included, so a dev run downloads its own copy).
+Nothing else is written there, so deleting the directory is a clean uninstall
+(as is Remove in Settings). A download in flight is a `download-<pid>.tmp`
+alongside; a run killed mid-download leaves one behind and the next attempt
+sweeps it.
+
+| Layer | File |
+| --- | --- |
+| Settings section | `src/components/SettingsScreen/DictationSection/` |
+| IPC | `dictation_model_status` / `set_dictation_engine` / `dictation_model_download` / `dictation_model_remove` |
+| Event | `src/api/events.ts` — `dictation:model_progress` |
+| Catalog | `src-tauri/src/dictation/whisper/models.rs` |
+| Download | `src-tauri/src/dictation/whisper/install.rs`, on the shared `download::download_verified` |
+
+### Swapping the default model
+
+`src-tauri/src/dictation/whisper/models.rs` pins every candidate: file name,
+URL, SHA-256, and exact byte size. Nothing is discovered at runtime — the
+digest is the supply-chain boundary, and the size is both the progress total
+and the cheap installed check. To change what a fresh opt-in downloads:
+
+1. Open `https://huggingface.co/ggerganov/whisper.cpp/raw/main/<file>` — the
+   LFS pointer, not the file itself. Copy `oid sha256` and `size` verbatim.
+2. Add a `WhisperModel` entry to `MODELS` with those values, a `label`, and a
+   one-line `note` (both are display copy in Settings).
+3. Point `DEFAULT_MODEL_ID` at the new `id`.
+
+Users who already downloaded the old model keep it on disk; the new default is
+a fresh download. `size` is also where the "Downloads a 574 MB model once."
+copy comes from, so the UI can't drift from the pinned file.
+
 ## On-device vs Apple's servers
 
 The request sets `requiresOnDeviceRecognition` to whatever the recognizer

--- a/src-tauri/src/codegraph/install.rs
+++ b/src-tauri/src/codegraph/install.rs
@@ -115,7 +115,9 @@ pub async fn ensure_installed() -> Result<PathBuf> {
     tracing::info!(version = CODEGRAPH_VERSION, "installing codegraph bundle");
     let dest = version_dir(&install_dir);
     tokio::time::timeout(INSTALL_TIMEOUT, async {
-        let tarball = download_verified(&url, sha, &install_dir).await?;
+        // No progress consumer: this install is silent (see the module docs).
+        let tarball =
+            crate::download::download_verified(&url, sha, &install_dir, |_, _| {}).await?;
         // Blocking CPU/fs work off the async runtime.
         let dest = dest.clone();
         tokio::task::spawn_blocking(move || extract_bundle(&tarball, &dest))
@@ -135,58 +137,6 @@ pub async fn ensure_installed() -> Result<PathBuf> {
     prune_old_versions(&install_dir, &dest).await;
     tracing::info!(path = %bin.display(), "codegraph installed");
     Ok(bin)
-}
-
-/// Stream the release tarball to a temp file inside `install_dir`, hashing as
-/// it downloads; error (and remove the temp file) unless the digest matches
-/// the pinned SHA-256. Returns the temp path.
-async fn download_verified(url: &str, expected_sha: &str, install_dir: &Path) -> Result<PathBuf> {
-    use sha2::Digest;
-    use tokio::io::AsyncWriteExt;
-
-    let mut resp = reqwest::get(url)
-        .await
-        .map_err(|e| Error::Other(format!("download codegraph bundle: {e}")))?
-        .error_for_status()
-        .map_err(|e| Error::Other(format!("download codegraph bundle: {e}")))?;
-
-    let tmp_path = install_dir.join(format!("download-{}.tmp", std::process::id()));
-    let mut file = tokio::fs::File::create(&tmp_path)
-        .await
-        .map_err(|e| Error::Other(format!("create {}: {e}", tmp_path.display())))?;
-
-    let mut hasher = sha2::Sha256::new();
-    let result: Result<()> = async {
-        while let Some(chunk) = resp
-            .chunk()
-            .await
-            .map_err(|e| Error::Other(format!("download codegraph bundle: {e}")))?
-        {
-            hasher.update(&chunk);
-            file.write_all(&chunk)
-                .await
-                .map_err(|e| Error::Other(format!("write {}: {e}", tmp_path.display())))?;
-        }
-        file.flush()
-            .await
-            .map_err(|e| Error::Other(format!("flush {}: {e}", tmp_path.display())))?;
-        Ok(())
-    }
-    .await;
-    drop(file);
-    if let Err(e) = result {
-        let _ = tokio::fs::remove_file(&tmp_path).await;
-        return Err(e);
-    }
-
-    let digest = format!("{:x}", hasher.finalize());
-    if !digest.eq_ignore_ascii_case(expected_sha) {
-        let _ = tokio::fs::remove_file(&tmp_path).await;
-        return Err(Error::Other(format!(
-            "codegraph bundle checksum mismatch (got {digest}, expected {expected_sha})"
-        )));
-    }
-    Ok(tmp_path)
 }
 
 /// Unpack `tarball` and move the bundle into `dest`. Extraction goes to a

--- a/src-tauri/src/dictation/mod.rs
+++ b/src-tauri/src/dictation/mod.rs
@@ -26,6 +26,9 @@ use crate::error::Result;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod apple;
+// Compiles everywhere (the catalog and download are plain Rust); the engine
+// itself is gated inside. `pub` so `lib.rs` can seed the models root.
+pub mod whisper;
 
 /// A TCC (privacy) permission state, for either the microphone or speech
 /// recognition. Mirrors both `SFSpeechRecognizerAuthorizationStatus` and

--- a/src-tauri/src/dictation/mod.rs
+++ b/src-tauri/src/dictation/mod.rs
@@ -17,12 +17,11 @@
 //! a platform check of its own.
 
 use serde::Serialize;
-use tauri::AppHandle;
-// Only the (Apple-gated) emitters below need the trait in scope.
-#[cfg(any(target_os = "macos", target_os = "ios"))]
-use tauri::Emitter;
+use tauri::{AppHandle, Emitter};
 
+use crate::database;
 use crate::error::Result;
+use crate::DbState;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod apple;
@@ -106,7 +105,6 @@ struct StatePayload {
 
 /// Emit one event, logging (not propagating) failure — same posture as
 /// `supervisor::events`: no event is delivery-guaranteed.
-#[cfg(any(target_os = "macos", target_os = "ios"))]
 fn emit<T: Serialize + Clone>(app: &AppHandle, event: &str, payload: T) {
     if let Err(e) = app.emit(event, payload) {
         tracing::warn!(error = %e, event, "emit failed");
@@ -137,6 +135,110 @@ fn emit_state(app: &AppHandle, session: u64, state: State, error: Option<String>
             error,
         },
     );
+}
+
+/// The local engine's opt-in state, plus the one model it would use. Separate
+/// from [`Availability`], which describes the platform recognizer: this is the
+/// Settings section's contract, and both sides can be true at once (the engine
+/// is chosen, the weights are still downloading).
+#[derive(Clone, Serialize)]
+pub struct ModelStatus {
+    /// The `dictation_engine` setting selects the local engine.
+    enabled: bool,
+    /// The weights are on disk and verified, so the engine can load them.
+    installed: bool,
+    /// A download is running in this process; progress arrives as
+    /// `dictation:model_progress`.
+    downloading: bool,
+    model: ModelInfo,
+}
+
+/// The catalog entry Settings describes. `size` is the exact byte count, so
+/// every size string in the UI is derived rather than pinned in two places.
+#[derive(Clone, Serialize)]
+pub struct ModelInfo {
+    id: &'static str,
+    label: &'static str,
+    note: &'static str,
+    size: u64,
+}
+
+fn model_status(enabled: bool, install: whisper::install::Status) -> ModelStatus {
+    let model = whisper::models::default_model();
+    ModelStatus {
+        enabled,
+        installed: install.installed,
+        downloading: install.downloading,
+        model: ModelInfo {
+            id: model.id,
+            label: model.label,
+            note: model.note,
+            size: model.size,
+        },
+    }
+}
+
+fn engine_enabled(state: &tauri::State<'_, DbState>) -> bool {
+    let conn = state.lock();
+    whisper::parse_enabled(database::get_setting(&conn, whisper::ENGINE_SETTING).as_deref())
+}
+
+/// Where the local engine stands: the opt-in, the weights, and what a download
+/// would fetch. Cheap — a metadata stat, no hashing — so the Settings pane
+/// calls it on mount and after every action.
+#[tauri::command]
+pub fn dictation_model_status(state: tauri::State<'_, DbState>) -> ModelStatus {
+    model_status(engine_enabled(&state), whisper::install::status())
+}
+
+/// Choose the dictation engine. Persists `dictation_engine` (backend-owned
+/// snake_case key, so the renderer reads it as `s.dictation_engine`) and, when
+/// enabling without the weights on disk, kicks the download off in the
+/// background — the toggle can't await half a gigabyte. Same persist-then-act
+/// shape as `set_code_indexing_enabled`.
+///
+/// Turning it off leaves the weights alone; removing them is a separate,
+/// explicit action.
+#[tauri::command]
+pub fn set_dictation_engine(
+    enabled: bool,
+    app: AppHandle,
+    state: tauri::State<'_, DbState>,
+) -> Result<()> {
+    {
+        let conn = state.lock();
+        database::set_setting(
+            &conn,
+            whisper::ENGINE_SETTING,
+            if enabled {
+                whisper::ENGINE_WHISPER
+            } else {
+                whisper::ENGINE_APPLE
+            },
+        )?;
+    }
+    if enabled {
+        whisper::install::download(app);
+    }
+    Ok(())
+}
+
+/// Retry a failed or never-started model download. Returns immediately with
+/// the state the call left things in; a download already running (or an
+/// already-installed model) makes it a no-op.
+#[tauri::command]
+pub fn dictation_model_download(app: AppHandle, state: tauri::State<'_, DbState>) -> ModelStatus {
+    let install = whisper::install::download(app);
+    model_status(engine_enabled(&state), install)
+}
+
+/// Delete the downloaded weights. The caller is expected to turn the engine off
+/// first — an enabled engine with no model would fall back to the platform
+/// recognizer, but silently.
+#[tauri::command]
+pub fn dictation_model_remove(state: tauri::State<'_, DbState>) -> ModelStatus {
+    let install = whisper::install::remove();
+    model_status(engine_enabled(&state), install)
 }
 
 /// Whether dictation works here, and what permissions stand in the way. Cheap

--- a/src-tauri/src/dictation/whisper/install.rs
+++ b/src-tauri/src/dictation/whisper/install.rs
@@ -12,6 +12,7 @@
 
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use serde::Serialize;
 use tauri::AppHandle;
@@ -148,19 +149,38 @@ async fn run(app: &AppHandle, model: &'static WhisperModel) -> Result<()> {
     Ok(())
 }
 
-/// Drop temp files from an earlier run. The download path removes its own on
+/// A temp file untouched for this long is a dead download. A live one is
+/// written every network chunk, so even a slow link moves it far more often;
+/// only a process killed mid-stream leaves one that goes quiet.
+const STALE_TMP_AFTER: Duration = Duration::from_secs(10 * 60);
+
+/// Drop temp files from a run that died. The download path removes its own on
 /// failure, but a process killed mid-stream leaves a partial half-gigabyte
-/// behind under a pid-stamped name that is never reused. Our own in-flight
-/// file is skipped so a second app instance's sweep can't truncate this one.
+/// behind under a pid-stamped name that is never reused.
+///
+/// Staleness is judged by age, not by pid: `IN_FLIGHT` only coordinates one
+/// process, and a second app instance sharing this directory has its own
+/// in-flight file here that must not be unlinked from under it (its rename
+/// would fail after the whole download). Anything modified recently is
+/// presumed live, whoever owns it.
 async fn clear_stale_tmp(root: &Path) {
-    let ours = download::tmp_path(root);
     let Ok(mut dir) = tokio::fs::read_dir(root).await else {
         return;
     };
     while let Ok(Some(entry)) = dir.next_entry().await {
-        let path = entry.path();
-        if path != ours && download::is_tmp_name(&entry.file_name().to_string_lossy()) {
-            let _ = tokio::fs::remove_file(&path).await;
+        if !download::is_tmp_name(&entry.file_name().to_string_lossy()) {
+            continue;
+        }
+        let idle = entry
+            .metadata()
+            .await
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.elapsed().ok());
+        // An unreadable mtime is left alone: a spurious keep costs disk until
+        // the next sweep, a spurious delete costs someone their download.
+        if idle.is_some_and(|d| d >= STALE_TMP_AFTER) {
+            let _ = tokio::fs::remove_file(entry.path()).await;
         }
     }
 }
@@ -192,23 +212,39 @@ mod tests {
     use super::*;
 
     /// A sweep must clear a killed run's leftovers without touching an
-    /// installed model or the temp file this process is streaming into.
+    /// installed model, or a temp file that is still being written — ours or
+    /// another instance's.
     #[tokio::test]
     async fn stale_temp_files_are_swept_and_nothing_else() {
         let dir = tempfile::tempdir().unwrap();
         let root = dir.path();
         let stale = root.join("download-424242.tmp");
+        let live = root.join("download-424243.tmp");
         let model = root.join("ggml-large-v3-turbo-q5_0.bin");
-        let ours = download::tmp_path(root);
-        for f in [&stale, &model, &ours] {
+        for f in [&stale, &live, &model] {
             std::fs::write(f, b"x").unwrap();
         }
+        let long_ago = std::time::SystemTime::now() - STALE_TMP_AFTER * 2;
+        std::fs::File::open(&stale)
+            .unwrap()
+            .set_modified(long_ago)
+            .unwrap();
+        std::fs::File::open(&model)
+            .unwrap()
+            .set_modified(long_ago)
+            .unwrap();
 
         clear_stale_tmp(root).await;
 
-        assert!(!stale.exists(), "a previous run's temp file must be swept");
-        assert!(model.exists(), "installed weights must survive");
-        assert!(ours.exists(), "our own in-flight temp file must survive");
+        assert!(!stale.exists(), "a dead run's temp file must be swept");
+        assert!(
+            live.exists(),
+            "a temp file still being written must survive"
+        );
+        assert!(
+            model.exists(),
+            "installed weights must survive, however old"
+        );
     }
 
     /// Without `whisper::init` there is no models root, so nothing can be

--- a/src-tauri/src/dictation/whisper/install.rs
+++ b/src-tauri/src/dictation/whisper/install.rs
@@ -150,9 +150,13 @@ async fn run(app: &AppHandle, model: &'static WhisperModel) -> Result<()> {
 }
 
 /// A temp file untouched for this long is a dead download. A live one is
-/// written every network chunk, so even a slow link moves it far more often;
-/// only a process killed mid-stream leaves one that goes quiet.
+/// written every network chunk, and a request that receives nothing for
+/// [`download::READ_TIMEOUT`] fails and removes its own file — so a file this
+/// idle has no request behind it, only a process that died mid-stream.
 const STALE_TMP_AFTER: Duration = Duration::from_secs(10 * 60);
+// The sweep is only safe while the read timeout fires well before it: a
+// stalled-but-live request must be gone before its file looks stale.
+const _: () = assert!(STALE_TMP_AFTER.as_secs() >= 5 * download::READ_TIMEOUT.as_secs());
 
 /// Drop temp files from a run that died. The download path removes its own on
 /// failure, but a process killed mid-stream leaves a partial half-gigabyte
@@ -161,8 +165,8 @@ const STALE_TMP_AFTER: Duration = Duration::from_secs(10 * 60);
 /// Staleness is judged by age, not by pid: `IN_FLIGHT` only coordinates one
 /// process, and a second app instance sharing this directory has its own
 /// in-flight file here that must not be unlinked from under it (its rename
-/// would fail after the whole download). Anything modified recently is
-/// presumed live, whoever owns it.
+/// would fail after the whole download). Anything modified within the window
+/// is presumed live, whoever owns it.
 async fn clear_stale_tmp(root: &Path) {
     let Ok(mut dir) = tokio::fs::read_dir(root).await else {
         return;

--- a/src-tauri/src/dictation/whisper/install.rs
+++ b/src-tauri/src/dictation/whisper/install.rs
@@ -1,0 +1,222 @@
+//! Getting the pinned weights onto disk.
+//!
+//! The download is fire-and-forget: half a gigabyte can't be awaited by the
+//! Settings toggle that asks for it, so [`download`] returns the moment the
+//! work is underway and progress arrives as `dictation:model_progress`
+//! events. That makes the event stream the only live channel, and [`status`]
+//! the truth a freshly mounted UI reads.
+//!
+//! The file appears at its final path only once its digest matched: the
+//! download streams to a temp file and is renamed in, which is what lets
+//! [`models::installed_path`] treat "right size, right place" as verified.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use serde::Serialize;
+use tauri::AppHandle;
+
+use super::models::{self, WhisperModel};
+use crate::download;
+use crate::error::{Error, Result};
+
+/// Guards the one download allowed at a time. The Settings toggle and its
+/// retry button both reach [`download`], and two streams would share one
+/// per-process temp path.
+static IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+
+/// How far along the model install is. `Verifying` is the tail of the
+/// download, not a separate pass — the digest is computed as bytes arrive.
+#[derive(Clone, Copy, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum State {
+    Downloading,
+    Verifying,
+    Installed,
+    Error,
+}
+
+/// Payload of `dictation:model_progress`. `total` is absent only when the
+/// server sends no length and the catalog size is unknown; `error` is set for
+/// `Error` alone and carries the message shown in Settings.
+#[derive(Clone, Serialize)]
+struct Progress {
+    model_id: &'static str,
+    state: State,
+    received: u64,
+    total: Option<u64>,
+    error: Option<String>,
+}
+
+/// A snapshot of the default model's install state. `downloading` is this
+/// process's in-flight flag, so it is honest across a Settings screen that
+/// mounted mid-download and missed the events so far.
+#[derive(Clone, Copy, Debug, Serialize)]
+pub struct Status {
+    pub installed: bool,
+    pub downloading: bool,
+}
+
+pub fn status() -> Status {
+    Status {
+        installed: models::installed_path(models::default_model()).is_some(),
+        downloading: IN_FLIGHT.load(Ordering::Acquire),
+    }
+}
+
+/// Start fetching the default model, unless it is already installed or a
+/// download is running — either way the returned status says what the caller
+/// asked about, so an opt-in and a retry are the same call.
+pub fn download(app: AppHandle) -> Status {
+    let model = models::default_model();
+    if models::installed_path(model).is_some() {
+        return Status {
+            installed: true,
+            downloading: false,
+        };
+    }
+    // The claim on the flag is the guard, so it's also the "already running"
+    // check — a separate read first would just be a wider race window.
+    if IN_FLIGHT
+        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+        .is_err()
+    {
+        return Status {
+            installed: false,
+            downloading: true,
+        };
+    }
+
+    tauri::async_runtime::spawn(async move {
+        let result = run(&app, model).await;
+        IN_FLIGHT.store(false, Ordering::Release);
+        match result {
+            Ok(()) => emit(&app, model, State::Installed, model.size, None),
+            Err(e) => {
+                tracing::warn!(error = %e, model = model.id, "whisper model download failed");
+                emit(&app, model, State::Error, 0, Some(e.to_string()));
+            }
+        }
+    });
+    Status {
+        installed: false,
+        downloading: true,
+    }
+}
+
+/// Delete the installed weights, so the disk cost of an engine the user turned
+/// off doesn't linger. Returns the state after the attempt.
+pub fn remove() -> Status {
+    let model = models::default_model();
+    if let Some(path) = models::installed_path(model) {
+        if let Err(e) = std::fs::remove_file(&path) {
+            tracing::warn!(error = %e, path = %path.display(), "removing whisper model failed");
+        }
+    }
+    status()
+}
+
+async fn run(app: &AppHandle, model: &'static WhisperModel) -> Result<()> {
+    let dest = models::path(model)
+        .ok_or_else(|| Error::Other("whisper models root is not initialized".into()))?;
+    let root = dest
+        .parent()
+        .expect("a model path is a file inside the models root");
+    tokio::fs::create_dir_all(root)
+        .await
+        .map_err(|e| Error::Other(format!("create {}: {e}", root.display())))?;
+    clear_stale_tmp(root).await;
+
+    emit(app, model, State::Downloading, 0, None);
+    let tmp = download::download_verified(model.url, model.sha256, root, |received, total| {
+        // The last call lands after the final byte, when all that's left is
+        // finalizing the hash and the rename — so report that as verifying
+        // rather than parking the bar at 100% under a "downloading" label.
+        let state = if total.is_some_and(|t| received >= t) {
+            State::Verifying
+        } else {
+            State::Downloading
+        };
+        emit(app, model, state, received, None);
+    })
+    .await?;
+
+    tokio::fs::rename(&tmp, &dest)
+        .await
+        .map_err(|e| Error::Other(format!("install {}: {e}", dest.display())))?;
+    tracing::info!(model = model.id, path = %dest.display(), "whisper model installed");
+    Ok(())
+}
+
+/// Drop temp files from an earlier run. The download path removes its own on
+/// failure, but a process killed mid-stream leaves a partial half-gigabyte
+/// behind under a pid-stamped name that is never reused. Our own in-flight
+/// file is skipped so a second app instance's sweep can't truncate this one.
+async fn clear_stale_tmp(root: &Path) {
+    let ours = download::tmp_path(root);
+    let Ok(mut dir) = tokio::fs::read_dir(root).await else {
+        return;
+    };
+    while let Ok(Some(entry)) = dir.next_entry().await {
+        let path = entry.path();
+        if path != ours && download::is_tmp_name(&entry.file_name().to_string_lossy()) {
+            let _ = tokio::fs::remove_file(&path).await;
+        }
+    }
+}
+
+fn emit(
+    app: &AppHandle,
+    model: &'static WhisperModel,
+    state: State,
+    received: u64,
+    error: Option<String>,
+) {
+    crate::dictation::emit(
+        app,
+        "dictation:model_progress",
+        Progress {
+            model_id: model.id,
+            state,
+            received,
+            // The catalog's size is the pin the digest belongs to, so it beats
+            // whatever `Content-Length` the CDN reports.
+            total: Some(model.size),
+            error,
+        },
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A sweep must clear a killed run's leftovers without touching an
+    /// installed model or the temp file this process is streaming into.
+    #[tokio::test]
+    async fn stale_temp_files_are_swept_and_nothing_else() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let stale = root.join("download-424242.tmp");
+        let model = root.join("ggml-large-v3-turbo-q5_0.bin");
+        let ours = download::tmp_path(root);
+        for f in [&stale, &model, &ours] {
+            std::fs::write(f, b"x").unwrap();
+        }
+
+        clear_stale_tmp(root).await;
+
+        assert!(!stale.exists(), "a previous run's temp file must be swept");
+        assert!(model.exists(), "installed weights must survive");
+        assert!(ours.exists(), "our own in-flight temp file must survive");
+    }
+
+    /// Without `whisper::init` there is no models root, so nothing can be
+    /// installed — the status must say so rather than panic on the missing path.
+    #[test]
+    fn status_without_a_models_root_is_not_installed() {
+        let s = status();
+        assert!(!s.installed);
+        assert!(!s.downloading);
+    }
+}

--- a/src-tauri/src/dictation/whisper/mod.rs
+++ b/src-tauri/src/dictation/whisper/mod.rs
@@ -1,5 +1,6 @@
-//! Local dictation on whisper.cpp: the model catalog and its on-disk install
-//! (`models`), and the transcriber that runs it (`engine`).
+//! Local dictation on whisper.cpp: the model catalog (`models`), getting its
+//! weights onto disk (`install`), and the transcriber that runs them
+//! (`engine`).
 //!
 //! The platform recognizer (`super::apple`) stays the default. The user opts
 //! into this engine from Settings, which downloads the pinned model into
@@ -7,19 +8,18 @@
 //! setting is on AND the model is installed, so a half-finished download can
 //! never leave the mic button dead.
 
-// Scaffolding commit: the catalog lands before its download command and the
-// engine, so nothing reads it yet. Drop this once the commands consume it.
-#![allow(dead_code)]
-
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+pub mod install;
 pub mod models;
 
 /// `settings` key for the engine choice. Only [`ENGINE_WHISPER`] selects the
-/// local engine; unset or anything else means the platform recognizer.
+/// local engine; anything else means the platform recognizer — written as
+/// [`ENGINE_APPLE`] rather than cleared, so an opt-out is a recorded choice.
 pub const ENGINE_SETTING: &str = "dictation_engine";
 pub const ENGINE_WHISPER: &str = "whisper";
+pub const ENGINE_APPLE: &str = "apple";
 
 /// Interpret the raw setting value. Opt-in: only an explicit `"whisper"` is on.
 pub fn parse_enabled(raw: Option<&str>) -> bool {

--- a/src-tauri/src/dictation/whisper/mod.rs
+++ b/src-tauri/src/dictation/whisper/mod.rs
@@ -1,0 +1,40 @@
+//! Local dictation on whisper.cpp: the model catalog and its on-disk install
+//! (`models`), and the transcriber that runs it (`engine`).
+//!
+//! The platform recognizer (`super::apple`) stays the default. The user opts
+//! into this engine from Settings, which downloads the pinned model into
+//! [`models_root`]; the dictation commands dispatch here only when the
+//! setting is on AND the model is installed, so a half-finished download can
+//! never leave the mic button dead.
+
+// Scaffolding commit: the catalog lands before its download command and the
+// engine, so nothing reads it yet. Drop this once the commands consume it.
+#![allow(dead_code)]
+
+use std::path::PathBuf;
+use std::sync::OnceLock;
+
+pub mod models;
+
+/// `settings` key for the engine choice. Only [`ENGINE_WHISPER`] selects the
+/// local engine; unset or anything else means the platform recognizer.
+pub const ENGINE_SETTING: &str = "dictation_engine";
+pub const ENGINE_WHISPER: &str = "whisper";
+
+/// Interpret the raw setting value. Opt-in: only an explicit `"whisper"` is on.
+pub fn parse_enabled(raw: Option<&str>) -> bool {
+    raw == Some(ENGINE_WHISPER)
+}
+
+/// Where model files live: `<app data>/whisper-models`. Set once from `setup`,
+/// like `git_dist::init`, so download and load paths never need an `AppHandle`.
+static MODELS_ROOT: OnceLock<PathBuf> = OnceLock::new();
+
+pub fn init(root: PathBuf) {
+    let _ = MODELS_ROOT.set(root);
+}
+
+/// `None` only before `init` ran (tests, or a call from a build without setup).
+pub fn models_root() -> Option<PathBuf> {
+    MODELS_ROOT.get().cloned()
+}

--- a/src-tauri/src/dictation/whisper/models.rs
+++ b/src-tauri/src/dictation/whisper/models.rs
@@ -1,0 +1,99 @@
+//! The Whisper model catalog. Weights are pinned here, not fetched from a
+//! listing: each entry names the exact file, its SHA-256, and its size, so a
+//! download is verified before it is ever loaded and a swap is a one-line
+//! change to [`DEFAULT_MODEL_ID`] (plus a new entry) when a better model ships.
+//!
+//! Files come from the ggml conversions at
+//! <https://huggingface.co/ggerganov/whisper.cpp>. To add one, take `oid
+//! sha256` and `size` verbatim from the LFS pointer at
+//! `https://huggingface.co/ggerganov/whisper.cpp/raw/main/<file>`.
+
+use std::path::PathBuf;
+
+/// One downloadable model. `id` is the stable key stored in settings and shown
+/// to the frontend; `label`/`note` are display copy.
+#[derive(Clone, Copy, Debug)]
+pub struct WhisperModel {
+    pub id: &'static str,
+    pub label: &'static str,
+    /// One line on when to pick it (shown under the label in Settings).
+    pub note: &'static str,
+    pub file_name: &'static str,
+    pub url: &'static str,
+    /// Lowercase hex SHA-256 of the file.
+    pub sha256: &'static str,
+    /// Exact byte size, for progress and the cheap "is it installed" check.
+    pub size: u64,
+}
+
+/// What a fresh opt-in downloads. Swap by pointing at another catalog entry.
+pub const DEFAULT_MODEL_ID: &str = "large-v3-turbo-q5_0";
+
+pub const MODELS: &[WhisperModel] = &[
+    WhisperModel {
+        id: "large-v3-turbo-q5_0",
+        label: "Large v3 Turbo (5-bit)",
+        note: "Best accuracy per second on Apple Silicon. Multilingual.",
+        file_name: "ggml-large-v3-turbo-q5_0.bin",
+        url:
+            "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin",
+        sha256: "394221709cd5ad1f40c46e6031ca61bce88931e6e088c188294c6d5a55ffa7e2",
+        size: 574_041_195,
+    },
+    WhisperModel {
+        id: "small.en-q8_0",
+        label: "Small English (8-bit)",
+        note: "Much faster on Intel Macs. English only.",
+        file_name: "ggml-small.en-q8_0.bin",
+        url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en-q8_0.bin",
+        sha256: "67a179f608ea6114bd3fdb9060e762b588a3fb3bd00c4387971be4d177958067",
+        size: 264_477_561,
+    },
+];
+
+pub fn default_model() -> &'static WhisperModel {
+    find(DEFAULT_MODEL_ID).expect("DEFAULT_MODEL_ID names a catalog entry")
+}
+
+pub fn find(id: &str) -> Option<&'static WhisperModel> {
+    MODELS.iter().find(|m| m.id == id)
+}
+
+/// Where this model lives once installed: `<models_root>/<file_name>`.
+/// `None` before `whisper::init`.
+pub fn path(model: &WhisperModel) -> Option<PathBuf> {
+    super::models_root().map(|root| root.join(model.file_name))
+}
+
+/// The model's file, if it is fully present. Checks the exact byte size, not
+/// the hash: the download path verifies the digest before moving the file into
+/// place, so a file of the right size at this path is one that passed.
+pub fn installed_path(model: &WhisperModel) -> Option<PathBuf> {
+    let p = path(model)?;
+    let len = std::fs::metadata(&p).ok()?.len();
+    (len == model.size).then_some(p)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_in_catalog() {
+        assert_eq!(default_model().id, DEFAULT_MODEL_ID);
+    }
+
+    #[test]
+    fn catalog_entries_are_well_formed() {
+        for m in MODELS {
+            assert_eq!(m.sha256.len(), 64, "{}: sha256 must be 32 bytes hex", m.id);
+            assert!(m.sha256.bytes().all(|b| b.is_ascii_hexdigit()), "{}", m.id);
+            assert!(
+                m.url.ends_with(m.file_name),
+                "{}: url must end in file_name",
+                m.id
+            );
+            assert!(m.size > 0, "{}", m.id);
+        }
+    }
+}

--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -9,6 +9,8 @@
 //! final location appearing complete or absent, never half-written.
 
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+use std::time::Duration;
 
 use crate::error::{Error, Result};
 
@@ -16,6 +18,23 @@ use crate::error::{Error, Result};
 /// same artifact don't stream over each other.
 const TMP_PREFIX: &str = "download-";
 const TMP_SUFFIX: &str = ".tmp";
+
+/// How long a download may go without receiving a byte before it fails. This
+/// is what makes a temp file's age meaningful: a live download touches its
+/// file at least this often, and one that stalls longer is torn down (and its
+/// temp file removed) rather than left hanging on a connection the network
+/// forgot. Sweeps that reclaim leftovers key their threshold off this.
+pub const READ_TIMEOUT: Duration = Duration::from_secs(60);
+
+fn client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .read_timeout(READ_TIMEOUT)
+            .build()
+            .expect("static reqwest client")
+    })
+}
 
 /// Where [`download_verified`] streams to for `dest_dir`. Exposed so a caller
 /// sweeping leftovers can tell its own in-flight file from a stale one.
@@ -65,7 +84,9 @@ async fn stream_verified(
     use sha2::Digest;
     use tokio::io::AsyncWriteExt;
 
-    let mut resp = reqwest::get(url)
+    let mut resp = client()
+        .get(url)
+        .send()
         .await
         .map_err(|e| Error::Other(format!("download {url}: {e}")))?
         .error_for_status()

--- a/src-tauri/src/download.rs
+++ b/src-tauri/src/download.rs
@@ -1,0 +1,132 @@
+//! One verified download for the whole app: the portable git dist, the
+//! codegraph bundle, and the Whisper weights all fetch a single pinned file
+//! and must never load a partial or substituted one.
+//!
+//! Every artifact lands in a temp file next to its destination and is hashed
+//! while it streams, so a mismatch costs one pass and leaves nothing behind.
+//! The temp path is returned rather than the final one: only the caller knows
+//! whether "installed" means a rename or an extraction, and staging keeps the
+//! final location appearing complete or absent, never half-written.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
+
+/// The temp file is named per-process so two Fletch instances fetching the
+/// same artifact don't stream over each other.
+const TMP_PREFIX: &str = "download-";
+const TMP_SUFFIX: &str = ".tmp";
+
+/// Where [`download_verified`] streams to for `dest_dir`. Exposed so a caller
+/// sweeping leftovers can tell its own in-flight file from a stale one.
+pub fn tmp_path(dest_dir: &Path) -> PathBuf {
+    dest_dir.join(format!("{TMP_PREFIX}{}{TMP_SUFFIX}", std::process::id()))
+}
+
+/// Whether `name` is one of this module's temp files. A process killed
+/// mid-download leaves one behind (the cleanup below only runs for failures we
+/// live to see), and the pid in the name means it is never reused — so
+/// directories that hold large artifacts sweep for these on their next run.
+pub fn is_tmp_name(name: &str) -> bool {
+    name.starts_with(TMP_PREFIX) && name.ends_with(TMP_SUFFIX)
+}
+
+/// Stream `url` into a temp file inside `dest_dir`, hashing as it downloads;
+/// error unless the digest matches `expected_sha256`. Returns the temp path,
+/// which the caller renames or unpacks into place. On any failure — transport,
+/// disk, or a digest mismatch — the temp file is removed.
+///
+/// `on_progress(received, total)` is throttled to ~5% steps (or every 8 MiB
+/// when the server sends no `Content-Length`), plus one final call once the
+/// last byte is in, so a UI gets a live number without an event per network
+/// chunk.
+pub async fn download_verified(
+    url: &str,
+    expected_sha256: &str,
+    dest_dir: &Path,
+    on_progress: impl Fn(u64, Option<u64>),
+) -> Result<PathBuf> {
+    let tmp = tmp_path(dest_dir);
+    match stream_verified(url, expected_sha256, &tmp, on_progress).await {
+        Ok(()) => Ok(tmp),
+        Err(e) => {
+            let _ = tokio::fs::remove_file(&tmp).await;
+            Err(e)
+        }
+    }
+}
+
+async fn stream_verified(
+    url: &str,
+    expected_sha256: &str,
+    tmp: &Path,
+    on_progress: impl Fn(u64, Option<u64>),
+) -> Result<()> {
+    use sha2::Digest;
+    use tokio::io::AsyncWriteExt;
+
+    let mut resp = reqwest::get(url)
+        .await
+        .map_err(|e| Error::Other(format!("download {url}: {e}")))?
+        .error_for_status()
+        .map_err(|e| Error::Other(format!("download {url}: {e}")))?;
+    let total = resp.content_length();
+
+    let mut file = tokio::fs::File::create(tmp)
+        .await
+        .map_err(|e| Error::Other(format!("create {}: {e}", tmp.display())))?;
+
+    let mut hasher = sha2::Sha256::new();
+    let mut received: u64 = 0;
+    let mut last_reported: u64 = 0;
+    while let Some(chunk) = resp
+        .chunk()
+        .await
+        .map_err(|e| Error::Other(format!("download {url}: {e}")))?
+    {
+        hasher.update(&chunk);
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| Error::Other(format!("write {}: {e}", tmp.display())))?;
+        received += chunk.len() as u64;
+        let step = total.map_or(8 * 1024 * 1024, |t| t / 20).max(1);
+        if received - last_reported >= step {
+            last_reported = received;
+            on_progress(received, total);
+        }
+    }
+    file.flush()
+        .await
+        .map_err(|e| Error::Other(format!("flush {}: {e}", tmp.display())))?;
+    drop(file);
+    on_progress(received, total);
+
+    let digest = format!("{:x}", hasher.finalize());
+    if !digest.eq_ignore_ascii_case(expected_sha256) {
+        return Err(Error::Other(format!(
+            "checksum mismatch for {url} (got {digest}, expected {expected_sha256})"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A sweep for leftovers has to recognize our temp files by name alone —
+    /// and must not match the artifacts sitting in the same directory.
+    #[test]
+    fn tmp_names_are_recognizable() {
+        let dir = Path::new("/tmp/x");
+        let name = tmp_path(dir)
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        assert!(is_tmp_name(&name));
+        assert!(is_tmp_name("download-1.tmp"));
+        assert!(!is_tmp_name("ggml-large-v3-turbo-q5_0.bin"));
+        assert!(!is_tmp_name("download-1.tmp.bin"));
+    }
+}

--- a/src-tauri/src/git_dist.rs
+++ b/src-tauri/src/git_dist.rs
@@ -377,7 +377,9 @@ pub async fn ensure_installed(on_progress: impl Fn(u64, Option<u64>)) -> Result<
 
     let url = format!("{DIST_URL_BASE}{asset}");
     tracing::info!(%url, "downloading portable git");
-    let tarball = download_verified(&url, sha, on_progress).await?;
+    let tarball = crate::download::download_verified(&url, sha, &root, on_progress)
+        .await
+        .map_err(|e| format!("portable git: {e}"))?;
 
     let dest = root.join(DIST_TAG);
     tokio::task::spawn_blocking(move || extract_dist(&tarball, &dest))
@@ -399,73 +401,6 @@ fn activate_portable() {
     if let Some(bin) = installed_portable_git() {
         *active().write().unwrap() = Some(Arc::new(bin));
     }
-}
-
-/// Stream the artifact to a temp file, hashing as it downloads; error unless
-/// the digest matches the pinned SHA-256. Returns the temp path.
-async fn download_verified(
-    url: &str,
-    expected_sha: &str,
-    on_progress: impl Fn(u64, Option<u64>),
-) -> Result<PathBuf, String> {
-    use sha2::Digest;
-    use tokio::io::AsyncWriteExt;
-
-    let resp = reqwest::get(url)
-        .await
-        .map_err(|e| format!("download: {e}"))?
-        .error_for_status()
-        .map_err(|e| format!("download: {e}"))?;
-    let total = resp.content_length();
-
-    let root = INSTALL_ROOT.get().expect("checked by caller").clone();
-    let tmp_path = root.join(format!("download-{}.tmp", std::process::id()));
-    let mut file = tokio::fs::File::create(&tmp_path)
-        .await
-        .map_err(|e| format!("create {}: {e}", tmp_path.display()))?;
-
-    let mut hasher = sha2::Sha256::new();
-    let mut received: u64 = 0;
-    let mut last_reported: u64 = 0;
-    let mut resp = resp;
-    loop {
-        let chunk = match resp.chunk().await {
-            Ok(Some(c)) => c,
-            Ok(None) => break,
-            Err(e) => {
-                let _ = tokio::fs::remove_file(&tmp_path).await;
-                return Err(format!("download: {e}"));
-            }
-        };
-        hasher.update(&chunk);
-        if let Err(e) = file.write_all(&chunk).await {
-            let _ = tokio::fs::remove_file(&tmp_path).await;
-            return Err(format!("write {}: {e}", tmp_path.display()));
-        }
-        received += chunk.len() as u64;
-        // Report at ~5% steps (or every 8 MiB when the size is unknown) so the
-        // UI gets a live number without an event per network chunk.
-        let step = total.map(|t| t / 20).unwrap_or(8 * 1024 * 1024).max(1);
-        if received - last_reported >= step {
-            last_reported = received;
-            on_progress(received, total);
-        }
-    }
-    if let Err(e) = file.flush().await {
-        let _ = tokio::fs::remove_file(&tmp_path).await;
-        return Err(format!("flush {}: {e}", tmp_path.display()));
-    }
-    drop(file);
-    on_progress(received, total);
-
-    let digest = format!("{:x}", hasher.finalize());
-    if !digest.eq_ignore_ascii_case(expected_sha) {
-        let _ = tokio::fs::remove_file(&tmp_path).await;
-        return Err(format!(
-            "portable git checksum mismatch (got {digest}, expected {expected_sha})"
-        ));
-    }
-    Ok(tmp_path)
 }
 
 /// Unpack `tarball` and move the dist into `dest`. Extraction goes to a

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1487,6 +1487,9 @@ pub fn run() {
             // at launch, not at the onboarding readiness screen, so a
             // git-less machine is usually ready before the user gets there.
             git_dist::init(data_dir.join("git-dist"));
+            // Whisper dictation weights live next to it; the engine loads
+            // from here and Settings downloads into it.
+            dictation::whisper::init(data_dir.join("whisper-models"));
             // Seed the in-process GitHub token so API calls and git network
             // auth work without a DB handle (updated on sign-in).
             seed_secret_mirror(&db, github::TOKEN_SETTING, github::seed_token);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -54,7 +54,10 @@ use tauri::Manager;
 use crate::supervisor::Supervisor;
 use crate::workspace::WorkspaceManager;
 
-type DbState = Arc<Mutex<Connection>>;
+/// The managed DB handle every command that reads or writes settings asks for.
+/// `pub(crate)` because those commands don't all live here (see
+/// `dictation::dictation_model_status`).
+pub(crate) type DbState = Arc<Mutex<Connection>>;
 
 /// The app's bundle identifier. Must match `identifier` in `tauri.conf.json`;
 /// macOS derives the app's on-disk folder names from it.
@@ -1915,6 +1918,10 @@ pub fn run() {
             dictation::dictation_availability,
             dictation::dictation_start,
             dictation::dictation_stop,
+            dictation::dictation_model_status,
+            dictation::set_dictation_engine,
+            dictation::dictation_model_download,
+            dictation::dictation_model_remove,
         ])
         .build(tauri::generate_context!())
         .expect("error while building fletch")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@ mod codegraph;
 mod commands;
 mod database;
 mod dictation;
+mod download;
 mod editors;
 mod error;
 mod exec_session;

--- a/src/api/domains/dictation.ts
+++ b/src/api/domains/dictation.ts
@@ -1,5 +1,9 @@
 import { invoke } from "../invoke";
-import type { DictationAvailability, DictationSessionId } from "../types/dictation";
+import type {
+  DictationAvailability,
+  DictationModelStatus,
+  DictationSessionId,
+} from "../types/dictation";
 
 export const dictationApi = {
   /** Whether native dictation exists on this platform and what the user has
@@ -24,4 +28,19 @@ export const dictationApi = {
    *  and only `stopped` arrives — so treat `stopped` as the point to commit
    *  whatever text was last received. No-op when not listening. */
   dictationStop: () => invoke<void>("dictation_stop"),
+
+  /** The local (Whisper) engine's opt-in plus the state of its weights. Cheap
+   *  — a metadata stat — so the Settings pane calls it on mount. */
+  dictationModelStatus: () => invoke<DictationModelStatus>("dictation_model_status"),
+  /** Pick the dictation engine. Persists `dictation_engine` and, when enabling
+   *  without the weights on disk, starts the download in the background —
+   *  resolves immediately either way, with progress arriving via
+   *  `onDictationModelProgress`. Backend-owned, like `setCodeIndexingEnabled`. */
+  setDictationEngine: (enabled: boolean) => invoke<void>("set_dictation_engine", { enabled }),
+  /** Retry a failed (or never-started) model download. Resolves at once with
+   *  the state the call left things in; a no-op while one is already running. */
+  dictationModelDownload: () => invoke<DictationModelStatus>("dictation_model_download"),
+  /** Delete the downloaded weights. Turn the engine off first — an enabled
+   *  engine with no model silently falls back to the platform recognizer. */
+  dictationModelRemove: () => invoke<DictationModelStatus>("dictation_model_remove"),
 };

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -12,7 +12,11 @@ import type {
   AgentViewEvent,
   ShellOutputEvent,
 } from "./types/agent";
-import type { DictationStateEvent, DictationTranscriptEvent } from "./types/dictation";
+import type {
+  DictationModelProgressEvent,
+  DictationStateEvent,
+  DictationTranscriptEvent,
+} from "./types/dictation";
 import type { PrStateChangedEvent } from "./types/pr";
 import type { AgentInstallEvent } from "./types/providers";
 import type {
@@ -188,6 +192,18 @@ export function onDictationTranscript(
  *  unmounted mid-session leaves its terminal event to land on the next one). */
 export function onDictationState(cb: (e: DictationStateEvent) => void): Promise<UnlistenFn> {
   return listen<DictationStateEvent>("dictation:state", (event) => cb(event.payload));
+}
+
+/** Progress of the local engine's model download, ending in `installed` or
+ *  `error`. The download outlives the Settings screen that started it, so a
+ *  subscriber that mounts late reads `dictationModelStatus` for where it
+ *  stands and then follows along here. */
+export function onDictationModelProgress(
+  cb: (e: DictationModelProgressEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<DictationModelProgressEvent>("dictation:model_progress", (event) =>
+    cb(event.payload),
+  );
 }
 
 export function onAgentEvent(cb: (e: AgentManagedEvent) => void): Promise<UnlistenFn> {

--- a/src/api/types/dictation.ts
+++ b/src/api/types/dictation.ts
@@ -51,3 +51,42 @@ export interface DictationStateEvent {
   state: DictationState;
   error: string | null;
 }
+
+/** The one Whisper model the local engine would use, as pinned in the Rust
+ *  catalog (`dictation/whisper/models.rs`). */
+export interface DictationModel {
+  id: string;
+  label: string;
+  /** One line on when to pick it. */
+  note: string;
+  /** Exact download size in bytes. Every size string in the UI is derived from
+   *  it, so the copy can't drift from the pinned file. */
+  size: number;
+}
+
+/** The local (Whisper) engine's opt-in and the state of its weights. `enabled`
+ *  and `installed` move independently: the engine can be chosen while the
+ *  download is still running, in which case dictation keeps using the platform
+ *  recognizer. */
+export interface DictationModelStatus {
+  enabled: boolean;
+  installed: boolean;
+  /** A download is running right now; watch `onDictationModelProgress`. */
+  downloading: boolean;
+  model: DictationModel;
+}
+
+/** `verifying` is the tail of the download (the digest is computed as bytes
+ *  arrive), not a second pass — so it always follows a full `received`. */
+export type DictationModelState = "downloading" | "verifying" | "installed" | "error";
+
+/** Payload of the `dictation:model_progress` event. `total` is the pinned
+ *  catalog size, not the server's `Content-Length`. `error` is set for the
+ *  `error` state alone and is shown as-is. */
+export interface DictationModelProgressEvent {
+  model_id: string;
+  state: DictationModelState;
+  received: number;
+  total: number | null;
+  error: string | null;
+}

--- a/src/components/SettingsScreen/DictationSection/ModelStatusRow.tsx
+++ b/src/components/SettingsScreen/DictationSection/ModelStatusRow.tsx
@@ -1,0 +1,83 @@
+import type { DictationModelProgressEvent, DictationModelStatus } from "@/api";
+import { Button } from "@/components/ui/Button";
+import { downloadPercent, formatBytes } from "@/util/format";
+
+/** The line under the engine toggle: what the weights are doing and the one
+ *  action that applies. Shown while the engine is on, and also while it's off
+ *  but the model is still on disk — otherwise turning the engine off would
+ *  strand half a gigabyte with no way to reclaim it. */
+export function ModelStatusRow({
+  enabled,
+  status,
+  progress,
+  onDownload,
+  onRemove,
+}: {
+  enabled: boolean;
+  status: DictationModelStatus;
+  progress: DictationModelProgressEvent | null;
+  onDownload: () => void;
+  onRemove: () => void;
+}) {
+  const size = formatBytes(status.model.size);
+  const error = progress?.state === "error" ? progress.error || "Download failed" : null;
+  const busy =
+    status.downloading || progress?.state === "downloading" || progress?.state === "verifying";
+
+  if (!enabled && !status.installed && !busy && !error) return null;
+
+  let line: React.ReactNode;
+  let action: React.ReactNode;
+  let bar: number | null | undefined;
+
+  if (error) {
+    line = <span className="set-dict-status err">{error}</span>;
+    action = (
+      <Button variant="outline" size="sm" onClick={onDownload}>
+        Retry
+      </Button>
+    );
+  } else if (busy) {
+    // No progress event yet (a screen that opened mid-download) means no
+    // percentage to show, so the bar runs indeterminate.
+    const pct = progress ? downloadPercent(progress.received, progress.total) : null;
+    bar = pct;
+    line = (
+      <span className="set-dict-status">
+        {progress?.state === "verifying"
+          ? "Verifying…"
+          : pct === null
+            ? "Downloading…"
+            : `Downloading ${pct}% · ${formatBytes(progress?.received ?? 0)} of ${size}`}
+      </span>
+    );
+  } else if (status.installed) {
+    line = <span className="set-dict-status">Installed · {size}</span>;
+    action = (
+      <Button variant="outline" size="sm" onClick={onRemove}>
+        Remove
+      </Button>
+    );
+  } else {
+    line = <span className="set-dict-status">Not downloaded · {size}</span>;
+    action = (
+      <Button variant="outline" size="sm" onClick={onDownload}>
+        Download
+      </Button>
+    );
+  }
+
+  return (
+    <div className="set-dict">
+      <div className="set-dict-head flex-center">
+        {line}
+        {action}
+      </div>
+      {bar !== undefined && (
+        <div className={`set-dict-bar ${bar === null ? "indet" : ""}`}>
+          <i style={bar === null ? undefined : { width: `${bar}%` }} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/DictationSection/index.tsx
+++ b/src/components/SettingsScreen/DictationSection/index.tsx
@@ -8,7 +8,11 @@ import { useDictationModel } from "./useDictationModel";
  *  of Apple's recognizer. The opt-in and the weights are separate states — the
  *  toggle flips immediately and the model downloads behind it — so the row
  *  below the toggle is the only place that says whether dictation can actually
- *  run locally yet. macOS-only, like the recognizer it replaces. */
+ *  run locally yet. macOS-only, like the recognizer it replaces.
+ *
+ *  Not mounted in `GeneralPane` until the engine that honours the setting
+ *  lands: a toggle that downloads weights nothing reads would be a broken
+ *  promise in any build shipped in between. */
 export function DictationSection() {
   const enabled = useAppStore((s) => s.dictationEngineEnabled);
   const setEnabled = useAppStore((s) => s.setDictationEngineEnabled);
@@ -32,10 +36,11 @@ export function DictationSection() {
           status={status}
           progress={progress}
           onDownload={download}
-          onRemove={() => {
+          onRemove={async () => {
             // Deleting the weights under an enabled engine would leave it
-            // silently falling back, so the opt-in goes with them.
-            if (enabled) setEnabled(false);
+            // silently falling back, so the opt-in goes first — and only if it
+            // actually persisted do the weights follow.
+            if (enabled && !(await setEnabled(false))) return;
             remove();
           }}
         />

--- a/src/components/SettingsScreen/DictationSection/index.tsx
+++ b/src/components/SettingsScreen/DictationSection/index.tsx
@@ -1,0 +1,45 @@
+import { useAppStore } from "@/store";
+import { formatBytes } from "@/util/format";
+import { SetGroup, SetRow, SetToggle } from "../primitives";
+import { ModelStatusRow } from "./ModelStatusRow";
+import { useDictationModel } from "./useDictationModel";
+
+/** Settings › General › Dictation: opt into the local Whisper engine instead
+ *  of Apple's recognizer. The opt-in and the weights are separate states — the
+ *  toggle flips immediately and the model downloads behind it — so the row
+ *  below the toggle is the only place that says whether dictation can actually
+ *  run locally yet. macOS-only, like the recognizer it replaces. */
+export function DictationSection() {
+  const enabled = useAppStore((s) => s.dictationEngineEnabled);
+  const setEnabled = useAppStore((s) => s.setDictationEngineEnabled);
+  const { status, progress, download, remove } = useDictationModel();
+
+  const size = status ? formatBytes(status.model.size) : null;
+
+  return (
+    <SetGroup label="Dictation">
+      <SetRow
+        title="Local speech recognition"
+        sub={`Transcribe with OpenAI's Whisper on this Mac instead of Apple's recognizer.${
+          size ? ` Downloads a ${size} model once.` : ""
+        }`}
+      >
+        <SetToggle on={enabled} onClick={() => setEnabled(!enabled)} />
+      </SetRow>
+      {status && (
+        <ModelStatusRow
+          enabled={enabled}
+          status={status}
+          progress={progress}
+          onDownload={download}
+          onRemove={() => {
+            // Deleting the weights under an enabled engine would leave it
+            // silently falling back, so the opt-in goes with them.
+            if (enabled) setEnabled(false);
+            remove();
+          }}
+        />
+      )}
+    </SetGroup>
+  );
+}

--- a/src/components/SettingsScreen/DictationSection/useDictationModel.ts
+++ b/src/components/SettingsScreen/DictationSection/useDictationModel.ts
@@ -1,0 +1,71 @@
+import type { UnlistenFn } from "@tauri-apps/api/event";
+import { useCallback, useEffect, useState } from "react";
+import {
+  api,
+  type DictationModelProgressEvent,
+  type DictationModelStatus,
+  onDictationModelProgress,
+} from "@/api";
+
+export interface DictationModelView {
+  /** `null` until the first fetch resolves. */
+  status: DictationModelStatus | null;
+  /** The latest progress event, or `null` before one arrives (and after an
+   *  action that makes it stale). */
+  progress: DictationModelProgressEvent | null;
+  download: () => void;
+  remove: () => void;
+}
+
+/** The model's install state, kept live. The download runs in the backend and
+ *  outlives this screen, so the state is fetched on mount (for a screen that
+ *  opened mid-download, or after a failure whose event we never saw) and then
+ *  followed through `dictation:model_progress`. Terminal events change what's
+ *  on disk, so they trigger a re-fetch rather than a locally inferred status. */
+export function useDictationModel(): DictationModelView {
+  const [status, setStatus] = useState<DictationModelStatus | null>(null);
+  const [progress, setProgress] = useState<DictationModelProgressEvent | null>(null);
+
+  useEffect(() => {
+    let disposed = false;
+    const refresh = () => {
+      void api
+        .dictationModelStatus()
+        .then((s) => {
+          if (!disposed) setStatus(s);
+        })
+        .catch(() => {});
+    };
+    refresh();
+
+    let unlisten: UnlistenFn | undefined;
+    void onDictationModelProgress((e) => {
+      if (disposed) return;
+      setProgress(e);
+      if (e.state === "installed" || e.state === "error") refresh();
+    }).then((fn) => {
+      // The effect may have been cleaned up while listen() was in flight.
+      if (disposed) fn();
+      else unlisten = fn;
+    });
+
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
+
+  const act = useCallback((call: () => Promise<DictationModelStatus>) => {
+    // Drop the last progress event: it describes the download this action
+    // replaces (a failure being retried, or an install being removed).
+    setProgress(null);
+    void call()
+      .then(setStatus)
+      .catch(() => {});
+  }, []);
+
+  const download = useCallback(() => act(api.dictationModelDownload), [act]);
+  const remove = useCallback(() => act(api.dictationModelRemove), [act]);
+
+  return { status, progress, download, remove };
+}

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -5,7 +5,9 @@ import { Select } from "@/components/ui/Select";
 import { ACCENTS, mcpCapableLabels } from "@/data/providers";
 import type { SandboxEngine, ThemeMode } from "@/storage/preferences";
 import { useAppStore } from "@/store";
+import { IS_MAC } from "@/util/platform";
 import { ContainerAuth } from "./ContainerAuth";
+import { DictationSection } from "./DictationSection";
 import { type FeatureItem, SetGroup, SetHead, SetRow, SetSeg, SetToggle } from "./primitives";
 
 // A container runtime can start or stop while this pane stays open, so we
@@ -189,6 +191,10 @@ export function GeneralPane() {
           />
         </SetRow>
       </SetGroup>
+
+      {/* The engine this replaces is Apple's, so there is nothing to choose
+          from anywhere else. */}
+      {IS_MAC && <DictationSection />}
 
       <SetGroup label="Sandbox">
         <SetRow

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -5,9 +5,7 @@ import { Select } from "@/components/ui/Select";
 import { ACCENTS, mcpCapableLabels } from "@/data/providers";
 import type { SandboxEngine, ThemeMode } from "@/storage/preferences";
 import { useAppStore } from "@/store";
-import { IS_MAC } from "@/util/platform";
 import { ContainerAuth } from "./ContainerAuth";
-import { DictationSection } from "./DictationSection";
 import { type FeatureItem, SetGroup, SetHead, SetRow, SetSeg, SetToggle } from "./primitives";
 
 // A container runtime can start or stop while this pane stays open, so we
@@ -191,10 +189,6 @@ export function GeneralPane() {
           />
         </SetRow>
       </SetGroup>
-
-      {/* The engine this replaces is Apple's, so there is nothing to choose
-          from anywhere else. */}
-      {IS_MAC && <DictationSection />}
 
       <SetGroup label="Sandbox">
         <SetRow

--- a/src/components/SettingsScreen/SettingsScreen.css
+++ b/src/components/SettingsScreen/SettingsScreen.css
@@ -756,6 +756,55 @@
   background: var(--bg-2);
 }
 
+/* ── DICTATION ───────────────────────────────────────────────────────── */
+/* The local-engine model row: a status line with the one action that applies,
+   plus the download bar. Sits under its toggle row like `.set-sandbox-warn`. */
+.set-dict {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 10px 0 4px;
+}
+.set-dict-head {
+  gap: 10px;
+}
+.set-dict-status {
+  flex: 1;
+  min-width: 0;
+  color: var(--fg-2);
+  font-size: var(--fs-sm);
+  line-height: var(--lh-normal);
+}
+.set-dict-status.err {
+  color: var(--danger);
+}
+.set-dict-bar {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--bd);
+  overflow: hidden;
+}
+.set-dict-bar i {
+  display: block;
+  height: 100%;
+  border-radius: 2px;
+  background: var(--accent);
+  transition: width 0.3s var(--ease);
+}
+/* No Content-Length (or no event yet), so there's no percentage to show. */
+.set-dict-bar.indet i {
+  width: 40%;
+  animation: set-dict-indet 1.2s var(--ease) infinite;
+}
+@keyframes set-dict-indet {
+  from {
+    transform: translateX(-100%);
+  }
+  to {
+    transform: translateX(350%);
+  }
+}
+
 /* ── quick-popover "All settings" footer button ──────────────────────── */
 .sp-allbtn {
   gap: 9px;

--- a/src/store/account.ts
+++ b/src/store/account.ts
@@ -9,6 +9,9 @@ export interface AccountSlice {
   telemetryEnabled: boolean;
   /** Code-indexing (codegraph) consent. Opt-out: defaults on. */
   codeIndexingEnabled: boolean;
+  /** Local (Whisper) dictation engine chosen over the platform recognizer.
+   *  Opt-in: defaults off, since it costs a model download. */
+  dictationEngineEnabled: boolean;
   /** GitHub connection: null until the first probe, then the live status.
    *  `authenticated` gates push/PR/clone affordances app-wide. */
   github: GhStatus | null;
@@ -30,12 +33,14 @@ export interface AccountSlice {
   refreshLinear: () => Promise<void>;
   setTelemetryEnabled: (enabled: boolean) => void;
   setCodeIndexingEnabled: (enabled: boolean) => void;
+  setDictationEngineEnabled: (enabled: boolean) => void;
 }
 
 export const createAccountSlice: SliceCreator<AccountSlice> = (set, get) => ({
   account: null,
   telemetryEnabled: true,
   codeIndexingEnabled: true,
+  dictationEngineEnabled: false,
   github: null,
   linear: null,
 
@@ -98,5 +103,11 @@ export const createAccountSlice: SliceCreator<AccountSlice> = (set, get) => ({
     // The backend command persists `code_indexing_enabled` and (when enabling)
     // warms the index in the background, so we don't also call setSetting here.
     void api.setCodeIndexingEnabled(enabled);
+  },
+  setDictationEngineEnabled: (enabled) => {
+    set({ dictationEngineEnabled: enabled });
+    // The backend command persists `dictation_engine` and (when enabling)
+    // downloads the model in the background, so we don't also call setSetting.
+    void api.setDictationEngine(enabled);
   },
 });

--- a/src/store/account.ts
+++ b/src/store/account.ts
@@ -33,7 +33,9 @@ export interface AccountSlice {
   refreshLinear: () => Promise<void>;
   setTelemetryEnabled: (enabled: boolean) => void;
   setCodeIndexingEnabled: (enabled: boolean) => void;
-  setDictationEngineEnabled: (enabled: boolean) => void;
+  /** Resolves `true` once the choice is persisted; `false` (with the store
+   *  reverted) if the backend rejected it. */
+  setDictationEngineEnabled: (enabled: boolean) => Promise<boolean>;
 }
 
 export const createAccountSlice: SliceCreator<AccountSlice> = (set, get) => ({
@@ -104,10 +106,19 @@ export const createAccountSlice: SliceCreator<AccountSlice> = (set, get) => ({
     // warms the index in the background, so we don't also call setSetting here.
     void api.setCodeIndexingEnabled(enabled);
   },
-  setDictationEngineEnabled: (enabled) => {
+  setDictationEngineEnabled: async (enabled) => {
+    const previous = get().dictationEngineEnabled;
     set({ dictationEngineEnabled: enabled });
     // The backend command persists `dictation_engine` and (when enabling)
     // downloads the model in the background, so we don't also call setSetting.
-    void api.setDictationEngine(enabled);
+    // Optimistic, but not blindly: a failed write puts the toggle back, since
+    // this one gates a half-gigabyte download and a delete.
+    try {
+      await api.setDictationEngine(enabled);
+      return true;
+    } catch {
+      set({ dictationEngineEnabled: previous });
+      return false;
+    }
   },
 });

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -150,6 +150,10 @@ export const hydrateSettings = async (set: AppSet, get: AppGet) => {
       // the `set_code_indexing_enabled` Rust command): read `s.code_indexing_enabled`,
       // never setSetting it. Only an explicit "false" disables.
       codeIndexingEnabled: s.code_indexing_enabled !== "false",
+      // The local dictation engine is opt-in and backend-owned (written by
+      // `set_dictation_engine`): only an explicit "whisper" selects it, which
+      // matches Rust's `whisper::parse_enabled`.
+      dictationEngineEnabled: s.dictation_engine === "whisper",
       // Backend-owned like telemetry_enabled (snake_case, written by the
       // `set_sandbox_engine` Rust command) — read it, never setSetting it.
       sandboxEngine: parseSandboxEngine(s.sandbox_engine),

--- a/src/util/format.ts
+++ b/src/util/format.ts
@@ -89,3 +89,22 @@ export function formatCost(usd: number): string {
   if (usd > 0 && usd < 0.01) return "<$0.01";
   return `$${usd.toFixed(usd < 1 ? 3 : 2)}`;
 }
+
+/** A download size in decimal units (574 MB), the way the files themselves are
+ *  advertised — a binary-unit "547 MiB" for the same bytes reads as a
+ *  different download. One decimal below 10 of a unit, none above. */
+export function formatBytes(bytes: number): string {
+  const mb = bytes / 1_000_000;
+  if (mb < 1) return `${Math.round(bytes / 1_000)} kB`;
+  if (mb < 1_000) return `${mb.toFixed(mb < 10 ? 1 : 0)} MB`;
+  const gb = mb / 1_000;
+  return `${gb.toFixed(gb < 10 ? 1 : 0)} GB`;
+}
+
+/** Whole-percent progress, clamped to 0–100. `null` when the total is unknown
+ *  or zero, which is the caller's cue for an indeterminate bar rather than a
+ *  bogus 0%. */
+export function downloadPercent(received: number, total: number | null): number | null {
+  if (!total || total <= 0) return null;
+  return Math.min(100, Math.max(0, Math.round((received / total) * 100)));
+}

--- a/tests/util/format.test.ts
+++ b/tests/util/format.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { downloadPercent, formatBytes } from "@/util/format";
+
+describe("formatBytes", () => {
+  it("matches how the pinned artifacts advertise their size", () => {
+    // The default Whisper model's exact byte count — the Settings copy says
+    // "574 MB", and it has to come out of this function, not a literal.
+    expect(formatBytes(574_041_195)).toBe("574 MB");
+    expect(formatBytes(264_477_561)).toBe("264 MB");
+  });
+
+  it("keeps one decimal below ten of a unit and drops it above", () => {
+    expect(formatBytes(1_500_000)).toBe("1.5 MB");
+    expect(formatBytes(42_000_000)).toBe("42 MB");
+    expect(formatBytes(2_400_000_000)).toBe("2.4 GB");
+  });
+
+  it("falls back to kB under a megabyte", () => {
+    expect(formatBytes(0)).toBe("0 kB");
+    expect(formatBytes(12_800)).toBe("13 kB");
+  });
+});
+
+describe("downloadPercent", () => {
+  it("rounds to whole percent", () => {
+    expect(downloadPercent(287_020_597, 574_041_195)).toBe(50);
+    expect(downloadPercent(1, 3)).toBe(33);
+  });
+
+  it("has no answer for an unknown total, so the bar goes indeterminate", () => {
+    expect(downloadPercent(1_000, null)).toBeNull();
+    expect(downloadPercent(1_000, 0)).toBeNull();
+  });
+
+  it("clamps a server that over-reports", () => {
+    expect(downloadPercent(600, 500)).toBe(100);
+  });
+});


### PR DESCRIPTION
First of two PRs replacing Apple's SFSpeechRecognizer dictation with a local whisper.cpp engine. This one lands the plumbing: a pinned model catalog, a verified download, and the Settings opt-in. Dictation itself is unchanged here; the engine that consumes the downloaded weights follows in a stacked PR.

## What's in it

- **Model catalog** (`src-tauri/src/dictation/whisper/models.rs`): ggml weights pinned by file name, SHA-256 and exact size, taken from the HuggingFace LFS pointers. Default is `large-v3-turbo-q5_0` (574 MB). Swapping the default is a new entry plus a one-line change to `DEFAULT_MODEL_ID`; `docs/dictation.md` documents the procedure.
- **One shared verified download** (`src-tauri/src/download.rs`): extracted from the two near-identical copies in `git_dist.rs` and `codegraph/install.rs`, which now both call it. Streams to a pid-stamped temp file, hashes while writing, throttles progress, deletes the temp on any failure or digest mismatch. No behaviour change for git or codegraph installs.
- **Model install** (`whisper/install.rs`): fire-and-forget download with one-in-flight guard, stale temp sweep, atomic rename into `<app data>/whisper-models/`, and `dictation:model_progress` events (`downloading` / `verifying` / `installed` / `error`).
- **Commands**: `dictation_model_status`, `set_dictation_engine`, `dictation_model_download`, `dictation_model_remove`. The engine choice persists as the `dictation_engine` setting (`"whisper"` / `"apple"`), backend-owned like `code_indexing_enabled`.
- **Settings › General › Dictation** (macOS only): a "Local speech recognition" toggle that starts the download, with a progress bar, Installed/Remove, and error/Retry states. Built as `SettingsScreen/DictationSection/` (index, status row, hook). Size copy is derived from the catalog, never hardcoded.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` (1487 passed)
- `bun run lint`, `bun run check`, `bun run test` (1102 passed)
- New tests: temp-name recognition, stale-temp sweep leaves installed weights and the in-flight file alone, status without a models root, `formatBytes` / `downloadPercent`.
- Not exercised in the sandbox: the actual 574 MB download against HuggingFace and the rendered Settings section. Worth a manual pass: toggle on, watch progress, Remove, Retry after a failure.

## Known limits

- `remove()` deletes only the current default model's file; if `DEFAULT_MODEL_ID` moves, a former default's weights linger until removed by hand.
- The catalog's second entry (`small.en-q8_0`, for Intel Macs) is present but not selectable from the UI yet.