### PR TITLE
chore: bump version to v0.7.23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fletch",
   "private": true,
-  "version": "0.7.22",
+  "version": "0.7.23",
   "license": "AGPL-3.0-only",
   "author": "Alex Chaplinsky and fwdai.org",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "fletch"
-version = "0.7.22"
+version = "0.7.23"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fletch"
-version = "0.7.22"
+version = "0.7.23"
 description = "Spawn coding agents in isolated sandboxes"
 authors = ["Alex Chaplinsky", "fwdai.org"]
 license = "AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Fletch",
   "mainBinaryName": "Fletch",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "identifier": "com.fletch.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Bumps the app version from 0.7.22 to 0.7.23 across the four places it is declared:

- `package.json`
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock` (the `fletch` package entry)
- `src-tauri/tauri.conf.json`

Patch bump only — no behavior changes.