### PR TITLE
fix(chat): wrap long unbroken tokens instead of overflowing the transcript

### DIFF
--- a/src/components/Workspace/Chat.css
+++ b/src/components/Workspace/Chat.css
@@ -504,6 +504,20 @@
   opacity: 1;
 }
 
+/* Transcript text is arbitrary: a $PATH dump, a URL, a base64 blob, a stack
+   frame. Those carry no space to break at, so `pre-wrap` alone leaves them
+   running past the bubble and drags the whole column into horizontal scroll.
+   `anywhere` breaks mid-token as a last resort — and because `overflow-wrap`
+   inherits, one declaration per prose root also covers its paragraphs, list
+   items, table cells, links and code spans. */
+.m-user,
+.m-agent,
+.m-reasoning,
+.m-cmdout__body,
+.m-sysbit__text {
+  overflow-wrap: anywhere;
+}
+
 .m-user {
   align-self: flex-end;
   max-width: 78%;
@@ -599,17 +613,25 @@
 .m-agent pre {
   margin: 12px 0 16px;
   padding: 12px 14px;
+  /* Kept as a backstop for anything unbreakable the wrap below can't split;
+     with soft-wrapped code it normally never engages. */
   overflow-x: auto;
   background: var(--bg-2);
   border: 1px solid var(--bd-soft);
   border-radius: var(--r-sm);
 }
+/* Soft-wrap rather than scroll. The transcript column is narrow (and narrower
+   still with the right panel open), so a horizontal scroller inside a block
+   that is itself inside a vertical scroller hides content behind a gesture
+   nobody reaches for. `pre-wrap` keeps indentation and explicit newlines and
+   only folds lines that don't fit; the inherited `overflow-wrap: anywhere`
+   handles the long unbroken token inside one. */
 .m-agent pre code {
   display: block;
   padding: 0;
   background: transparent;
   border: 0;
-  white-space: pre;
+  white-space: pre-wrap;
 }
 .m-agent table {
   width: 100%;
@@ -705,7 +727,6 @@
   line-height: var(--lh-relaxed);
   color: var(--fg-1);
   white-space: pre-wrap;
-  word-break: break-word;
 }
 
 /* A background-task notification, rendered as a single quiet system line

--- a/src/components/Workspace/messages/UserInput/UserInput.css
+++ b/src/components/Workspace/messages/UserInput/UserInput.css
@@ -89,6 +89,12 @@
   color: var(--fg-1);
   max-height: 280px;
   overflow: auto;
+  /* Same rule as the transcript's prose (Chat.css): break mid-token rather
+     than let a path or URL push the card into horizontal scroll. */
+  overflow-wrap: anywhere;
+}
+.q-body pre {
+  white-space: pre-wrap;
 }
 .q-body > *:first-child {
   margin-top: 0;


### PR DESCRIPTION
## The problem

A long unbroken token in a chat message — a pasted `$PATH` dump, a URL, a base64 blob — has no space to wrap at. The user bubble renders as plain text with `white-space: pre-wrap`, which only breaks at spaces, so those tokens ran past the bubble edge and dragged the whole transcript column into horizontal scroll.

Agent code blocks were a separate instance of the same complaint: `.m-agent pre code` was hard `white-space: pre`, so a long line scrolled sideways inside the block.

## The fix

CSS only, two files.

**`Chat.css`**
- One grouped `overflow-wrap: anywhere` on the transcript's prose roots: `.m-user`, `.m-agent`, `.m-reasoning`, `.m-cmdout__body`, `.m-sysbit__text`. `overflow-wrap` inherits, so that single declaration per root also covers its paragraphs, list items, table cells, links and inline code spans.
- `.m-agent pre code`: `white-space: pre` → `pre-wrap`. Wrapping beats scrolling here — the transcript column is narrow and gets narrower with the right panel open, and a horizontal scroller nested inside a vertical one hides content behind a gesture people don't reach for. `pre-wrap` preserves indentation and explicit newlines and only folds lines that don't fit; the inherited `overflow-wrap` handles a long token inside one. `overflow-x: auto` stays on the `pre` as a backstop.
- Dropped the now-redundant `word-break: break-word` from `.m-cmdout__body`.

**`UserInput.css`**
- The question card's `.q-body` is the one chat markdown surface that doesn't borrow the `.m-agent` skin, and its `pre` had no styling at all. Same treatment. It has its own `overflow: auto`, so it was never breaking the outer layout — a contained version of the same complaint.

Because `ArtifactPanel` and the roadmap's `ProductBrief` reuse the `.m-agent` prose skin, they pick this up too.

## Verification

Not verified — flagging honestly. `node_modules` is absent in this workspace, so `npm run lint` (biome) could not run; the biome CSS formatter has not confirmed the formatting. The change is CSS-only, so there is nothing for `tsc` to check. It has not been rendered in the app either — worth pasting a long path-bearing error into a chat to confirm the bubble now holds.