### PR TITLE
feat(dictation): hands-free auto-stop on the local engine

### DIFF
--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -204,16 +204,25 @@ gone quiet, so dictating is one click rather than two. Apple's recognizer is
 untouched — it streams results and manages its own end-of-utterance, and there
 is no PCM buffer on that path to measure.
 
-The detector is a handful of atomics on the capture buffer, updated by the tap
-on the render thread. Each buffer's RMS is computed in the same pass that
-averages the channels (the samples are already in registers), and counts as
-speech when it clears `max(3 × noise floor, MIN_RMS)`. The noise floor is the
-running *minimum* of buffer RMS, clamped to `NOISE_FLOOR_MIN`: a laptop's
-built-in mic and a hot USB interface differ by more than an order of magnitude
-in what "a quiet room" measures, so a fixed threshold would either stop
-mid-sentence on one or never trigger on the other. The absolute bound is
-`engine::MIN_RMS`, the same threshold the [silence gate](#the-silence-gate)
-uses — audio too quiet to transcribe isn't worth holding a session open for.
+The detector is two atomics on the capture buffer, updated by the tap on the
+render thread. Each buffer's RMS is computed in the same pass that averages the
+channels (the samples are already in registers), and counts as speech when it
+clears `SPEECH_ABS` outright, or else `max(3 × noise floor, MIN_RMS)`. The
+noise floor is the running *minimum* of buffer RMS, clamped to
+`NOISE_FLOOR_MIN`: a laptop's built-in mic and a hot USB interface differ by
+more than an order of magnitude in what "a quiet room" measures, so a fixed
+ratio threshold alone would either stop mid-sentence on one or never trigger on
+the other. A buffer is judged against the floor as it stood *before* that
+buffer is folded in, and `SPEECH_ABS` covers the case the ratio can't: someone
+who starts talking as they click has no quiet buffer yet, so their own voice
+would become the floor. The lower bound is `engine::MIN_RMS`, the same
+threshold the [silence gate](#the-silence-gate) uses — audio too quiet to
+transcribe isn't worth holding a session open for.
+
+"When was speech last heard" is one atomic word (milliseconds plus one, zero
+for never) rather than a flag beside a timestamp, so the monitor can never see
+"spoken" paired with a timestamp that hasn't landed and mistake the whole
+session so far for the pause.
 
 One tokio task per whisper session polls those atomics every
 `SILENCE_POLL` (100 ms) and stops on whichever comes first:

--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -207,17 +207,25 @@ is no PCM buffer on that path to measure.
 The detector is two atomics on the capture buffer, updated by the tap on the
 render thread. Each buffer's RMS is computed in the same pass that averages the
 channels (the samples are already in registers), and counts as speech when it
-clears `SPEECH_ABS` outright, or else `max(3 × noise floor, MIN_RMS)`. The
-noise floor is the running *minimum* of buffer RMS, clamped to
-`NOISE_FLOOR_MIN`: a laptop's built-in mic and a hot USB interface differ by
-more than an order of magnitude in what "a quiet room" measures, so a fixed
-ratio threshold alone would either stop mid-sentence on one or never trigger on
-the other. A buffer is judged against the floor as it stood *before* that
-buffer is folded in, and `SPEECH_ABS` covers the case the ratio can't: someone
-who starts talking as they click has no quiet buffer yet, so their own voice
-would become the floor. The lower bound is `engine::MIN_RMS`, the same
-threshold the [silence gate](#the-silence-gate) uses — audio too quiet to
-transcribe isn't worth holding a session open for.
+clears `max(3 × noise floor, MIN_RMS)`. The noise floor is the running
+*minimum* of buffer RMS, clamped to `NOISE_FLOOR_MIN`: a laptop's built-in mic
+and a hot USB interface differ by more than an order of magnitude in what "a
+quiet room" measures, so a fixed threshold would either stop mid-sentence on
+one or never trigger on the other. A buffer is judged against the floor as it
+stood *before* that buffer is folded in, so a loud first buffer isn't its own
+floor. The lower bound is `engine::MIN_RMS`, the same threshold the
+[silence gate](#the-silence-gate) uses — audio too quiet to transcribe isn't
+worth holding a session open for.
+
+Two consequences of "relative to the floor only", both deliberate. Someone who
+is already talking when the first buffer arrives sets the floor to their own
+voice, and is recognised at the first gap between words (tap buffers are
+~20 ms, so within the first second); the alternative — an absolute "this loud is
+always speech" level — was tried and dropped, because steady noise above it
+(music, air conditioning) refreshed the speech clock forever and the session
+could only end at the capture cap. And steady noise of any level never counts
+as speech, so a session in a loud room ends on the no-speech timeout like a
+silent one.
 
 "When was speech last heard" is one atomic word (milliseconds plus one, zero
 for never) rather than a flag beside a timestamp, so the monitor can never see

--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -197,6 +197,46 @@ silence at the head or tail of a real utterance.
 Empty text emits **no** `dictation:transcript` — only the terminal `stopped` —
 so a mistimed press leaves the composer exactly as it was.
 
+### Hands-free: auto-stop
+
+On the local engine a session ends itself once the user has spoken and then
+gone quiet, so dictating is one click rather than two. Apple's recognizer is
+untouched — it streams results and manages its own end-of-utterance, and there
+is no PCM buffer on that path to measure.
+
+The detector is a handful of atomics on the capture buffer, updated by the tap
+on the render thread. Each buffer's RMS is computed in the same pass that
+averages the channels (the samples are already in registers), and counts as
+speech when it clears `max(3 × noise floor, MIN_RMS)`. The noise floor is the
+running *minimum* of buffer RMS, clamped to `NOISE_FLOOR_MIN`: a laptop's
+built-in mic and a hot USB interface differ by more than an order of magnitude
+in what "a quiet room" measures, so a fixed threshold would either stop
+mid-sentence on one or never trigger on the other. The absolute bound is
+`engine::MIN_RMS`, the same threshold the [silence gate](#the-silence-gate)
+uses — audio too quiet to transcribe isn't worth holding a session open for.
+
+One tokio task per whisper session polls those atomics every
+`SILENCE_POLL` (100 ms) and stops on whichever comes first:
+
+| Constant | Value | Ends the session when |
+| --- | --- | --- |
+| `SILENCE_STOP` | 2 s | Something was said, and nothing has been since |
+| `NO_SPEECH_TIMEOUT` | 10 s | Nothing was ever said — clicked the mic, walked away |
+
+The second case stops with no transcript at all: the clip has no speech in it,
+so the gate answers empty and only `stopped` is emitted. The stop itself goes
+through the same path a second click takes (`stop_session`), so
+`transcribing` → transcript → `stopped` arrive in the usual order and the
+frontend needs nothing new.
+
+The monitor is scoped to its session's generation at both ends. It exits as
+soon as its buffer is marked closed — `Sink::cancel`, which every teardown runs
+— and the stop it issues names its own generation, so a monitor that wakes up
+after the user already stopped can't cut the *next* session short.
+
+There is no Settings toggle yet. The three constants are the whole policy, so
+an opt-out would gate the monitor rather than change them.
+
 ### `transcribing`, and the model's lifetime
 
 Apple's recognizer streams revisions while the user speaks; whisper.cpp has

--- a/src-tauri/src/dictation/apple.rs
+++ b/src-tauri/src/dictation/apple.rs
@@ -108,11 +108,13 @@ enum Sink {
 
 impl Sink {
     /// Drop the sink's work without waiting for a result — for a session that
-    /// failed to come up, or one being torn down. The local engine has nothing
-    /// to cancel: its buffer is simply dropped.
+    /// failed to come up, or one being torn down. The local engine's buffer is
+    /// simply dropped; marking it closed is what retires its silence monitor.
     fn cancel(&self) {
-        if let Sink::Speech { task, .. } = self {
-            unsafe { task.cancel() };
+        match self {
+            Sink::Speech { task, .. } => unsafe { task.cancel() },
+            #[cfg(target_os = "macos")]
+            Sink::Pcm(pcm) => pcm.close(),
         }
     }
 }
@@ -170,6 +172,20 @@ async fn on_main<T: Send + 'static>(
 /// Is the session that `generation` belongs to still the live one?
 fn is_live(generation: u64) -> bool {
     SESSION.with_borrow(|s| s.as_ref().is_some_and(|s| s.generation == generation))
+}
+
+/// The live session's capture buffer, if `generation` is still it and it is a
+/// local-engine session. Main thread, like every read of `SESSION`; the buffer
+/// itself is then readable from anywhere.
+#[cfg(target_os = "macos")]
+fn captured(generation: u64) -> Option<std::sync::Arc<super::capture::Pcm>> {
+    SESSION.with_borrow(|slot| {
+        let session = slot.as_ref().filter(|s| s.generation == generation)?;
+        match &session.sink {
+            Sink::Pcm(pcm) => Some(pcm.clone()),
+            Sink::Speech { .. } => None,
+        }
+    })
 }
 
 /// Claim the live session, but only if it is still `generation`. Returning
@@ -358,14 +374,51 @@ pub async fn start(app: AppHandle, engine: Engine) -> Result<Option<u64>> {
         return Err(e);
     }
     let handle = app.clone();
-    match on_main(&app, move || begin(handle, engine)).await {
-        Ok(started) => started,
+    let started = match on_main(&app, move || begin(handle, engine)).await {
+        Ok(started) => started?,
         // The closure never ran, so `begin` never took the claim.
         Err(e) => {
             ACTIVE.store(false, Ordering::SeqCst);
-            Err(e)
+            return Err(e);
         }
+    };
+    // Hands-free stop is the local engine's alone: Apple's recognizer decides
+    // for itself when an utterance has ended, and we have no PCM to measure.
+    #[cfg(target_os = "macos")]
+    if let (Some(generation), Engine::Whisper) = (started, engine) {
+        watch_for_silence(app, generation);
     }
+    Ok(started)
+}
+
+/// Poll a local-engine session's speech tracker and stop it once the user has
+/// spoken and then gone quiet — the whole of hands-free dictation. Stops
+/// through the same path a second click takes, so `transcribing`, the
+/// transcript and `stopped` follow in the usual order.
+///
+/// Everything here is keyed on `generation`: the task exits as soon as the
+/// buffer it was given is closed (any teardown does that), and the stop it
+/// finally issues names its own session, so a monitor that outlives its
+/// session cannot cut a later one short.
+#[cfg(target_os = "macos")]
+fn watch_for_silence(app: AppHandle, generation: u64) {
+    tokio::spawn(async move {
+        let Ok(Some(pcm)) = on_main(&app, move || captured(generation)).await else {
+            return;
+        };
+        loop {
+            tokio::time::sleep(super::capture::SILENCE_POLL).await;
+            if pcm.is_closed() {
+                return;
+            }
+            if pcm.done_talking() {
+                break;
+            }
+        }
+        if let Err(e) = stop_session(app, Some(generation)).await {
+            tracing::warn!(error = %e, "dictation: silence auto-stop failed");
+        }
+    });
 }
 
 fn begin(app: AppHandle, engine: Engine) -> Result<Option<u64>> {
@@ -550,11 +603,21 @@ fn result_handler(
 }
 
 pub async fn stop(app: AppHandle) -> Result<()> {
-    let stopped = on_main(&app, || {
+    stop_session(app, None).await
+}
+
+/// End the live session. `expect` is `None` for a user's stop — whatever is
+/// listening — and `Some(generation)` for the silence monitor, which owns one
+/// session and must be a no-op against any other.
+async fn stop_session(app: AppHandle, expect: Option<u64>) -> Result<()> {
+    let stopped = on_main(&app, move || {
         // Clone the handles out before calling into ObjC: the rule for
         // `SESSION` is that no borrow is ever held across a framework call.
         let live = SESSION.with_borrow_mut(|slot| {
             let session = slot.as_mut()?;
+            if expect.is_some_and(|g| g != session.generation) {
+                return None;
+            }
             session.stopping = true;
             Some((
                 session.generation,
@@ -564,11 +627,14 @@ pub async fn stop(app: AppHandle) -> Result<()> {
             ))
         });
         let Some((generation, audio, input, sink)) = live else {
-            // No session — but a claimed `ACTIVE` with an empty `SESSION` means
-            // a `start` is still sitting on the permission prompts, so leave
-            // the request for `begin` to consume. Genuinely idle, record
-            // nothing: a flag left behind here would cancel a later start.
-            if ACTIVE.load(Ordering::SeqCst) {
+            // No session of ours — but a claimed `ACTIVE` with an empty
+            // `SESSION` means a `start` is still sitting on the permission
+            // prompts, so leave the request for `begin` to consume. Genuinely
+            // idle, record nothing: a flag left behind here would cancel a
+            // later start. A generation-scoped stop never leaves one: its own
+            // session existed, so this is a session that has already ended, and
+            // the pending start is somebody else's.
+            if expect.is_none() && ACTIVE.load(Ordering::SeqCst) {
                 STOP_PENDING.set(true);
             }
             return None;

--- a/src-tauri/src/dictation/capture.rs
+++ b/src-tauri/src/dictation/capture.rs
@@ -59,14 +59,13 @@ const NO_SPEECH_TIMEOUT: Duration = Duration::from_secs(10);
 pub(super) const SILENCE_POLL: Duration = Duration::from_millis(100);
 
 /// How far above the room's own noise a buffer has to be to count as speech.
+///
+/// Deliberately the only loudness rule: an absolute "this loud is always
+/// speech" level was tried and dropped, because steady noise above it (music,
+/// air conditioning, a hot input) would refresh the speech clock on every
+/// buffer and the session could never observe a pause. Relative to the floor,
+/// steady noise *is* the floor and never counts.
 const SPEECH_OVER_FLOOR: f32 = 3.0;
-
-/// Loud enough to be speech whatever the room is doing: a voice at
-/// conversational distance on a typical input. The ratio rule needs a floor to
-/// compare against, and the floor is only known once a quiet buffer has been
-/// heard — someone who starts talking as they click would otherwise set the
-/// floor to their own voice and never clear three times it.
-const SPEECH_ABS: f32 = 0.02;
 
 /// Floor under the noise floor. Digital silence would otherwise put the speech
 /// threshold at zero and make the first faint buffer an utterance.
@@ -97,12 +96,12 @@ pub(super) struct Pcm {
 
 /// Is a buffer this loud speech, in a room whose noise floor is `floor`?
 ///
-/// Pure, and the whole of the detector. Three rules: clearly loud is speech
-/// ([`SPEECH_ABS`]); otherwise it has to stand out from the room
-/// ([`SPEECH_OVER_FLOOR`]); and nothing under the engine's clip gate counts —
-/// audio too quiet to transcribe can't be worth waiting for silence after.
+/// Pure, and the whole of the detector: a buffer has to stand out from the
+/// room ([`SPEECH_OVER_FLOOR`]), and nothing under the engine's clip gate
+/// counts — audio too quiet to transcribe can't be worth waiting for silence
+/// after.
 fn is_speech(rms: f32, floor: f32) -> bool {
-    rms >= SPEECH_ABS || rms >= (floor * SPEECH_OVER_FLOOR).max(engine::MIN_RMS)
+    rms >= (floor * SPEECH_OVER_FLOOR).max(engine::MIN_RMS)
 }
 
 /// Fold a buffer's loudness into the noise floor: the running minimum, never
@@ -414,11 +413,23 @@ mod tests {
         assert_eq!(speech[15..], [false; 5], "the pause never arrives");
     }
 
-    /// Talking from the very first buffer — clicking mid-sentence — must not
-    /// make that voice the room's noise floor.
+    /// Talking from the very first buffer — clicking mid-sentence — sets the
+    /// floor to the voice itself, so nothing counts until the first gap between
+    /// words lowers it; from then on the speech does.
     #[test]
-    fn speech_in_the_first_buffer_still_counts() {
-        assert_eq!(detect(&[0.05, 0.05, 0.001]), [true, true, false]);
+    fn speech_from_the_first_buffer_counts_after_the_first_gap() {
+        assert_eq!(
+            detect(&[0.05, 0.05, 0.002, 0.05, 0.05, 0.002]),
+            [false, false, false, true, true, false]
+        );
+    }
+
+    /// Steady noise of any level is the room, not a voice: it must never keep
+    /// the session open, however loud.
+    #[test]
+    fn steady_noise_is_never_speech() {
+        assert_eq!(detect(&[0.02; 6]), [false; 6]);
+        assert_eq!(detect(&[0.2; 6]), [false; 6]);
     }
 
     /// A hot input's noise is louder than a quiet one's speech, so below the

--- a/src-tauri/src/dictation/capture.rs
+++ b/src-tauri/src/dictation/capture.rs
@@ -17,7 +17,9 @@
 
 use std::cell::Cell;
 use std::ptr::NonNull;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use block2::RcBlock;
 use objc2::rc::Retained;
@@ -38,6 +40,31 @@ use crate::error::{Error, Result};
 /// Audio past it is dropped, which truncates the transcript rather than failing.
 const MAX_CAPTURE_SECS: f64 = 300.0;
 
+/// How long a pause has to last, once something has been said, for the session
+/// to end itself — long enough to think mid-sentence, short enough that the
+/// text lands while the user is still looking at the composer.
+///
+/// This and the two constants below are the whole of the hands-free policy, so
+/// a Settings opt-out would gate the monitor that reads them rather than change
+/// them.
+const SILENCE_STOP: Duration = Duration::from_secs(2);
+
+/// How long a session in which nothing was ever said stays open: the user
+/// clicked the mic and walked away. The clip has no speech in it, so the
+/// engine's gate answers empty and the session just ends.
+const NO_SPEECH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How often the monitor looks. Well under [`SILENCE_STOP`], and cheap: three
+/// relaxed atomic loads.
+pub(super) const SILENCE_POLL: Duration = Duration::from_millis(100);
+
+/// How far above the room's own noise a buffer has to be to count as speech.
+const SPEECH_OVER_FLOOR: f32 = 3.0;
+
+/// Floor under the noise floor. Digital silence would otherwise put the speech
+/// threshold at zero and make the first faint buffer an utterance.
+const NOISE_FLOOR_MIN: f32 = 0.000_5;
+
 /// A session's captured audio: mono f32 at the microphone's own sample rate.
 pub(super) struct Pcm {
     /// The microphone's rate, which [`transcribe`] resamples from.
@@ -45,6 +72,81 @@ pub(super) struct Pcm {
     /// Sample ceiling derived from [`MAX_CAPTURE_SECS`] and `rate`.
     limit: usize,
     samples: Mutex<Vec<f32>>,
+    /// When capture began, which the two timings below are measured from.
+    start: Instant,
+    /// Set once a buffer has been loud enough to be speech. Until then a pause
+    /// is the user not having started, not the user having finished.
+    speech_seen: AtomicBool,
+    /// Milliseconds since [`Pcm::start`] of the last buffer that was speech.
+    /// Meaningless while `speech_seen` is false.
+    last_speech_ms: AtomicU64,
+    /// The quietest buffer heard so far (`f32` bits), i.e. this room on this
+    /// microphone with nobody talking. Adaptive because a threshold that suits
+    /// a laptop's built-in mic is silence on a hot USB interface.
+    floor: AtomicU32,
+    /// Set by `apple`'s `Sink::cancel` when the session is torn down, so the
+    /// silence monitor stops polling a buffer nothing will fill again.
+    closed: AtomicBool,
+}
+
+/// Is a buffer this loud speech, in a room whose noise floor is `floor`?
+///
+/// Pure, and the whole of the detector: the adaptive part is `floor`, and the
+/// absolute part is the same threshold the engine's clip gate uses — audio too
+/// quiet to transcribe can't be worth waiting for silence after.
+fn is_speech(rms: f32, floor: f32) -> bool {
+    rms >= (floor * SPEECH_OVER_FLOOR).max(engine::MIN_RMS)
+}
+
+/// Fold a buffer's loudness into the noise floor: the running minimum, never
+/// below [`NOISE_FLOOR_MIN`].
+fn settle_floor(floor: f32, rms: f32) -> f32 {
+    floor.min(rms.max(NOISE_FLOOR_MIN))
+}
+
+/// Should the session end itself now? Pure so the thresholds are testable
+/// without a microphone.
+fn should_auto_stop(speech_seen: bool, elapsed: Duration, since_speech: Duration) -> bool {
+    if speech_seen {
+        since_speech >= SILENCE_STOP
+    } else {
+        elapsed >= NO_SPEECH_TIMEOUT
+    }
+}
+
+impl Pcm {
+    /// Render thread: fold one buffer's loudness into the speech tracker. The
+    /// render thread is the only writer, so a load and a store are enough —
+    /// no read-modify-write to lose.
+    fn track_speech(&self, rms: f32) {
+        let floor = settle_floor(f32::from_bits(self.floor.load(Ordering::Relaxed)), rms);
+        self.floor.store(floor.to_bits(), Ordering::Relaxed);
+        if is_speech(rms, floor) {
+            self.speech_seen.store(true, Ordering::Relaxed);
+            self.last_speech_ms
+                .store(self.start.elapsed().as_millis() as u64, Ordering::Relaxed);
+        }
+    }
+
+    /// Has the user spoken and then gone quiet (or never spoken at all)? Read
+    /// by the silence monitor, off both the render and the main thread.
+    pub(super) fn done_talking(&self) -> bool {
+        let elapsed = self.start.elapsed();
+        let last = Duration::from_millis(self.last_speech_ms.load(Ordering::Relaxed));
+        should_auto_stop(
+            self.speech_seen.load(Ordering::Relaxed),
+            elapsed,
+            elapsed.saturating_sub(last),
+        )
+    }
+
+    pub(super) fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Relaxed)
+    }
+
+    pub(super) fn close(&self) {
+        self.closed.store(true, Ordering::Relaxed);
+    }
 }
 
 /// Build the accumulator and the tap block that fills it.
@@ -70,6 +172,13 @@ pub(super) fn sink(format: &AVAudioFormat) -> Result<(Arc<Pcm>, Tap)> {
         // Pre-sized to a long dictation so the render thread appends into spare
         // capacity instead of reallocating mid-buffer.
         samples: Mutex::new(Vec::with_capacity((rate * 60.0) as usize)),
+        start: Instant::now(),
+        speech_seen: AtomicBool::new(false),
+        last_speech_ms: AtomicU64::new(0),
+        // A running minimum has to start above anything it will see; the first
+        // buffer sets it, and can't be speech against itself.
+        floor: AtomicU32::new(1.0f32.to_bits()),
+        closed: AtomicBool::new(false),
     });
 
     let tap_pcm = pcm.clone();
@@ -81,10 +190,13 @@ pub(super) fn sink(format: &AVAudioFormat) -> Result<(Arc<Pcm>, Tap)> {
     Ok((pcm, tap))
 }
 
-/// Real-time audio thread: average the channels down and return. The only other
-/// lock holder is the one-shot take in [`transcribe`], so `try_lock` all but
-/// never fails — and dropping one buffer beats blocking the render thread if it
-/// ever does.
+/// Real-time audio thread: average the channels down, note how loud the result
+/// was, and return. The only other lock holder is the one-shot take in
+/// [`transcribe`], so `try_lock` all but never fails — and dropping one buffer
+/// beats blocking the render thread if it ever does.
+///
+/// The RMS rides along in the same pass because the silence monitor needs it
+/// and the samples are already in registers here.
 fn append_mono(pcm: &Pcm, buffer: &AVAudioPCMBuffer) {
     let frames = unsafe { buffer.frameLength() } as usize;
     let channels = unsafe { buffer.format().channelCount() } as usize;
@@ -98,6 +210,7 @@ fn append_mono(pcm: &Pcm, buffer: &AVAudioPCMBuffer) {
     if samples.len() + frames > pcm.limit {
         return;
     }
+    let mut squares = 0.0f64;
     for frame in 0..frames {
         let mut sum = 0.0;
         for channel in 0..channels {
@@ -105,8 +218,11 @@ fn append_mono(pcm: &Pcm, buffer: &AVAudioPCMBuffer) {
             // to `frameLength` contiguous samples.
             sum += unsafe { *(*data.add(channel)).as_ptr().add(frame) };
         }
-        samples.push(sum / channels as f32);
+        let mono = sum / channels as f32;
+        squares += f64::from(mono) * f64::from(mono);
+        samples.push(mono);
     }
+    pcm.track_speech(((squares / frames as f64).sqrt()) as f32);
 }
 
 /// Take the session's audio and transcribe it. Consumes the buffer: the session
@@ -251,6 +367,62 @@ mod tests {
             / out.len() as f64)
             .sqrt();
         assert!(rms > 0.5, "tone was lost: rms {rms}");
+    }
+
+    /// Walk a sequence of buffer RMS values through the detector the way the
+    /// render thread would, and report which of them counted as speech.
+    fn detect(sequence: &[f32]) -> Vec<bool> {
+        let mut floor = 1.0;
+        sequence
+            .iter()
+            .map(|rms| {
+                floor = settle_floor(floor, *rms);
+                is_speech(*rms, floor)
+            })
+            .collect()
+    }
+
+    /// The shape every session has: a quiet room, an utterance, then quiet
+    /// again. Only the utterance may count, and the trailing silence must not —
+    /// that is what ends the session.
+    #[test]
+    fn detects_speech_between_silences() {
+        let mut sequence = vec![0.001; 5];
+        sequence.extend([0.05; 10]);
+        sequence.extend([0.001; 5]);
+
+        let speech = detect(&sequence);
+
+        assert_eq!(speech[..5], [false; 5], "quiet room read as speech");
+        assert_eq!(speech[5..15], [true; 10], "speech missed");
+        assert_eq!(speech[15..], [false; 5], "the pause never arrives");
+    }
+
+    /// A hot input's noise is louder than a quiet one's speech, so the
+    /// threshold has to follow the room rather than sit at a fixed level.
+    #[test]
+    fn floor_adapts_to_the_room() {
+        assert_eq!(detect(&[0.01, 0.01, 0.02]), [false, false, false]);
+        assert_eq!(detect(&[0.0005, 0.0005, 0.02]), [false, false, true]);
+    }
+
+    /// A muted or unplugged input is all zeroes: the adaptive threshold
+    /// collapses to nothing there, and the absolute one has to hold.
+    #[test]
+    fn silence_is_never_speech() {
+        assert_eq!(detect(&[0.0; 4]), [false; 4]);
+        assert!(!is_speech(engine::MIN_RMS / 2.0, 0.0));
+    }
+
+    #[test]
+    fn auto_stops_on_a_pause_but_not_before_speech() {
+        let long = NO_SPEECH_TIMEOUT + Duration::from_secs(1);
+        assert!(!should_auto_stop(true, long, SILENCE_STOP / 2));
+        assert!(should_auto_stop(true, long, SILENCE_STOP));
+        // Never spoke: the pause is the whole session, and only the longer
+        // deadline ends it.
+        assert!(!should_auto_stop(false, SILENCE_STOP * 2, SILENCE_STOP * 2));
+        assert!(should_auto_stop(false, long, long));
     }
 
     #[test]

--- a/src-tauri/src/dictation/capture.rs
+++ b/src-tauri/src/dictation/capture.rs
@@ -54,12 +54,19 @@ const SILENCE_STOP: Duration = Duration::from_secs(2);
 /// engine's gate answers empty and the session just ends.
 const NO_SPEECH_TIMEOUT: Duration = Duration::from_secs(10);
 
-/// How often the monitor looks. Well under [`SILENCE_STOP`], and cheap: three
+/// How often the monitor looks. Well under [`SILENCE_STOP`], and cheap: two
 /// relaxed atomic loads.
 pub(super) const SILENCE_POLL: Duration = Duration::from_millis(100);
 
 /// How far above the room's own noise a buffer has to be to count as speech.
 const SPEECH_OVER_FLOOR: f32 = 3.0;
+
+/// Loud enough to be speech whatever the room is doing: a voice at
+/// conversational distance on a typical input. The ratio rule needs a floor to
+/// compare against, and the floor is only known once a quiet buffer has been
+/// heard — someone who starts talking as they click would otherwise set the
+/// floor to their own voice and never clear three times it.
+const SPEECH_ABS: f32 = 0.02;
 
 /// Floor under the noise floor. Digital silence would otherwise put the speech
 /// threshold at zero and make the first faint buffer an utterance.
@@ -72,14 +79,13 @@ pub(super) struct Pcm {
     /// Sample ceiling derived from [`MAX_CAPTURE_SECS`] and `rate`.
     limit: usize,
     samples: Mutex<Vec<f32>>,
-    /// When capture began, which the two timings below are measured from.
+    /// When capture began, which the timing below is measured from.
     start: Instant,
-    /// Set once a buffer has been loud enough to be speech. Until then a pause
-    /// is the user not having started, not the user having finished.
-    speech_seen: AtomicBool,
-    /// Milliseconds since [`Pcm::start`] of the last buffer that was speech.
-    /// Meaningless while `speech_seen` is false.
-    last_speech_ms: AtomicU64,
+    /// When speech was last heard, as milliseconds since [`Pcm::start`] plus
+    /// one; zero means never. One word rather than a flag and a timestamp, so
+    /// the monitor can't read a flag that says "spoken" next to a timestamp
+    /// that hasn't landed yet and take the whole session so far for a pause.
+    last_speech: AtomicU64,
     /// The quietest buffer heard so far (`f32` bits), i.e. this room on this
     /// microphone with nobody talking. Adaptive because a threshold that suits
     /// a laptop's built-in mic is silence on a hot USB interface.
@@ -91,11 +97,12 @@ pub(super) struct Pcm {
 
 /// Is a buffer this loud speech, in a room whose noise floor is `floor`?
 ///
-/// Pure, and the whole of the detector: the adaptive part is `floor`, and the
-/// absolute part is the same threshold the engine's clip gate uses — audio too
-/// quiet to transcribe can't be worth waiting for silence after.
+/// Pure, and the whole of the detector. Three rules: clearly loud is speech
+/// ([`SPEECH_ABS`]); otherwise it has to stand out from the room
+/// ([`SPEECH_OVER_FLOOR`]); and nothing under the engine's clip gate counts —
+/// audio too quiet to transcribe can't be worth waiting for silence after.
 fn is_speech(rms: f32, floor: f32) -> bool {
-    rms >= (floor * SPEECH_OVER_FLOOR).max(engine::MIN_RMS)
+    rms >= SPEECH_ABS || rms >= (floor * SPEECH_OVER_FLOOR).max(engine::MIN_RMS)
 }
 
 /// Fold a buffer's loudness into the noise floor: the running minimum, never
@@ -104,13 +111,20 @@ fn settle_floor(floor: f32, rms: f32) -> f32 {
     floor.min(rms.max(NOISE_FLOOR_MIN))
 }
 
-/// Should the session end itself now? Pure so the thresholds are testable
+/// Classify one buffer against the floor as it stood *before* this buffer, then
+/// fold the buffer in. Judging a buffer against a floor it has just lowered
+/// would make the first loud buffer of a session its own noise floor.
+fn track(floor: f32, rms: f32) -> (bool, f32) {
+    (is_speech(rms, floor), settle_floor(floor, rms))
+}
+
+/// Should the session end itself now? `last_speech` is when speech was last
+/// heard, or `None` if it never was. Pure so the thresholds are testable
 /// without a microphone.
-fn should_auto_stop(speech_seen: bool, elapsed: Duration, since_speech: Duration) -> bool {
-    if speech_seen {
-        since_speech >= SILENCE_STOP
-    } else {
-        elapsed >= NO_SPEECH_TIMEOUT
+fn should_auto_stop(last_speech: Option<Duration>, elapsed: Duration) -> bool {
+    match last_speech {
+        Some(last) => elapsed.saturating_sub(last) >= SILENCE_STOP,
+        None => elapsed >= NO_SPEECH_TIMEOUT,
     }
 }
 
@@ -119,25 +133,23 @@ impl Pcm {
     /// render thread is the only writer, so a load and a store are enough —
     /// no read-modify-write to lose.
     fn track_speech(&self, rms: f32) {
-        let floor = settle_floor(f32::from_bits(self.floor.load(Ordering::Relaxed)), rms);
+        let (speech, floor) = track(f32::from_bits(self.floor.load(Ordering::Relaxed)), rms);
         self.floor.store(floor.to_bits(), Ordering::Relaxed);
-        if is_speech(rms, floor) {
-            self.speech_seen.store(true, Ordering::Relaxed);
-            self.last_speech_ms
-                .store(self.start.elapsed().as_millis() as u64, Ordering::Relaxed);
+        if speech {
+            let ms = self.start.elapsed().as_millis() as u64;
+            self.last_speech.store(ms + 1, Ordering::Relaxed);
         }
     }
 
     /// Has the user spoken and then gone quiet (or never spoken at all)? Read
     /// by the silence monitor, off both the render and the main thread.
     pub(super) fn done_talking(&self) -> bool {
-        let elapsed = self.start.elapsed();
-        let last = Duration::from_millis(self.last_speech_ms.load(Ordering::Relaxed));
-        should_auto_stop(
-            self.speech_seen.load(Ordering::Relaxed),
-            elapsed,
-            elapsed.saturating_sub(last),
-        )
+        let last = self
+            .last_speech
+            .load(Ordering::Relaxed)
+            .checked_sub(1)
+            .map(Duration::from_millis);
+        should_auto_stop(last, self.start.elapsed())
     }
 
     pub(super) fn is_closed(&self) -> bool {
@@ -177,8 +189,7 @@ pub(super) fn sink(format: &AVAudioFormat) -> Result<(Arc<Pcm>, Tap)> {
         // memory.
         samples: Mutex::new(Vec::with_capacity(limit)),
         start: Instant::now(),
-        speech_seen: AtomicBool::new(false),
-        last_speech_ms: AtomicU64::new(0),
+        last_speech: AtomicU64::new(0),
         // A running minimum has to start above anything it will see; the first
         // buffer sets it, and can't be speech against itself.
         floor: AtomicU32::new(1.0f32.to_bits()),
@@ -380,8 +391,9 @@ mod tests {
         sequence
             .iter()
             .map(|rms| {
-                floor = settle_floor(floor, *rms);
-                is_speech(*rms, floor)
+                let (speech, next) = track(floor, *rms);
+                floor = next;
+                speech
             })
             .collect()
     }
@@ -402,16 +414,24 @@ mod tests {
         assert_eq!(speech[15..], [false; 5], "the pause never arrives");
     }
 
-    /// A hot input's noise is louder than a quiet one's speech, so the
-    /// threshold has to follow the room rather than sit at a fixed level.
+    /// Talking from the very first buffer — clicking mid-sentence — must not
+    /// make that voice the room's noise floor.
+    #[test]
+    fn speech_in_the_first_buffer_still_counts() {
+        assert_eq!(detect(&[0.05, 0.05, 0.001]), [true, true, false]);
+    }
+
+    /// A hot input's noise is louder than a quiet one's speech, so below the
+    /// absolute level the threshold follows the room rather than a fixed
+    /// number.
     #[test]
     fn floor_adapts_to_the_room() {
-        assert_eq!(detect(&[0.01, 0.01, 0.02]), [false, false, false]);
-        assert_eq!(detect(&[0.0005, 0.0005, 0.02]), [false, false, true]);
+        assert_eq!(detect(&[0.01, 0.01, 0.015]), [false, false, false]);
+        assert_eq!(detect(&[0.0005, 0.0005, 0.005]), [false, false, true]);
     }
 
     /// A muted or unplugged input is all zeroes: the adaptive threshold
-    /// collapses to nothing there, and the absolute one has to hold.
+    /// collapses to nothing there, and the lower bound has to hold.
     #[test]
     fn silence_is_never_speech() {
         assert_eq!(detect(&[0.0; 4]), [false; 4]);
@@ -421,12 +441,19 @@ mod tests {
     #[test]
     fn auto_stops_on_a_pause_but_not_before_speech() {
         let long = NO_SPEECH_TIMEOUT + Duration::from_secs(1);
-        assert!(!should_auto_stop(true, long, SILENCE_STOP / 2));
-        assert!(should_auto_stop(true, long, SILENCE_STOP));
+        let spoke_at = Duration::from_secs(1);
+        assert!(!should_auto_stop(
+            Some(spoke_at),
+            spoke_at + SILENCE_STOP / 2
+        ));
+        assert!(should_auto_stop(Some(spoke_at), spoke_at + SILENCE_STOP));
+        // Speech that started after a long wait counts from when it was heard,
+        // not from the start of the session.
+        assert!(!should_auto_stop(Some(long), long + SILENCE_STOP / 2));
         // Never spoke: the pause is the whole session, and only the longer
         // deadline ends it.
-        assert!(!should_auto_stop(false, SILENCE_STOP * 2, SILENCE_STOP * 2));
-        assert!(should_auto_stop(false, long, long));
+        assert!(!should_auto_stop(None, SILENCE_STOP * 2));
+        assert!(should_auto_stop(None, long));
     }
 
     #[test]

--- a/src-tauri/src/dictation/whisper/engine.rs
+++ b/src-tauri/src/dictation/whisper/engine.rs
@@ -36,7 +36,11 @@ const MIN_DURATION: Duration = Duration::from_millis(500);
 /// would hallucinate the same invented sentences over it. Well under speech at
 /// a conversational distance (RMS ~0.02 and up) and well over a muted or
 /// unplugged input's noise floor.
-const MIN_RMS: f32 = 0.002;
+///
+/// Also `capture`'s silence detector's absolute lower bound, so the two can't
+/// disagree about what silence is: audio the gate would refuse to transcribe
+/// isn't worth holding a session open for either.
+pub const MIN_RMS: f32 = 0.002;
 
 /// How long a loaded model may sit unused before its memory is released.
 const IDLE_UNLOAD: Duration = Duration::from_secs(600);

--- a/src/components/Composer/dictation/DictationButton.tsx
+++ b/src/components/Composer/dictation/DictationButton.tsx
@@ -13,6 +13,11 @@ const SETTINGS_HINT =
  *  looking for a permission it doesn't use. */
 const MIC_HINT = "Enable Microphone for Fletch in System Settings → Privacy & Security";
 
+/** The local engine ends the session itself once the user stops talking, so the
+ *  tooltip has to say so — a mic that stops on its own otherwise reads as a bug,
+ *  and the pause is the only thing the user has to do. */
+const AUTO_STOP_HINT = "Listening… stops when you pause";
+
 /** Authorization states the app can't recover from on its own — `restricted` is
  *  an MDM/parental lock, `denied` needs a trip to System Settings. */
 const BLOCKED: DictationAuthorization[] = ["denied", "restricted"];
@@ -47,19 +52,21 @@ export function DictationButton({
   if (!availability?.supported) return null;
 
   // The speech grant gates only Apple's recognizer; the local engine is blocked
-  // by the microphone alone.
-  const needsSpeech = availability.engine !== "whisper";
+  // by the microphone alone — and it's the only one that stops itself.
+  const isLocal = availability.engine === "whisper";
   const blocked =
     BLOCKED.includes(availability.microphone) ||
-    (needsSpeech && BLOCKED.includes(availability.speech));
+    (!isLocal && BLOCKED.includes(availability.speech));
   const label = transcribing ? "Transcribing…" : listening ? "Stop dictation" : "Dictate";
 
-  // The last failure outranks the standing permission hint, which outranks the
-  // plain affordance. Blocked still clicks through: permission can be granted
-  // between attempts, and the failed start is what surfaces the reason.
+  // The last failure outranks the standing permission hint, which outranks
+  // what a live session is doing, which outranks the plain affordance. Blocked
+  // still clicks through: permission can be granted between attempts, and the
+  // failed start is what surfaces the reason.
   function tip() {
     if (error) return error;
-    if (blocked) return needsSpeech ? SETTINGS_HINT : MIC_HINT;
+    if (blocked) return isLocal ? MIC_HINT : SETTINGS_HINT;
+    if (listening && isLocal) return AUTO_STOP_HINT;
     return label;
   }
 


### PR DESCRIPTION
Follow-up to #646 (stacked on it). On the whisper.cpp engine the session now ends itself once the user has spoken and then gone quiet, so the text lands without a second click. Apple's recognizer path is untouched: it already decides for itself when an utterance ends.

## How it works

- **Speech tracking on the render thread** (`capture.rs`). The tap already averages channels per buffer; it now computes that buffer's RMS in the same pass and folds it into three atomics on the capture buffer: whether speech has been seen, when it was last heard, and an adaptive noise floor (the running minimum of buffer loudness, clamped). A buffer counts as speech when it is 3× above the floor and above the engine's existing clip-gate threshold, which is now shared rather than duplicated. No allocation, no new locks.
- **The monitor** (`apple.rs`). Starting a whisper session spawns one task keyed to that session's generation. It polls the atomics every 100 ms and stops the session through the same code path a click takes, so `transcribing` → transcript → `stopped` is unchanged, when either the pause after speech reaches 2 s, or nothing was said for 10 s (empty clip, so just `stopped`).
- **Can't stop the wrong session.** Every teardown marks the capture buffer closed, which ends the monitor on its next tick. The stop it issues names its own generation and is a no-op against any other live session, and unlike a user stop it never leaves a pending-cancel flag that could cancel a later start sitting on a permission prompt.
- **Frontend.** No hook changes were needed; a backend-initiated stop already flows through the existing `transcribing` → `stopped` handling. The mic tooltip while listening on the local engine now reads "Listening… stops when you pause".

## Constants

| | |
| --- | --- |
| pause after speech that ends the session | 2 s |
| session with no speech at all ends after | 10 s |
| speech threshold | 3× noise floor, at least the engine's clip gate |

No Settings toggle in this PR; the constants are named so a toggle can gate the monitor later, and the doc says so.

## Verification

- `cargo check --all-targets`, `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` (1494 passed, 4 new detector tests: speech between silences, floor adapts, silence is never speech, stops on a pause but not before speech), `bun run lint` / `check` / `test` (1102 passed).
- **Not verified:** anything with a real microphone. The RMS against actual speech, whether 2 s feels right, and the live monitor interaction need a manual pass: enable the local engine, click the mic, say a sentence, stop talking, confirm the spinner appears after about two seconds and the text lands. Also try clicking the mic and saying nothing for ten seconds.