### PR TITLE
feat(dictation): transcribe locally with whisper.cpp

### DIFF
--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -71,6 +71,17 @@ The failure mode when this doesn't reach `codesign` is quiet: dev builds work,
 the notarized app lights the mic and transcribes silence. If dictation returns
 an empty transcript only in a released build, check the entitlement first.
 
+## On-device vs Apple's servers
+
+The request sets `requiresOnDeviceRecognition` to whatever the recognizer
+reports as `supportsOnDeviceRecognition()`. Where that is true (a supported
+locale on Apple Silicon, with the assets downloaded) **no audio leaves the
+machine**. Where it is false, recognition is server-backed and Apple caps a
+session at roughly a minute, after which the recognizer ends it itself — the
+composer sees the ordinary final transcript and `stopped`, so a long dictation
+simply stops rather than breaking. `dictation_availability` reports which mode
+this machine is in as `on_device`.
+
 ## Local Whisper engine (opt-in)
 
 Settings › General › Dictation offers a second engine: whisper.cpp running
@@ -124,18 +135,7 @@ Users who already downloaded the old model keep it on disk; the new default is
 a fresh download. `size` is also where the "Downloads a 574 MB model once."
 copy comes from, so the UI can't drift from the pinned file.
 
-## On-device vs Apple's servers
-
-The request sets `requiresOnDeviceRecognition` to whatever the recognizer
-reports as `supportsOnDeviceRecognition()`. Where that is true (a supported
-locale on Apple Silicon, with the assets downloaded) **no audio leaves the
-machine**. Where it is false, recognition is server-backed and Apple caps a
-session at roughly a minute, after which the recognizer ends it itself — the
-composer sees the ordinary final transcript and `stopped`, so a long dictation
-simply stops rather than breaking. `dictation_availability` reports which mode
-this machine is in as `on_device`.
-
-## The local engine
+### How a session runs on it
 
 Opting in to whisper.cpp in Settings replaces the recognizer, not the mic:
 `apple.rs` still opens the `AVAudioEngine` and installs the tap, and the

--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -1,18 +1,21 @@
 # Voice dictation
 
-The mic button in the agent composer (beside the paperclip) streams the
-platform's native speech recognizer into the prompt box. This document is the
-part that isn't obvious from the code: which platforms have it, what the OS
-demands before it works, and where your audio goes.
+The mic button in the agent composer (beside the paperclip) streams a speech
+recognizer into the prompt box. This document is the part that isn't obvious
+from the code: which platforms have it, what the OS demands before it works,
+and where your audio goes.
 
 ## Platform support
 
-**Apple only.** The implementation is Apple's Speech framework
+**Apple only.** The default implementation is Apple's Speech framework
 (`SFSpeechRecognizer` fed by an `AVAudioEngine` mic tap), reached through the
 `objc2` bindings — the same code compiles for macOS and iOS, with no Swift
 toolchain step. Linux and Windows get a stub that reports `supported: false`,
 and the composer hides the button entirely rather than offer one that can only
 fail.
+
+macOS additionally has a local whisper.cpp engine the user can opt into; see
+[The local engine](#the-local-engine) below.
 
 The flow, end to end:
 
@@ -23,11 +26,12 @@ The flow, end to end:
 | IPC | `src/api/domains/dictation.ts` → `dictation_availability` / `dictation_start` / `dictation_stop` |
 | Events | `src/api/events.ts` — `dictation:transcript`, `dictation:state` |
 | Commands + contract | `src-tauri/src/dictation/mod.rs` |
-| Recognizer | `src-tauri/src/dictation/apple.rs` |
+| Microphone (both engines) | `src-tauri/src/dictation/apple.rs` |
+| Local engine | `src-tauri/src/dictation/capture.rs`, `src-tauri/src/dictation/whisper/` |
 
 ## Permissions
 
-Dictation needs **two** separate TCC grants, prompted on the first
+Apple's recognizer needs **two** separate TCC grants, prompted on the first
 `dictation_start` (speech first, then the microphone, one dialog at a time):
 
 - `NSSpeechRecognitionUsageDescription`
@@ -38,6 +42,12 @@ filename and `tauri-codegen` also embeds into the dev binary — so the prompts
 work under `tauri dev`, not just in a bundle. The speech string is load-bearing
 rather than cosmetic: `requestAuthorization:` crashes the process outright if
 it is missing.
+
+The local engine asks for the microphone only. Opting out of Apple's speech
+service and then being made to authorize it would be a contradiction, so that
+path never calls `requestAuthorization:` — and `dictation_availability`'s
+`speech` field is meaningless when `engine` is `whisper`, which is why the
+button ignores it there.
 
 A denied grant can only be undone in System Settings › Privacy & Security, so
 the button shows a slashed mic and says so. To get the first-run prompts back
@@ -124,3 +134,104 @@ session at roughly a minute, after which the recognizer ends it itself — the
 composer sees the ordinary final transcript and `stopped`, so a long dictation
 simply stops rather than breaking. `dictation_availability` reports which mode
 this machine is in as `on_device`.
+
+## The local engine
+
+Opting in to whisper.cpp in Settings replaces the recognizer, not the mic:
+`apple.rs` still opens the `AVAudioEngine` and installs the tap, and the
+commands, the events and the session-id contract are identical. What changes is
+the tap's *sink*, and what a stop means.
+
+### Dispatch
+
+`dictation_start` and `dictation_availability` both go through
+`dictation::engine`, which answers `whisper` only when **both** hold:
+
+- the `dictation_engine` setting is exactly `"whisper"`, and
+- the pinned model file is fully present (`whisper::models::installed_path`
+  checks the exact byte size, and the download only moves a digest-verified
+  file into place).
+
+Dispatching on the setting alone would let an interrupted download leave the
+mic button dead, so a half-finished install silently falls back to Apple's
+recognizer. `dictation_availability` reports the answer as `engine`, so the UI
+never has to guess which one a click will get.
+
+whisper.cpp is compiled from source by `whisper-rs-sys`, which needs **cmake**
+on the build host. The dependency lives under
+`[target.'cfg(target_os = "macos")'.dependencies]` for two reasons: `metal`
+puts inference on the GPU, and the Linux CI build has no business compiling a
+C++ tree it will never run. iOS therefore keeps Apple's recognizer whatever the
+setting says — `dictation/capture.rs` and `dictation/whisper/engine.rs` don't
+exist there. No link flags of our own are needed; `whisper-rs-sys` emits the
+`c++`/Accelerate/Foundation/Metal/MetalKit lines itself.
+
+### Capture, and why resampling isn't decimation
+
+whisper.cpp takes 16 kHz mono `f32`; the microphone is typically 48 kHz and may
+be stereo. The two conversions are split by thread on purpose:
+
+- **Channel averaging happens in the tap**, on Apple's real-time render thread,
+  because it is a few adds per frame into a pre-sized buffer behind a
+  `try_lock`. Nothing else happens there — no allocation, no session state, no
+  events.
+- **Resampling happens at stop**, in a `spawn_blocking` task, using
+  `AVAudioConverter`. Taking every third sample would be cheap enough for the
+  tap, but decimating without a low-pass folds everything above 8 kHz back into
+  the speech band and the model hears the aliases.
+
+A session is capped at five minutes of audio (`MAX_CAPTURE_SECS`); past that,
+new buffers are dropped, which truncates the transcript rather than failing.
+
+### The silence gate
+
+Whisper does not return nothing for nothing. Given silence or a fraction of a
+second of noise it invents a plausible sentence — "Thank you.", "[BLANK_AUDIO]",
+a line of subtitle boilerplate — because that is what its training data has in
+those places. So `whisper::engine::transcribe` refuses to run the model at all
+when the clip is under `MIN_DURATION` (0.5 s, i.e. a tap on the button) or its
+RMS is under `MIN_RMS` (0.002, i.e. a muted or unplugged input), and returns
+empty text. `whisper.cpp`'s own `suppress_blank` handles the milder case of
+silence at the head or tail of a real utterance.
+
+Empty text emits **no** `dictation:transcript` — only the terminal `stopped` —
+so a mistimed press leaves the composer exactly as it was.
+
+### `transcribing`, and the model's lifetime
+
+Apple's recognizer streams revisions while the user speaks; whisper.cpp has
+nothing to say until the whole clip is in. A stop on the local engine therefore
+closes the mic, emits a new `dictation:state` of **`transcribing`**, runs the
+model, and only then emits the one final transcript and `stopped` (or `error`
+with a readable message). `transcribing` is not terminal: `useDictation` treats
+it as "still stopping, not listening" and keeps the control held, and the button
+swaps the mic for a spinner and says "Transcribing…".
+
+The weights are hundreds of megabytes and take long enough to load to be felt
+between the stop and the text, so a loaded `WhisperContext` is cached and shared
+by every session — then dropped after ten minutes (`IDLE_UNLOAD`) without a
+transcription. One sleeper task at a time checks the last-use `Instant` rather
+than trusting its own deadline, so a session that starts while it sleeps keeps
+the model.
+
+### Testing it without the GUI
+
+`whisper/engine.rs` has an end-to-end test that is `#[ignore]`d because it needs
+real weights. Point it at a model and a **16 kHz mono 16-bit** WAV:
+
+```sh
+curl -L -o /tmp/ggml-small.en-q8_0.bin \
+  https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small.en-q8_0.bin
+say -o /tmp/hello.wav --data-format=LEI16@16000 "hello world, this is a dictation test"
+
+FLETCH_WHISPER_TEST_MODEL=/tmp/ggml-small.en-q8_0.bin \
+FLETCH_WHISPER_TEST_WAV=/tmp/hello.wav \
+  cargo test --manifest-path src-tauri/Cargo.toml transcribes_a_wav -- --ignored --nocapture
+```
+
+The test asserts the transcript contains "hello world", case-insensitively.
+
+The silence gate needs no model, so its test always runs; set
+`FLETCH_WHISPER_TEST_SILENT_WAV` to try a real recording instead of synthetic
+zeroes. The resampler is likewise covered without a microphone — `capture.rs`
+puts a 440 Hz tone through it and checks the length and loudness that come out.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -293,6 +293,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.1",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +516,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +575,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1000,6 +1040,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1222,6 +1268,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "uuid",
+ "whisper-rs",
 ]
 
 [[package]]
@@ -2087,6 +2134,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,7 +2332,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2303,6 +2359,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2510,6 +2576,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "minisign-verify"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2635,6 +2707,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -6072,6 +6154,29 @@ dependencies = [
  "thiserror 2.0.18",
  "windows",
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "whisper-rs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
+dependencies = [
+ "tracing",
+ "whisper-rs-sys",
+]
+
+[[package]]
+name = "whisper-rs-sys"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
+dependencies = [
+ "bindgen",
+ "cfg-if",
+ "cmake",
+ "fs_extra",
+ "semver",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -79,6 +79,13 @@ tauri-plugin-window-state = "2"
 # transitively; pinned to the lockfile's major.
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "3"
+# Local dictation (dictation/whisper/): whisper.cpp, built from source by
+# whisper-rs-sys. macOS-only on purpose — `metal` puts inference on the GPU,
+# and the Linux CI build has no reason to compile a C++/CMake tree it never
+# runs (iOS keeps the platform recognizer). Requires cmake on the build host.
+# `tracing_backend` is what makes `install_logging_hooks` land whisper.cpp's and
+# GGML's own logging in our log file instead of on stderr.
+whisper-rs = { version = "0.16", features = ["metal", "tracing_backend"] }
 
 # Voice dictation (dictation/apple.rs): Apple's Speech framework driven by an
 # AVAudioEngine mic tap. objc2 + objc2-foundation + block2 are already in the
@@ -110,6 +117,9 @@ objc2-avf-audio = { version = "0.3", default-features = false, features = [
     "AVAudioFormat",
     "AVAudioTime",
     "AVAudioTypes",
+    # The local engine resamples the mic to whisper.cpp's 16 kHz with
+    # `AVAudioConverter` (dictation/capture.rs) rather than decimating by hand.
+    "AVAudioConverter",
 ] }
 # Microphone (as opposed to speech) authorization only: TCC's mic status lives
 # on AVCaptureDevice, which is in AVFoundation proper rather than AVFAudio.

--- a/src-tauri/src/dictation/apple.rs
+++ b/src-tauri/src/dictation/apple.rs
@@ -1,5 +1,12 @@
-//! Dictation on Apple's Speech framework: an `AVAudioEngine` mic tap feeding
-//! an `SFSpeechAudioBufferRecognitionRequest`.
+//! The microphone half of dictation: an `AVAudioEngine` input tap, and the two
+//! places its audio can go.
+//!
+//! Both engines share everything about opening the mic and owning the one live
+//! session; they differ only in the [`Sink`] the tap feeds. Apple's
+//! `SFSpeechAudioBufferRecognitionRequest` streams results back on its own,
+//! which is why a stop there hands off to the recognizer's flush. The local
+//! engine's sink is a plain PCM buffer (`super::capture`) that is transcribed in
+//! one pass once the mic is closed.
 //!
 //! # Threading
 //!
@@ -15,8 +22,8 @@
 //! state on rather than re-entering us, so it cannot run until the
 //! `on_main` block that created the task has returned. The one exception is
 //! the audio tap, which Apple invokes on a real-time render thread — it
-//! deliberately touches no session state, only `appendAudioPCMBuffer` on its
-//! own retained request, which is the pattern Apple documents for it.
+//! deliberately touches no session state, only its own retained sink, which is
+//! the pattern Apple documents for it.
 //!
 //! Note that `#[tauri::command]` futures must be `Send`, which is the second
 //! reason for this shape: no ObjC handle is ever live across an `.await`.
@@ -30,7 +37,9 @@ use block2::RcBlock;
 use objc2::rc::Retained;
 use objc2::AllocAnyThread;
 use objc2_av_foundation::{AVAuthorizationStatus, AVCaptureDevice, AVMediaTypeAudio};
-use objc2_avf_audio::{AVAudioEngine, AVAudioInputNode, AVAudioPCMBuffer, AVAudioTime};
+use objc2_avf_audio::{
+    AVAudioEngine, AVAudioFormat, AVAudioInputNode, AVAudioPCMBuffer, AVAudioTime,
+};
 use objc2_foundation::NSError;
 use objc2_speech::{
     SFSpeechAudioBufferRecognitionRequest, SFSpeechRecognitionResult, SFSpeechRecognitionTask,
@@ -38,7 +47,7 @@ use objc2_speech::{
 };
 use tauri::AppHandle;
 
-use super::{emit_state, emit_transcript, Auth, Availability, State};
+use super::{emit_state, emit_transcript, Auth, Availability, Engine, State};
 use crate::error::{Error, Result};
 
 /// The engine's only input bus.
@@ -53,6 +62,10 @@ const TAP_BUFFER_FRAMES: u32 = 1024;
 /// deadline exists so a wedged recognizer can't leave the UI stuck in
 /// `listening` with no way back.
 const FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The tap block Apple invokes on the render thread. Owned by the session for
+/// as long as the tap is installed.
+pub(super) type Tap = RcBlock<dyn Fn(NonNull<AVAudioPCMBuffer>, NonNull<AVAudioTime>)>;
 
 thread_local! {
     /// The one live session, main-thread only. See the module's threading note.
@@ -78,6 +91,32 @@ static ACTIVE: AtomicBool = AtomicBool::new(false);
 
 static NEXT_GENERATION: AtomicU64 = AtomicU64::new(0);
 
+/// Where a session's audio goes. `Retained` and `Arc` both clone cheaply, so
+/// `stop` can lift the sink out of `SESSION` before calling into ObjC.
+#[derive(Clone)]
+enum Sink {
+    /// Apple's recognizer, which delivers its own results through
+    /// `result_handler` and needs `endAudio` to flush the last of them.
+    Speech {
+        request: Retained<SFSpeechAudioBufferRecognitionRequest>,
+        task: Retained<SFSpeechRecognitionTask>,
+    },
+    /// The local engine's capture buffer, transcribed in one pass at stop.
+    #[cfg(target_os = "macos")]
+    Pcm(std::sync::Arc<super::capture::Pcm>),
+}
+
+impl Sink {
+    /// Drop the sink's work without waiting for a result — for a session that
+    /// failed to come up, or one being torn down. The local engine has nothing
+    /// to cancel: its buffer is simply dropped.
+    fn cancel(&self) {
+        if let Sink::Speech { task, .. } = self {
+            unsafe { task.cancel() };
+        }
+    }
+}
+
 struct Session {
     /// Distinguishes this session from its successors. Every block Apple may
     /// invoke late (a post-cancel result, the flush deadline) carries the
@@ -85,19 +124,29 @@ struct Session {
     /// — otherwise a straggler could tear down a session the user has since
     /// started.
     generation: u64,
-    engine: Retained<AVAudioEngine>,
+    audio: Retained<AVAudioEngine>,
     input: Retained<AVAudioInputNode>,
-    request: Retained<SFSpeechAudioBufferRecognitionRequest>,
-    task: Retained<SFSpeechRecognitionTask>,
+    sink: Sink,
     /// Kept alive for the tap's lifetime. `installTapOnBus` is documented to
     /// take ownership, but holding our own reference costs nothing and takes
     /// a use-after-free off the table.
-    _tap: RcBlock<dyn Fn(NonNull<AVAudioPCMBuffer>, NonNull<AVAudioTime>)>,
-    /// True once the user asked to stop. After that point the recognizer
+    _tap: Tap,
+    /// True once the user asked to stop. After that point Apple's recognizer
     /// reports the end of the stream *as an error* (a cancellation or
     /// no-speech code from a private domain), which is the expected tail of a
     /// normal session and must surface as `stopped`, not `error`.
     stopping: bool,
+}
+
+/// What a stop left for the caller to finish once it is off the main thread.
+enum Stopping {
+    /// Apple's recognizer owns the rest: `endAudio` makes it flush a final
+    /// result, and that result drives the teardown and the terminal state.
+    Flushing(u64),
+    /// The local engine: the mic is already closed and the session claimed, and
+    /// the audio is the caller's to transcribe.
+    #[cfg(target_os = "macos")]
+    Captured(u64, std::sync::Arc<super::capture::Pcm>),
 }
 
 // ---------------------------------------------------------------------------
@@ -136,13 +185,13 @@ fn claim(generation: u64) -> Option<Session> {
     })
 }
 
-/// Release the microphone and the recognizer, and let a new session start.
+/// Release the microphone and the sink, and let a new session start.
 fn teardown(session: Session) {
     unsafe {
-        session.engine.stop();
+        session.audio.stop();
         session.input.removeTapOnBus(BUS);
-        session.task.cancel();
     }
+    session.sink.cancel();
     ACTIVE.store(false, Ordering::SeqCst);
 }
 
@@ -238,17 +287,23 @@ fn request_microphone_auth() -> tokio::sync::oneshot::Receiver<Auth> {
     rx
 }
 
-/// Ensure both permissions are granted, prompting for whichever hasn't been
-/// asked yet. Sequential rather than concurrent so the user sees one dialog at
-/// a time.
-async fn ensure_authorized() -> Result<()> {
-    let mut speech = speech_auth();
-    if speech == Auth::NotDetermined {
-        speech = request_speech_auth().await.map_err(|_| {
-            Error::Other("dictation: speech permission prompt was dismissed".into())
-        })?;
+/// Ensure the permissions this engine needs, prompting for whichever hasn't
+/// been asked yet. Sequential rather than concurrent so the user sees one
+/// dialog at a time.
+///
+/// The local engine touches Apple's recognizer for nothing, so it must not
+/// raise its TCC prompt either: opting out of Apple's speech service and then
+/// being asked to authorize it would be a straight contradiction.
+async fn ensure_authorized(engine: Engine) -> Result<()> {
+    if engine == Engine::Apple {
+        let mut speech = speech_auth();
+        if speech == Auth::NotDetermined {
+            speech = request_speech_auth().await.map_err(|_| {
+                Error::Other("dictation: speech permission prompt was dismissed".into())
+            })?;
+        }
+        authorized_or_error("speech recognition", speech)?;
     }
-    authorized_or_error("speech recognition", speech)?;
 
     let mut mic = microphone_auth();
     if mic == Auth::NotDetermined {
@@ -262,24 +317,27 @@ async fn ensure_authorized() -> Result<()> {
 // ---------------------------------------------------------------------------
 // Commands
 
-pub fn availability() -> Availability {
-    // A recognizer only exists for a supported locale; without one there is
-    // nothing to ask about on-device support, so report the conservative
-    // answer and let `start` produce the readable error.
-    let on_device = unsafe { SFSpeechRecognizer::init(SFSpeechRecognizer::alloc()) }
-        .is_some_and(|r| unsafe { r.supportsOnDeviceRecognition() });
+pub fn availability(engine: Engine) -> Availability {
+    // The local engine is on-device by construction and needs no recognizer, so
+    // don't probe for one. Otherwise: a recognizer only exists for a supported
+    // locale, and without one there is nothing to ask about on-device support —
+    // report the conservative answer and let `start` produce the readable error.
+    let on_device = engine == Engine::Whisper
+        || unsafe { SFSpeechRecognizer::init(SFSpeechRecognizer::alloc()) }
+            .is_some_and(|r| unsafe { r.supportsOnDeviceRecognition() });
     Availability {
         supported: true,
         speech: speech_auth(),
         microphone: microphone_auth(),
         on_device,
+        engine,
     }
 }
 
 /// `Ok(Some(id))` once a session is live and `listening` has been emitted —
 /// the id every event of that session carries; `Ok(None)` when nothing was
 /// started, so no terminal event will follow.
-pub async fn start(app: AppHandle) -> Result<Option<u64>> {
+pub async fn start(app: AppHandle, engine: Engine) -> Result<Option<u64>> {
     // Claiming ACTIVE up front is what makes a second start a no-op, and it
     // has to happen before the permission prompts, which can sit on screen
     // for a long time.
@@ -291,7 +349,7 @@ pub async fn start(app: AppHandle) -> Result<Option<u64>> {
     // session is up. Handing it over rather than clearing it from here means
     // a caller who drops this future after the session came up can't leave a
     // live recognizer behind a cleared flag.
-    if let Err(e) = ensure_authorized().await {
+    if let Err(e) = ensure_authorized(engine).await {
         ACTIVE.store(false, Ordering::SeqCst);
         // The only path that drops the claim without `begin` consuming a stop
         // that landed during the prompts — clear it, or it would cancel an
@@ -300,7 +358,7 @@ pub async fn start(app: AppHandle) -> Result<Option<u64>> {
         return Err(e);
     }
     let handle = app.clone();
-    match on_main(&app, move || begin(handle)).await {
+    match on_main(&app, move || begin(handle, engine)).await {
         Ok(started) => started,
         // The closure never ran, so `begin` never took the claim.
         Err(e) => {
@@ -310,7 +368,7 @@ pub async fn start(app: AppHandle) -> Result<Option<u64>> {
     }
 }
 
-fn begin(app: AppHandle) -> Result<Option<u64>> {
+fn begin(app: AppHandle, engine: Engine) -> Result<Option<u64>> {
     // The user asked to stop while the permission prompts were up. Honour it
     // instead of opening the mic behind their back. No state event: the
     // session never came up, so there is nothing to close out — the `None`
@@ -319,7 +377,7 @@ fn begin(app: AppHandle) -> Result<Option<u64>> {
         ACTIVE.store(false, Ordering::SeqCst);
         return Ok(None);
     }
-    match build_session(app) {
+    match build_session(app, engine) {
         Ok(generation) => Ok(Some(generation)),
         Err(e) => {
             // `build_session` unwinds whatever it installed, so releasing the
@@ -335,7 +393,83 @@ fn begin(app: AppHandle) -> Result<Option<u64>> {
 /// keys events on. Main thread; permissions are already granted, which matters
 /// because reading `inputNode`'s format before that yields a zero-rate format
 /// and installing a tap with it throws in ObjC.
-fn build_session(app: AppHandle) -> Result<u64> {
+fn build_session(app: AppHandle, engine: Engine) -> Result<u64> {
+    let (audio, input, format) = open_microphone()?;
+    let generation = NEXT_GENERATION.fetch_add(1, Ordering::SeqCst);
+
+    let (sink, tap) = match engine {
+        Engine::Apple => speech_sink(&app, generation)?,
+        #[cfg(target_os = "macos")]
+        Engine::Whisper => {
+            let (pcm, tap) = super::capture::sink(&format)?;
+            (Sink::Pcm(pcm), tap)
+        }
+        // iOS: `super::engine` never answers `Whisper` where whisper.cpp isn't
+        // built, so this is unreachable rather than a fallback.
+        #[cfg(not(target_os = "macos"))]
+        Engine::Whisper => {
+            return Err(Error::Other(
+                "Local dictation isn't available on this platform.".into(),
+            ))
+        }
+    };
+
+    unsafe {
+        input.installTapOnBus_bufferSize_format_block(
+            BUS,
+            TAP_BUFFER_FRAMES,
+            Some(&format),
+            RcBlock::as_ptr(&tap),
+        );
+        audio.prepare();
+        if let Err(e) = audio.startAndReturnError() {
+            // Unwind what we just built rather than leaving a tap installed
+            // and a task running behind a failed start.
+            input.removeTapOnBus(BUS);
+            sink.cancel();
+            return Err(Error::Other(format!(
+                "Couldn't start the microphone: {}",
+                e.localizedDescription()
+            )));
+        }
+    }
+
+    SESSION.set(Some(Session {
+        generation,
+        audio,
+        input,
+        sink,
+        _tap: tap,
+        stopping: false,
+    }));
+    // Audio is flowing. Only now can the frontend show a live mic.
+    emit_state(&app, generation, State::Listening, None);
+    Ok(generation)
+}
+
+/// The input node and the format its tap will deliver.
+fn open_microphone() -> Result<(
+    Retained<AVAudioEngine>,
+    Retained<AVAudioInputNode>,
+    Retained<AVAudioFormat>,
+)> {
+    let audio = unsafe { AVAudioEngine::new() };
+    let input = unsafe { audio.inputNode() };
+    let format = unsafe { input.outputFormatForBus(BUS) };
+    // A zero-rate or channel-less format means the OS gave us no usable input
+    // device. Installing a tap with it raises an ObjC exception, which would
+    // abort the process rather than surface an error, so check first.
+    if unsafe { format.sampleRate() } <= 0.0 || unsafe { format.channelCount() } == 0 {
+        return Err(Error::Other(
+            "No microphone input is available. Check your input device in System Settings > Sound."
+                .into(),
+        ));
+    }
+    Ok((audio, input, format))
+}
+
+/// Apple's recognizer, plus the tap that streams the mic straight into it.
+fn speech_sink(app: &AppHandle, generation: u64) -> Result<(Sink, Tap)> {
     let recognizer = unsafe { SFSpeechRecognizer::init(SFSpeechRecognizer::alloc()) }
         .ok_or_else(|| Error::Other("Dictation doesn't support this Mac's language.".into()))?;
     if !unsafe { recognizer.isAvailable() } {
@@ -355,21 +489,6 @@ fn build_session(app: AppHandle) -> Result<u64> {
         request.setRequiresOnDeviceRecognition(recognizer.supportsOnDeviceRecognition());
     }
 
-    let engine = unsafe { AVAudioEngine::new() };
-    let input = unsafe { engine.inputNode() };
-    let format = unsafe { input.outputFormatForBus(BUS) };
-    // A zero-rate or channel-less format means the OS gave us no usable input
-    // device. Installing a tap with it raises an ObjC exception, which would
-    // abort the process rather than surface an error, so check first.
-    if unsafe { format.sampleRate() } <= 0.0 || unsafe { format.channelCount() } == 0 {
-        return Err(Error::Other(
-            "No microphone input is available. Check your input device in System Settings > Sound."
-                .into(),
-        ));
-    }
-
-    let generation = NEXT_GENERATION.fetch_add(1, Ordering::SeqCst);
-
     let tap_request = request.clone();
     let tap = RcBlock::new(
         move |buffer: NonNull<AVAudioPCMBuffer>, _when: NonNull<AVAudioTime>| {
@@ -378,44 +497,10 @@ fn build_session(app: AppHandle) -> Result<u64> {
             unsafe { tap_request.appendAudioPCMBuffer(buffer.as_ref()) };
         },
     );
-    unsafe {
-        input.installTapOnBus_bufferSize_format_block(
-            BUS,
-            TAP_BUFFER_FRAMES,
-            Some(&format),
-            RcBlock::as_ptr(&tap),
-        );
-    }
 
     let results = result_handler(app.clone(), generation);
     let task = unsafe { recognizer.recognitionTaskWithRequest_resultHandler(&request, &results) };
-
-    unsafe {
-        engine.prepare();
-        if let Err(e) = engine.startAndReturnError() {
-            // Unwind what we just built rather than leaving a tap installed
-            // and a task running behind a failed start.
-            input.removeTapOnBus(BUS);
-            task.cancel();
-            return Err(Error::Other(format!(
-                "Couldn't start the microphone: {}",
-                e.localizedDescription()
-            )));
-        }
-    }
-
-    SESSION.set(Some(Session {
-        generation,
-        engine,
-        input,
-        request,
-        task,
-        _tap: tap,
-        stopping: false,
-    }));
-    // Audio is flowing. Only now can the frontend show a live mic.
-    emit_state(&app, generation, State::Listening, None);
-    Ok(generation)
+    Ok((Sink::Speech { request, task }, tap))
 }
 
 /// The recognizer's result handler. Runs on the recognizer's queue — the main
@@ -465,8 +550,6 @@ fn result_handler(
 }
 
 pub async fn stop(app: AppHandle) -> Result<()> {
-    // The session stays in `SESSION` — the result handler still needs it to
-    // deliver the final transcript and own the teardown.
     let stopped = on_main(&app, || {
         // Clone the handles out before calling into ObjC: the rule for
         // `SESSION` is that no borrow is ever held across a framework call.
@@ -475,12 +558,12 @@ pub async fn stop(app: AppHandle) -> Result<()> {
             session.stopping = true;
             Some((
                 session.generation,
-                session.engine.clone(),
+                session.audio.clone(),
                 session.input.clone(),
-                session.request.clone(),
+                session.sink.clone(),
             ))
         });
-        let Some((generation, engine, input, request)) = live else {
+        let Some((generation, audio, input, sink)) = live else {
             // No session — but a claimed `ACTIVE` with an empty `SESSION` means
             // a `start` is still sitting on the permission prompts, so leave
             // the request for `begin` to consume. Genuinely idle, record
@@ -490,39 +573,83 @@ pub async fn stop(app: AppHandle) -> Result<()> {
             }
             return None;
         };
+        // The mic goes quiet either way; what happens after depends on the sink.
         unsafe {
-            engine.stop();
+            audio.stop();
             input.removeTapOnBus(BUS);
-            // Deliberately not `task.cancel()`: ending the audio is what makes
-            // the recognizer flush its final result, and that result is what
-            // drives the `stopped` emit. Cancelling would discard it.
-            request.endAudio();
         }
-        Some(generation)
+        match sink {
+            Sink::Speech { request, .. } => {
+                // Deliberately not `task.cancel()`: ending the audio is what
+                // makes the recognizer flush its final result, and that result
+                // is what drives the `stopped` emit. Cancelling would discard
+                // it — so the session stays in `SESSION` for the handler.
+                unsafe { request.endAudio() };
+                Some(Stopping::Flushing(generation))
+            }
+            #[cfg(target_os = "macos")]
+            Sink::Pcm(pcm) => {
+                // Nothing will flush, so the session is over here. Claiming it
+                // now gives the transcription sole ownership of the terminal
+                // state, and releases the mic for the next start.
+                if let Some(session) = claim(generation) {
+                    teardown(session);
+                }
+                Some(Stopping::Captured(generation, pcm))
+            }
+        }
     })
     .await?;
 
-    // Idle: nothing to stop, and no event.
-    let Some(generation) = stopped else {
-        return Ok(());
-    };
-
-    let handle = app.clone();
-    tokio::spawn(async move {
-        tokio::time::sleep(FLUSH_TIMEOUT).await;
-        let emit_to = handle.clone();
-        let _ = on_main(&handle, move || {
-            // Still live means the final result never arrived; `claim` is what
-            // keeps this from double-emitting against the result handler.
-            if let Some(session) = claim(generation) {
-                tracing::warn!(
-                    "dictation: no final result before the flush deadline; forcing stop"
-                );
-                teardown(session);
-                emit_state(&emit_to, generation, State::Stopped, None);
-            }
-        })
-        .await;
-    });
-    Ok(())
+    match stopped {
+        // Idle: nothing to stop, and no event.
+        None => Ok(()),
+        Some(Stopping::Flushing(generation)) => {
+            let handle = app.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(FLUSH_TIMEOUT).await;
+                let emit_to = handle.clone();
+                let _ = on_main(&handle, move || {
+                    // Still live means the final result never arrived; `claim`
+                    // is what keeps this from double-emitting against the
+                    // result handler.
+                    if let Some(session) = claim(generation) {
+                        tracing::warn!(
+                            "dictation: no final result before the flush deadline; forcing stop"
+                        );
+                        teardown(session);
+                        emit_state(&emit_to, generation, State::Stopped, None);
+                    }
+                })
+                .await;
+            });
+            Ok(())
+        }
+        #[cfg(target_os = "macos")]
+        Some(Stopping::Captured(generation, pcm)) => {
+            // The mic is already closed, but the model still has to run, which
+            // is seconds rather than milliseconds — the frontend gets a state
+            // of its own for that wait instead of a mic that looks stuck.
+            emit_state(&app, generation, State::Transcribing, None);
+            tokio::spawn(async move {
+                match super::capture::transcribe(pcm).await {
+                    Ok(text) => {
+                        // Empty means the clip had no speech in it (see the
+                        // engine's silence gate); there is nothing to splice
+                        // into the composer, but the session still ends.
+                        if !text.is_empty() {
+                            emit_transcript(&app, generation, text, true);
+                        }
+                        emit_state(&app, generation, State::Stopped, None);
+                    }
+                    Err(e) => {
+                        let message = e.to_string();
+                        tracing::warn!(error = %message, "dictation: transcription failed");
+                        emit_state(&app, generation, State::Error, Some(message));
+                    }
+                }
+            });
+            Ok(())
+        }
+    }
 }

--- a/src-tauri/src/dictation/capture.rs
+++ b/src-tauri/src/dictation/capture.rs
@@ -67,9 +67,13 @@ pub(super) fn sink(format: &AVAudioFormat) -> Result<(Arc<Pcm>, Tap)> {
     let pcm = Arc::new(Pcm {
         rate,
         limit,
-        // Pre-sized to a long dictation so the render thread appends into spare
-        // capacity instead of reallocating mid-buffer.
-        samples: Mutex::new(Vec::with_capacity((rate * 60.0) as usize)),
+        // Sized to the cap up front: `append_mono` refuses to grow past `limit`,
+        // so the render thread only ever writes into reserved capacity and a
+        // reallocation — a copy of minutes of audio on the real-time thread —
+        // can't happen. Reserving is cheap: the OS commits pages as they're
+        // written, so an idle reservation of this size costs address space, not
+        // memory.
+        samples: Mutex::new(Vec::with_capacity(limit)),
     });
 
     let tap_pcm = pcm.clone();

--- a/src-tauri/src/dictation/capture.rs
+++ b/src-tauri/src/dictation/capture.rs
@@ -1,0 +1,264 @@
+//! The local engine's half of the mic tap: where the audio goes when there is
+//! no recognizer streaming results back.
+//!
+//! whisper.cpp wants one complete clip at 16 kHz mono, so a session accumulates
+//! [`Pcm`] while the user speaks and [`transcribe`] runs the model once on stop.
+//! The two conversions are deliberately split by thread:
+//!
+//! - **Channel averaging happens in the tap**, on Apple's real-time render
+//!   thread, because it is a handful of adds per frame into a pre-sized buffer.
+//! - **Resampling happens at stop**, off both the render thread and the main
+//!   thread, because it is a framework call (`AVAudioConverter`) with an
+//!   allocation behind it. Decimating 48 kHz by taking every third sample would
+//!   be cheap enough for the tap, but folds everything above 8 kHz back into the
+//!   speech band, and the model hears the aliases.
+//!
+//! macOS-only, like `whisper::engine` — iOS keeps the platform recognizer.
+
+use std::cell::Cell;
+use std::ptr::NonNull;
+use std::sync::Arc;
+
+use block2::RcBlock;
+use objc2::rc::Retained;
+use objc2::AllocAnyThread;
+use objc2_avf_audio::{
+    AVAudioBuffer, AVAudioCommonFormat, AVAudioConverter, AVAudioConverterInputStatus,
+    AVAudioConverterOutputStatus, AVAudioFormat, AVAudioPCMBuffer, AVAudioTime,
+};
+use parking_lot::Mutex;
+
+use super::apple::Tap;
+use super::whisper::engine;
+use crate::error::{Error, Result};
+
+/// How much audio one session may capture. A dictation is a sentence or two;
+/// this is the bound that keeps a mic left open by a forgotten window from
+/// growing the buffer — and the transcription that follows — without limit.
+/// Audio past it is dropped, which truncates the transcript rather than failing.
+const MAX_CAPTURE_SECS: f64 = 300.0;
+
+/// A session's captured audio: mono f32 at the microphone's own sample rate.
+pub(super) struct Pcm {
+    /// The microphone's rate, which [`transcribe`] resamples from.
+    rate: f64,
+    /// Sample ceiling derived from [`MAX_CAPTURE_SECS`] and `rate`.
+    limit: usize,
+    samples: Mutex<Vec<f32>>,
+}
+
+/// Build the accumulator and the tap block that fills it.
+pub(super) fn sink(format: &AVAudioFormat) -> Result<(Arc<Pcm>, Tap)> {
+    // The input node hands out deinterleaved float32 on every OS that has
+    // shipped. Reading a buffer in any other layout would be reading the wrong
+    // memory, so refuse the session instead of guessing at it.
+    if unsafe { format.commonFormat() } != AVAudioCommonFormat::PCMFormatFloat32
+        || unsafe { format.isInterleaved() }
+    {
+        return Err(Error::Other(
+            "This microphone's audio format isn't supported by local dictation. Switch the \
+             dictation engine back to the system recognizer in Settings."
+                .into(),
+        ));
+    }
+
+    let rate = unsafe { format.sampleRate() };
+    let limit = (rate * MAX_CAPTURE_SECS) as usize;
+    let pcm = Arc::new(Pcm {
+        rate,
+        limit,
+        // Pre-sized to a long dictation so the render thread appends into spare
+        // capacity instead of reallocating mid-buffer.
+        samples: Mutex::new(Vec::with_capacity((rate * 60.0) as usize)),
+    });
+
+    let tap_pcm = pcm.clone();
+    let tap = RcBlock::new(
+        move |buffer: NonNull<AVAudioPCMBuffer>, _when: NonNull<AVAudioTime>| {
+            append_mono(&tap_pcm, unsafe { buffer.as_ref() });
+        },
+    );
+    Ok((pcm, tap))
+}
+
+/// Real-time audio thread: average the channels down and return. The only other
+/// lock holder is the one-shot take in [`transcribe`], so `try_lock` all but
+/// never fails — and dropping one buffer beats blocking the render thread if it
+/// ever does.
+fn append_mono(pcm: &Pcm, buffer: &AVAudioPCMBuffer) {
+    let frames = unsafe { buffer.frameLength() } as usize;
+    let channels = unsafe { buffer.format().channelCount() } as usize;
+    let data = unsafe { buffer.floatChannelData() };
+    if data.is_null() || frames == 0 || channels == 0 {
+        return;
+    }
+    let Some(mut samples) = pcm.samples.try_lock() else {
+        return;
+    };
+    if samples.len() + frames > pcm.limit {
+        return;
+    }
+    for frame in 0..frames {
+        let mut sum = 0.0;
+        for channel in 0..channels {
+            // Deinterleaved (checked in `sink`): one pointer per channel, each
+            // to `frameLength` contiguous samples.
+            sum += unsafe { *(*data.add(channel)).as_ptr().add(frame) };
+        }
+        samples.push(sum / channels as f32);
+    }
+}
+
+/// Take the session's audio and transcribe it. Consumes the buffer: the session
+/// is already over by the time this runs.
+pub(super) async fn transcribe(pcm: Arc<Pcm>) -> Result<String> {
+    let rate = pcm.rate;
+    let samples = std::mem::take(&mut *pcm.samples.lock());
+    let samples = tokio::task::spawn_blocking(move || resample(rate, samples))
+        .await
+        .map_err(|e| Error::Other(format!("dictation: resampling task failed: {e}")))??;
+    engine::transcribe(samples).await
+}
+
+/// Extra output capacity for the converter's priming, which can emit a little
+/// more than the rate ratio implies.
+const RESAMPLE_SLACK_FRAMES: u32 = 4096;
+
+/// Convert mono `samples` at `rate` to the mono 16 kHz whisper.cpp wants.
+///
+/// Every ObjC handle here is created, used and dropped inside this call, so
+/// nothing is shared across threads and nothing is live across an `.await` —
+/// the same rule the recognizer path follows.
+fn resample(rate: f64, samples: Vec<f32>) -> Result<Vec<f32>> {
+    let target = f64::from(engine::SAMPLE_RATE);
+    if rate == target || samples.is_empty() {
+        return Ok(samples);
+    }
+
+    let from = standard_mono(rate)?;
+    let to = standard_mono(target)?;
+    let converter =
+        unsafe { AVAudioConverter::initFromFormat_toFormat(AVAudioConverter::alloc(), &from, &to) }
+            .ok_or_else(|| Error::Other("dictation: couldn't build the audio converter".into()))?;
+
+    let frames = samples.len() as u32;
+    let input = pcm_buffer(&from, frames)?;
+    unsafe {
+        std::ptr::copy_nonoverlapping(samples.as_ptr(), channel(&input)?.as_ptr(), samples.len());
+        input.setFrameLength(frames);
+    }
+
+    let capacity = (samples.len() as f64 * target / rate).ceil() as u32 + RESAMPLE_SLACK_FRAMES;
+    let output = pcm_buffer(&to, capacity)?;
+
+    // The converter pulls input through a block rather than taking a buffer,
+    // because a rate conversion may need more or less than it is given. There
+    // is only ever one buffer to hand over here: serve it, then say the stream
+    // has ended.
+    let served = Cell::new(false);
+    let feed = RcBlock::new(
+        move |_packets: u32, status: NonNull<AVAudioConverterInputStatus>| -> *mut AVAudioBuffer {
+            if served.replace(true) {
+                unsafe { *status.as_ptr() = AVAudioConverterInputStatus::EndOfStream };
+                return std::ptr::null_mut();
+            }
+            unsafe { *status.as_ptr() = AVAudioConverterInputStatus::HaveData };
+            Retained::as_ptr(&input).cast_mut().cast()
+        },
+    );
+
+    let mut error = None;
+    let status = unsafe {
+        converter.convertToBuffer_error_withInputFromBlock(
+            &output,
+            Some(&mut error),
+            RcBlock::as_ptr(&feed),
+        )
+    };
+    if status == AVAudioConverterOutputStatus::Error {
+        let message = error.map_or_else(
+            || "unknown error".to_string(),
+            |e| e.localizedDescription().to_string(),
+        );
+        return Err(Error::Other(format!(
+            "dictation: couldn't resample the recording: {message}"
+        )));
+    }
+
+    // Whatever the status, `frameLength` is what was actually converted.
+    let converted = unsafe { output.frameLength() } as usize;
+    let mut out = vec![0.0; converted];
+    unsafe {
+        std::ptr::copy_nonoverlapping(channel(&output)?.as_ptr(), out.as_mut_ptr(), converted)
+    };
+    Ok(out)
+}
+
+/// Deinterleaved float32, one channel, at `rate`.
+fn standard_mono(rate: f64) -> Result<Retained<AVAudioFormat>> {
+    unsafe {
+        AVAudioFormat::initStandardFormatWithSampleRate_channels(AVAudioFormat::alloc(), rate, 1)
+    }
+    .ok_or_else(|| {
+        Error::Other(format!(
+            "dictation: {rate} Hz mono isn't a valid audio format"
+        ))
+    })
+}
+
+fn pcm_buffer(format: &AVAudioFormat, frames: u32) -> Result<Retained<AVAudioPCMBuffer>> {
+    unsafe {
+        AVAudioPCMBuffer::initWithPCMFormat_frameCapacity(AVAudioPCMBuffer::alloc(), format, frames)
+    }
+    .ok_or_else(|| Error::Other("dictation: couldn't allocate an audio buffer".into()))
+}
+
+/// The one channel's samples. Null for a buffer that isn't float32, which the
+/// formats above always are.
+fn channel(buffer: &AVAudioPCMBuffer) -> Result<NonNull<f32>> {
+    NonNull::new(unsafe { buffer.floatChannelData() })
+        .map(|data| unsafe { *data.as_ptr() })
+        .ok_or_else(|| Error::Other("dictation: audio buffer has no float samples".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The resampler is the one part of the capture path that can be exercised
+    /// without a microphone: a 440 Hz tone is well inside the 8 kHz band 16 kHz
+    /// can carry, so it must come out the same length in seconds and the same
+    /// loudness.
+    #[test]
+    fn resample_keeps_a_tone_that_fits() {
+        let rate = 48_000.0;
+        let input: Vec<f32> = (0..48_000)
+            .map(|i| (i as f32 * 440.0 * std::f32::consts::TAU / 48_000.0).sin())
+            .collect();
+
+        let out = resample(rate, input).unwrap();
+
+        let expected = engine::SAMPLE_RATE as i64;
+        assert!(
+            (out.len() as i64 - expected).abs() < expected / 20,
+            "one second in, {} samples out",
+            out.len()
+        );
+        let rms = (out
+            .iter()
+            .map(|s| f64::from(*s) * f64::from(*s))
+            .sum::<f64>()
+            / out.len() as f64)
+            .sqrt();
+        assert!(rms > 0.5, "tone was lost: rms {rms}");
+    }
+
+    #[test]
+    fn resample_passes_matching_rates_through() {
+        let samples = vec![0.25; 100];
+        assert_eq!(
+            resample(f64::from(engine::SAMPLE_RATE), samples.clone()).unwrap(),
+            samples
+        );
+    }
+}

--- a/src-tauri/src/dictation/mod.rs
+++ b/src-tauri/src/dictation/mod.rs
@@ -11,6 +11,13 @@
 //! words as later context arrives ("to" → "two" → "too"), so a delta stream
 //! would be unreconstructable. Each event replaces the last.
 //!
+//! There are two engines behind these commands, chosen per session by
+//! [`engine`]: Apple's recognizer, which streams revisions while the user
+//! speaks, and local whisper.cpp, which has nothing to say until the mic
+//! closes and so spends the gap in `transcribing`. The commands, the events
+//! and the session-id contract are identical either way — `apple` owns the
+//! microphone for both.
+//!
 //! Only Apple platforms have an implementation (`apple`); everywhere else the
 //! commands are stubs that report `supported: false`, which is what keeps the
 //! Linux CI build compiling and lets the frontend hide the mic button without
@@ -25,6 +32,9 @@ use crate::DbState;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 mod apple;
+// The local engine's sink for the shared mic tap. macOS-only, like whisper.cpp.
+#[cfg(target_os = "macos")]
+mod capture;
 // Compiles everywhere (the catalog and download are plain Rust); the engine
 // itself is gated inside. `pub` so `lib.rs` can seed the models root.
 pub mod whisper;
@@ -47,18 +57,37 @@ pub enum Auth {
     Restricted,
 }
 
+/// Which recognizer a session would use. Reported by `dictation_availability`
+/// so the UI knows, among other things, that the local engine has no use for
+/// the speech-recognition grant.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+// Both variants are the wire contract everywhere, but `Whisper` is only ever
+// chosen where whisper.cpp is built.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+pub enum Engine {
+    /// Apple's `SFSpeechRecognizer`, the default.
+    Apple,
+    /// Local whisper.cpp (see [`whisper`]).
+    Whisper,
+}
+
 /// What dictation can do on this machine, for a UI that wants to disable the
 /// mic button (or explain why) before the user ever presses it.
 #[derive(Clone, Debug, Serialize)]
 pub struct Availability {
     /// False on non-Apple platforms — nothing else in this struct matters.
     supported: bool,
+    /// Irrelevant when `engine` is `whisper`: that path never calls Apple's
+    /// recognizer, so it never prompts for this and can't be blocked by it.
     speech: Auth,
     microphone: Auth,
     /// The recognizer can transcribe without a network round-trip. When true
     /// we pin the request on-device, so no audio leaves the machine; when
-    /// false recognition is server-backed and capped at about a minute.
+    /// false recognition is server-backed and capped at about a minute. Always
+    /// true for the local engine.
     on_device: bool,
+    engine: Engine,
 }
 
 // The event machinery below is gated on the platforms that have an
@@ -87,8 +116,14 @@ struct TranscriptPayload {
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 #[derive(Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
+// `Transcribing` belongs to the local engine, which iOS doesn't build.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 enum State {
     Listening,
+    /// The mic is closed and the local engine is running the model. Only the
+    /// whisper path emits this, between `listening` and the terminal state:
+    /// the session is still alive and its final transcript is still coming.
+    Transcribing,
     Stopped,
     Error,
 }
@@ -241,28 +276,51 @@ pub fn dictation_model_remove(state: tauri::State<'_, DbState>) -> ModelStatus {
     model_status(engine_enabled(&state), install)
 }
 
+/// Which engine a session started right now would use. The local one takes
+/// both the opt-in AND a fully downloaded model: dispatching on the setting
+/// alone would let an interrupted download leave the mic button dead.
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn engine(app: &AppHandle) -> Engine {
+    use tauri::Manager;
+
+    // whisper.cpp is built for macOS only, so iOS keeps the platform
+    // recognizer whatever the setting says.
+    if !cfg!(target_os = "macos") {
+        return Engine::Apple;
+    }
+    let selected = engine_enabled(&app.state::<DbState>());
+    if selected && whisper::install::status().installed {
+        Engine::Whisper
+    } else {
+        Engine::Apple
+    }
+}
+
 /// Whether dictation works here, and what permissions stand in the way. Cheap
 /// and side-effect free — it never prompts, so the UI can call it on mount.
 #[tauri::command]
-pub async fn dictation_availability() -> Availability {
+pub async fn dictation_availability(app: AppHandle) -> Availability {
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     {
-        apple::availability()
+        apple::availability(engine(&app))
     }
     #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     {
+        let _ = app;
         Availability {
             supported: false,
             speech: Auth::NotDetermined,
             microphone: Auth::NotDetermined,
             on_device: false,
+            engine: Engine::Apple,
         }
     }
 }
 
-/// Start listening. Requests microphone and speech permission on first use
-/// (so the first call can block on two TCC prompts), and resolves once audio
-/// is actually flowing.
+/// Start listening. Requests the permissions the chosen engine needs on first
+/// use — microphone and speech for Apple's recognizer (so the first call can
+/// block on two TCC prompts), microphone alone for the local engine — and
+/// resolves once audio is actually flowing.
 ///
 /// `Some(id)` means a session is now live and `dictation:state` `listening` has
 /// been emitted, so a terminal state will follow; every event of that session
@@ -276,7 +334,8 @@ pub async fn dictation_availability() -> Availability {
 pub async fn dictation_start(app: AppHandle) -> Result<Option<u64>> {
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     {
-        apple::start(app).await
+        let engine = engine(&app);
+        apple::start(app, engine).await
     }
     #[cfg(not(any(target_os = "macos", target_os = "ios")))]
     {
@@ -290,9 +349,10 @@ pub async fn dictation_start(app: AppHandle) -> Result<Option<u64>> {
 /// Stop listening. Returns as soon as the microphone is released; the final
 /// transcript and the terminal `dictation:state` follow asynchronously once
 /// the recognizer has flushed, and a recognizer that doesn't flush in time
-/// yields the terminal state alone. A no-op when idle, except that a stop
-/// issued while `dictation_start` waits on a permission prompt cancels that
-/// pending session.
+/// yields the terminal state alone. The local engine takes the same shape,
+/// with a `transcribing` state for the gap while the model runs. A no-op when
+/// idle, except that a stop issued while `dictation_start` waits on a
+/// permission prompt cancels that pending session.
 #[tauri::command]
 pub async fn dictation_stop(app: AppHandle) -> Result<()> {
     #[cfg(any(target_os = "macos", target_os = "ios"))]

--- a/src-tauri/src/dictation/whisper/engine.rs
+++ b/src-tauri/src/dictation/whisper/engine.rs
@@ -1,0 +1,278 @@
+//! whisper.cpp inference: a whole clip of 16 kHz mono audio in, one final
+//! transcript out.
+//!
+//! There is no streaming here. whisper.cpp transcribes a complete utterance in
+//! one pass — feeding it a growing prefix every few hundred milliseconds costs
+//! more than the whole clip and still revises everything — so the session
+//! buffers audio while the user speaks and runs the model once on stop. That
+//! wait is why the contract has a `transcribing` state at all.
+//!
+//! The weights are hundreds of megabytes, and loading them takes long enough to
+//! be felt between the stop and the text, so a loaded model is cached and
+//! reused. It is also given back after [`IDLE_UNLOAD`] of disuse: someone who
+//! dictated one sentence this morning shouldn't still be paying half a gigabyte
+//! of resident memory for it at lunchtime.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use parking_lot::Mutex;
+use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
+
+use super::models;
+use crate::error::{Error, Result};
+
+/// The only input rate whisper.cpp accepts; capture resamples to it.
+pub const SAMPLE_RATE: u32 = 16_000;
+
+/// Clips shorter than this can't hold an utterance — they're a tap on the mic
+/// button. Whisper answers a too-short clip with an invented sentence rather
+/// than nothing ("Thank you.", "[BLANK_AUDIO]"), so they never reach the model.
+const MIN_DURATION: Duration = Duration::from_millis(500);
+
+/// RMS below which the clip is a quiet room rather than speech, and whisper
+/// would hallucinate the same invented sentences over it. Well under speech at
+/// a conversational distance (RMS ~0.02 and up) and well over a muted or
+/// unplugged input's noise floor.
+const MIN_RMS: f32 = 0.002;
+
+/// How long a loaded model may sit unused before its memory is released.
+const IDLE_UNLOAD: Duration = Duration::from_secs(600);
+
+/// The loaded model, shared by every session until it is unloaded.
+static CONTEXT: Mutex<Option<Loaded>> = Mutex::new(None);
+
+/// Set while an unload sleeper is pending, so a burst of sessions can't stack
+/// up timers.
+static UNLOAD_ARMED: AtomicBool = AtomicBool::new(false);
+
+struct Loaded {
+    ctx: Arc<WhisperContext>,
+    /// When the model was last handed to a transcription — the unload sleeper
+    /// compares this against [`IDLE_UNLOAD`] rather than trusting its own
+    /// deadline, so a session that started while it slept keeps the model.
+    used: Instant,
+}
+
+/// Transcribe one whole clip of 16 kHz mono audio.
+///
+/// `Ok("")` for a clip with no speech in it (see [`MIN_DURATION`] and
+/// [`MIN_RMS`]) — that answer costs nothing, because the gate runs before the
+/// model is even loaded.
+pub async fn transcribe(samples: Vec<f32>) -> Result<String> {
+    if !has_speech(&samples) {
+        return Ok(String::new());
+    }
+    arm_unload();
+    // Inference pins a core for seconds; it has no business on the async
+    // runtime's worker threads.
+    tokio::task::spawn_blocking(move || {
+        let ctx = context()?;
+        decode(&ctx, &samples)
+    })
+    .await
+    .map_err(|e| Error::Other(format!("dictation: transcription task failed: {e}")))?
+}
+
+/// Cheap "is there anything in here to transcribe" gate.
+fn has_speech(samples: &[f32]) -> bool {
+    let min_samples = (f64::from(SAMPLE_RATE) * MIN_DURATION.as_secs_f64()) as usize;
+    samples.len() >= min_samples && rms(samples) >= MIN_RMS
+}
+
+fn rms(samples: &[f32]) -> f32 {
+    let sum: f64 = samples.iter().map(|s| f64::from(*s) * f64::from(*s)).sum();
+    (sum / samples.len() as f64).sqrt() as f32
+}
+
+/// The cached model, loading it on first use. Also stamps the load as used,
+/// which is what keeps [`arm_unload`]'s sleeper from taking it out from under a
+/// session that has only just started.
+fn context() -> Result<Arc<WhisperContext>> {
+    let mut slot = CONTEXT.lock();
+    if let Some(loaded) = slot.as_mut() {
+        loaded.used = Instant::now();
+        return Ok(loaded.ctx.clone());
+    }
+    let path = models::installed_path(models::default_model()).ok_or_else(|| {
+        Error::Other(
+            "The local dictation model isn't installed. Download it in Settings > Dictation."
+                .into(),
+        )
+    })?;
+    let ctx = Arc::new(load(&path)?);
+    *slot = Some(Loaded {
+        ctx: ctx.clone(),
+        used: Instant::now(),
+    });
+    Ok(ctx)
+}
+
+fn load(path: &Path) -> Result<WhisperContext> {
+    // whisper.cpp and GGML print a page of model and backend detail per load
+    // straight to stderr. Route it through `tracing` like everything else the
+    // app logs; the call is idempotent.
+    whisper_rs::install_logging_hooks();
+    let started = Instant::now();
+    let ctx = WhisperContext::new_with_params(path, WhisperContextParameters::default()).map_err(
+        |e| {
+            Error::Other(format!(
+                "Couldn't load the local dictation model: {e}. Re-download it in Settings."
+            ))
+        },
+    )?;
+    tracing::info!(
+        model = %path.display(),
+        elapsed_ms = started.elapsed().as_millis(),
+        "dictation: loaded whisper model"
+    );
+    Ok(ctx)
+}
+
+/// Release the model once it has gone [`IDLE_UNLOAD`] without a transcription.
+/// One sleeper at a time; it re-sleeps while the model is still in use rather
+/// than unloading on its own deadline.
+fn arm_unload() {
+    if UNLOAD_ARMED.swap(true, Ordering::SeqCst) {
+        return;
+    }
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(IDLE_UNLOAD).await;
+            let unloaded = {
+                let mut slot = CONTEXT.lock();
+                let idle = !slot
+                    .as_ref()
+                    .is_some_and(|l| l.used.elapsed() < IDLE_UNLOAD);
+                if idle {
+                    *slot = None;
+                }
+                idle
+            };
+            if unloaded {
+                UNLOAD_ARMED.store(false, Ordering::SeqCst);
+                return;
+            }
+        }
+    });
+}
+
+/// Run the model. Split from [`transcribe`] so the end-to-end test can point it
+/// at a model of its own instead of the installed one.
+fn decode(ctx: &WhisperContext, samples: &[f32]) -> Result<String> {
+    let mut state = ctx.create_state().map_err(transcription_failed)?;
+
+    // Greedy: dictation is one short utterance going straight into a text box,
+    // where a beam search buys accuracy the user would rather have as latency.
+    let mut params = FullParams::new(SamplingStrategy::Greedy { best_of: 1 });
+    // whisper.cpp's own detect-from-the-audio sentinel — better than guessing
+    // from the system locale, which says nothing about what the user speaks.
+    params.set_language(Some("auto"));
+    params.set_translate(false);
+    // One utterance, one text box: segment framing and timestamps would only
+    // have to be stripped back out.
+    params.set_no_timestamps(true);
+    params.set_token_timestamps(false);
+    // Leading and trailing silence otherwise decodes as invented words. This is
+    // whisper.cpp's own guard against it, and the counterpart to `has_speech`.
+    params.set_suppress_blank(true);
+    // Nothing here has a console to print to.
+    params.set_print_progress(false);
+    params.set_print_realtime(false);
+    params.set_print_special(false);
+    params.set_print_timestamps(false);
+
+    state.full(params, samples).map_err(transcription_failed)?;
+
+    let mut text = String::new();
+    for segment in state.as_iter() {
+        text.push_str(&segment.to_str_lossy().map_err(transcription_failed)?);
+    }
+    Ok(text.trim().to_string())
+}
+
+fn transcription_failed(e: whisper_rs::WhisperError) -> Error {
+    Error::Other(format!("Dictation couldn't transcribe the recording: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The gate that keeps whisper from inventing a sentence out of a quiet
+    /// room. It runs before the model is loaded, which is the point — this test
+    /// needs no weights. Point `FLETCH_WHISPER_TEST_SILENT_WAV` at a real
+    /// recording to try one instead of synthetic zeroes.
+    #[tokio::test]
+    async fn silence_never_reaches_the_model() {
+        let silence = match std::env::var_os("FLETCH_WHISPER_TEST_SILENT_WAV") {
+            Some(p) => read_wav(Path::new(&p)),
+            None => vec![0.0; SAMPLE_RATE as usize * 2],
+        };
+        assert_eq!(transcribe(silence).await.unwrap(), "");
+        // Too short to be an utterance, however loud.
+        assert_eq!(
+            transcribe(vec![0.5; SAMPLE_RATE as usize / 10])
+                .await
+                .unwrap(),
+            ""
+        );
+    }
+
+    /// The real thing, against real weights — ignored because they are hundreds
+    /// of megabytes CI has no reason to download:
+    ///
+    /// ```sh
+    /// say -o /tmp/hello.wav --data-format=LEI16@16000 "hello world, this is a dictation test"
+    /// FLETCH_WHISPER_TEST_MODEL=/tmp/ggml-small.en-q8_0.bin \
+    /// FLETCH_WHISPER_TEST_WAV=/tmp/hello.wav \
+    ///   cargo test --manifest-path src-tauri/Cargo.toml transcribes -- --ignored --nocapture
+    /// ```
+    #[test]
+    #[ignore = "needs FLETCH_WHISPER_TEST_MODEL and FLETCH_WHISPER_TEST_WAV"]
+    fn transcribes_a_wav() {
+        let model = std::env::var("FLETCH_WHISPER_TEST_MODEL").expect("FLETCH_WHISPER_TEST_MODEL");
+        let wav = std::env::var("FLETCH_WHISPER_TEST_WAV").expect("FLETCH_WHISPER_TEST_WAV");
+        let samples = read_wav(Path::new(&wav));
+        assert!(has_speech(&samples), "{wav} has no speech in it");
+
+        let ctx = load(Path::new(&model)).unwrap();
+        let text = decode(&ctx, &samples).unwrap();
+        println!("transcript: {text:?}");
+        assert!(
+            text.to_lowercase().contains("hello world"),
+            "expected the phrase in {text:?}"
+        );
+    }
+
+    /// Minimal reader for the one shape this test takes: 16 kHz mono 16-bit
+    /// PCM, as `say --data-format=LEI16@16000` writes it.
+    fn read_wav(path: &Path) -> Vec<f32> {
+        let bytes = std::fs::read(path).expect("read wav");
+        assert_eq!(&bytes[0..4], b"RIFF", "{} is not a WAV", path.display());
+        // Walk the chunk list rather than assuming a fixed header: `say` writes
+        // a plain fmt+data pair, but other writers add LIST/fact chunks.
+        let mut at = 12;
+        while at + 8 <= bytes.len() {
+            let id = &bytes[at..at + 4];
+            let size = u32::from_le_bytes(bytes[at + 4..at + 8].try_into().unwrap()) as usize;
+            let body = &bytes[at + 8..(at + 8 + size).min(bytes.len())];
+            if id == b"fmt " {
+                let channels = u16::from_le_bytes(body[2..4].try_into().unwrap());
+                let rate = u32::from_le_bytes(body[4..8].try_into().unwrap());
+                let bits = u16::from_le_bytes(body[14..16].try_into().unwrap());
+                assert_eq!((channels, rate, bits), (1, SAMPLE_RATE, 16), "{path:?}");
+            }
+            if id == b"data" {
+                return body
+                    .chunks_exact(2)
+                    .map(|s| f32::from(i16::from_le_bytes([s[0], s[1]])) / 32768.0)
+                    .collect();
+            }
+            at += 8 + size + (size & 1);
+        }
+        panic!("{} has no data chunk", path.display());
+    }
+}

--- a/src-tauri/src/dictation/whisper/engine.rs
+++ b/src-tauri/src/dictation/whisper/engine.rs
@@ -65,7 +65,6 @@ pub async fn transcribe(samples: Vec<f32>) -> Result<String> {
     if !has_speech(&samples) {
         return Ok(String::new());
     }
-    arm_unload();
     // Inference pins a core for seconds; it has no business on the async
     // runtime's worker threads.
     tokio::task::spawn_blocking(move || {
@@ -107,6 +106,11 @@ fn context() -> Result<Arc<WhisperContext>> {
         ctx: ctx.clone(),
         used: Instant::now(),
     });
+    // Armed under the same lock the sleeper unloads under, so "a model is
+    // loaded" and "a sleeper is watching it" change together: the sleeper can't
+    // retire between our check and our load and leave this context resident
+    // forever.
+    arm_unload();
     Ok(ctx)
 }
 
@@ -134,24 +138,24 @@ fn load(path: &Path) -> Result<WhisperContext> {
 /// Release the model once it has gone [`IDLE_UNLOAD`] without a transcription.
 /// One sleeper at a time; it re-sleeps while the model is still in use rather
 /// than unloading on its own deadline.
+///
+/// Called with [`CONTEXT`] held (see [`context`]), and the sleeper disarms
+/// itself while holding it too, so the flag and the cache never disagree.
+/// Spawned on the app runtime by handle rather than `tokio::spawn`, because
+/// the caller is on a blocking thread.
 fn arm_unload() {
     if UNLOAD_ARMED.swap(true, Ordering::SeqCst) {
         return;
     }
-    tokio::spawn(async move {
+    tauri::async_runtime::spawn(async move {
         loop {
             tokio::time::sleep(IDLE_UNLOAD).await;
-            let unloaded = {
-                let mut slot = CONTEXT.lock();
-                let idle = !slot
-                    .as_ref()
-                    .is_some_and(|l| l.used.elapsed() < IDLE_UNLOAD);
-                if idle {
-                    *slot = None;
-                }
-                idle
-            };
-            if unloaded {
+            let mut slot = CONTEXT.lock();
+            let idle = !slot
+                .as_ref()
+                .is_some_and(|l| l.used.elapsed() < IDLE_UNLOAD);
+            if idle {
+                *slot = None;
                 UNLOAD_ARMED.store(false, Ordering::SeqCst);
                 return;
             }

--- a/src-tauri/src/dictation/whisper/mod.rs
+++ b/src-tauri/src/dictation/whisper/mod.rs
@@ -11,6 +11,11 @@
 use std::path::PathBuf;
 use std::sync::OnceLock;
 
+// whisper.cpp itself is built for macOS only (iOS keeps the platform
+// recognizer), so the catalog and install compile everywhere but the
+// transcriber doesn't.
+#[cfg(target_os = "macos")]
+pub mod engine;
 pub mod install;
 pub mod models;
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -56,7 +56,8 @@ use crate::workspace::WorkspaceManager;
 
 /// The managed DB handle every command that reads or writes settings asks for.
 /// `pub(crate)` because those commands don't all live here (see
-/// `dictation::dictation_model_status`).
+/// `dictation::dictation_model_status`, and `dictation::engine` which reaches
+/// it through `AppHandle::state`).
 pub(crate) type DbState = Arc<Mutex<Connection>>;
 
 /// The app's bundle identifier. Must match `identifier` in `tauri.conf.json`;

--- a/src/api/domains/dictation.ts
+++ b/src/api/domains/dictation.ts
@@ -9,7 +9,8 @@ export const dictationApi = {
   /** Whether native dictation exists on this platform and what the user has
    *  authorized so far. Cheap; safe to call on every composer mount. */
   dictationAvailability: () => invoke<DictationAvailability>("dictation_availability"),
-  /** Start listening. Requests mic + speech permission on first use. Rejects
+  /** Start listening. Requests whatever permission the chosen engine needs on
+   *  first use — mic + speech for `apple`, mic alone for `whisper`. Rejects
    *  with a message if permission is denied or the recognizer can't start.
    *
    *  Resolves with the session id once audio is flowing: `dictation:state`
@@ -26,7 +27,9 @@ export const dictationApi = {
    *  `dictation:state` `stopped`. The final transcript is best-effort — a
    *  recognizer that hasn't flushed within a couple of seconds is torn down
    *  and only `stopped` arrives — so treat `stopped` as the point to commit
-   *  whatever text was last received. No-op when not listening. */
+   *  whatever text was last received. The `whisper` engine has nothing to
+   *  flush and everything to compute: it emits `transcribing` first, then the
+   *  one final transcript, then `stopped`. No-op when not listening. */
   dictationStop: () => invoke<void>("dictation_stop"),
 
   /** The local (Whisper) engine's opt-in plus the state of its weights. Cheap

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -186,7 +186,8 @@ export function onDictationTranscript(
   return listen<DictationTranscriptEvent>("dictation:transcript", (event) => cb(event.payload));
 }
 
-/** Dictation session lifecycle: listening → stopped, or error with a reason.
+/** Dictation session lifecycle: listening → (transcribing) → stopped, or error
+ *  with a reason.
  *  App-wide, like the session itself — every subscriber sees every session's
  *  events, so a consumer that owns one has to ignore the rest (a composer that
  *  unmounted mid-session leaves its terminal event to land on the next one). */

--- a/src/api/types/dictation.ts
+++ b/src/api/types/dictation.ts
@@ -8,16 +8,25 @@
  *  MDM lock the user can't lift from the app. */
 export type DictationAuthorization = "not_determined" | "authorized" | "denied" | "restricted";
 
+/** Which recognizer a session would use: the platform's (`apple`) or the local
+ *  whisper.cpp model the user can opt into in Settings (`whisper`). The backend
+ *  picks per session — `whisper` only once its model is fully downloaded — so
+ *  this is what the engine *would* be, not just what the setting says. */
+export type DictationEngine = "apple" | "whisper";
+
 export interface DictationAvailability {
   /** False on platforms with no native recognizer (Linux, Windows). The
    *  composer hides the mic button entirely when this is false. */
   supported: boolean;
+  /** Meaningless when `engine` is `whisper`: that engine never calls Apple's
+   *  recognizer, so it neither prompts for this grant nor is blocked by it. */
   speech: DictationAuthorization;
   microphone: DictationAuthorization;
   /** The recognizer for the current locale can run without sending audio to
    *  Apple. When false, recognition uses Apple's servers and sessions are
-   *  capped at roughly one minute. */
+   *  capped at roughly one minute. Always true for `whisper`. */
   on_device: boolean;
+  engine: DictationEngine;
 }
 
 /** Identifies one dictation session: the value `dictationStart` resolved with,
@@ -38,7 +47,10 @@ export interface DictationTranscriptEvent {
   is_final: boolean;
 }
 
-export type DictationState = "listening" | "stopped" | "error";
+/** `transcribing` only happens on the `whisper` engine: the mic is closed but
+ *  the model is still running, so the session is alive and its final transcript
+ *  is still coming. It always precedes a terminal `stopped` or `error`. */
+export type DictationState = "listening" | "transcribing" | "stopped" | "error";
 
 /** Payload of the `dictation:state` event. `error` is a human-readable reason,
  *  set only when `state` is `error`, which only happens when a session that

--- a/src/components/Composer/dictation/DictationButton.tsx
+++ b/src/components/Composer/dictation/DictationButton.tsx
@@ -1,12 +1,17 @@
 import type { DictationAuthorization, DictationAvailability } from "@/api";
 import { Icon } from "@/components/Icon";
 import { IconButton } from "@/components/ui/IconButton";
+import { Spinner } from "@/components/ui/Spinner";
 
 /** What the user has to do outside the app. The backend answers a blocked start
  *  with the same guidance, so the tooltip reads identically whether we knew up
  *  front or found out on the attempt. */
 const SETTINGS_HINT =
   "Enable Microphone and Speech Recognition for Fletch in System Settings → Privacy & Security";
+
+/** The local engine never calls Apple's recognizer, so don't send the user
+ *  looking for a permission it doesn't use. */
+const MIC_HINT = "Enable Microphone for Fletch in System Settings → Privacy & Security";
 
 /** Authorization states the app can't recover from on its own — `restricted` is
  *  an MDM/parental lock, `denied` needs a trip to System Settings. */
@@ -19,6 +24,9 @@ interface Props {
   /** The previous session is still tearing down. The backend starts nothing in
    *  that window, so the control is held for the (sub-second) flush. */
   stopping: boolean;
+  /** The local engine's model is running on what was just recorded — the same
+   *  held window as `stopping`, but long enough to need saying so. */
+  transcribing: boolean;
   /** Reason the last start failed, or null. */
   error: string | null;
   onToggle: () => void;
@@ -26,21 +34,32 @@ interface Props {
 
 /** The composer's mic. Sits with the insert actions because dictation puts text
  *  into *this* message, like attaching a file does. */
-export function DictationButton({ availability, listening, stopping, error, onToggle }: Props) {
+export function DictationButton({
+  availability,
+  listening,
+  stopping,
+  transcribing,
+  error,
+  onToggle,
+}: Props) {
   // Nothing at all until we know there's a native recognizer: a mic that can
   // only ever error is worse than no mic (Linux/Windows have none).
   if (!availability?.supported) return null;
 
+  // The speech grant gates only Apple's recognizer; the local engine is blocked
+  // by the microphone alone.
+  const needsSpeech = availability.engine !== "whisper";
   const blocked =
-    BLOCKED.includes(availability.speech) || BLOCKED.includes(availability.microphone);
-  const label = listening ? "Stop dictation" : "Dictate";
+    BLOCKED.includes(availability.microphone) ||
+    (needsSpeech && BLOCKED.includes(availability.speech));
+  const label = transcribing ? "Transcribing…" : listening ? "Stop dictation" : "Dictate";
 
   // The last failure outranks the standing permission hint, which outranks the
   // plain affordance. Blocked still clicks through: permission can be granted
   // between attempts, and the failed start is what surfaces the reason.
   function tip() {
     if (error) return error;
-    if (blocked) return SETTINGS_HINT;
+    if (blocked) return needsSpeech ? SETTINGS_HINT : MIC_HINT;
     return label;
   }
 
@@ -53,7 +72,7 @@ export function DictationButton({ availability, listening, stopping, error, onTo
       disabled={stopping}
       onClick={onToggle}
     >
-      <Icon name={blocked ? "micOff" : "mic"} size={15} />
+      {transcribing ? <Spinner size={15} /> : <Icon name={blocked ? "micOff" : "mic"} size={15} />}
     </IconButton>
   );
 }

--- a/src/components/Composer/dictation/useDictation.ts
+++ b/src/components/Composer/dictation/useDictation.ts
@@ -17,6 +17,7 @@ const UNAVAILABLE: DictationAvailability = {
   speech: "not_determined",
   microphone: "not_determined",
   on_device: false,
+  engine: "apple",
 };
 
 /** Voice dictation for one composer: owns the session state and pipes the
@@ -36,6 +37,10 @@ export function useDictation(input: ComposerInput) {
   // window. Holding the control until the session actually ends is what keeps a
   // quick second click from lighting the mic with nothing behind it.
   const [stopping, setStopping] = useState(false);
+  // The local engine's model is running: the mic is already closed, but the
+  // transcript is still coming. A subset of `stopping` — the button shows it as
+  // busy rather than as a live mic, because it can take a few seconds.
+  const [transcribing, setTranscribing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // The text present when this session started; the transcript is spliced onto
@@ -167,6 +172,14 @@ export function useDictation(input: ComposerInput) {
         // Someone else's session (see `sessionRef`) — the event is app-wide,
         // but the state it reports isn't ours to act on.
         if (e.session !== sessionRef.current) return;
+        if (e.state === "transcribing") {
+          // Not terminal: the mic is off but the final transcript is still
+          // coming, so keep the control held exactly as a flush does.
+          setListeningState(false);
+          setStoppingState(true);
+          setTranscribing(true);
+          return;
+        }
         // `stopped` and `error` both end the session; only `error` has a reason
         // worth showing (the backend's message doubles as the fix instruction).
         // Either one means teardown is done, so the mic is startable again.
@@ -174,6 +187,7 @@ export function useDictation(input: ComposerInput) {
         sessionRef.current = null;
         setListeningState(false);
         setStoppingState(false);
+        setTranscribing(false);
         acceptingRef.current = false;
         if (e.state === "error") setError(e.error ?? "Dictation failed");
       });
@@ -312,5 +326,5 @@ export function useDictation(input: ComposerInput) {
     }
   }
 
-  return { availability, listening, stopping, error, toggle, stop };
+  return { availability, listening, stopping, transcribing, error, toggle, stop };
 }

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -390,6 +390,7 @@ export function Composer({
             availability={dictation.availability}
             listening={dictation.listening}
             stopping={dictation.stopping}
+            transcribing={dictation.transcribing}
             error={dictation.error}
             onToggle={dictation.toggle}
           />

--- a/src/components/SettingsScreen/DictationSection/index.tsx
+++ b/src/components/SettingsScreen/DictationSection/index.tsx
@@ -8,11 +8,7 @@ import { useDictationModel } from "./useDictationModel";
  *  of Apple's recognizer. The opt-in and the weights are separate states — the
  *  toggle flips immediately and the model downloads behind it — so the row
  *  below the toggle is the only place that says whether dictation can actually
- *  run locally yet. macOS-only, like the recognizer it replaces.
- *
- *  Not mounted in `GeneralPane` until the engine that honours the setting
- *  lands: a toggle that downloads weights nothing reads would be a broken
- *  promise in any build shipped in between. */
+ *  run locally yet. macOS-only, like the recognizer it replaces. */
 export function DictationSection() {
   const enabled = useAppStore((s) => s.dictationEngineEnabled);
   const setEnabled = useAppStore((s) => s.setDictationEngineEnabled);

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -5,7 +5,9 @@ import { Select } from "@/components/ui/Select";
 import { ACCENTS, mcpCapableLabels } from "@/data/providers";
 import type { SandboxEngine, ThemeMode } from "@/storage/preferences";
 import { useAppStore } from "@/store";
+import { IS_MAC } from "@/util/platform";
 import { ContainerAuth } from "./ContainerAuth";
+import { DictationSection } from "./DictationSection";
 import { type FeatureItem, SetGroup, SetHead, SetRow, SetSeg, SetToggle } from "./primitives";
 
 // A container runtime can start or stop while this pane stays open, so we
@@ -189,6 +191,10 @@ export function GeneralPane() {
           />
         </SetRow>
       </SetGroup>
+
+      {/* The engine this replaces is Apple's, so there is nothing to choose
+          from anywhere else. */}
+      {IS_MAC && <DictationSection />}
 
       <SetGroup label="Sandbox">
         <SetRow


### PR DESCRIPTION
Second of two PRs replacing Apple's SFSpeechRecognizer dictation with a local whisper.cpp engine. Stacked on #644, which lands the model catalog, the verified download, and the Settings opt-in. This PR makes the opt-in do something: when the user has enabled it and the model is fully downloaded, dictation records the utterance, runs whisper.cpp on it when the mic closes, and puts the final text in the composer. Apple's recognizer stays the default and the fallback.

## How it works

- **One mic, two sinks.** `apple.rs` still opens the `AVAudioEngine` and owns the single session slot, generations, and the session-id contract. The tap now feeds either the SFSpeech request (unchanged) or a PCM accumulator (`capture.rs`, macOS only). Which one is decided per session by `dictation::engine`: the `dictation_engine` setting AND a fully installed model, so an interrupted download can never leave the mic dead.
- **Capture → 16 kHz mono f32.** Channels are averaged on the render thread into a pre-sized buffer behind a `try_lock`; resampling to whisper's 16 kHz uses `AVAudioConverter` off the audio thread, not linear decimation. Five-minute capture cap.
- **Engine** (`whisper/engine.rs`): greedy sampling, language auto-detect, no timestamps, `suppress_blank`. A silence gate (clip under 0.5 s or RMS under 0.002) returns empty without loading the model, because Whisper invents sentences over silence. The loaded model is cached and released after 10 minutes idle.
- **Stop flow.** On `dictation_stop` the whisper path releases the mic and the session slot immediately, emits a new `transcribing` state, runs the model, then emits one final `dictation:transcript` (only if non-empty) and `stopped`; failures emit `error`. Only the microphone permission is requested on this path, never Speech Recognition.
- **Contract.** `DictationAvailability` gains `engine: "apple" | "whisper"`; `DictationState` gains `"transcribing"` (non-terminal, always followed by `stopped`/`error`). The composer button shows a spinner and "Transcribing…" during that window and ignores the speech grant when the engine is whisper.
- **Settings.** The Dictation section built in #644 is now mounted in General, since a build that honours the toggle exists.
- **Build.** `whisper-rs` 0.16 with `metal` under `cfg(target_os = "macos")` only; Linux CI never compiles whisper.cpp, iOS keeps Apple's recognizer. No extra link flags were needed; whisper-rs-sys emits them. The release runner needs cmake, which macos-latest has.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` (1490 passed), `cargo build`; `bun run lint` / `check` / `test` (1102 passed).
- **Real transcription, without the GUI:** an ignored test loads a model and a WAV from env vars. Run against `ggml-small.en-q8_0.bin` and a clip generated with macOS `say`, it produced `"Hello world, this is a dictation test."` in 8.4 s in a debug build including model load. The silence gate short-circuits a real 2 s silent WAV in 0 ms. Two unit tests cover the AVAudioConverter resampler synthetically. Instructions are in `docs/dictation.md`.
- **Not verified here:** the live microphone path (no mic or TCC in the sandbox), Metal inference speed in a release build, and an iOS compile. Worth a manual pass: enable the toggle, wait for the download, dictate a sentence, confirm no Speech Recognition prompt appears and the text lands after the spinner.

## Consciously left out

- No partial transcripts on the whisper path; whole-utterance is the design, and `transcribing` exists for the wait.
- Silence auto-stop for hands-free use is the planned follow-up.