### PR TITLE
feat(dictation): let the user choose the Whisper model

### DIFF
--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -92,7 +92,8 @@ user makes.
 
 The opt-in is the `dictation_engine` settings row (`whisper` or `apple`),
 written by the backend `set_dictation_engine` command. Enabling it starts the
-download in a background task and returns immediately; progress arrives as
+download of the chosen model (see [Choosing a model](#choosing-a-model)) in a
+background task and returns immediately; progress arrives as
 `dictation:model_progress` events, and `dictation_model_status` is what a
 freshly opened Settings screen reads instead. Weights only reach their final
 path after their SHA-256 matched, so "the file is there, at the pinned size"
@@ -105,35 +106,69 @@ is the same statement as "it was verified" — that is what
 `~/Library/Application Support/com.fletch.desktop/whisper-models` in a bundle,
 and `…/com.fletch.desktop/dev/whisper-models` in a debug build (`tauri dev`
 gets its own data dir, weights included, so a dev run downloads its own copy).
-Nothing else is written there, so deleting the directory is a clean uninstall
-(as is Remove in Settings). A download in flight is a `download-<pid>.tmp`
-alongside; a run killed mid-download leaves one behind and the next attempt
-sweeps it.
+One file per model the user has downloaded, so more than one can sit there at
+once. Nothing else is written there, so deleting the directory is a clean
+uninstall (as is Remove on every row in Settings). A download in flight is a
+`download-<pid>.tmp` alongside; a run killed mid-download leaves one behind and
+the next attempt sweeps it.
 
 | Layer | File |
 | --- | --- |
 | Settings section | `src/components/SettingsScreen/DictationSection/` |
-| IPC | `dictation_model_status` / `set_dictation_engine` / `dictation_model_download` / `dictation_model_remove` |
+| IPC | `dictation_model_status` / `set_dictation_engine` / `set_dictation_model` / `dictation_model_download` / `dictation_model_remove` |
 | Event | `src/api/events.ts` — `dictation:model_progress` |
 | Catalog | `src-tauri/src/dictation/whisper/models.rs` |
 | Download | `src-tauri/src/dictation/whisper/install.rs`, on the shared `download::download_verified` |
 
-### Swapping the default model
+### Choosing a model
+
+Settings lists every catalog entry with its size and a radio, and the choice
+is the `dictation_model` setting (a `WhisperModel::id`), written by
+`set_dictation_model`. Picking one while the engine is on starts its download
+if it isn't already there; picking one while the engine is off just records the
+choice.
+
+Absent or unrecognized, the setting resolves to the **platform default** —
+`small.en-q8_0` when `std::env::consts::ARCH` is `x86_64`, `DEFAULT_MODEL_ID`
+otherwise. Intel (and Rosetta, which reports the same arch) has no
+Metal-class GPU to hide the large model's decode behind, where a dictated
+sentence takes longer than saying it again. An id that isn't in `MODELS` is
+treated as absent rather than as an error, so dropping an entry in an update
+can't leave dictation unable to name a model at all.
+
+The model you switch away from **stays on disk**: it is already paid for, and
+switching back shouldn't cost the download twice. Its row keeps saying
+"Installed" with a Remove button, which is the only way to reclaim the space.
+
+One download runs at a time process-wide, and changing the selection does not
+cancel one in flight — `dictation_model_status` reports `downloading` plus
+`downloading_id` so the bar stays on the row actually being fetched.
+
+Everything reads the choice through one helper (`whisper::selected`, off a
+`&Connection`), so the row's status, the download target and the weights a
+session loads can't disagree. `whisper::engine` is the exception: it runs from
+the mic tap's teardown with no connection of its own and goes through
+`whisper::selected_now`, which takes the handle `whisper::init` was given. Its
+cached `WhisperContext` is keyed on the path it loaded from, so a switch drops
+the old weights before loading the new ones.
+
+### Adding a model to the catalog
 
 `src-tauri/src/dictation/whisper/models.rs` pins every candidate: file name,
 URL, SHA-256, and exact byte size. Nothing is discovered at runtime — the
 digest is the supply-chain boundary, and the size is both the progress total
-and the cheap installed check. To change what a fresh opt-in downloads:
+and the cheap installed check. Settings offers whatever `MODELS` holds, so:
 
 1. Open `https://huggingface.co/ggerganov/whisper.cpp/raw/main/<file>` — the
    LFS pointer, not the file itself. Copy `oid sha256` and `size` verbatim.
 2. Add a `WhisperModel` entry to `MODELS` with those values, a `label`, and a
    one-line `note` (both are display copy in Settings).
-3. Point `DEFAULT_MODEL_ID` at the new `id`.
+3. To make it what a fresh opt-in gets, point `DEFAULT_MODEL_ID` (or
+   `SMALL_MODEL_ID`, the Intel default) at the new `id`. Users who already
+   chose a model keep it.
 
-Users who already downloaded the old model keep it on disk; the new default is
-a fresh download. `size` is also where the "Downloads a 574 MB model once."
-copy comes from, so the UI can't drift from the pinned file.
+`size` is also where the "Downloads a 574 MB model once." copy comes from, so
+the UI can't drift from the pinned file.
 
 ### How a session runs on it
 
@@ -148,9 +183,9 @@ the tap's *sink*, and what a stop means.
 `dictation::engine`, which answers `whisper` only when **both** hold:
 
 - the `dictation_engine` setting is exactly `"whisper"`, and
-- the pinned model file is fully present (`whisper::models::installed_path`
-  checks the exact byte size, and the download only moves a digest-verified
-  file into place).
+- the *selected* model's file is fully present
+  (`whisper::models::installed_path` checks the exact byte size, and the
+  download only moves a digest-verified file into place).
 
 Dispatching on the setting alone would let an interrupted download leave the
 mic button dead, so a half-finished install silently falls back to Apple's
@@ -212,7 +247,9 @@ between the stop and the text, so a loaded `WhisperContext` is cached and shared
 by every session — then dropped after ten minutes (`IDLE_UNLOAD`) without a
 transcription. One sleeper task at a time checks the last-use `Instant` rather
 than trusting its own deadline, so a session that starts while it sleeps keeps
-the model.
+the model. The cache is keyed on the file it loaded, because a `WhisperContext`
+says nothing about which weights it holds and the user can change the choice
+between one session and the next.
 
 ### Testing it without the GUI
 

--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -146,11 +146,12 @@ cancel one in flight — `dictation_model_status` reports `downloading` plus
 
 Everything reads the choice through one helper (`whisper::selected`, off a
 `&Connection`), so the row's status, the download target and the weights a
-session loads can't disagree. `whisper::engine` is the exception: it runs from
-the mic tap's teardown with no connection of its own and goes through
-`whisper::selected_now`, which takes the handle `whisper::init` was given. Its
-cached `WhisperContext` is keyed on the path it loaded from, so a switch drops
-the old weights before loading the new ones.
+session loads can't disagree. The engine itself has no database handle: `stop`
+reads the choice when the mic closes and passes the model down through
+`capture::transcribe` to `engine::transcribe`, so a session transcribes with
+whatever Settings showed at the moment it ended. The engine's cached
+`WhisperContext` is keyed on the path it loaded from, so a switch drops the old
+weights before loading the new ones.
 
 ### Adding a model to the catalog
 

--- a/src-tauri/src/dictation/apple.rs
+++ b/src-tauri/src/dictation/apple.rs
@@ -631,8 +631,14 @@ pub async fn stop(app: AppHandle) -> Result<()> {
             // is seconds rather than milliseconds — the frontend gets a state
             // of its own for that wait instead of a mic that looks stuck.
             emit_state(&app, generation, State::Transcribing, None);
+            // The model is read here, at the stop, so the choice a session
+            // transcribes with is the one showing in Settings when it ended.
+            let (_, model) = {
+                use tauri::Manager;
+                super::engine_settings(&app.state::<crate::DbState>())
+            };
             tokio::spawn(async move {
-                match super::capture::transcribe(pcm).await {
+                match super::capture::transcribe(pcm, model).await {
                     Ok(text) => {
                         // Empty means the clip had no speech in it (see the
                         // engine's silence gate); there is nothing to splice

--- a/src-tauri/src/dictation/capture.rs
+++ b/src-tauri/src/dictation/capture.rs
@@ -113,15 +113,18 @@ fn append_mono(pcm: &Pcm, buffer: &AVAudioPCMBuffer) {
     }
 }
 
-/// Take the session's audio and transcribe it. Consumes the buffer: the session
-/// is already over by the time this runs.
-pub(super) async fn transcribe(pcm: Arc<Pcm>) -> Result<String> {
+/// Take the session's audio and transcribe it with `model`. Consumes the
+/// buffer: the session is already over by the time this runs.
+pub(super) async fn transcribe(
+    pcm: Arc<Pcm>,
+    model: &'static super::whisper::models::WhisperModel,
+) -> Result<String> {
     let rate = pcm.rate;
     let samples = std::mem::take(&mut *pcm.samples.lock());
     let samples = tokio::task::spawn_blocking(move || resample(rate, samples))
         .await
         .map_err(|e| Error::Other(format!("dictation: resampling task failed: {e}")))??;
-    engine::transcribe(samples).await
+    engine::transcribe(model, samples).await
 }
 
 /// Extra output capacity for the converter's priming, which can emit a little

--- a/src-tauri/src/dictation/mod.rs
+++ b/src-tauri/src/dictation/mod.rs
@@ -172,58 +172,87 @@ fn emit_state(app: &AppHandle, session: u64, state: State, error: Option<String>
     );
 }
 
-/// The local engine's opt-in state, plus the one model it would use. Separate
-/// from [`Availability`], which describes the platform recognizer: this is the
-/// Settings section's contract, and both sides can be true at once (the engine
-/// is chosen, the weights are still downloading).
+/// The local engine's opt-in state, the model it is set to use, and the
+/// catalog to choose from. Separate from [`Availability`], which describes the
+/// platform recognizer: this is the Settings section's contract, and both
+/// sides can be true at once (the engine is chosen, the weights are still
+/// downloading).
 #[derive(Clone, Serialize)]
 pub struct ModelStatus {
     /// The `dictation_engine` setting selects the local engine.
     enabled: bool,
-    /// The weights are on disk and verified, so the engine can load them.
+    /// The selected model's weights are on disk and verified, so the engine
+    /// can load them.
     installed: bool,
     /// A download is running in this process; progress arrives as
-    /// `dictation:model_progress`.
+    /// `dictation:model_progress`. Process-wide, so it can be a model other
+    /// than the selected one — [`ModelStatus::downloading_id`] says which.
     downloading: bool,
+    downloading_id: Option<&'static str>,
+    /// The `dictation_model` selection, or the platform default until the user
+    /// makes one.
     model: ModelInfo,
+    /// Every catalog entry, so Settings can offer the choice without a second
+    /// command.
+    models: Vec<ModelInfo>,
 }
 
-/// The catalog entry Settings describes. `size` is the exact byte count, so
-/// every size string in the UI is derived rather than pinned in two places.
+/// One catalog entry as Settings describes it. `size` is the exact byte count,
+/// so every size string in the UI is derived rather than pinned in two places.
 #[derive(Clone, Serialize)]
 pub struct ModelInfo {
     id: &'static str,
     label: &'static str,
     note: &'static str,
     size: u64,
+    /// This entry's weights are on disk. Per-entry because a model the user
+    /// switched away from stays downloaded until it is removed explicitly.
+    installed: bool,
 }
 
-fn model_status(enabled: bool, install: whisper::install::Status) -> ModelStatus {
-    let model = whisper::models::default_model();
+fn model_info(model: &'static whisper::models::WhisperModel) -> ModelInfo {
+    ModelInfo {
+        id: model.id,
+        label: model.label,
+        note: model.note,
+        size: model.size,
+        installed: whisper::models::installed_path(model).is_some(),
+    }
+}
+
+fn model_status(
+    enabled: bool,
+    selected: &'static whisper::models::WhisperModel,
+    install: whisper::install::Status,
+) -> ModelStatus {
     ModelStatus {
         enabled,
         installed: install.installed,
         downloading: install.downloading,
-        model: ModelInfo {
-            id: model.id,
-            label: model.label,
-            note: model.note,
-            size: model.size,
-        },
+        downloading_id: install.downloading_id,
+        model: model_info(selected),
+        models: whisper::models::MODELS.iter().map(model_info).collect(),
     }
 }
 
-fn engine_enabled(state: &tauri::State<'_, DbState>) -> bool {
+/// The opt-in and the chosen model, read under one lock — the two settings
+/// always travel together, and the connection isn't reentrant.
+fn engine_settings(
+    state: &tauri::State<'_, DbState>,
+) -> (bool, &'static whisper::models::WhisperModel) {
     let conn = state.lock();
-    whisper::parse_enabled(database::get_setting(&conn, whisper::ENGINE_SETTING).as_deref())
+    let enabled =
+        whisper::parse_enabled(database::get_setting(&conn, whisper::ENGINE_SETTING).as_deref());
+    (enabled, whisper::selected(&conn))
 }
 
-/// Where the local engine stands: the opt-in, the weights, and what a download
-/// would fetch. Cheap — a metadata stat, no hashing — so the Settings pane
-/// calls it on mount and after every action.
+/// Where the local engine stands: the opt-in, the choice, and what each
+/// candidate's weights are doing. Cheap — a metadata stat per entry, no hashing
+/// — so the Settings pane calls it on mount and after every action.
 #[tauri::command]
 pub fn dictation_model_status(state: tauri::State<'_, DbState>) -> ModelStatus {
-    model_status(engine_enabled(&state), whisper::install::status())
+    let (enabled, model) = engine_settings(&state);
+    model_status(enabled, model, whisper::install::status(model))
 }
 
 /// Choose the dictation engine. Persists `dictation_engine` (backend-owned
@@ -240,7 +269,7 @@ pub fn set_dictation_engine(
     app: AppHandle,
     state: tauri::State<'_, DbState>,
 ) -> Result<()> {
-    {
+    let model = {
         let conn = state.lock();
         database::set_setting(
             &conn,
@@ -251,29 +280,83 @@ pub fn set_dictation_engine(
                 whisper::ENGINE_APPLE
             },
         )?;
-    }
+        whisper::selected(&conn)
+    };
     if enabled {
-        whisper::install::download(app);
+        whisper::install::download(app, model);
     }
     Ok(())
 }
 
-/// Retry a failed or never-started model download. Returns immediately with
-/// the state the call left things in; a download already running (or an
-/// already-installed model) makes it a no-op.
+/// Choose which catalog entry the local engine uses. Persists
+/// `dictation_model` and, when the engine is on and the new choice isn't
+/// downloaded, starts fetching it in the background — same shape as
+/// [`set_dictation_engine`], because the choice can't await half a gigabyte
+/// either.
+///
+/// The model being switched away from is left on disk: it is already paid for,
+/// and switching back shouldn't cost the download twice. Removing it is a
+/// separate, explicit action.
 #[tauri::command]
-pub fn dictation_model_download(app: AppHandle, state: tauri::State<'_, DbState>) -> ModelStatus {
-    let install = whisper::install::download(app);
-    model_status(engine_enabled(&state), install)
+pub fn set_dictation_model(
+    id: String,
+    app: AppHandle,
+    state: tauri::State<'_, DbState>,
+) -> Result<ModelStatus> {
+    let model = catalog_entry(&id)?;
+    let enabled = {
+        let conn = state.lock();
+        database::set_setting(&conn, whisper::MODEL_SETTING, model.id)?;
+        whisper::parse_enabled(database::get_setting(&conn, whisper::ENGINE_SETTING).as_deref())
+    };
+    let install = if enabled {
+        whisper::install::download(app, model)
+    } else {
+        whisper::install::status(model)
+    };
+    Ok(model_status(enabled, model, install))
 }
 
-/// Delete the downloaded weights. The caller is expected to turn the engine off
-/// first — an enabled engine with no model would fall back to the platform
-/// recognizer, but silently.
+/// Retry a failed or never-started download of the selected model. Returns
+/// immediately with the state the call left things in; an already-installed
+/// model, or any download already running, makes it a no-op.
 #[tauri::command]
-pub fn dictation_model_remove(state: tauri::State<'_, DbState>) -> ModelStatus {
-    let install = whisper::install::remove();
-    model_status(engine_enabled(&state), install)
+pub fn dictation_model_download(app: AppHandle, state: tauri::State<'_, DbState>) -> ModelStatus {
+    let (enabled, model) = engine_settings(&state);
+    let install = whisper::install::download(app, model);
+    model_status(enabled, model, install)
+}
+
+/// Delete a model's downloaded weights — the selected one unless `id` names
+/// another, since a model switched away from stays on disk and Settings is the
+/// only place to reclaim it. When removing the selected model, the caller is
+/// expected to turn the engine off first: an enabled engine with no model would
+/// fall back to the platform recognizer, but silently.
+#[tauri::command]
+pub fn dictation_model_remove(
+    id: Option<String>,
+    state: tauri::State<'_, DbState>,
+) -> Result<ModelStatus> {
+    let (enabled, selected) = engine_settings(&state);
+    let target = match &id {
+        Some(id) => catalog_entry(id)?,
+        None => selected,
+    };
+    whisper::install::remove(target);
+    Ok(model_status(
+        enabled,
+        selected,
+        whisper::install::status(selected),
+    ))
+}
+
+/// An id from the frontend is only ever one the catalog handed it, so an
+/// unknown one is a bug rather than a state to fall back from — silently
+/// acting on the selected model instead would download or delete the wrong
+/// weights.
+fn catalog_entry(id: &str) -> Result<&'static whisper::models::WhisperModel> {
+    whisper::models::find(id)
+        .ok_or_else(|| crate::error::Error::Other(format!("unknown dictation model: {id}")))
 }
 
 /// Which engine a session started right now would use. The local one takes
@@ -288,8 +371,8 @@ fn engine(app: &AppHandle) -> Engine {
     if !cfg!(target_os = "macos") {
         return Engine::Apple;
     }
-    let selected = engine_enabled(&app.state::<DbState>());
-    if selected && whisper::install::status().installed {
+    let (enabled, model) = engine_settings(&app.state::<DbState>());
+    if enabled && whisper::models::installed_path(model).is_some() {
         Engine::Whisper
     } else {
         Engine::Apple

--- a/src-tauri/src/dictation/whisper/engine.rs
+++ b/src-tauri/src/dictation/whisper/engine.rs
@@ -21,7 +21,7 @@ use std::time::{Duration, Instant};
 use parking_lot::Mutex;
 use whisper_rs::{FullParams, SamplingStrategy, WhisperContext, WhisperContextParameters};
 
-use super::models;
+use super::models::{self, WhisperModel};
 use crate::error::{Error, Result};
 
 /// The only input rate whisper.cpp accepts; capture resamples to it.
@@ -61,19 +61,22 @@ struct Loaded {
     used: Instant,
 }
 
-/// Transcribe one whole clip of 16 kHz mono audio.
+/// Transcribe one whole clip of 16 kHz mono audio with `model`, the user's
+/// choice as the caller read it from settings — the engine has no database
+/// handle of its own, and a session should use the model that was chosen when
+/// it stopped.
 ///
 /// `Ok("")` for a clip with no speech in it (see [`MIN_DURATION`] and
 /// [`MIN_RMS`]) — that answer costs nothing, because the gate runs before the
 /// model is even loaded.
-pub async fn transcribe(samples: Vec<f32>) -> Result<String> {
+pub async fn transcribe(model: &'static WhisperModel, samples: Vec<f32>) -> Result<String> {
     if !has_speech(&samples) {
         return Ok(String::new());
     }
     // Inference pins a core for seconds; it has no business on the async
     // runtime's worker threads.
     tokio::task::spawn_blocking(move || {
-        let ctx = context()?;
+        let ctx = context(model)?;
         decode(&ctx, &samples)
     })
     .await
@@ -91,11 +94,11 @@ fn rms(samples: &[f32]) -> f32 {
     (sum / samples.len() as f64).sqrt() as f32
 }
 
-/// The cached model for the current selection, loading it on first use. Also
-/// stamps the load as used, which is what keeps [`arm_unload`]'s sleeper from
-/// taking it out from under a session that has only just started.
-fn context() -> Result<Arc<WhisperContext>> {
-    let path = models::installed_path(super::selected_now()).ok_or_else(|| {
+/// The cached context for `model`, loading it on first use. Also stamps the
+/// load as used, which is what keeps [`arm_unload`]'s sleeper from taking it
+/// out from under a session that has only just started.
+fn context(model: &WhisperModel) -> Result<Arc<WhisperContext>> {
+    let path = models::installed_path(model).ok_or_else(|| {
         Error::Other(
             "The local dictation model isn't installed. Download it in Settings > Dictation."
                 .into(),
@@ -224,10 +227,12 @@ mod tests {
             Some(p) => read_wav(Path::new(&p)),
             None => vec![0.0; SAMPLE_RATE as usize * 2],
         };
-        assert_eq!(transcribe(silence).await.unwrap(), "");
+        // Any catalog entry will do: the gate answers before the model matters.
+        let model = models::platform_default();
+        assert_eq!(transcribe(model, silence).await.unwrap(), "");
         // Too short to be an utterance, however loud.
         assert_eq!(
-            transcribe(vec![0.5; SAMPLE_RATE as usize / 10])
+            transcribe(model, vec![0.5; SAMPLE_RATE as usize / 10])
                 .await
                 .unwrap(),
             ""

--- a/src-tauri/src/dictation/whisper/engine.rs
+++ b/src-tauri/src/dictation/whisper/engine.rs
@@ -13,7 +13,7 @@
 //! dictated one sentence this morning shouldn't still be paying half a gigabyte
 //! of resident memory for it at lunchtime.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -50,6 +50,11 @@ static UNLOAD_ARMED: AtomicBool = AtomicBool::new(false);
 
 struct Loaded {
     ctx: Arc<WhisperContext>,
+    /// The weights this context came from. The user can change the model in
+    /// Settings between one session and the next, and a `WhisperContext` says
+    /// nothing about which file it holds — so the cache is keyed on the path
+    /// rather than assumed to be the current choice.
+    path: PathBuf,
     /// When the model was last handed to a transcription — the unload sleeper
     /// compares this against [`IDLE_UNLOAD`] rather than trusting its own
     /// deadline, so a session that started while it slept keeps the model.
@@ -86,24 +91,28 @@ fn rms(samples: &[f32]) -> f32 {
     (sum / samples.len() as f64).sqrt() as f32
 }
 
-/// The cached model, loading it on first use. Also stamps the load as used,
-/// which is what keeps [`arm_unload`]'s sleeper from taking it out from under a
-/// session that has only just started.
+/// The cached model for the current selection, loading it on first use. Also
+/// stamps the load as used, which is what keeps [`arm_unload`]'s sleeper from
+/// taking it out from under a session that has only just started.
 fn context() -> Result<Arc<WhisperContext>> {
-    let mut slot = CONTEXT.lock();
-    if let Some(loaded) = slot.as_mut() {
-        loaded.used = Instant::now();
-        return Ok(loaded.ctx.clone());
-    }
-    let path = models::installed_path(models::default_model()).ok_or_else(|| {
+    let path = models::installed_path(super::selected_now()).ok_or_else(|| {
         Error::Other(
             "The local dictation model isn't installed. Download it in Settings > Dictation."
                 .into(),
         )
     })?;
+    let mut slot = CONTEXT.lock();
+    if let Some(loaded) = slot.as_mut().filter(|l| l.path == path) {
+        loaded.used = Instant::now();
+        return Ok(loaded.ctx.clone());
+    }
+    // Drop a context for the previous choice before loading the new one, so a
+    // switch doesn't briefly hold both models resident.
+    *slot = None;
     let ctx = Arc::new(load(&path)?);
     *slot = Some(Loaded {
         ctx: ctx.clone(),
+        path,
         used: Instant::now(),
     });
     // Armed under the same lock the sleeper unloads under, so "a model is

--- a/src-tauri/src/dictation/whisper/engine.rs
+++ b/src-tauri/src/dictation/whisper/engine.rs
@@ -48,6 +48,13 @@ static CONTEXT: Mutex<Option<Loaded>> = Mutex::new(None);
 /// up timers.
 static UNLOAD_ARMED: AtomicBool = AtomicBool::new(false);
 
+/// One transcription at a time. Inference already saturates the GPU or a
+/// core, so two wouldn't finish sooner — and serialising them is what makes a
+/// model switch clean: the previous decode has dropped its handle on the old
+/// context before [`context`] clears the slot and loads the new one, so the two
+/// models are never resident together. Taken before [`CONTEXT`], never after.
+static DECODING: Mutex<()> = Mutex::new(());
+
 struct Loaded {
     ctx: Arc<WhisperContext>,
     /// The weights this context came from. The user can change the model in
@@ -76,6 +83,7 @@ pub async fn transcribe(model: &'static WhisperModel, samples: Vec<f32>) -> Resu
     // Inference pins a core for seconds; it has no business on the async
     // runtime's worker threads.
     tokio::task::spawn_blocking(move || {
+        let _one_at_a_time = DECODING.lock();
         let ctx = context(model)?;
         decode(&ctx, &samples)
     })
@@ -110,7 +118,8 @@ fn context(model: &WhisperModel) -> Result<Arc<WhisperContext>> {
         return Ok(loaded.ctx.clone());
     }
     // Drop a context for the previous choice before loading the new one, so a
-    // switch doesn't briefly hold both models resident.
+    // switch doesn't hold both models resident. This is the last handle: any
+    // decode that held another finished before we took `DECODING`.
     *slot = None;
     let ctx = Arc::new(load(&path)?);
     *slot = Some(Loaded {

--- a/src-tauri/src/dictation/whisper/install.rs
+++ b/src-tauri/src/dictation/whisper/install.rs
@@ -1,4 +1,4 @@
-//! Getting the pinned weights onto disk.
+//! Getting a catalog entry's pinned weights onto disk.
 //!
 //! The download is fire-and-forget: half a gigabyte can't be awaited by the
 //! Settings toggle that asks for it, so [`download`] returns the moment the
@@ -11,9 +11,9 @@
 //! [`models::installed_path`] treat "right size, right place" as verified.
 
 use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use parking_lot::Mutex;
 use serde::Serialize;
 use tauri::AppHandle;
 
@@ -21,10 +21,11 @@ use super::models::{self, WhisperModel};
 use crate::download;
 use crate::error::{Error, Result};
 
-/// Guards the one download allowed at a time. The Settings toggle and its
-/// retry button both reach [`download`], and two streams would share one
-/// per-process temp path.
-static IN_FLIGHT: AtomicBool = AtomicBool::new(false);
+/// The one download allowed at a time, and which model it is for. The Settings
+/// rows all reach [`download`], and two streams would share one per-process
+/// temp path — so a second request is refused rather than queued, and the id is
+/// what lets [`status`] say whose bar is moving.
+static IN_FLIGHT: Mutex<Option<&'static WhisperModel>> = Mutex::new(None);
 
 /// How far along the model install is. `Verifying` is the tail of the
 /// download, not a separate pass — the digest is computed as bytes arrive.
@@ -49,48 +50,43 @@ struct Progress {
     error: Option<String>,
 }
 
-/// A snapshot of the default model's install state. `downloading` is this
-/// process's in-flight flag, so it is honest across a Settings screen that
-/// mounted mid-download and missed the events so far.
+/// A snapshot of one model's install state. `downloading` is this process's
+/// in-flight flag, so it is honest across a Settings screen that mounted
+/// mid-download and missed the events so far.
+///
+/// `installed` is about the model asked after, but `downloading` /
+/// `downloading_id` are process-wide: switching the selection while another
+/// model is being fetched doesn't cancel it, so the status reports whose
+/// download is actually running rather than pretending there is none.
 #[derive(Clone, Copy, Debug, Serialize)]
 pub struct Status {
     pub installed: bool,
     pub downloading: bool,
+    pub downloading_id: Option<&'static str>,
 }
 
-pub fn status() -> Status {
+pub fn status(model: &WhisperModel) -> Status {
+    let in_flight = *IN_FLIGHT.lock();
     Status {
-        installed: models::installed_path(models::default_model()).is_some(),
-        downloading: IN_FLIGHT.load(Ordering::Acquire),
+        installed: models::installed_path(model).is_some(),
+        downloading: in_flight.is_some(),
+        downloading_id: in_flight.map(|m| m.id),
     }
 }
 
-/// Start fetching the default model, unless it is already installed or a
-/// download is running — either way the returned status says what the caller
-/// asked about, so an opt-in and a retry are the same call.
-pub fn download(app: AppHandle) -> Status {
-    let model = models::default_model();
-    if models::installed_path(model).is_some() {
-        return Status {
-            installed: true,
-            downloading: false,
-        };
-    }
-    // The claim on the flag is the guard, so it's also the "already running"
-    // check — a separate read first would just be a wider race window.
-    if IN_FLIGHT
-        .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-        .is_err()
-    {
-        return Status {
-            installed: false,
-            downloading: true,
-        };
+/// Start fetching `model`, unless it is already installed or a download is
+/// running — either way the returned status says what the caller asked about,
+/// so an opt-in and a retry are the same call.
+pub fn download(app: AppHandle, model: &'static WhisperModel) -> Status {
+    // Taking the slot is the guard, so it's also the "already running" check —
+    // a separate read first would just be a wider race window.
+    if models::installed_path(model).is_some() || !claim(model) {
+        return status(model);
     }
 
     tauri::async_runtime::spawn(async move {
         let result = run(&app, model).await;
-        IN_FLIGHT.store(false, Ordering::Release);
+        *IN_FLIGHT.lock() = None;
         match result {
             Ok(()) => emit(&app, model, State::Installed, model.size, None),
             Err(e) => {
@@ -102,19 +98,28 @@ pub fn download(app: AppHandle) -> Status {
     Status {
         installed: false,
         downloading: true,
+        downloading_id: Some(model.id),
     }
 }
 
-/// Delete the installed weights, so the disk cost of an engine the user turned
-/// off doesn't linger. Returns the state after the attempt.
-pub fn remove() -> Status {
-    let model = models::default_model();
+fn claim(model: &'static WhisperModel) -> bool {
+    let mut slot = IN_FLIGHT.lock();
+    if slot.is_some() {
+        return false;
+    }
+    *slot = Some(model);
+    true
+}
+
+/// Delete a model's installed weights, so the disk cost of one the user isn't
+/// using doesn't linger. Returns the state after the attempt.
+pub fn remove(model: &WhisperModel) -> Status {
     if let Some(path) = models::installed_path(model) {
         if let Err(e) = std::fs::remove_file(&path) {
             tracing::warn!(error = %e, path = %path.display(), "removing whisper model failed");
         }
     }
-    status()
+    status(model)
 }
 
 async fn run(app: &AppHandle, model: &'static WhisperModel) -> Result<()> {
@@ -255,8 +260,9 @@ mod tests {
     /// installed — the status must say so rather than panic on the missing path.
     #[test]
     fn status_without_a_models_root_is_not_installed() {
-        let s = status();
+        let s = status(models::platform_default());
         assert!(!s.installed);
         assert!(!s.downloading);
+        assert!(s.downloading_id.is_none());
     }
 }

--- a/src-tauri/src/dictation/whisper/mod.rs
+++ b/src-tauri/src/dictation/whisper/mod.rs
@@ -3,13 +3,18 @@
 //! (`engine`).
 //!
 //! The platform recognizer (`super::apple`) stays the default. The user opts
-//! into this engine from Settings, which downloads the pinned model into
+//! into this engine from Settings, which downloads the chosen model into
 //! [`models_root`]; the dictation commands dispatch here only when the
-//! setting is on AND the model is installed, so a half-finished download can
+//! setting is on AND that model is installed, so a half-finished download can
 //! never leave the mic button dead.
 
 use std::path::PathBuf;
 use std::sync::OnceLock;
+
+use rusqlite::Connection;
+
+use crate::database;
+use crate::DbState;
 
 // whisper.cpp itself is built for macOS only (iOS keeps the platform
 // recognizer), so the catalog and install compile everywhere but the
@@ -31,15 +36,68 @@ pub fn parse_enabled(raw: Option<&str>) -> bool {
     raw == Some(ENGINE_WHISPER)
 }
 
+/// `settings` key for which catalog entry the engine uses, by
+/// [`models::WhisperModel::id`]. Absent until the user picks one, which is not
+/// the same as "no model": see [`selected_model`].
+pub const MODEL_SETTING: &str = "dictation_model";
+
+/// Interpret the raw setting value. An id that isn't in the catalog is treated
+/// as absent rather than as an error — a model dropped from `MODELS` in an
+/// update must not leave dictation unable to name a model at all.
+pub fn selected_model(raw: Option<&str>) -> &'static models::WhisperModel {
+    raw.and_then(models::find)
+        .unwrap_or_else(models::platform_default)
+}
+
+/// The chosen model, for a caller that already holds the connection. The one
+/// path the commands and `dictation::engine` share, so the status a Settings
+/// row shows and the weights a session loads can't disagree.
+pub fn selected(conn: &Connection) -> &'static models::WhisperModel {
+    selected_model(database::get_setting(conn, MODEL_SETTING).as_deref())
+}
+
 /// Where model files live: `<app data>/whisper-models`. Set once from `setup`,
 /// like `git_dist::init`, so download and load paths never need an `AppHandle`.
 static MODELS_ROOT: OnceLock<PathBuf> = OnceLock::new();
 
-pub fn init(root: PathBuf) {
+/// The database, for the one caller that reads the selection without a
+/// connection of its own — the engine loading weights mid-session, reached
+/// from the mic tap's teardown rather than from a command.
+static DB: OnceLock<DbState> = OnceLock::new();
+
+pub fn init(root: PathBuf, db: DbState) {
     let _ = MODELS_ROOT.set(root);
+    let _ = DB.set(db);
+}
+
+/// The chosen model, taking the database lock itself. A caller already holding
+/// the connection must use [`selected`] instead — this one would deadlock.
+/// Before `init` (tests) it answers with the platform default.
+pub fn selected_now() -> &'static models::WhisperModel {
+    match DB.get() {
+        Some(db) => selected(&db.lock()),
+        None => models::platform_default(),
+    }
 }
 
 /// `None` only before `init` ran (tests, or a call from a build without setup).
 pub fn models_root() -> Option<PathBuf> {
     MODELS_ROOT.get().cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_stored_choice_wins_and_anything_else_falls_back() {
+        assert_eq!(
+            selected_model(Some(models::SMALL_MODEL_ID)).id,
+            models::SMALL_MODEL_ID
+        );
+        let fallback = models::platform_default().id;
+        assert_eq!(selected_model(None).id, fallback);
+        assert_eq!(selected_model(Some("tiny.en")).id, fallback);
+        assert_eq!(selected_model(Some("")).id, fallback);
+    }
 }

--- a/src-tauri/src/dictation/whisper/mod.rs
+++ b/src-tauri/src/dictation/whisper/mod.rs
@@ -14,7 +14,6 @@ use std::sync::OnceLock;
 use rusqlite::Connection;
 
 use crate::database;
-use crate::DbState;
 
 // whisper.cpp itself is built for macOS only (iOS keeps the platform
 // recognizer), so the catalog and install compile everywhere but the
@@ -60,24 +59,8 @@ pub fn selected(conn: &Connection) -> &'static models::WhisperModel {
 /// like `git_dist::init`, so download and load paths never need an `AppHandle`.
 static MODELS_ROOT: OnceLock<PathBuf> = OnceLock::new();
 
-/// The database, for the one caller that reads the selection without a
-/// connection of its own — the engine loading weights mid-session, reached
-/// from the mic tap's teardown rather than from a command.
-static DB: OnceLock<DbState> = OnceLock::new();
-
-pub fn init(root: PathBuf, db: DbState) {
+pub fn init(root: PathBuf) {
     let _ = MODELS_ROOT.set(root);
-    let _ = DB.set(db);
-}
-
-/// The chosen model, taking the database lock itself. A caller already holding
-/// the connection must use [`selected`] instead — this one would deadlock.
-/// Before `init` (tests) it answers with the platform default.
-pub fn selected_now() -> &'static models::WhisperModel {
-    match DB.get() {
-        Some(db) => selected(&db.lock()),
-        None => models::platform_default(),
-    }
 }
 
 /// `None` only before `init` ran (tests, or a call from a build without setup).

--- a/src-tauri/src/dictation/whisper/models.rs
+++ b/src-tauri/src/dictation/whisper/models.rs
@@ -1,7 +1,7 @@
 //! The Whisper model catalog. Weights are pinned here, not fetched from a
 //! listing: each entry names the exact file, its SHA-256, and its size, so a
-//! download is verified before it is ever loaded and a swap is a one-line
-//! change to [`DEFAULT_MODEL_ID`] (plus a new entry) when a better model ships.
+//! download is verified before it is ever loaded and adding a candidate is one
+//! entry here plus nothing else — Settings offers whatever [`MODELS`] holds.
 //!
 //! Files come from the ggml conversions at
 //! <https://huggingface.co/ggerganov/whisper.cpp>. To add one, take `oid
@@ -29,6 +29,12 @@ pub struct WhisperModel {
 /// What a fresh opt-in downloads. Swap by pointing at another catalog entry.
 pub const DEFAULT_MODEL_ID: &str = "large-v3-turbo-q5_0";
 
+/// The default on Intel, where there is no Metal-class GPU to hide the large
+/// model's decode behind and a dictated sentence would take longer than saying
+/// it again. Overridable — the choice is the user's — but not as a first
+/// impression of the feature.
+pub const SMALL_MODEL_ID: &str = "small.en-q8_0";
+
 pub const MODELS: &[WhisperModel] = &[
     WhisperModel {
         id: "large-v3-turbo-q5_0",
@@ -51,8 +57,21 @@ pub const MODELS: &[WhisperModel] = &[
     },
 ];
 
-pub fn default_model() -> &'static WhisperModel {
-    find(DEFAULT_MODEL_ID).expect("DEFAULT_MODEL_ID names a catalog entry")
+/// What this machine gets before the user has picked anything.
+pub fn platform_default() -> &'static WhisperModel {
+    default_for_arch(std::env::consts::ARCH)
+}
+
+/// The arch rule, taking the arch as a value so it can be tested off an Intel
+/// Mac. Rosetta reports `x86_64` too, which is the right answer: a translated
+/// build has no Metal backend either.
+fn default_for_arch(arch: &str) -> &'static WhisperModel {
+    let id = if arch == "x86_64" {
+        SMALL_MODEL_ID
+    } else {
+        DEFAULT_MODEL_ID
+    };
+    find(id).expect("the default ids name catalog entries")
 }
 
 pub fn find(id: &str) -> Option<&'static WhisperModel> {
@@ -79,8 +98,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn default_is_in_catalog() {
-        assert_eq!(default_model().id, DEFAULT_MODEL_ID);
+    fn intel_defaults_to_the_small_model_and_apple_silicon_to_the_large_one() {
+        assert_eq!(default_for_arch("x86_64").id, SMALL_MODEL_ID);
+        assert_eq!(default_for_arch("aarch64").id, DEFAULT_MODEL_ID);
+        // Anything else is treated as capable rather than special-cased.
+        assert_eq!(default_for_arch("riscv64").id, DEFAULT_MODEL_ID);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1493,10 +1493,8 @@ pub fn run() {
             // git-less machine is usually ready before the user gets there.
             git_dist::init(data_dir.join("git-dist"));
             // Whisper dictation weights live next to it; the engine loads
-            // from here and Settings downloads into it. The handle is for the
-            // model choice, which the engine reads mid-session with no
-            // connection of its own.
-            dictation::whisper::init(data_dir.join("whisper-models"), db.clone());
+            // from here and Settings downloads into it.
+            dictation::whisper::init(data_dir.join("whisper-models"));
             // Seed the in-process GitHub token so API calls and git network
             // auth work without a DB handle (updated on sign-in).
             seed_secret_mirror(&db, github::TOKEN_SETTING, github::seed_token);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1493,8 +1493,10 @@ pub fn run() {
             // git-less machine is usually ready before the user gets there.
             git_dist::init(data_dir.join("git-dist"));
             // Whisper dictation weights live next to it; the engine loads
-            // from here and Settings downloads into it.
-            dictation::whisper::init(data_dir.join("whisper-models"));
+            // from here and Settings downloads into it. The handle is for the
+            // model choice, which the engine reads mid-session with no
+            // connection of its own.
+            dictation::whisper::init(data_dir.join("whisper-models"), db.clone());
             // Seed the in-process GitHub token so API calls and git network
             // auth work without a DB handle (updated on sign-in).
             seed_secret_mirror(&db, github::TOKEN_SETTING, github::seed_token);
@@ -1921,6 +1923,7 @@ pub fn run() {
             dictation::dictation_stop,
             dictation::dictation_model_status,
             dictation::set_dictation_engine,
+            dictation::set_dictation_model,
             dictation::dictation_model_download,
             dictation::dictation_model_remove,
         ])

--- a/src/api/domains/dictation.ts
+++ b/src/api/domains/dictation.ts
@@ -32,18 +32,28 @@ export const dictationApi = {
    *  one final transcript, then `stopped`. No-op when not listening. */
   dictationStop: () => invoke<void>("dictation_stop"),
 
-  /** The local (Whisper) engine's opt-in plus the state of its weights. Cheap
-   *  — a metadata stat — so the Settings pane calls it on mount. */
+  /** The local (Whisper) engine's opt-in, its model choice and the state of
+   *  every candidate's weights. Cheap — a metadata stat per entry — so the
+   *  Settings pane calls it on mount. */
   dictationModelStatus: () => invoke<DictationModelStatus>("dictation_model_status"),
   /** Pick the dictation engine. Persists `dictation_engine` and, when enabling
    *  without the weights on disk, starts the download in the background —
    *  resolves immediately either way, with progress arriving via
    *  `onDictationModelProgress`. Backend-owned, like `setCodeIndexingEnabled`. */
   setDictationEngine: (enabled: boolean) => invoke<void>("set_dictation_engine", { enabled }),
-  /** Retry a failed (or never-started) model download. Resolves at once with
-   *  the state the call left things in; a no-op while one is already running. */
+  /** Pick which catalog model the local engine uses. Persists
+   *  `dictation_model` and, when the engine is on and the choice isn't
+   *  downloaded, starts fetching it in the background. Rejects an id the
+   *  catalog doesn't have. The previous model is left on disk. */
+  setDictationModel: (id: string) => invoke<DictationModelStatus>("set_dictation_model", { id }),
+  /** Retry a failed (or never-started) download of the selected model.
+   *  Resolves at once with the state the call left things in; a no-op while any
+   *  download is already running. */
   dictationModelDownload: () => invoke<DictationModelStatus>("dictation_model_download"),
-  /** Delete the downloaded weights. Turn the engine off first — an enabled
-   *  engine with no model silently falls back to the platform recognizer. */
-  dictationModelRemove: () => invoke<DictationModelStatus>("dictation_model_remove"),
+  /** Delete a model's downloaded weights — the selected one unless `id` names
+   *  another. Turn the engine off first when removing the selected model: an
+   *  enabled engine with no model silently falls back to the platform
+   *  recognizer. */
+  dictationModelRemove: (id?: string) =>
+    invoke<DictationModelStatus>("dictation_model_remove", { id }),
 };

--- a/src/api/types/dictation.ts
+++ b/src/api/types/dictation.ts
@@ -64,7 +64,7 @@ export interface DictationStateEvent {
   error: string | null;
 }
 
-/** The one Whisper model the local engine would use, as pinned in the Rust
+/** One Whisper model the local engine can be pointed at, as pinned in the Rust
  *  catalog (`dictation/whisper/models.rs`). */
 export interface DictationModel {
   id: string;
@@ -74,18 +74,29 @@ export interface DictationModel {
   /** Exact download size in bytes. Every size string in the UI is derived from
    *  it, so the copy can't drift from the pinned file. */
   size: number;
+  /** These weights are on disk and verified. Per model, because one the user
+   *  switched away from stays downloaded until it is removed in Settings. */
+  installed: boolean;
 }
 
-/** The local (Whisper) engine's opt-in and the state of its weights. `enabled`
- *  and `installed` move independently: the engine can be chosen while the
- *  download is still running, in which case dictation keeps using the platform
- *  recognizer. */
+/** The local (Whisper) engine's opt-in, which model it is set to use, and the
+ *  catalog to choose from. `enabled` and `installed` move independently: the
+ *  engine can be chosen while the download is still running, in which case
+ *  dictation keeps using the platform recognizer. */
 export interface DictationModelStatus {
   enabled: boolean;
+  /** The selected model's weights are ready. */
   installed: boolean;
   /** A download is running right now; watch `onDictationModelProgress`. */
   downloading: boolean;
+  /** Which model that download is for — one runs at a time process-wide, and
+   *  changing the selection doesn't cancel it, so this needn't be `model.id`.
+   *  `null` when nothing is downloading. */
+  downloading_id: string | null;
+  /** The `dictation_model` selection, or the platform default until the user
+   *  makes one (the small English model on Intel, the large one elsewhere). */
   model: DictationModel;
+  models: DictationModel[];
 }
 
 /** `verifying` is the tail of the download (the digest is computed as bytes

--- a/src/components/SettingsScreen/DictationSection/ModelRow.tsx
+++ b/src/components/SettingsScreen/DictationSection/ModelRow.tsx
@@ -1,0 +1,55 @@
+import type { DictationModel, DictationModelProgressEvent, DictationModelStatus } from "@/api";
+import { SetRow } from "../primitives";
+import { ModelStatusRow } from "./ModelStatusRow";
+
+/** One catalog entry in the chooser: its copy, a radio that makes it the
+ *  engine's model, and the line saying what its weights are doing. The radio
+ *  sits in the row's control slot so it lines up with the toggle above it. */
+export function ModelRow({
+  model,
+  status,
+  progress,
+  onSelect,
+  onDownload,
+  onRemove,
+}: {
+  model: DictationModel;
+  status: DictationModelStatus;
+  progress: DictationModelProgressEvent | null;
+  onSelect: () => void;
+  onDownload: () => void;
+  onRemove: () => void;
+}) {
+  const selected = status.model.id === model.id;
+
+  return (
+    <SetRow
+      align="start"
+      title={model.label}
+      sub={
+        <>
+          {model.note}
+          <ModelStatusRow
+            model={model}
+            status={status}
+            progress={progress}
+            onDownload={onDownload}
+            onRemove={onRemove}
+          />
+        </>
+      }
+    >
+      <button
+        type="button"
+        className="set-radio"
+        role="radio"
+        aria-checked={selected}
+        aria-label={`Use ${model.label}`}
+        data-on={selected ? "1" : "0"}
+        onClick={onSelect}
+      >
+        <i />
+      </button>
+    </SetRow>
+  );
+}

--- a/src/components/SettingsScreen/DictationSection/ModelStatusRow.tsx
+++ b/src/components/SettingsScreen/DictationSection/ModelStatusRow.tsx
@@ -1,30 +1,32 @@
-import type { DictationModelProgressEvent, DictationModelStatus } from "@/api";
+import type { DictationModel, DictationModelProgressEvent, DictationModelStatus } from "@/api";
 import { Button } from "@/components/ui/Button";
 import { downloadPercent, formatBytes } from "@/util/format";
 
-/** The line under the engine toggle: what the weights are doing and the one
- *  action that applies. Shown while the engine is on, and also while it's off
- *  but the model is still on disk — otherwise turning the engine off would
- *  strand half a gigabyte with no way to reclaim it. */
+/** What one model's weights are doing and the single action that applies, for
+ *  the line under its label in the chooser. Both the in-flight flag and the
+ *  progress event are process-wide, so each is checked against this model:
+ *  changing the selection doesn't cancel a download, and the bar belongs on
+ *  whichever row is actually being fetched. */
 export function ModelStatusRow({
-  enabled,
+  model,
   status,
   progress,
   onDownload,
   onRemove,
 }: {
-  enabled: boolean;
+  model: DictationModel;
   status: DictationModelStatus;
   progress: DictationModelProgressEvent | null;
   onDownload: () => void;
   onRemove: () => void;
 }) {
-  const size = formatBytes(status.model.size);
-  const error = progress?.state === "error" ? progress.error || "Download failed" : null;
+  const size = formatBytes(model.size);
+  const mine = progress?.model_id === model.id ? progress : null;
+  const error = mine?.state === "error" ? mine.error || "Download failed" : null;
   const busy =
-    status.downloading || progress?.state === "downloading" || progress?.state === "verifying";
-
-  if (!enabled && !status.installed && !busy && !error) return null;
+    status.downloading_id === model.id ||
+    mine?.state === "downloading" ||
+    mine?.state === "verifying";
 
   let line: React.ReactNode;
   let action: React.ReactNode;
@@ -40,18 +42,18 @@ export function ModelStatusRow({
   } else if (busy) {
     // No progress event yet (a screen that opened mid-download) means no
     // percentage to show, so the bar runs indeterminate.
-    const pct = progress ? downloadPercent(progress.received, progress.total) : null;
+    const pct = mine ? downloadPercent(mine.received, mine.total) : null;
     bar = pct;
     line = (
       <span className="set-dict-status">
-        {progress?.state === "verifying"
+        {mine?.state === "verifying"
           ? "Verifying…"
           : pct === null
             ? "Downloading…"
-            : `Downloading ${pct}% · ${formatBytes(progress?.received ?? 0)} of ${size}`}
+            : `Downloading ${pct}% · ${formatBytes(mine?.received ?? 0)} of ${size}`}
       </span>
     );
-  } else if (status.installed) {
+  } else if (model.installed) {
     line = <span className="set-dict-status">Installed · {size}</span>;
     action = (
       <Button variant="outline" size="sm" onClick={onRemove}>

--- a/src/components/SettingsScreen/DictationSection/index.tsx
+++ b/src/components/SettingsScreen/DictationSection/index.tsx
@@ -16,15 +16,6 @@ export function DictationSection() {
   const { status, progress, select, download, remove } = useDictationModel();
 
   const size = status ? formatBytes(status.model.size) : null;
-  // Hidden while there is nothing to act on, and shown as soon as there is:
-  // weights on disk outlive the opt-in, so turning the engine off must not
-  // strand half a gigabyte with no way to reclaim it.
-  const chooser =
-    status &&
-    (enabled ||
-      status.downloading ||
-      progress?.state === "error" ||
-      status.models.some((m) => m.installed));
 
   return (
     <SetGroup label="Dictation">
@@ -36,8 +27,11 @@ export function DictationSection() {
       >
         <SetToggle on={enabled} onClick={() => setEnabled(!enabled)} />
       </SetRow>
-      {chooser &&
-        status.models.map((model) => (
+      {/* Always offered, engine on or off: the choice has to be makeable
+          before the opt-in, or enabling would fetch the platform default out
+          from under someone who wanted the other model — and weights on disk
+          outlive the opt-in, so the Remove action has to stay reachable too. */}
+      {status?.models.map((model) => (
           <ModelRow
             key={model.id}
             model={model}

--- a/src/components/SettingsScreen/DictationSection/index.tsx
+++ b/src/components/SettingsScreen/DictationSection/index.tsx
@@ -32,23 +32,23 @@ export function DictationSection() {
           from under someone who wanted the other model — and weights on disk
           outlive the opt-in, so the Remove action has to stay reachable too. */}
       {status?.models.map((model) => (
-          <ModelRow
-            key={model.id}
-            model={model}
-            status={status}
-            progress={progress}
-            onSelect={() => select(model.id)}
-            onDownload={() => download(model.id)}
-            onRemove={async () => {
-              // Deleting the weights under an enabled engine would leave it
-              // silently falling back, so the opt-in goes first — and only if
-              // it actually persisted do the weights follow. A model that
-              // isn't the selected one is nothing the engine would load.
-              if (enabled && model.id === status.model.id && !(await setEnabled(false))) return;
-              remove(model.id);
-            }}
-          />
-        ))}
+        <ModelRow
+          key={model.id}
+          model={model}
+          status={status}
+          progress={progress}
+          onSelect={() => select(model.id)}
+          onDownload={() => download(model.id)}
+          onRemove={async () => {
+            // Deleting the weights under an enabled engine would leave it
+            // silently falling back, so the opt-in goes first — and only if
+            // it actually persisted do the weights follow. A model that
+            // isn't the selected one is nothing the engine would load.
+            if (enabled && model.id === status.model.id && !(await setEnabled(false))) return;
+            remove(model.id);
+          }}
+        />
+      ))}
     </SetGroup>
   );
 }

--- a/src/components/SettingsScreen/DictationSection/index.tsx
+++ b/src/components/SettingsScreen/DictationSection/index.tsx
@@ -1,20 +1,30 @@
 import { useAppStore } from "@/store";
 import { formatBytes } from "@/util/format";
 import { SetGroup, SetRow, SetToggle } from "../primitives";
-import { ModelStatusRow } from "./ModelStatusRow";
+import { ModelRow } from "./ModelRow";
 import { useDictationModel } from "./useDictationModel";
 
 /** Settings › General › Dictation: opt into the local Whisper engine instead
- *  of Apple's recognizer. The opt-in and the weights are separate states — the
- *  toggle flips immediately and the model downloads behind it — so the row
- *  below the toggle is the only place that says whether dictation can actually
- *  run locally yet. macOS-only, like the recognizer it replaces. */
+ *  of Apple's recognizer, and pick which model it runs. The opt-in and the
+ *  weights are separate states — the toggle flips immediately and the model
+ *  downloads behind it — so the chooser below is the only place that says
+ *  whether dictation can actually run locally yet. macOS-only, like the
+ *  recognizer it replaces. */
 export function DictationSection() {
   const enabled = useAppStore((s) => s.dictationEngineEnabled);
   const setEnabled = useAppStore((s) => s.setDictationEngineEnabled);
-  const { status, progress, download, remove } = useDictationModel();
+  const { status, progress, select, download, remove } = useDictationModel();
 
   const size = status ? formatBytes(status.model.size) : null;
+  // Hidden while there is nothing to act on, and shown as soon as there is:
+  // weights on disk outlive the opt-in, so turning the engine off must not
+  // strand half a gigabyte with no way to reclaim it.
+  const chooser =
+    status &&
+    (enabled ||
+      status.downloading ||
+      progress?.state === "error" ||
+      status.models.some((m) => m.installed));
 
   return (
     <SetGroup label="Dictation">
@@ -26,21 +36,25 @@ export function DictationSection() {
       >
         <SetToggle on={enabled} onClick={() => setEnabled(!enabled)} />
       </SetRow>
-      {status && (
-        <ModelStatusRow
-          enabled={enabled}
-          status={status}
-          progress={progress}
-          onDownload={download}
-          onRemove={async () => {
-            // Deleting the weights under an enabled engine would leave it
-            // silently falling back, so the opt-in goes first — and only if it
-            // actually persisted do the weights follow.
-            if (enabled && !(await setEnabled(false))) return;
-            remove();
-          }}
-        />
-      )}
+      {chooser &&
+        status.models.map((model) => (
+          <ModelRow
+            key={model.id}
+            model={model}
+            status={status}
+            progress={progress}
+            onSelect={() => select(model.id)}
+            onDownload={() => download(model.id)}
+            onRemove={async () => {
+              // Deleting the weights under an enabled engine would leave it
+              // silently falling back, so the opt-in goes first — and only if
+              // it actually persisted do the weights follow. A model that
+              // isn't the selected one is nothing the engine would load.
+              if (enabled && model.id === status.model.id && !(await setEnabled(false))) return;
+              remove(model.id);
+            }}
+          />
+        ))}
     </SetGroup>
   );
 }

--- a/src/components/SettingsScreen/DictationSection/useDictationModel.ts
+++ b/src/components/SettingsScreen/DictationSection/useDictationModel.ts
@@ -11,13 +11,16 @@ export interface DictationModelView {
   /** `null` until the first fetch resolves. */
   status: DictationModelStatus | null;
   /** The latest progress event, or `null` before one arrives (and after an
-   *  action that makes it stale). */
+   *  action that makes it stale). Carries `model_id`, so a row must check it
+   *  is the one being described. */
   progress: DictationModelProgressEvent | null;
-  download: () => void;
-  remove: () => void;
+  select: (id: string) => void;
+  download: (id: string) => void;
+  remove: (id: string) => void;
 }
 
-/** The model's install state, kept live. The download runs in the backend and
+/** The model choice and each candidate's install state, kept live. The
+ *  download runs in the backend and
  *  outlives this screen, so the state is fetched on mount (for a screen that
  *  opened mid-download, or after a failure whose event we never saw) and then
  *  followed through `dictation:model_progress`. Terminal events change what's
@@ -64,8 +67,20 @@ export function useDictationModel(): DictationModelView {
       .catch(() => {});
   }, []);
 
-  const download = useCallback(() => act(api.dictationModelDownload), [act]);
-  const remove = useCallback(() => act(api.dictationModelRemove), [act]);
+  const select = useCallback((id: string) => act(() => api.setDictationModel(id)), [act]);
+  // A download the user asked for on a row is also a choice of that row's
+  // model, so it selects first — `dictation_model_download` only ever fetches
+  // the selected one. Selecting what is already selected is a harmless
+  // re-write, which keeps this one path for both a fresh download and a retry.
+  const download = useCallback(
+    (id: string) =>
+      act(async () => {
+        await api.setDictationModel(id);
+        return api.dictationModelDownload();
+      }),
+    [act],
+  );
+  const remove = useCallback((id: string) => act(() => api.dictationModelRemove(id)), [act]);
 
-  return { status, progress, download, remove };
+  return { status, progress, select, download, remove };
 }

--- a/src/components/SettingsScreen/SettingsScreen.css
+++ b/src/components/SettingsScreen/SettingsScreen.css
@@ -757,8 +757,36 @@
 }
 
 /* ── DICTATION ───────────────────────────────────────────────────────── */
-/* The local-engine model row: a status line with the one action that applies,
-   plus the download bar. Sits under its toggle row like `.set-sandbox-warn`. */
+/* Which model the local engine runs: one row per catalog entry, so the radio
+   lands in the same column as the engine toggle above it. */
+.set-radio {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--bg-0);
+  box-shadow: inset 0 0 0 1px var(--bd);
+  transition: var(--transition-ui);
+}
+.set-radio[data-on="1"] {
+  background: var(--accent);
+  box-shadow: none;
+}
+.set-radio i {
+  display: block;
+  width: 6px;
+  height: 6px;
+  margin: 6px;
+  border-radius: 50%;
+  background: oklch(0.98 0.01 60);
+  opacity: 0;
+  transition: opacity 0.18s var(--ease);
+}
+.set-radio[data-on="1"] i {
+  opacity: 1;
+}
+
+/* The status line for one model: what its weights are doing plus the one
+   action that applies, and the download bar. Sits under the model's note. */
 .set-dict {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Follow-up to #646 (stacked on it). The catalog already pinned two models but everything hardcoded the default. The model is now a persisted choice, Settings offers it, and download, remove, status and the engine all follow the selection. Intel Macs default to the small English model, since the large one on CPU is too slow to be usable.

## How it works

- **Selection.** A `dictation_model` setting holds a catalog id. A known id wins; anything else falls back to the platform default: `small.en-q8_0` on x86_64 (including Rosetta), `large-v3-turbo-q5_0` elsewhere. The arch rule sits next to the catalog with a pure, tested function. Commands and the engine dispatch read it through one helper off the DB connection, so the row Settings shows, the download target, and the weights a session loads cannot disagree.
- **Install operates on a model.** Status, download and remove take the model. One download at a time process-wide is unchanged, but the in-flight guard now names the model, so switching selection mid-download reports honestly instead of cancelling or pretending nothing is running.
- **Engine.** The stop path reads the selection when the mic closes and passes the model down to the engine, which keeps no database handle. The cached context is keyed on the file it loaded from, so a switch drops the old weights before loading the new ones and never holds both resident.
- **Settings.** Below the engine toggle, one row per catalog entry with label, note, size, a radio control aligned with the toggle, and the same status line as before generalised per model: Installed / Remove, Downloading with a bar on the row actually being fetched, Not downloaded / Download, error / Retry. Pressing Download on a row selects it. Both fixes from #644 hold: the store reverts on failed persistence, and Remove disables the engine first only when it is the selected model of an enabled engine.
- **Contract.** `dictation_model_status` now returns `downloading_id`, `installed` per entry, and a `models` list; `set_dictation_model(id)` is new and rejects unknown ids; `dictation_model_remove` takes an optional id defaulting to the selection; `set_dictation_engine` downloads the selected model. The progress event is unchanged.

## Verification

- `cargo check --all-targets`, `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test` (1491 passed, new: arch default rule, stored choice wins and anything else falls back), `bun run lint` / `check` / `test` (1102 passed).
- **Not verified:** a real download, the honest-reporting path when switching mid-download, the rendered radio rows, and the Intel default on actual hardware. Manual pass: with the engine on, pick the small model, watch its row download, dictate, switch back to the large one and confirm the transcript still lands.

## Note

Both this and #647 stack on #646 and touch the engine and stop path. Whichever merges second will need a small rebase.