### PR TITLE
fix(build): link clang's runtime so whisper.cpp's @available resolves on arm64

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -42,7 +42,65 @@ fn main() {
         println!("cargo::rerun-if-env-changed={key}");
     }
 
+    link_clang_runtime();
+
     tauri_build::build()
+}
+
+/// whisper.cpp's Metal backend guards its residency-set path on
+/// `@available(macOS 15.0, ...)` (`ggml/src/ggml-metal/ggml-metal-device.m`),
+/// which clang lowers to a call to `___isPlatformVersionAtLeast`. That helper
+/// lives in clang's own runtime library, `libclang_rt.osx.a`, and rustc drives
+/// the final link with `-nodefaultlibs` — so nothing puts it on the link line
+/// and the `fletch` binary fails to link with three undefined symbols.
+///
+/// It only bites when the SDK is >= 15.0 (which turns the path on) *and* the
+/// deployment target is below it (which makes the check a runtime one rather
+/// than a folded constant) — i.e. every release build, since
+/// `minimumSystemVersion` is 13.0. Only the arm64 slice is affected; the guard
+/// is `!TARGET_CPU_X86_64`, so x86_64 compiles the path out. Linux CI never sees
+/// it either: `whisper-rs` is macOS-only (see Cargo.toml).
+///
+/// The archive is linked without a `static=` kind on purpose, so the linker
+/// pulls in only the availability object rather than bundling all of
+/// compiler-rt into the rlib and colliding with Rust's own
+/// `compiler_builtins`.
+fn link_clang_runtime() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
+        return;
+    }
+
+    // Ask the same compiler that will drive the link (see the `cc` invocation in
+    // the failing linker output) where its runtime lives, rather than guessing a
+    // versioned path under Xcode.
+    println!("cargo::rerun-if-env-changed=CC");
+    let cc = std::env::var("CC").unwrap_or_else(|_| "cc".to_string());
+
+    let dir = match std::process::Command::new(&cc)
+        .arg("-print-runtime-dir")
+        .output()
+    {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        _ => {
+            println!("cargo::warning=`{cc} -print-runtime-dir` failed; not linking clang_rt.osx");
+            return;
+        }
+    };
+
+    // clang prints the path it *would* use, whether or not it exists, so check
+    // for the archive itself. Warn rather than panic: a toolchain without it can
+    // still build everything that doesn't need the availability helper.
+    if dir.is_empty()
+        || !std::path::Path::new(&dir)
+            .join("libclang_rt.osx.a")
+            .exists()
+    {
+        println!("cargo::warning=libclang_rt.osx.a not found in `{dir}`; not linking clang_rt.osx");
+        return;
+    }
+
+    println!("cargo::rustc-link-search=native={dir}");
+    println!("cargo::rustc-link-lib=clang_rt.osx");
 }
 
 /// Minimal `.env` parser: `KEY=VALUE` lines, optional `export ` prefix and


### PR DESCRIPTION
## Problem

The Release workflow fails at the Build stage while linking the `aarch64-apple-darwin` slice:

```
Undefined symbols for architecture arm64:
  "___isPlatformVersionAtLeast", referenced from:
      ___ggml_metal_rsets_init_block_invoke in libwhisper_rs_sys-*.rlib[28](ggml-metal-device.m.o)
      _ggml_metal_buffer_rset_init         in libwhisper_rs_sys-*.rlib[28](ggml-metal-device.m.o)
      _ggml_metal_buffer_free              in libwhisper_rs_sys-*.rlib[28](ggml-metal-device.m.o)
```

First release since 05559a10 added `whisper-rs` (metal), i.e. v0.7.23.

## Root cause

whisper.cpp's Metal backend guards its residency-set path on `@available(macOS 15.0, ...)`
(`ggml/src/ggml-metal/ggml-metal-device.m`, three sites — exactly the three symbols above).
Clang lowers that runtime check to a call to `___isPlatformVersionAtLeast`, which lives in
clang's own runtime library, `libclang_rt.osx.a`. rustc drives the final link with
`-nodefaultlibs` and adds no clang resource directory, so nothing puts it on the link line.
Rust's own `compiler_builtins` does not carry the Objective-C availability helper.

It needs three conditions, all true only in the release build:

- SDK >= 15.0, which turns the path on (`__MAC_OS_X_VERSION_MAX_ALLOWED >= 150000`)
- deployment target below it, which makes the check a real call rather than a folded
  constant — the Tauri CLI exports `MACOSX_DEPLOYMENT_TARGET=13.0` from
  `minimumSystemVersion`, hence `-mmacosx-version-min=13.0.0` on the failing link line
- arm64 — the ggml guard is `!TARGET_CPU_X86_64`, so the x86_64 slice compiles the path out

## Why CI never caught it

Both `ci.yml` jobs run on `ubuntu-latest`, and `whisper-rs` is gated to
`[target.'cfg(target_os = "macos")'.dependencies]`. The Objective-C/Metal tree is never
compiled or linked outside the release build.

## Fix

Ask the linking compiler where its runtime lives (`cc -print-runtime-dir`) rather than
hardcoding a versioned Xcode path, and put the archive on the link line. Linked without a
`static=` kind on purpose, so the linker pulls in only the availability object instead of
bundling all of compiler-rt into the rlib alongside Rust's own `compiler_builtins`. macOS
targets only; a missing `libclang_rt.osx.a` produces a `cargo::warning` rather than a panic.

## Verification

- A/B link test on a minimal `@available(macOS 15.0, *)` object at
  `-mmacosx-version-min=13.0.0` with `-nodefaultlibs`: without `clang_rt` it reproduces the
  exact error above; with it, links, zero undefined references, and the check evaluates
  correctly at runtime
- Failure reproduced locally, byte-for-byte identical to CI
- x86_64 slice rebuilt at the same deployment target emits **0** references, confirming the
  `!TARGET_CPU_X86_64` guard
- `cargo fmt --check` and `clippy -D warnings` clean on the pinned 1.97.0 (build scripts are
  host-compiled, so this is linted on Linux CI too)
- Full local `tauri build` with the fix applied is being validated

## Follow-up, deliberately not in this PR

`whisper-rs-sys` does not declare `rerun-if-env-changed=MACOSX_DEPLOYMENT_TARGET`, so cargo
treats its build as fresh when the deployment target changes. That let an object compiled at
`minos 26.0` survive into a binary declaring `minos 13.0` — where the residency-set calls are
unconditional with no runtime guard, which would hit `newResidencySetWithDescriptor:` on
macOS 13/14. Since `Swatinem/rust-cache` caches `target/`, that can in principle yield a green
release that crashes on older macOS. Worth addressing separately.