### PR TITLE
feat(remote): paired-device WebSocket server for the mobile companion

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,7 @@
         "lucide-react": "^1.21.0",
         "material-icon-theme": "^5.36.0",
         "partial-json": "^0.1.7",
+        "qrcode.react": "^4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
@@ -530,6 +531,8 @@
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "qrcode.react": ["qrcode.react@4.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -225,8 +225,12 @@ stop reconnecting until it is paired or the host is enabled again.
 `RemoteDevice = { deviceId, name, platform, createdAt, lastSeenAt, connected }`,
 where `connected` is derived from the live connections, not from `lastSeenAt`.
 `error` is a standing problem with the remote surface itself — currently only
-"`devices.json` is not writable", which also blocks pairing — and the Settings
-pane shows it inline.
+"`devices.json` could not be read or written", which also blocks pairing — and
+the Settings pane shows it inline. A failed write is sticky: the in-memory list
+stays authoritative (a revoked device is revoked, its sockets are closed), the
+error stays in `error`, and every `remote_status` retries the write until it
+lands, so the stale file cannot quietly bring a revoked device back at the next
+launch once the disk recovers.
 
 ## Out of scope for v1 (tracked, not built)
 

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -1,0 +1,201 @@
+# Fletch remote protocol (mobile ↔ desktop)
+
+Status: v1 contract. Both the desktop `remote` module (`src-tauri/src/remote/`)
+and the mobile client (`mobile/src/remote/`) implement exactly this document.
+Deviations are made here first, then in code.
+
+## Concept
+
+The phone is a control panel. Code and agents live on the Mac. The desktop app
+("host") runs a small WebSocket server; a paired phone connects, receives the
+workspace snapshot, then a live event stream, and sends operations. Every op
+mirrors an existing Tauri command by name, argument keys and result DTO, so
+the host dispatcher calls the same `Supervisor` functions the commands do and
+the phone reuses the desktop's TypeScript DTOs (`src/api/types/*`) and chat
+adapters (`src/adapters/*`) unchanged.
+
+## Transport
+
+- WebSocket, text frames, JSON, UTF-8. One connection per device.
+- Host listens on TCP port `47285` by default (setting `remote.port`), all
+  interfaces, path `/ws`. `ws://<host>:<port>/ws`. No TLS in v1; intended for
+  LAN and Tailscale. A relay and TLS are out of scope for v1.
+- Host sends a WebSocket ping every 20 s and closes the connection after two
+  missed pongs. Client reconnects with exponential backoff (1 s, 2 s, 4 s … 30 s).
+- Frames larger than 4 MiB are rejected (close code 1009).
+
+## Envelope
+
+Client → host request:
+
+```json
+{ "id": "3f9c…", "op": "send_user_message", "args": { "agentId": "arabia", "turnId": "…", "text": "…", "attachments": [] } }
+```
+
+Host → client response (exactly one per request, any order):
+
+```json
+{ "id": "3f9c…", "ok": true,  "result": { … } }
+{ "id": "3f9c…", "ok": false, "error": "human-readable message" }
+```
+
+Host → client event (no id, never acknowledged):
+
+```json
+{ "event": "agent:status", "payload": { … } }
+```
+
+`id` is a client-chosen unique string (UUID v4). `args` is always an object,
+possibly empty. `result` is the command's return value serialized exactly as
+Tauri would serialize it for `invoke` (snake_case DTO fields, camelCase arg
+keys, `null` for `Option::None`, `null` result for `()`).
+
+## Authentication and pairing
+
+The first frame on a connection MUST be `pair` or `hello`. Any other first
+frame closes the connection with code `4001`. Any request before a successful
+`hello` closes with `4003`. A bad or revoked device token closes with `4003`.
+
+### `pair`
+
+Desktop Settings → "Mobile devices" → "Pair a device" calls the Tauri command
+`remote_begin_pairing`, which mints a one-time pairing token (8 chars from
+`A-Z2-9`, no ambiguous glyphs), valid 5 minutes, single use. Settings shows it
+as text and as a QR code encoding:
+
+```
+fletch://pair?host=<ip-or-hostname>&port=<port>&token=<token>&name=<url-encoded host name>
+```
+
+Client request:
+
+```json
+{ "id": "…", "op": "pair", "args": { "token": "K7PQ2M9X", "device": { "name": "Alex's iPhone", "platform": "ios", "appVersion": "0.1.0" } } }
+```
+
+Result:
+
+```json
+{ "deviceId": "uuid", "deviceToken": "43-byte base64url secret", "host": { "name": "Alex's MacBook Pro", "appVersion": "0.7.23", "os": "macos" } }
+```
+
+The host persists `{ deviceId, name, platform, tokenHash (sha256), createdAt, lastSeenAt }`
+in `<app_data_dir>/remote/devices.json`. Plain tokens are never stored on the host.
+After `pair` the connection is authenticated as if `hello` had succeeded and
+the host starts forwarding events. The host does NOT push a snapshot; the
+client issues `get_workspace` itself right after a successful `pair`.
+
+### `hello`
+
+```json
+{ "id": "…", "op": "hello", "args": { "deviceToken": "…", "client": { "name": "Alex's iPhone", "platform": "ios", "appVersion": "0.1.0" } } }
+```
+
+Result:
+
+```json
+{ "host": { "name": "…", "appVersion": "…", "os": "macos" }, "workspace": <Workspace | null> }
+```
+
+`workspace` is the exact `get_workspace` result. After the response the host
+starts forwarding events for this connection.
+
+## Operations (v1 allowlist)
+
+Op name, argument keys and result type are identical to the Tauri command of
+the same name (see `src/api/domains/*.ts` for the argument keys and
+`src/api/types/*.ts` for the DTOs). The host dispatches through an explicit
+allowlist; any op not listed returns `{ ok: false, error: "unknown op" }`.
+
+| op | args | result |
+|---|---|---|
+| `get_workspace` | `{}` | `Workspace \| null` |
+| `allocate_draft_name` | `{ drafts: string[] }` | `string` |
+| `spawn_agent` | as command; host forces `view: "custom"`, ignores `purpose`, `skills`, `mcpServers`, `customAgentId` in v1 | `AgentRecord` |
+| `send_user_message` | `{ agentId, turnId, text, attachments: [] }` | `boolean` |
+| `answer_tool_use` | `{ agentId, requestId, updatedInput, behavior, message? }` | `null` |
+| `stop_agent` | `{ agentId }` | `null` |
+| `resume_agent` | `{ agentId }` | `null` |
+| `archive_agent` | `{ agentId }` | `null` |
+| `set_agent_model` | `{ agentId, model }` | `null` |
+| `set_agent_effort` | `{ agentId, effort }` | `null` |
+| `read_session_records` | `{ agentId }` | `SessionRecord[]` |
+| `read_user_turns` | `{ agentId }` | `UserTurn[]` |
+| `get_git_state` | `{ agentId }` | `GitState \| null` |
+| `get_agent_diff_stats` | `{ agentId }` | `DiffStats` |
+| `list_checkout_tree` | as command | `CheckoutFile[]` |
+| `read_checkout_file` | `{ agentId, path, baseMode? }` | `CheckoutFileContents` |
+| `get_file_diff` | as command | `string` |
+| `commit_agent` | as command | `null` |
+| `push_agent` | as command | `string` |
+| `create_pr` | as command | `PrState` |
+| `get_pr_state` | as command | `PrState \| null` |
+| `get_pr_checks` | as command | `PrChecks \| null` |
+| `get_pr_live` | as command | `PrLive \| null` |
+| `list_repo_branches` | `{ repoPath }` | `string[]` |
+| `repo_default_branch` | `{ repoPath }` | `string` |
+| `discover_supported_models` | as command | `AgentModels[]` |
+
+Never exposed, by design: the generic `db_*` table bridge, every file mutation
+(`write_checkout_file`, `rename_*`, `delete_*`, `create_*`, `copy_*`), shell
+ops (`open_agent_shell`, `write_to_shell`, …), `write_to_agent` (raw PTY),
+editor/log/telemetry/provider-install ops, workflow, roadmap and run ops.
+Adding an op means adding a row here and a match arm in the dispatcher.
+
+The spawn flow is the desktop's: `allocate_draft_name` → `spawn_agent` →
+wait for `agent:status` to leave `spawning` → `send_user_message` with the
+prompt as the first turn (`turnId` = client UUID). The phone does not send
+the prompt through `instructions`.
+
+## Events (v1 whitelist)
+
+Forwarded verbatim with the desktop event name and payload (see
+`src/api/events.ts` for payload types). The host taps the Tauri event bus once
+with `Listener::listen_any` and forwards only these names to every
+authenticated connection:
+
+```
+agent:event            agent:status           agent:task
+agent:branch           agent:model            agent:effort
+agent:repo_added       agent:git-action       session:records-appended
+turn:started           workspace:changed      pr:state_changed
+verify:report          publish:approval-requested
+```
+
+`agent:event` is forwarded unfiltered, including the provider's
+`control_request` records: that is the only way a held tool-use approval
+reaches the phone, and `answer_tool_use` needs the `request_id` it carries.
+On the `error` status transition, `agent:status` must carry the real
+`last_error`, since both clients keep the previous error when it is null.
+
+Never forwarded: `agent:output`, `shell:output` (raw PTY bytes), `run:*`,
+`wf:*`, `roadmap:*`, `dictation:*`, `docker:*`, `agent-install:*`.
+
+Delivery is best effort, exactly like the desktop frontend: the phone must
+refetch `get_workspace` on reconnect and on returning to the foreground, and
+`read_session_records` when it opens an agent.
+
+## Errors
+
+Host errors are strings (the `Display` of the Rust `Error`). Auth failures are
+WebSocket close codes, not error responses: `4001` bad first frame, `4003`
+unauthenticated or revoked, `4004` host has remote access disabled.
+
+## Host-side settings and commands (desktop Tauri commands, not remote ops)
+
+| command | purpose |
+|---|---|
+| `remote_status` | `{ enabled, listening, port, addresses: string[], devices: RemoteDevice[] }` |
+| `remote_set_enabled` | `{ enabled }` start/stop the listener; persists setting `remote.enabled` |
+| `remote_begin_pairing` | `{ token, url, expiresAt }` |
+| `remote_revoke_device` | `{ deviceId }` |
+
+`RemoteDevice = { deviceId, name, platform, createdAt, lastSeenAt, connected }`.
+
+## Out of scope for v1 (tracked, not built)
+
+TLS or a relay for off-network access, push notifications (needs a relay and
+APNs), QR scanning on the phone (manual entry of host, port and token in v1;
+`fletch://pair` deep link parsing is fine to include), Add project / clone,
+voice, attachments, Run scripts, Keychain storage of the device token on the
+phone (v1 stores it in the app data dir).

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -23,6 +23,31 @@ adapters (`src/adapters/*`) unchanged.
 - Host sends a WebSocket ping every 20 s and closes the connection after two
   missed pongs. Client reconnects with exponential backoff (1 s, 2 s, 4 s … 30 s).
 - Frames larger than 4 MiB are rejected (close code 1009).
+- Everything the host holds for a connection is bounded, and ends with it. The
+  outbound queue holds 64 frames: a client that stops reading while the host
+  still has frames for it has its socket dropped (no close frame — the queue is
+  what one would travel through), and reconnects. At most 8 requests may be in
+  flight per connection; further requests are answered immediately with
+  `{ ok: false, error: "too many in-flight requests" }` and never dispatched.
+  Requests still running when the socket goes away are abandoned.
+
+## Threat model (v1)
+
+The transport is cleartext `ws://` on all interfaces, so v1 assumes a trusted
+LAN (or a Tailscale network). Anyone who can observe that network while a phone
+pairs or says `hello` sees the device token and can replay it: the token is a
+bearer credential, and there is nothing else to present.
+
+What is in place today: pairing needs a single-use code, minted on the desktop
+and valid five minutes; only the device token's sha256 is stored on the host;
+revoking a device drops the credential *and* closes its live connections with
+`4003`; turning remote access off closes every connection with `4004`; ops are
+an explicit allowlist with no shell, no file writes and no raw PTY, and events
+are a whitelist that excludes PTY output.
+
+Planned fix (follow-up, not v1): TLS with a self-signed host certificate whose
+fingerprint travels in the pairing QR and is pinned by the phone, which removes
+both the plaintext credential and the impersonable host.
 
 ## Envelope
 
@@ -177,20 +202,31 @@ refetch `get_workspace` on reconnect and on returning to the foreground, and
 
 ## Errors
 
-Host errors are strings (the `Display` of the Rust `Error`). Auth failures are
-WebSocket close codes, not error responses: `4001` bad first frame, `4003`
-unauthenticated or revoked, `4004` host has remote access disabled.
+Host errors are strings (the `Display` of the Rust `Error`). Two are reserved:
+`"unknown op"` for anything off the allowlist and `"too many in-flight
+requests"` for a connection over its concurrency cap.
+
+Auth failures are WebSocket close codes, not error responses: `4001` bad first
+frame, `4003` unauthenticated or revoked, `4004` host has remote access
+disabled. `4003` also arrives unprompted when the host revokes the device this
+connection is authenticated as, and `4004` when the host turns remote access
+off — in both cases the credential is gone or dormant, so the client should
+stop reconnecting until it is paired or the host is enabled again.
 
 ## Host-side settings and commands (desktop Tauri commands, not remote ops)
 
 | command | purpose |
 |---|---|
-| `remote_status` | `{ enabled, listening, port, addresses: string[], devices: RemoteDevice[] }` |
-| `remote_set_enabled` | `{ enabled }` start/stop the listener; persists setting `remote.enabled` |
-| `remote_begin_pairing` | `{ token, url, expiresAt }` |
-| `remote_revoke_device` | `{ deviceId }` |
+| `remote_status` | `{ enabled, listening, port, addresses: string[], devices: RemoteDevice[], error: string \| null }` |
+| `remote_set_enabled` | `{ enabled }` start/stop the listener; persists setting `remote.enabled`; disabling closes live connections with `4004` |
+| `remote_begin_pairing` | `{ token, url, expiresAt }`; refused while the listener is down or `error` is set |
+| `remote_revoke_device` | `{ deviceId }`; drops the credential and closes that device's live connections with `4003` |
 
-`RemoteDevice = { deviceId, name, platform, createdAt, lastSeenAt, connected }`.
+`RemoteDevice = { deviceId, name, platform, createdAt, lastSeenAt, connected }`,
+where `connected` is derived from the live connections, not from `lastSeenAt`.
+`error` is a standing problem with the remote surface itself — currently only
+"`devices.json` is not writable", which also blocks pairing — and the Settings
+pane shows it inline.
 
 ## Out of scope for v1 (tracked, not built)
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lucide-react": "^1.21.0",
     "material-icon-theme": "^5.36.0",
     "partial-json": "^0.1.7",
+    "qrcode.react": "^4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",

--- a/scripts/remote-smoke.ts
+++ b/scripts/remote-smoke.ts
@@ -1,0 +1,237 @@
+#!/usr/bin/env bun
+/**
+ * End-to-end smoke test for the paired-device remote server
+ * (`src-tauri/src/remote/`, contract in `docs/remote-protocol.md`).
+ *
+ * Pairs (or says hello with a saved credential), prints the workspace summary,
+ * then prints every forwarded event for 20 seconds.
+ *
+ * Usage
+ *   # first run: mint a code in Settings › General › Mobile devices › Pair a device
+ *   bun scripts/remote-smoke.ts ws://192.168.1.24:47285/ws --token K7PQ2M9X
+ *
+ *   # later runs: the device token from the first run is reused automatically
+ *   bun scripts/remote-smoke.ts ws://192.168.1.24:47285/ws
+ *
+ *   # or pass one explicitly
+ *   bun scripts/remote-smoke.ts ws://192.168.1.24:47285/ws --device-token <43-char secret>
+ *
+ * Flags
+ *   --token <code>          8-character pairing code; pairs and saves the device token
+ *   --device-token <secret> device token to `hello` with
+ *   --seconds <n>           how long to listen for events (default 20)
+ *   --store <path>          where the device token is cached
+ *                           (default $TMPDIR/fletch-remote-smoke.json)
+ *
+ * Exits 0 on success, 1 on any protocol or connection failure.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+interface Args {
+  url: string;
+  token?: string;
+  deviceToken?: string;
+  seconds: number;
+  store: string;
+}
+
+function parseArgs(argv: string[]): Args {
+  const positional: string[] = [];
+  const flags: Record<string, string> = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith("--")) {
+      const [name, inline] = arg.slice(2).split("=", 2);
+      flags[name] = inline ?? argv[++i] ?? "";
+    } else {
+      positional.push(arg);
+    }
+  }
+  const url = positional[0];
+  if (!url) {
+    console.error("usage: bun scripts/remote-smoke.ts ws://host:port/ws [--token CODE]");
+    process.exit(1);
+  }
+  return {
+    url,
+    token: flags.token || undefined,
+    deviceToken: flags["device-token"] || undefined,
+    seconds: Number(flags.seconds ?? 20),
+    store: flags.store || join(tmpdir(), "fletch-remote-smoke.json"),
+  };
+}
+
+function readSavedToken(store: string, url: string): string | undefined {
+  if (!existsSync(store)) return undefined;
+  try {
+    const saved = JSON.parse(readFileSync(store, "utf8")) as Record<string, string>;
+    return saved[url];
+  } catch {
+    return undefined;
+  }
+}
+
+function saveToken(store: string, url: string, token: string): void {
+  let saved: Record<string, string> = {};
+  if (existsSync(store)) {
+    try {
+      saved = JSON.parse(readFileSync(store, "utf8")) as Record<string, string>;
+    } catch {
+      saved = {};
+    }
+  }
+  saved[url] = token;
+  writeFileSync(store, JSON.stringify(saved, null, 2), { mode: 0o600 });
+}
+
+type Reply = { id: string; ok: boolean; result?: unknown; error?: string };
+type Event = { event: string; payload: unknown };
+
+/** Minimal request/response client over the raw WebSocket. */
+class Client {
+  private pending = new Map<string, (reply: Reply) => void>();
+  private next = 0;
+  onEvent: ((event: Event) => void) | null = null;
+
+  constructor(private socket: WebSocket) {
+    socket.addEventListener("message", (ev) => {
+      const frame = JSON.parse(String(ev.data)) as Reply | Event;
+      if ("event" in frame) {
+        this.onEvent?.(frame);
+        return;
+      }
+      const resolve = this.pending.get(frame.id);
+      if (!resolve) {
+        console.warn(`! reply for unknown id ${frame.id}`);
+        return;
+      }
+      this.pending.delete(frame.id);
+      resolve(frame);
+    });
+  }
+
+  request(op: string, args: Record<string, unknown> = {}): Promise<Reply> {
+    const id = `smoke-${++this.next}`;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${op} timed out`));
+      }, 30_000);
+      this.pending.set(id, (reply) => {
+        clearTimeout(timer);
+        resolve(reply);
+      });
+      this.socket.send(JSON.stringify({ id, op, args }));
+    });
+  }
+
+  async call(op: string, args: Record<string, unknown> = {}): Promise<unknown> {
+    const reply = await this.request(op, args);
+    if (!reply.ok) throw new Error(`${op}: ${reply.error}`);
+    return reply.result;
+  }
+}
+
+function connect(url: string): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(url);
+    socket.addEventListener("open", () => resolve(socket));
+    socket.addEventListener("error", () => reject(new Error(`cannot connect to ${url}`)));
+    socket.addEventListener("close", (ev) => {
+      // 4001/4003/4004 are the protocol's auth failures; anything else here is
+      // a normal teardown after we're done.
+      if (ev.code >= 4000) {
+        console.error(`\n✗ host closed the connection: ${ev.code} ${ev.reason}`);
+        process.exit(1);
+      }
+    });
+  });
+}
+
+interface Workspace {
+  projects?: { id: string; name?: string }[];
+  agents?: { id: string; status?: string; provider?: string; archive?: unknown }[];
+}
+
+function printWorkspace(workspace: unknown): void {
+  if (!workspace || typeof workspace !== "object") {
+    console.log("  (no workspace — no project is pinned yet)");
+    return;
+  }
+  const ws = workspace as Workspace;
+  const live = (ws.agents ?? []).filter((a) => !a.archive);
+  console.log(`  projects: ${ws.projects?.length ?? 0}`);
+  console.log(`  agents:   ${live.length} live / ${ws.agents?.length ?? 0} total`);
+  for (const agent of live.slice(0, 10)) {
+    console.log(`    · ${agent.id.padEnd(16)} ${agent.provider ?? "?"} ${agent.status ?? "?"}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  console.log(`→ connecting to ${args.url}`);
+  const socket = await connect(args.url);
+  const client = new Client(socket);
+
+  if (args.token) {
+    console.log(`→ pair with code ${args.token}`);
+    const result = (await client.call("pair", {
+      token: args.token,
+      device: { name: "remote-smoke", platform: "cli", appVersion: "0.0.0" },
+    })) as { deviceId: string; deviceToken: string; host: Record<string, string> };
+    console.log(`✓ paired as ${result.deviceId}`);
+    console.log(`  host: ${result.host.name} (${result.host.os}, v${result.host.appVersion})`);
+    saveToken(args.store, args.url, result.deviceToken);
+    console.log(`  device token saved to ${args.store}`);
+    // `pair` pushes no snapshot by contract — the get_workspace below is it.
+  } else {
+    const deviceToken = args.deviceToken ?? readSavedToken(args.store, args.url);
+    if (!deviceToken) {
+      console.error(`✗ no device token for ${args.url}; pass --token <pairing code> first`);
+      process.exit(1);
+    }
+    console.log("→ hello");
+    const result = (await client.call("hello", {
+      deviceToken,
+      client: { name: "remote-smoke", platform: "cli", appVersion: "0.0.0" },
+    })) as { host: Record<string, string>; workspace: unknown };
+    console.log(`✓ hello accepted`);
+    console.log(`  host: ${result.host.name} (${result.host.os}, v${result.host.appVersion})`);
+    console.log("\nworkspace (from the hello result):");
+    printWorkspace(result.workspace);
+  }
+
+  console.log("\n→ get_workspace");
+  printWorkspace(await client.call("get_workspace"));
+
+  // The allowlist should hold: a denied op answers, it does not disconnect.
+  const denied = await client.request("db_select", { table: "settings" });
+  console.log(
+    denied.ok
+      ? "✗ db_select was answered — the denylist is broken"
+      : `✓ db_select rejected: ${denied.error}`,
+  );
+
+  console.log(`\n→ listening for events for ${args.seconds}s (Ctrl-C to stop)\n`);
+  let count = 0;
+  client.onEvent = (event) => {
+    count++;
+    const payload = JSON.stringify(event.payload);
+    console.log(
+      `  ${new Date().toISOString().slice(11, 19)} ${event.event.padEnd(26)} ${
+        payload.length > 160 ? `${payload.slice(0, 160)}…` : payload
+      }`,
+    );
+  };
+  await new Promise((resolve) => setTimeout(resolve, args.seconds * 1000));
+  console.log(`\n✓ done — ${count} event(s) received`);
+  socket.close(1000, "smoke test complete");
+}
+
+main().catch((e) => {
+  console.error(`✗ ${e instanceof Error ? e.message : String(e)}`);
+  process.exit(1);
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -807,6 +807,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1238,8 @@ dependencies = [
  "chrono",
  "dirs 5.0.1",
  "flate2",
+ "futures-util",
+ "if-addrs",
  "nix 0.29.0",
  "objc2",
  "objc2-av-foundation",
@@ -1240,6 +1248,7 @@ dependencies = [
  "objc2-speech",
  "parking_lot",
  "portable-pty",
+ "rand",
  "reqwest 0.13.3",
  "rfd",
  "rusqlite",
@@ -1264,6 +1273,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
@@ -2065,6 +2075,16 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4418,6 +4438,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5363,6 +5394,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5641,6 +5684,23 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "typeid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,6 +68,23 @@ base64 = "0.22"
 sha2 = "0.10"
 flate2 = "1"
 tar = "0.4"
+# Paired-device remote access (`remote/`). Server side only: `handshake` is the
+# one feature needed, and no TLS backend is pulled in — v1 is plaintext on the
+# LAN or a Tailscale network by design (see docs/remote-protocol.md). Pinned to
+# 0.27 rather than 0.30 deliberately: 0.30 moves to sha1 0.11 / digest 0.11 and
+# rand 0.10, which would add a second copy of the whole hashing and RNG stack
+# next to the sha2 0.10 and rand 0.9 already in the tree.
+tokio-tungstenite = { version = "0.27", default-features = false, features = ["handshake"] }
+# `sink` for `SinkExt` on the split WebSocket writer; nothing else in the crate
+# needs the combinator zoo.
+futures-util = { version = "0.3", default-features = false, features = ["std", "sink"] }
+# Pairing codes and device tokens (`remote/auth.rs`). Already in the tree
+# transitively at this major.
+rand = "0.9"
+# The host's LAN addresses, for the pairing URL and the settings pane's
+# "reachable at" line. Smallest interface-enumeration crate: libc on unix,
+# windows-sys elsewhere, both already present.
+if-addrs = "0.13"
 
 # Window state (size/position/maximized) persistence — desktop only.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]

--- a/src-tauri/src/commands/agent.rs
+++ b/src-tauri/src/commands/agent.rs
@@ -34,7 +34,48 @@ pub async fn spawn_agent(
     // Absent for a normal spawn.
     purpose: Option<String>,
 ) -> Result<AgentRecord> {
-    let sup = supervisor.inner().clone();
+    spawn_agent_impl(
+        supervisor.inner().clone(),
+        app,
+        view,
+        repo_path,
+        provider,
+        name,
+        effort,
+        model,
+        instructions,
+        custom_agent_id,
+        skills,
+        mcp_servers,
+        fork_base,
+        issue_ref,
+        purpose,
+    )
+    .await
+}
+
+/// The user-spawn field mapping: the argument defaults every caller funnels
+/// through on the way to `Supervisor::spawn_agent`. Shared by the command above
+/// and the remote dispatcher, which passes `None` for the custom-agent fields
+/// the mobile surface does not expose.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn spawn_agent_impl(
+    sup: Arc<Supervisor>,
+    app: AppHandle,
+    view: Option<AgentView>,
+    repo_path: String,
+    provider: Option<String>,
+    name: Option<String>,
+    effort: Option<String>,
+    model: Option<String>,
+    instructions: Option<String>,
+    custom_agent_id: Option<String>,
+    skills: Option<Vec<crate::agent_profile::SkillSnapshot>>,
+    mcp_servers: Option<Vec<crate::agent_profile::McpServerSnapshot>>,
+    fork_base: Option<String>,
+    issue_ref: Option<String>,
+    purpose: Option<String>,
+) -> Result<AgentRecord> {
     sup.spawn_agent(
         app,
         SpawnRequest {

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -104,6 +104,14 @@ pub async fn get_agent_diff_stats(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
 ) -> Result<DiffStats> {
+    get_agent_diff_stats_impl(&supervisor, agent_id).await
+}
+
+/// Shared with the remote dispatcher.
+pub(crate) async fn get_agent_diff_stats_impl(
+    supervisor: &Supervisor,
+    agent_id: String,
+) -> Result<DiffStats> {
     let record = supervisor.workspace.agent(&agent_id)?;
     let mut stats = DiffStats::default();
 

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -402,16 +402,24 @@ pub async fn list_checkout_tree(
     supervisor: State<'_, Arc<Supervisor>>,
     agent_id: String,
 ) -> Result<Vec<CheckoutFile>> {
-    let record = supervisor.workspace.agent(&agent_id)?;
+    list_checkout_tree_impl(&supervisor, &agent_id).await
+}
+
+/// Shared with the remote dispatcher.
+pub(crate) async fn list_checkout_tree_impl(
+    supervisor: &Supervisor,
+    agent_id: &str,
+) -> Result<Vec<CheckoutFile>> {
+    let record = supervisor.workspace.agent(agent_id)?;
     if record.repos.len() <= 1 {
-        let (checkout, parent) = primary_checkout(&supervisor, &agent_id)?;
+        let (checkout, parent) = primary_checkout(supervisor, agent_id)?;
         return Ok(checkout_tree_files(&checkout, &parent, None).await);
     }
     let mut out = Vec::new();
     for repo in &record.repos {
         // One broken checkout shouldn't blank the whole tree — skip it and
         // keep listing the others.
-        let Ok(checkout) = repo.checkout_path(&agent_id) else {
+        let Ok(checkout) = repo.checkout_path(agent_id) else {
             continue;
         };
         let parent = diff_base(repo).unwrap_or_else(|| "main".to_string());
@@ -484,7 +492,17 @@ pub async fn read_checkout_file(
     path: String,
     base_mode: Option<DiffBaseMode>,
 ) -> Result<CheckoutFileContents> {
-    let (checkout, parent, path) = checkout_scope_for_path(&supervisor, &agent_id, &path)?;
+    read_checkout_file_impl(&supervisor, &agent_id, &path, base_mode).await
+}
+
+/// Shared with the remote dispatcher.
+pub(crate) async fn read_checkout_file_impl(
+    supervisor: &Supervisor,
+    agent_id: &str,
+    path: &str,
+    base_mode: Option<DiffBaseMode>,
+) -> Result<CheckoutFileContents> {
+    let (checkout, parent, path) = checkout_scope_for_path(supervisor, agent_id, path)?;
     let parent = match base_mode.unwrap_or_default() {
         DiffBaseMode::Head => "HEAD".to_string(),
         DiffBaseMode::Fork => parent,
@@ -558,7 +576,17 @@ pub async fn get_file_diff(
     path: String,
     base_mode: Option<DiffBaseMode>,
 ) -> Result<String> {
-    let (checkout, parent, path) = checkout_scope_for_path(&supervisor, &agent_id, &path)?;
+    get_file_diff_impl(&supervisor, &agent_id, &path, base_mode).await
+}
+
+/// Shared with the remote dispatcher.
+pub(crate) async fn get_file_diff_impl(
+    supervisor: &Supervisor,
+    agent_id: &str,
+    path: &str,
+    base_mode: Option<DiffBaseMode>,
+) -> Result<String> {
+    let (checkout, parent, path) = checkout_scope_for_path(supervisor, agent_id, path)?;
     let parent = match base_mode.unwrap_or_default() {
         DiffBaseMode::Head => "HEAD".to_string(),
         DiffBaseMode::Fork => parent,

--- a/src-tauri/src/commands/git_ops.rs
+++ b/src-tauri/src/commands/git_ops.rs
@@ -19,11 +19,22 @@ pub async fn push_agent(
     agent_id: String,
     subdir: Option<String>,
 ) -> Result<String> {
-    let (repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
+    push_agent_impl(supervisor.inner(), app, agent_id, subdir.as_deref()).await
+}
+
+/// Shared with the remote dispatcher, so a push from the phone triggers the
+/// same background PR-state fetch the desktop push does.
+pub(crate) async fn push_agent_impl(
+    supervisor: &Arc<Supervisor>,
+    app: AppHandle,
+    agent_id: String,
+    subdir: Option<&str>,
+) -> Result<String> {
+    let (repo, checkout) = agent_repo_checkout(supervisor, &agent_id, subdir)?;
     let branch = repo_branch(&repo)?.to_string();
     let summary = git::push(&checkout, &branch, false).await?;
     // After successful push, fetch PR state in background
-    supervisor.inner().fetch_and_emit_pr_state(app, agent_id);
+    supervisor.fetch_and_emit_pr_state(app, agent_id);
     Ok(summary)
 }
 
@@ -35,8 +46,18 @@ pub async fn commit_agent(
     message: String,
     subdir: Option<String>,
 ) -> Result<()> {
-    let (_repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
-    git::commit(&checkout, &message).await
+    commit_agent_impl(&supervisor, &agent_id, &message, subdir.as_deref()).await
+}
+
+/// Shared with the remote dispatcher.
+pub(crate) async fn commit_agent_impl(
+    supervisor: &Supervisor,
+    agent_id: &str,
+    message: &str,
+    subdir: Option<&str>,
+) -> Result<()> {
+    let (_repo, checkout) = agent_repo_checkout(supervisor, agent_id, subdir)?;
+    git::commit(&checkout, message).await
 }
 
 /// Discard every uncommitted change in the checkout (destructive).

--- a/src-tauri/src/commands/git_state.rs
+++ b/src-tauri/src/commands/git_state.rs
@@ -34,9 +34,16 @@ pub async fn get_git_state(
     agent_id: String,
     subdir: Option<String>,
 ) -> Result<Option<GitState>> {
-    let Some((repo, checkout)) =
-        agent_repo_checkout_opt(&supervisor, &agent_id, subdir.as_deref())?
-    else {
+    get_git_state_impl(&supervisor, &agent_id, subdir.as_deref()).await
+}
+
+/// Shared with the remote dispatcher.
+pub(crate) async fn get_git_state_impl(
+    supervisor: &Supervisor,
+    agent_id: &str,
+    subdir: Option<&str>,
+) -> Result<Option<GitState>> {
+    let Some((repo, checkout)) = agent_repo_checkout_opt(supervisor, agent_id, subdir)? else {
         return Ok(None);
     };
     let parent = base_branch(&repo).await;

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -105,9 +105,21 @@ pub async fn create_pr(
     body: String,
     subdir: Option<String>,
 ) -> Result<PrState> {
-    let (repo, checkout) = agent_repo_checkout(&supervisor, &agent_id, subdir.as_deref())?;
+    create_pr_impl(&supervisor, agent_id, &title, &body, subdir.as_deref()).await
+}
+
+/// Shared with the remote dispatcher, so a PR opened from the phone is bound,
+/// snapshotted and cross-linked exactly like a desktop one.
+pub(crate) async fn create_pr_impl(
+    supervisor: &Supervisor,
+    agent_id: String,
+    title: &str,
+    body: &str,
+    subdir: Option<&str>,
+) -> Result<PrState> {
+    let (repo, checkout) = agent_repo_checkout(supervisor, &agent_id, subdir)?;
     let base = repo.parent_branch.as_deref().unwrap_or("main");
-    let pr = gh::pr_create(&checkout, &title, &body, base).await?;
+    let pr = gh::pr_create(&checkout, title, body, base).await?;
     crate::telemetry::track("pr_opened", serde_json::json!({ "source": "manual" }));
     // Bind the PR to this agent (number + state snapshot) so later lookups
     // don't rely on the (recyclable) branch name. A failure here isn't fatal —
@@ -145,10 +157,19 @@ pub async fn get_pr_state(
     agent_id: String,
     subdir: Option<String>,
 ) -> Result<Option<PrState>> {
+    get_pr_state_impl(&supervisor, &agent_id, subdir.as_deref()).await
+}
+
+/// Shared with the remote dispatcher.
+pub(crate) async fn get_pr_state_impl(
+    supervisor: &Supervisor,
+    agent_id: &str,
+    subdir: Option<&str>,
+) -> Result<Option<PrState>> {
     Ok(crate::supervisor::resolve_pr_state(
         &supervisor.workspace,
-        &agent_id,
-        subdir.as_deref(),
+        agent_id,
+        subdir,
         // Called after a user action (create/merge/push, a delegated git op), so
         // a new PR is plausible right now — worth the branch scan immediately.
         crate::supervisor::Discovery::Forced,
@@ -211,9 +232,16 @@ pub async fn get_pr_checks(
     agent_id: String,
     subdir: Option<String>,
 ) -> Result<Option<gh::PrChecks>> {
-    let Some((repo, checkout)) =
-        agent_repo_checkout_opt(&supervisor, &agent_id, subdir.as_deref())?
-    else {
+    get_pr_checks_impl(&supervisor, &agent_id, subdir.as_deref()).await
+}
+
+/// Shared with the remote dispatcher.
+pub(crate) async fn get_pr_checks_impl(
+    supervisor: &Supervisor,
+    agent_id: &str,
+    subdir: Option<&str>,
+) -> Result<Option<gh::PrChecks>> {
+    let Some((repo, checkout)) = agent_repo_checkout_opt(supervisor, agent_id, subdir)? else {
         return Ok(None);
     };
     if repo.branch.is_none() {
@@ -246,10 +274,19 @@ pub async fn get_pr_live(
     agent_id: String,
     subdir: Option<String>,
 ) -> Result<Option<gh::PrLive>> {
+    get_pr_live_impl(&supervisor, &agent_id, subdir.as_deref()).await
+}
+
+/// Shared with the remote dispatcher.
+pub(crate) async fn get_pr_live_impl(
+    supervisor: &Supervisor,
+    agent_id: &str,
+    subdir: Option<&str>,
+) -> Result<Option<gh::PrLive>> {
     let Some((state, _bound)) = crate::supervisor::resolve_pr_state(
         &supervisor.workspace,
-        &agent_id,
-        subdir.as_deref(),
+        agent_id,
+        subdir,
         // A background poll: an unbound repo scans on an interval rather than
         // paying a point every tick for the same "still no PR".
         crate::supervisor::Discovery::Throttled,
@@ -266,9 +303,7 @@ pub async fn get_pr_live(
             checks: None,
         }));
     }
-    let Some((repo, checkout)) =
-        agent_repo_checkout_opt(&supervisor, &agent_id, subdir.as_deref())?
-    else {
+    let Some((repo, checkout)) = agent_repo_checkout_opt(supervisor, agent_id, subdir)? else {
         return Ok(Some(gh::PrLive {
             state,
             checks: None,

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,6 +12,10 @@ mod git_ops;
 mod git_state;
 mod github;
 mod issues;
+// Paired-device remote access is a desktop feature; the module it drives is
+// gated the same way.
+#[cfg(desktop)]
+mod remote;
 mod run;
 mod session;
 mod shell;
@@ -26,6 +30,8 @@ pub use git_ops::*;
 pub use git_state::*;
 pub use github::*;
 pub use issues::*;
+#[cfg(desktop)]
+pub use remote::*;
 pub use run::*;
 pub use session::*;
 pub use shell::*;

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -1,0 +1,72 @@
+//! Host-side commands for the paired-device remote server (Settings → Mobile
+//! devices). These are not remote ops: they are how the *desktop* turns the
+//! listener on, mints pairing codes and revokes devices.
+
+use std::sync::Arc;
+use tauri::State;
+
+use crate::database;
+use crate::error::{Error, Result};
+use crate::remote::{PairingInvite, RemoteState, RemoteStatus};
+use crate::DbState;
+
+#[tauri::command]
+pub fn remote_status(remote: State<'_, Arc<RemoteState>>) -> RemoteStatus {
+    remote.status()
+}
+
+/// Start or stop the listener and persist the intent, so the next launch agrees
+/// with the toggle. Returns the resulting status: the UI needs the bound port
+/// and the address list the moment the listener comes up, and a second
+/// round-trip could observe a different state.
+#[tauri::command]
+pub async fn remote_set_enabled(
+    remote: State<'_, Arc<RemoteState>>,
+    db: State<'_, DbState>,
+    enabled: bool,
+) -> Result<RemoteStatus> {
+    let port = {
+        let conn = db.lock();
+        crate::remote::parse_port(
+            database::get_setting(&conn, crate::remote::PORT_SETTING).as_deref(),
+        )
+    };
+    if enabled {
+        remote.inner().start(port)?;
+    } else {
+        remote.stop();
+    }
+    // Persisted after the bind so a port that cannot be opened does not leave
+    // the app trying (and failing) to listen on every future launch.
+    {
+        let conn = db.lock();
+        database::set_setting(
+            &conn,
+            crate::remote::ENABLED_SETTING,
+            if enabled { "true" } else { "false" },
+        )?;
+    }
+    Ok(remote.status())
+}
+
+/// Mint a single-use pairing code and the `fletch://pair` deep link that
+/// carries it. Refuses while the listener is down — a code nothing can be typed
+/// into is worse than an error.
+#[tauri::command]
+pub fn remote_begin_pairing(remote: State<'_, Arc<RemoteState>>) -> Result<PairingInvite> {
+    if !remote.status().listening {
+        return Err(Error::Other(
+            "Turn on mobile access before pairing a device.".into(),
+        ));
+    }
+    Ok(remote.begin_pairing())
+}
+
+#[tauri::command]
+pub fn remote_revoke_device(
+    remote: State<'_, Arc<RemoteState>>,
+    device_id: String,
+) -> Result<RemoteStatus> {
+    remote.revoke_device(&device_id)?;
+    Ok(remote.status())
+}

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -51,10 +51,15 @@ pub async fn remote_set_enabled(
 
 /// Mint a single-use pairing code and the `fletch://pair` deep link that
 /// carries it. Refuses while the listener is down — a code nothing can be typed
-/// into is worse than an error.
+/// into is worse than an error — and while the device store is unwritable,
+/// since that pairing would stop working at the next launch.
 #[tauri::command]
 pub fn remote_begin_pairing(remote: State<'_, Arc<RemoteState>>) -> Result<PairingInvite> {
-    if !remote.status().listening {
+    let status = remote.status();
+    if let Some(error) = status.error {
+        return Err(Error::Other(error));
+    }
+    if !status.listening {
         return Err(Error::Other(
             "Turn on mobile access before pairing a device.".into(),
         ));

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -29,6 +29,15 @@ pub fn allocate_draft_name(
     supervisor: State<'_, Arc<Supervisor>>,
     drafts: Vec<String>,
 ) -> Result<String> {
+    allocate_draft_name_impl(&supervisor, drafts)
+}
+
+/// Shared with the remote dispatcher, so a phone's draft allocation reserves
+/// against the same live set.
+pub(crate) fn allocate_draft_name_impl(
+    supervisor: &Supervisor,
+    drafts: Vec<String>,
+) -> Result<String> {
     let mut reserved = supervisor.workspace.live_agent_ids()?;
     reserved.extend(drafts);
     Ok(names::allocate(&reserved))

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1672,34 +1672,34 @@ pub fn run() {
                     app.handle().clone(),
                     supervisor.clone(),
                 ));
-                match remote::RemoteState::new(&data_dir.join("remote"), dispatch) {
-                    Ok(state) => {
-                        remote::install_taps(app.handle(), state.clone());
-                        let (enabled, port) = {
-                            let conn = db_for_remote.lock();
-                            (
-                                remote::parse_enabled(
-                                    database::get_setting(&conn, remote::ENABLED_SETTING).as_deref(),
-                                ),
-                                remote::parse_port(
-                                    database::get_setting(&conn, remote::PORT_SETTING).as_deref(),
-                                ),
-                            )
-                        };
-                        if enabled {
-                            // `start` binds synchronously but spawns onto the
-                            // async runtime, so it has to run inside it.
-                            let state = state.clone();
-                            tauri::async_runtime::spawn(async move {
-                                if let Err(e) = state.start(port) {
-                                    tracing::error!(error = %e, "remote: autostart failed");
-                                }
-                            });
+                // `RemoteState::new` cannot fail: the state has to be managed
+                // even when the device store is unusable, or `remote_status`
+                // panics the moment Settings opens. Such a failure travels as
+                // `RemoteStatus::error` instead.
+                let state = remote::RemoteState::new(&data_dir.join("remote"), dispatch);
+                remote::install_taps(app.handle(), state.clone());
+                let (enabled, port) = {
+                    let conn = db_for_remote.lock();
+                    (
+                        remote::parse_enabled(
+                            database::get_setting(&conn, remote::ENABLED_SETTING).as_deref(),
+                        ),
+                        remote::parse_port(
+                            database::get_setting(&conn, remote::PORT_SETTING).as_deref(),
+                        ),
+                    )
+                };
+                if enabled {
+                    // `start` binds synchronously but spawns onto the async
+                    // runtime, so it has to run inside it.
+                    let state = state.clone();
+                    tauri::async_runtime::spawn(async move {
+                        if let Err(e) = state.start(port) {
+                            tracing::error!(error = %e, "remote: autostart failed");
                         }
-                        app.manage(state);
-                    }
-                    Err(e) => tracing::error!(error = %e, "remote: state init failed"),
+                    });
                 }
+                app.manage(state);
             }
 
             // Menu-bar tray (close-to-tray + status line) — the second half of

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,6 +28,10 @@ mod new_project;
 mod oauth;
 mod power;
 mod pty_session;
+// Paired-device remote access (Settings → Mobile devices). Desktop-only: the
+// host is the machine agents run on, never the phone.
+#[cfg(desktop)]
+mod remote;
 mod roadmap;
 mod rpc;
 mod run_detect;
@@ -1589,6 +1593,8 @@ pub fn run() {
             let db_for_wf = db.clone();
             let db_for_roadmap = db.clone();
             let db_for_merge_sweep = db.clone();
+            #[cfg(desktop)]
+            let db_for_remote = db.clone();
             let workspace = Arc::new(WorkspaceManager::new(db));
 
             // Drop RPC mailboxes left by agents that are gone. Teardown removes
@@ -1654,6 +1660,47 @@ pub fn run() {
             // At most one `claude setup-token` capture runs at a time; the
             // code-submit / cancel commands reach it through this slot.
             app.manage(ClaudeSetupState::default());
+
+            // Paired-device remote access. The event taps go in unconditionally
+            // (with nothing connected, forwarding short-circuits before it
+            // touches a payload); the listener itself only starts when the user
+            // has turned it on. A failure here is never fatal — the app is a
+            // desktop app first.
+            #[cfg(desktop)]
+            {
+                let dispatch = Arc::new(remote::SupervisorDispatch::new(
+                    app.handle().clone(),
+                    supervisor.clone(),
+                ));
+                match remote::RemoteState::new(&data_dir.join("remote"), dispatch) {
+                    Ok(state) => {
+                        remote::install_taps(app.handle(), state.clone());
+                        let (enabled, port) = {
+                            let conn = db_for_remote.lock();
+                            (
+                                remote::parse_enabled(
+                                    database::get_setting(&conn, remote::ENABLED_SETTING).as_deref(),
+                                ),
+                                remote::parse_port(
+                                    database::get_setting(&conn, remote::PORT_SETTING).as_deref(),
+                                ),
+                            )
+                        };
+                        if enabled {
+                            // `start` binds synchronously but spawns onto the
+                            // async runtime, so it has to run inside it.
+                            let state = state.clone();
+                            tauri::async_runtime::spawn(async move {
+                                if let Err(e) = state.start(port) {
+                                    tracing::error!(error = %e, "remote: autostart failed");
+                                }
+                            });
+                        }
+                        app.manage(state);
+                    }
+                    Err(e) => tracing::error!(error = %e, "remote: state init failed"),
+                }
+            }
 
             // Menu-bar tray (close-to-tray + status line) — the second half of
             // the laptop-GUI hardening feature; the first half (the activity
@@ -1916,6 +1963,14 @@ pub fn run() {
             commands::detect_editors,
             commands::open_in_editor,
             commands::submit_feedback,
+            // Paired-device remote access. `generate_handler!` takes a flat
+            // path list with no room for a `cfg`, so these ride along
+            // unconditionally; the module behind them is desktop-gated, which
+            // is the only target this app ships for.
+            commands::remote_status,
+            commands::remote_set_enabled,
+            commands::remote_begin_pairing,
+            commands::remote_revoke_device,
             dictation::dictation_availability,
             dictation::dictation_start,
             dictation::dictation_stop,

--- a/src-tauri/src/remote/auth.rs
+++ b/src-tauri/src/remote/auth.rs
@@ -1,0 +1,236 @@
+//! Pairing tokens and device credentials for the remote server.
+//!
+//! Two secrets with two lifetimes: a short pairing token the user reads off the
+//! desktop (single use, five minutes) and a long-lived device token the phone
+//! keeps. Only the device token's sha256 is ever written to disk, so a copied
+//! `devices.json` can't be replayed as a credential.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use base64::Engine;
+use chrono::{DateTime, Utc};
+use parking_lot::Mutex;
+use rand::{Rng, RngCore};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::error::Result;
+
+/// Pairing-token alphabet — `A-Z2-9` per the protocol doc. `0` and `1` are out
+/// because they are the glyphs users misread as `O` and `I` when retyping a
+/// code off a screen.
+const PAIRING_ALPHABET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ23456789";
+const PAIRING_LEN: usize = 8;
+
+/// How long a minted pairing token stays redeemable.
+pub const PAIRING_TTL: Duration = Duration::from_secs(5 * 60);
+
+/// Device-token entropy: 32 bytes, which is 43 base64url characters.
+const DEVICE_TOKEN_BYTES: usize = 32;
+
+/// A freshly minted pairing token plus the wall-clock instant it lapses, which
+/// is what Settings counts down to.
+#[derive(Debug, Clone)]
+pub struct MintedToken {
+    pub token: String,
+    pub expires_at: DateTime<Utc>,
+}
+
+/// The outstanding pairing tokens. Small by construction: a token is dropped
+/// the moment it is redeemed, and every mint sweeps the lapsed ones.
+pub struct PairingTokens {
+    pending: Mutex<Vec<Pending>>,
+}
+
+struct Pending {
+    token: String,
+    /// Monotonic deadline, so a wall-clock jump can neither extend a token nor
+    /// void one early.
+    expires_at: Instant,
+}
+
+impl PairingTokens {
+    pub fn new() -> Self {
+        Self {
+            pending: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn mint(&self) -> MintedToken {
+        self.mint_with_ttl(PAIRING_TTL)
+    }
+
+    /// `ttl` is a parameter rather than the constant so tests can mint a token
+    /// that is already past its deadline.
+    pub fn mint_with_ttl(&self, ttl: Duration) -> MintedToken {
+        let token = random_code(PAIRING_LEN);
+        let now = Instant::now();
+        let mut pending = self.pending.lock();
+        pending.retain(|p| p.expires_at > now);
+        pending.push(Pending {
+            token: token.clone(),
+            expires_at: now + ttl,
+        });
+        let expires_at = Utc::now() + chrono::Duration::from_std(ttl).unwrap_or_default();
+        MintedToken { token, expires_at }
+    }
+
+    /// Redeem a token: true at most once per mint, and never past the TTL.
+    pub fn consume(&self, token: &str) -> bool {
+        let now = Instant::now();
+        let mut pending = self.pending.lock();
+        pending.retain(|p| p.expires_at > now);
+        match pending.iter().position(|p| p.token == token) {
+            Some(i) => {
+                pending.remove(i);
+                true
+            }
+            None => false,
+        }
+    }
+}
+
+impl Default for PairingTokens {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn random_code(len: usize) -> String {
+    let mut rng = rand::rng();
+    (0..len)
+        .map(|_| PAIRING_ALPHABET[rng.random_range(0..PAIRING_ALPHABET.len())] as char)
+        .collect()
+}
+
+/// One paired device as persisted in `devices.json`. camelCase on the wire and
+/// on disk, matching the `RemoteDevice` DTO in the protocol doc.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeviceRecord {
+    pub device_id: String,
+    pub name: String,
+    pub platform: String,
+    /// Hex sha256 of the device token. The plaintext exists only in the `pair`
+    /// response and on the phone.
+    pub token_hash: String,
+    pub created_at: String,
+    pub last_seen_at: Option<String>,
+}
+
+/// The paired-device registry, mirrored to `<dir>/devices.json`.
+pub struct DeviceStore {
+    path: PathBuf,
+    devices: Mutex<Vec<DeviceRecord>>,
+}
+
+impl DeviceStore {
+    /// Open (or start) the store at `<dir>/devices.json`. A file we can't parse
+    /// is treated as empty rather than fatal: the user can re-pair, whereas a
+    /// refusal to launch would be unrecoverable from the UI.
+    pub fn load(dir: &Path) -> Result<Self> {
+        std::fs::create_dir_all(dir)?;
+        let path = dir.join("devices.json");
+        let devices = match std::fs::read(&path) {
+            Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "remote: unreadable devices.json; starting empty");
+                Vec::new()
+            }),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+            Err(e) => return Err(e.into()),
+        };
+        Ok(Self {
+            path,
+            devices: Mutex::new(devices),
+        })
+    }
+
+    pub fn list(&self) -> Vec<DeviceRecord> {
+        self.devices.lock().clone()
+    }
+
+    /// Register a device and hand back its one-and-only plaintext token.
+    pub fn register(&self, name: &str, platform: &str) -> Result<(DeviceRecord, String)> {
+        let mut bytes = [0u8; DEVICE_TOKEN_BYTES];
+        rand::rng().fill_bytes(&mut bytes);
+        let token = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes);
+        let record = DeviceRecord {
+            device_id: uuid::Uuid::new_v4().to_string(),
+            name: name.to_string(),
+            platform: platform.to_string(),
+            token_hash: hash_token(&token),
+            created_at: Utc::now().to_rfc3339(),
+            last_seen_at: None,
+        };
+        let snapshot = {
+            let mut devices = self.devices.lock();
+            devices.push(record.clone());
+            devices.clone()
+        };
+        self.persist(&snapshot)?;
+        Ok((record, token))
+    }
+
+    /// Resolve a presented device token to its record. `None` for an unknown or
+    /// revoked token — the caller turns that into close code 4003.
+    pub fn verify(&self, token: &str) -> Option<DeviceRecord> {
+        let hash = hash_token(token);
+        self.devices
+            .lock()
+            .iter()
+            .find(|d| d.token_hash == hash)
+            .cloned()
+    }
+
+    /// Record that a device just authenticated. Best effort: a failed write
+    /// costs a "last seen" timestamp, never a connection.
+    pub fn touch(&self, device_id: &str) {
+        let now = Utc::now().to_rfc3339();
+        let snapshot = {
+            let mut devices = self.devices.lock();
+            match devices.iter_mut().find(|d| d.device_id == device_id) {
+                Some(d) => d.last_seen_at = Some(now),
+                None => return,
+            }
+            devices.clone()
+        };
+        if let Err(e) = self.persist(&snapshot) {
+            tracing::warn!(error = %e, "remote: persisting last-seen failed");
+        }
+    }
+
+    /// Drop a device's credential. Returns whether anything was removed.
+    pub fn revoke(&self, device_id: &str) -> Result<bool> {
+        let (removed, snapshot) = {
+            let mut devices = self.devices.lock();
+            let before = devices.len();
+            devices.retain(|d| d.device_id != device_id);
+            (devices.len() != before, devices.clone())
+        };
+        if removed {
+            self.persist(&snapshot)?;
+        }
+        Ok(removed)
+    }
+
+    /// Write the registry atomically (tmp + rename) at 0600 — it holds token
+    /// hashes, so it should not be world-readable even inside the app data dir.
+    fn persist(&self, devices: &[DeviceRecord]) -> Result<()> {
+        let json = serde_json::to_vec_pretty(devices)?;
+        let tmp = self.path.with_extension("json.tmp");
+        std::fs::write(&tmp, &json)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600))?;
+        }
+        std::fs::rename(&tmp, &self.path)?;
+        Ok(())
+    }
+}
+
+fn hash_token(token: &str) -> String {
+    let digest = Sha256::digest(token.as_bytes());
+    digest.iter().map(|b| format!("{b:02x}")).collect()
+}

--- a/src-tauri/src/remote/auth.rs
+++ b/src-tauri/src/remote/auth.rs
@@ -123,27 +123,56 @@ pub struct DeviceRecord {
 pub struct DeviceStore {
     path: PathBuf,
     devices: Mutex<Vec<DeviceRecord>>,
+    /// Why the store could not be opened, if it could not. Surfaced as
+    /// `RemoteStatus.error`; pairing refuses while it is set, because a
+    /// credential that cannot be persisted would silently stop working at the
+    /// next launch.
+    storage_error: Option<String>,
 }
 
 impl DeviceStore {
-    /// Open (or start) the store at `<dir>/devices.json`. A file we can't parse
-    /// is treated as empty rather than fatal: the user can re-pair, whereas a
-    /// refusal to launch would be unrecoverable from the UI.
-    pub fn load(dir: &Path) -> Result<Self> {
-        std::fs::create_dir_all(dir)?;
+    /// Open (or start) the store at `<dir>/devices.json`. Never fails: a file
+    /// we can't parse, or a directory we can't create, is treated as an empty
+    /// list rather than as fatal — the user can re-pair, whereas a refusal to
+    /// launch (or an unmanaged state that panics the settings pane) would be
+    /// unrecoverable from the UI. An unusable directory is remembered in
+    /// `storage_error`.
+    pub fn load(dir: &Path) -> Self {
+        let mut storage_error = None;
+        let mut devices = Vec::new();
         let path = dir.join("devices.json");
-        let devices = match std::fs::read(&path) {
-            Ok(bytes) => serde_json::from_slice(&bytes).unwrap_or_else(|e| {
-                tracing::warn!(error = %e, "remote: unreadable devices.json; starting empty");
-                Vec::new()
-            }),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
-            Err(e) => return Err(e.into()),
-        };
-        Ok(Self {
+        if let Err(e) = std::fs::create_dir_all(dir) {
+            storage_error = Some(format!(
+                "Paired devices cannot be stored in {}: {e}",
+                dir.display()
+            ));
+        } else {
+            match std::fs::read(&path) {
+                Ok(bytes) => devices = serde_json::from_slice(&bytes).unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "remote: unreadable devices.json; starting empty");
+                    Vec::new()
+                }),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => {
+                    storage_error = Some(format!(
+                        "Paired devices cannot be read from {}: {e}",
+                        path.display()
+                    ))
+                }
+            }
+        }
+        if let Some(error) = &storage_error {
+            tracing::error!(%error, "remote: device store unavailable");
+        }
+        Self {
             path,
             devices: Mutex::new(devices),
-        })
+            storage_error,
+        }
+    }
+
+    pub fn storage_error(&self) -> Option<&str> {
+        self.storage_error.as_deref()
     }
 
     pub fn list(&self) -> Vec<DeviceRecord> {
@@ -163,12 +192,7 @@ impl DeviceStore {
             created_at: Utc::now().to_rfc3339(),
             last_seen_at: None,
         };
-        let snapshot = {
-            let mut devices = self.devices.lock();
-            devices.push(record.clone());
-            devices.clone()
-        };
-        self.persist(&snapshot)?;
+        self.mutate(|devices| devices.push(record.clone()))?;
         Ok((record, token))
     }
 
@@ -183,35 +207,48 @@ impl DeviceStore {
             .cloned()
     }
 
+    /// Whether a device is still registered. Used to re-check a credential
+    /// after a connection has made itself revocable, closing the window where
+    /// a revoke lands between `verify` and that registration.
+    pub fn contains(&self, device_id: &str) -> bool {
+        self.devices.lock().iter().any(|d| d.device_id == device_id)
+    }
+
     /// Record that a device just authenticated. Best effort: a failed write
     /// costs a "last seen" timestamp, never a connection.
     pub fn touch(&self, device_id: &str) {
         let now = Utc::now().to_rfc3339();
-        let snapshot = {
-            let mut devices = self.devices.lock();
-            match devices.iter_mut().find(|d| d.device_id == device_id) {
-                Some(d) => d.last_seen_at = Some(now),
-                None => return,
+        let written = self.mutate(|devices| {
+            if let Some(d) = devices.iter_mut().find(|d| d.device_id == device_id) {
+                d.last_seen_at = Some(now);
             }
-            devices.clone()
-        };
-        if let Err(e) = self.persist(&snapshot) {
+        });
+        if let Err(e) = written {
             tracing::warn!(error = %e, "remote: persisting last-seen failed");
         }
     }
 
     /// Drop a device's credential. Returns whether anything was removed.
     pub fn revoke(&self, device_id: &str) -> Result<bool> {
-        let (removed, snapshot) = {
-            let mut devices = self.devices.lock();
+        self.mutate(|devices| {
             let before = devices.len();
             devices.retain(|d| d.device_id != device_id);
-            (devices.len() != before, devices.clone())
-        };
-        if removed {
-            self.persist(&snapshot)?;
-        }
-        Ok(removed)
+            devices.len() != before
+        })
+    }
+
+    /// The one write path: apply `f` to the list and persist it *while still
+    /// holding the lock*, so concurrent writers serialize.
+    ///
+    /// Every writer used to clone the list, release the lock and then write to
+    /// the same `devices.json.tmp`, which let two writes rename each other's
+    /// temp file and land out of order — a revoke overtaken by a `touch` would
+    /// resurrect the revoked credential at the next launch.
+    fn mutate<R>(&self, f: impl FnOnce(&mut Vec<DeviceRecord>) -> R) -> Result<R> {
+        let mut devices = self.devices.lock();
+        let out = f(&mut devices);
+        self.persist(&devices)?;
+        Ok(out)
     }
 
     /// Write the registry atomically (tmp + rename) at 0600 — it holds token

--- a/src-tauri/src/remote/auth.rs
+++ b/src-tauri/src/remote/auth.rs
@@ -6,6 +6,7 @@
 //! `devices.json` can't be replayed as a credential.
 
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
 use base64::Engine;
@@ -123,11 +124,17 @@ pub struct DeviceRecord {
 pub struct DeviceStore {
     path: PathBuf,
     devices: Mutex<Vec<DeviceRecord>>,
-    /// Why the store could not be opened, if it could not. Surfaced as
-    /// `RemoteStatus.error`; pairing refuses while it is set, because a
-    /// credential that cannot be persisted would silently stop working at the
-    /// next launch.
-    storage_error: Option<String>,
+    /// Why the store is not usable, if it is not: it could not be opened, or
+    /// the last write failed. Surfaced as `RemoteStatus.error` and cleared by
+    /// the next write that succeeds. Pairing refuses while it is set, because
+    /// a credential that cannot be persisted would silently stop working at
+    /// the next launch. Lock order: `devices` first, then this.
+    storage_error: Mutex<Option<String>>,
+    /// Memory is ahead of disk: a write failed after the list changed. `flush`
+    /// retries the write while this is set, so a transient failure (disk full,
+    /// a permissions slip) heals on its own instead of resurrecting a revoked
+    /// credential at the next launch.
+    unsaved: AtomicBool,
 }
 
 impl DeviceStore {
@@ -167,12 +174,24 @@ impl DeviceStore {
         Self {
             path,
             devices: Mutex::new(devices),
-            storage_error,
+            storage_error: Mutex::new(storage_error),
+            unsaved: AtomicBool::new(false),
         }
     }
 
-    pub fn storage_error(&self) -> Option<&str> {
-        self.storage_error.as_deref()
+    pub fn storage_error(&self) -> Option<String> {
+        self.storage_error.lock().clone()
+    }
+
+    /// Retry a write that failed earlier, if there is one outstanding. Called
+    /// from `RemoteState::status`, which Settings polls, so the retry runs a
+    /// few times a minute while the pane is open and on every host command.
+    pub fn flush(&self) {
+        if !self.unsaved.load(Ordering::Acquire) {
+            return;
+        }
+        let devices = self.devices.lock();
+        let _ = self.save(&devices);
     }
 
     pub fn list(&self) -> Vec<DeviceRecord> {
@@ -247,8 +266,32 @@ impl DeviceStore {
     fn mutate<R>(&self, f: impl FnOnce(&mut Vec<DeviceRecord>) -> R) -> Result<R> {
         let mut devices = self.devices.lock();
         let out = f(&mut devices);
-        self.persist(&devices)?;
+        self.save(&devices)?;
         Ok(out)
+    }
+
+    /// `persist` plus the bookkeeping that makes a failure visible and
+    /// retryable: a failed write sets `storage_error` and `unsaved`, a
+    /// successful one clears both. Caller holds the `devices` lock.
+    fn save(&self, devices: &[DeviceRecord]) -> Result<()> {
+        match self.persist(devices) {
+            Ok(()) => {
+                self.unsaved.store(false, Ordering::Release);
+                *self.storage_error.lock() = None;
+                Ok(())
+            }
+            Err(e) => {
+                let error = format!(
+                    "Paired devices could not be saved to {}: {e}. Revocations and new \
+                     pairings will not survive a relaunch until this is fixed.",
+                    self.path.display()
+                );
+                tracing::error!(%error, "remote: device store write failed");
+                self.unsaved.store(true, Ordering::Release);
+                *self.storage_error.lock() = Some(error);
+                Err(e)
+            }
+        }
     }
 
     /// Write the registry atomically (tmp + rename) at 0600 — it holds token

--- a/src-tauri/src/remote/dispatch.rs
+++ b/src-tauri/src/remote/dispatch.rs
@@ -1,0 +1,534 @@
+//! The remote op allowlist.
+//!
+//! Every arm deserializes the same camelCase argument keys the matching Tauri
+//! command receives from `invoke`, then calls the same supervisor/service
+//! function that command calls — so a phone and the desktop webview cannot
+//! drift apart in behaviour. Nothing outside [`OPS`] is reachable: `db_*`, the
+//! file mutations, the shell ops, raw PTY input, editor/log/telemetry/provider
+//! ops and the workflow/roadmap/run surfaces are all off the wire by
+//! construction.
+//!
+//! Adding an op is: a row in `docs/remote-protocol.md`, a name in [`OPS`], and
+//! one match arm here.
+
+use std::future::Future;
+use std::path::Path;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use serde_json::Value;
+use tauri::AppHandle;
+
+use crate::commands::DiffBaseMode;
+use crate::managed_session::ToolUseBehavior;
+use crate::supervisor::Supervisor;
+use crate::workspace::AgentView;
+
+/// A dispatched op's answer: the command's result serialized as Tauri would, or
+/// the `Display` of the Rust error.
+pub type DispatchResult = std::result::Result<Value, String>;
+pub type DispatchFuture<'a> = Pin<Box<dyn Future<Output = DispatchResult> + Send + 'a>>;
+
+/// What the WebSocket server needs from the op layer. A trait so the socket
+/// tests can drive the server with a stub while production runs the
+/// supervisor-backed impl below.
+pub trait Dispatch: Send + Sync + 'static {
+    fn dispatch<'a>(&'a self, op: &'a str, args: Value) -> DispatchFuture<'a>;
+}
+
+/// The error text the protocol reserves for an op that is not on the allowlist.
+pub const UNKNOWN_OP: &str = "unknown op";
+
+/// The v1 allowlist, in the order of the protocol doc's table. Load-bearing:
+/// `dispatch` rejects anything absent here before the `match` runs, so a name
+/// is only reachable when it appears both here and as an arm.
+pub const OPS: &[&str] = &[
+    "get_workspace",
+    "allocate_draft_name",
+    "spawn_agent",
+    "send_user_message",
+    "answer_tool_use",
+    "stop_agent",
+    "resume_agent",
+    "archive_agent",
+    "set_agent_model",
+    "set_agent_effort",
+    "read_session_records",
+    "read_user_turns",
+    "get_git_state",
+    "get_agent_diff_stats",
+    "list_checkout_tree",
+    "read_checkout_file",
+    "get_file_diff",
+    "commit_agent",
+    "push_agent",
+    "create_pr",
+    "get_pr_state",
+    "get_pr_checks",
+    "get_pr_live",
+    "list_repo_branches",
+    "repo_default_branch",
+    "discover_supported_models",
+];
+
+pub fn is_allowed(op: &str) -> bool {
+    OPS.contains(&op)
+}
+
+/// The production dispatcher: the supervisor and app handle the Tauri commands
+/// would have received through `State`/`AppHandle`.
+pub struct SupervisorDispatch {
+    app: AppHandle,
+    sup: Arc<Supervisor>,
+}
+
+impl SupervisorDispatch {
+    pub fn new(app: AppHandle, sup: Arc<Supervisor>) -> Self {
+        Self { app, sup }
+    }
+}
+
+impl Dispatch for SupervisorDispatch {
+    fn dispatch<'a>(&'a self, op: &'a str, args: Value) -> DispatchFuture<'a> {
+        Box::pin(async move {
+            if !is_allowed(op) {
+                return Err(UNKNOWN_OP.to_string());
+            }
+            let sup = &self.sup;
+            let app = &self.app;
+            match op {
+                "get_workspace" => ok(sup.current_workspace()),
+
+                "allocate_draft_name" => {
+                    let a: DraftsArgs = parse(args)?;
+                    res(crate::commands::allocate_draft_name_impl(sup, a.drafts))
+                }
+
+                // v1 forces the structured chat view and drops the custom-agent
+                // fields: the phone has no UI for a native PTY, and skills / MCP
+                // servers / a custom agent id are resolved by value from desktop
+                // storage the phone cannot see.
+                "spawn_agent" => {
+                    let a: SpawnArgs = parse(args)?;
+                    res(crate::commands::spawn_agent_impl(
+                        sup.clone(),
+                        app.clone(),
+                        Some(AgentView::Custom),
+                        a.repo_path,
+                        a.provider,
+                        a.name,
+                        a.effort,
+                        a.model,
+                        a.instructions,
+                        None,
+                        None,
+                        None,
+                        a.fork_base,
+                        a.issue_ref,
+                        None,
+                    )
+                    .await)
+                }
+
+                "send_user_message" => {
+                    let a: SendMessageArgs = parse(args)?;
+                    res(sup.clone().send_user_message(
+                        app,
+                        &a.agent_id,
+                        &a.turn_id,
+                        &a.text,
+                        &a.attachments,
+                    ))
+                }
+
+                "answer_tool_use" => {
+                    let a: AnswerToolUseArgs = parse(args)?;
+                    res(sup.answer_tool_use(
+                        &a.agent_id,
+                        &a.request_id,
+                        a.updated_input,
+                        a.behavior,
+                        a.message,
+                    ))
+                }
+
+                "stop_agent" => {
+                    let a: AgentArgs = parse(args)?;
+                    res(sup.clone().stop_agent(app.clone(), &a.agent_id).await)
+                }
+
+                "resume_agent" => {
+                    let a: AgentArgs = parse(args)?;
+                    res(sup.clone().resume_agent(app.clone(), &a.agent_id).await)
+                }
+
+                "archive_agent" => {
+                    let a: AgentArgs = parse(args)?;
+                    res(sup.clone().archive_agent(app.clone(), &a.agent_id).await)
+                }
+
+                "set_agent_model" => {
+                    let a: ModelArgs = parse(args)?;
+                    res(sup
+                        .set_agent_model(app, &a.agent_id, a.model.as_deref())
+                        .await)
+                }
+
+                "set_agent_effort" => {
+                    let a: EffortArgs = parse(args)?;
+                    res(sup
+                        .set_agent_effort(app, &a.agent_id, a.effort.as_deref())
+                        .await)
+                }
+
+                "read_session_records" => {
+                    let a: AgentArgs = parse(args)?;
+                    res(sup.workspace.read_session_records(&a.agent_id))
+                }
+
+                "read_user_turns" => {
+                    let a: AgentArgs = parse(args)?;
+                    res(sup.workspace.read_user_turns(&a.agent_id))
+                }
+
+                "get_git_state" => {
+                    let a: AgentSubdirArgs = parse(args)?;
+                    res(
+                        crate::commands::get_git_state_impl(sup, &a.agent_id, a.subdir.as_deref())
+                            .await,
+                    )
+                }
+
+                "get_agent_diff_stats" => {
+                    let a: AgentArgs = parse(args)?;
+                    res(crate::commands::get_agent_diff_stats_impl(sup, a.agent_id).await)
+                }
+
+                "list_checkout_tree" => {
+                    let a: AgentArgs = parse(args)?;
+                    res(crate::commands::list_checkout_tree_impl(sup, &a.agent_id).await)
+                }
+
+                "read_checkout_file" => {
+                    let a: FileArgs = parse(args)?;
+                    res(crate::commands::read_checkout_file_impl(
+                        sup,
+                        &a.agent_id,
+                        &a.path,
+                        a.base_mode,
+                    )
+                    .await)
+                }
+
+                "get_file_diff" => {
+                    let a: FileArgs = parse(args)?;
+                    res(
+                        crate::commands::get_file_diff_impl(sup, &a.agent_id, &a.path, a.base_mode)
+                            .await,
+                    )
+                }
+
+                "commit_agent" => {
+                    let a: CommitArgs = parse(args)?;
+                    res(crate::commands::commit_agent_impl(
+                        sup,
+                        &a.agent_id,
+                        &a.message,
+                        a.subdir.as_deref(),
+                    )
+                    .await)
+                }
+
+                "push_agent" => {
+                    let a: AgentSubdirArgs = parse(args)?;
+                    res(crate::commands::push_agent_impl(
+                        sup,
+                        app.clone(),
+                        a.agent_id,
+                        a.subdir.as_deref(),
+                    )
+                    .await)
+                }
+
+                "create_pr" => {
+                    let a: CreatePrArgs = parse(args)?;
+                    res(crate::commands::create_pr_impl(
+                        sup,
+                        a.agent_id,
+                        &a.title,
+                        &a.body,
+                        a.subdir.as_deref(),
+                    )
+                    .await)
+                }
+
+                "get_pr_state" => {
+                    let a: AgentSubdirArgs = parse(args)?;
+                    res(
+                        crate::commands::get_pr_state_impl(sup, &a.agent_id, a.subdir.as_deref())
+                            .await,
+                    )
+                }
+
+                "get_pr_checks" => {
+                    let a: AgentSubdirArgs = parse(args)?;
+                    res(
+                        crate::commands::get_pr_checks_impl(sup, &a.agent_id, a.subdir.as_deref())
+                            .await,
+                    )
+                }
+
+                "get_pr_live" => {
+                    let a: AgentSubdirArgs = parse(args)?;
+                    res(
+                        crate::commands::get_pr_live_impl(sup, &a.agent_id, a.subdir.as_deref())
+                            .await,
+                    )
+                }
+
+                "list_repo_branches" => {
+                    let a: RepoPathArgs = parse(args)?;
+                    res(crate::git::list_local_branches(Path::new(&a.repo_path)).await)
+                }
+
+                "repo_default_branch" => {
+                    let a: RepoPathArgs = parse(args)?;
+                    ok(crate::git::default_branch(Path::new(&a.repo_path)).await)
+                }
+
+                "discover_supported_models" => {
+                    ok(crate::model_catalog::discover_supported_models().await)
+                }
+
+                // Unreachable while `OPS` and the arms above agree; kept so a
+                // name added to one and not the other fails closed.
+                _ => Err(UNKNOWN_OP.to_string()),
+            }
+        })
+    }
+}
+
+fn parse<T: DeserializeOwned>(args: Value) -> std::result::Result<T, String> {
+    serde_json::from_value(args).map_err(|e| e.to_string())
+}
+
+fn ok<T: serde::Serialize>(value: T) -> DispatchResult {
+    serde_json::to_value(value).map_err(|e| e.to_string())
+}
+
+/// Commands answer with `crate::error::Result`; the wire carries the `Display`
+/// of the error, per the protocol doc.
+fn res<T: serde::Serialize>(result: crate::error::Result<T>) -> DispatchResult {
+    ok(result.map_err(|e| e.to_string())?)
+}
+
+// ---------------------------------------------------------------------------
+// Argument shapes. Keys match `src/api/domains/*.ts` exactly; unknown keys are
+// ignored, which is what lets `spawn_agent` accept (and drop) the fields v1
+// does not expose.
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentArgs {
+    agent_id: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AgentSubdirArgs {
+    agent_id: String,
+    #[serde(default)]
+    subdir: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RepoPathArgs {
+    repo_path: String,
+}
+
+#[derive(Deserialize)]
+struct DraftsArgs {
+    #[serde(default)]
+    drafts: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SpawnArgs {
+    repo_path: String,
+    #[serde(default)]
+    provider: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    effort: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    instructions: Option<String>,
+    #[serde(default)]
+    fork_base: Option<String>,
+    #[serde(default)]
+    issue_ref: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SendMessageArgs {
+    agent_id: String,
+    turn_id: String,
+    text: String,
+    #[serde(default)]
+    attachments: Vec<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AnswerToolUseArgs {
+    agent_id: String,
+    request_id: String,
+    updated_input: Value,
+    behavior: ToolUseBehavior,
+    #[serde(default)]
+    message: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ModelArgs {
+    agent_id: String,
+    #[serde(default)]
+    model: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EffortArgs {
+    agent_id: String,
+    #[serde(default)]
+    effort: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct FileArgs {
+    agent_id: String,
+    path: String,
+    #[serde(default)]
+    base_mode: Option<DiffBaseMode>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CommitArgs {
+    agent_id: String,
+    message: String,
+    #[serde(default)]
+    subdir: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CreatePrArgs {
+    agent_id: String,
+    title: String,
+    body: String,
+    #[serde(default)]
+    subdir: Option<String>,
+}
+
+#[cfg(test)]
+mod arg_tests {
+    use super::*;
+    use serde_json::json;
+
+    /// The mobile client sends the desktop's full `spawn_agent` payload, with
+    /// the fields v1 does not expose present but null. They must deserialize
+    /// away rather than fail the request.
+    #[test]
+    fn spawn_args_accept_the_full_desktop_payload() {
+        let args: SpawnArgs = parse(json!({
+            "view": "custom",
+            "repoPath": "/Users/alex/code/thing",
+            "provider": "claude",
+            "name": "arabia",
+            "effort": null,
+            "model": null,
+            "instructions": null,
+            "customAgentId": null,
+            "skills": null,
+            "mcpServers": null,
+            "forkBase": "main",
+            "issueRef": null,
+            "purpose": null,
+        }))
+        .expect("full desktop payload");
+        assert_eq!(args.repo_path, "/Users/alex/code/thing");
+        assert_eq!(args.provider.as_deref(), Some("claude"));
+        assert_eq!(args.name.as_deref(), Some("arabia"));
+        assert_eq!(args.fork_base.as_deref(), Some("main"));
+        assert!(args.instructions.is_none());
+        assert!(args.issue_ref.is_none());
+    }
+
+    #[test]
+    fn spawn_args_need_only_a_repo_path() {
+        let args: SpawnArgs = parse(json!({ "repoPath": "/tmp/repo" })).expect("minimal payload");
+        assert!(args.provider.is_none());
+        assert!(
+            parse::<SpawnArgs>(json!({})).is_err(),
+            "repoPath is required"
+        );
+    }
+
+    #[test]
+    fn message_and_tool_use_args_use_the_command_keys() {
+        let msg: SendMessageArgs = parse(json!({
+            "agentId": "arabia", "turnId": "t-1", "text": "go", "attachments": []
+        }))
+        .unwrap();
+        assert_eq!(msg.turn_id, "t-1");
+        assert!(msg.attachments.is_empty());
+        // `attachments` omitted is the same as empty — the phone has no
+        // attachment picker in v1.
+        assert!(parse::<SendMessageArgs>(json!({
+            "agentId": "arabia", "turnId": "t-1", "text": "go"
+        }))
+        .unwrap()
+        .attachments
+        .is_empty());
+
+        let tool: AnswerToolUseArgs = parse(json!({
+            "agentId": "arabia",
+            "requestId": "req-9",
+            "updatedInput": { "command": "ls" },
+            "behavior": "allow",
+            "message": null,
+        }))
+        .unwrap();
+        assert_eq!(tool.request_id, "req-9");
+        assert_eq!(tool.behavior, ToolUseBehavior::Allow);
+        assert!(tool.message.is_none());
+    }
+
+    #[test]
+    fn file_args_take_base_mode_or_leave_it_to_the_command_default() {
+        let bare: FileArgs = parse(json!({ "agentId": "a", "path": "src/lib.rs" })).unwrap();
+        assert!(bare.base_mode.is_none());
+        let head: FileArgs =
+            parse(json!({ "agentId": "a", "path": "src/lib.rs", "baseMode": "head" })).unwrap();
+        assert!(matches!(head.base_mode, Some(DiffBaseMode::Head)));
+    }
+
+    #[test]
+    fn subdir_is_optional_on_the_repo_scoped_ops() {
+        let bare: AgentSubdirArgs = parse(json!({ "agentId": "a" })).unwrap();
+        assert!(bare.subdir.is_none());
+        let explicit: AgentSubdirArgs = parse(json!({ "agentId": "a", "subdir": null })).unwrap();
+        assert!(explicit.subdir.is_none());
+    }
+}

--- a/src-tauri/src/remote/dispatch.rs
+++ b/src-tauri/src/remote/dispatch.rs
@@ -41,6 +41,11 @@ pub trait Dispatch: Send + Sync + 'static {
 /// The error text the protocol reserves for an op that is not on the allowlist.
 pub const UNKNOWN_OP: &str = "unknown op";
 
+/// The error text a connection gets when it already has the per-connection
+/// maximum of requests outstanding (`server::MAX_IN_FLIGHT`). The request is
+/// answered without being dispatched; the client retries.
+pub const TOO_MANY_IN_FLIGHT: &str = "too many in-flight requests";
+
 /// The v1 allowlist, in the order of the protocol doc's table. Load-bearing:
 /// `dispatch` rejects anything absent here before the `match` runs, so a name
 /// is only reachable when it appears both here and as an arm.

--- a/src-tauri/src/remote/events.rs
+++ b/src-tauri/src/remote/events.rs
@@ -1,0 +1,44 @@
+//! Taps on the Tauri event bus that mirror a whitelist of desktop events onto
+//! every authenticated connection.
+//!
+//! `Listener::listen_any` takes an event *name* (any target), so this installs
+//! one tap per whitelisted name rather than one tap for the whole bus — Tauri 2
+//! has no listen-to-everything API. The effect is the whitelist the protocol
+//! doc describes: nothing outside `FORWARDED_EVENTS` can reach a phone, and raw
+//! PTY output (`agent:output`, `shell:output`) in particular never does.
+
+use std::sync::Arc;
+
+use tauri::{AppHandle, Listener};
+
+use super::RemoteState;
+
+/// The v1 event whitelist, verbatim from `docs/remote-protocol.md`.
+pub const FORWARDED_EVENTS: &[&str] = &[
+    "agent:event",
+    "agent:status",
+    "agent:task",
+    "agent:branch",
+    "agent:model",
+    "agent:effort",
+    "agent:repo_added",
+    "agent:git-action",
+    "session:records-appended",
+    "turn:started",
+    "workspace:changed",
+    "pr:state_changed",
+    "verify:report",
+    "publish:approval-requested",
+];
+
+/// Install the taps. Safe to call once at launch regardless of whether the
+/// listener is enabled: with no connection subscribed, forwarding short-circuits
+/// before it touches the payload.
+pub fn install_taps(app: &AppHandle, state: Arc<RemoteState>) {
+    for name in FORWARDED_EVENTS.iter().copied() {
+        let state = state.clone();
+        app.listen_any(name, move |event| {
+            state.forward_event(name, event.payload());
+        });
+    }
+}

--- a/src-tauri/src/remote/mod.rs
+++ b/src-tauri/src/remote/mod.rs
@@ -7,13 +7,15 @@
 //! reuse the desktop's TypeScript DTOs unchanged.
 //!
 //! Layout: `auth` owns the two credentials, `server` the WebSocket listener,
-//! `dispatch` the op allowlist, `events` the Tauri event taps. This module owns
-//! the state those four share and the listener's lifecycle.
+//! `session` the live-connection registry, `dispatch` the op allowlist,
+//! `events` the Tauri event taps. This module owns the state those five share
+//! and the listener's lifecycle.
 
 mod auth;
 mod dispatch;
 mod events;
 mod server;
+mod session;
 #[cfg(test)]
 mod tests;
 
@@ -21,7 +23,6 @@ pub use auth::{DeviceStore, PairingTokens};
 pub use dispatch::{Dispatch, DispatchResult, SupervisorDispatch};
 pub use events::install_taps;
 
-use std::collections::HashMap;
 use std::net::Ipv4Addr;
 use std::sync::Arc;
 
@@ -30,6 +31,7 @@ use serde::Serialize;
 use serde_json::Value;
 use tokio::sync::broadcast;
 
+use self::session::{Sessions, CLOSE_DISABLED, CLOSE_REVOKED};
 use crate::error::{Error, Result};
 
 /// `settings` key mirroring whether the listener should run. Read once at
@@ -92,6 +94,10 @@ pub struct RemoteStatus {
     /// Every address a phone could reach this host on, best candidate first.
     pub addresses: Vec<String>,
     pub devices: Vec<RemoteDevice>,
+    /// A standing problem with the remote surface itself, for the pane to show
+    /// inline. Currently only one: `devices.json` is not writable, so pairing
+    /// is refused because the credential would not survive a restart.
+    pub error: Option<String>,
 }
 
 /// `remote_begin_pairing`' reply: the code to read out and the deep link to
@@ -114,40 +120,46 @@ struct Inner {
 
 struct ServerHandle {
     port: u16,
-    /// Fires once to stop the accept loop and close live connections with 4004.
+    /// Fires once to stop the accept loop. Live connections are closed through
+    /// the session registry, which can also address one device at a time.
     shutdown: broadcast::Sender<()>,
 }
 
 /// Everything the remote surface shares: credentials, the event fan-out, the
-/// live-session census and the listener handle. Held in Tauri managed state.
+/// live sessions and the listener handle. Held in Tauri managed state.
 pub struct RemoteState {
     dispatch: Arc<dyn Dispatch>,
     devices: Arc<DeviceStore>,
     pairing: PairingTokens,
     events: broadcast::Sender<Arc<str>>,
-    /// device id → live connection count, so `RemoteDevice::connected` is a
-    /// fact about sockets rather than about the last `hello`.
-    connected: Mutex<HashMap<String, usize>>,
+    /// Every live connection, so `RemoteDevice::connected` is a fact about
+    /// sockets and a revoke can reach the socket it just de-authorized.
+    sessions: Arc<Sessions>,
     inner: Mutex<Inner>,
 }
 
 impl RemoteState {
     /// Build the state, loading `devices.json` from `<dir>` (which is
     /// `<app_data_dir>/remote`). Does not start the listener.
-    pub fn new(dir: &std::path::Path, dispatch: Arc<dyn Dispatch>) -> Result<Arc<Self>> {
+    ///
+    /// Infallible on purpose: this is Tauri managed state, and a state that is
+    /// not managed turns `remote_status` — which Settings calls on open — into
+    /// a panic. An unusable device store instead reports itself through
+    /// `RemoteStatus::error` and refuses to pair.
+    pub fn new(dir: &std::path::Path, dispatch: Arc<dyn Dispatch>) -> Arc<Self> {
         let (events, _) = broadcast::channel(EVENT_BUFFER);
-        Ok(Arc::new(Self {
+        Arc::new(Self {
             dispatch,
-            devices: Arc::new(DeviceStore::load(dir)?),
+            devices: Arc::new(DeviceStore::load(dir)),
             pairing: PairingTokens::new(),
             events,
-            connected: Mutex::new(HashMap::new()),
+            sessions: Arc::new(Sessions::new()),
             inner: Mutex::new(Inner {
                 enabled: false,
                 port: DEFAULT_PORT,
                 server: None,
             }),
-        }))
+        })
     }
 
     pub fn devices(&self) -> &Arc<DeviceStore> {
@@ -201,11 +213,13 @@ impl RemoteState {
             let _ = handle.shutdown.send(());
             tracing::info!(port = handle.port, "remote: stopped");
         }
+        drop(inner);
+        self.sessions.close_all(CLOSE_DISABLED);
     }
 
     pub fn status(&self) -> RemoteStatus {
         let inner = self.inner.lock();
-        let connected = self.connected.lock();
+        let connected = self.sessions.connected_devices();
         RemoteStatus {
             enabled: inner.enabled,
             listening: inner.server.is_some(),
@@ -216,7 +230,7 @@ impl RemoteState {
                 .list()
                 .into_iter()
                 .map(|d| RemoteDevice {
-                    connected: connected.get(&d.device_id).copied().unwrap_or(0) > 0,
+                    connected: connected.contains(&d.device_id),
                     device_id: d.device_id,
                     name: d.name,
                     platform: d.platform,
@@ -224,6 +238,7 @@ impl RemoteState {
                     last_seen_at: d.last_seen_at,
                 })
                 .collect(),
+            error: self.devices.storage_error().map(str::to_string),
         }
     }
 
@@ -253,12 +268,22 @@ impl RemoteState {
         }
     }
 
-    /// Revoke a device. Its live connection (if any) is not torn down here —
-    /// the next `hello` fails with 4003, and the connection dies on its own
-    /// ping timeout. Keeping revoke a pure credential operation avoids reaching
-    /// into per-connection state for a case the user retries anyway.
+    /// Revoke a device and hang up on it.
+    ///
+    /// Credential first, socket second: in that order a connection that is
+    /// authenticating right now either fails `verify`, or registers itself and
+    /// then finds itself gone from the store (see `server::read_loop`) — there
+    /// is no interleaving that leaves an authorized socket behind.
     pub fn revoke_device(&self, device_id: &str) -> Result<bool> {
-        self.devices.revoke(device_id)
+        let removed = self.devices.revoke(device_id)?;
+        self.sessions.close_device(device_id, CLOSE_REVOKED);
+        Ok(removed)
+    }
+
+    /// Private to this module tree: only `server` registers sessions, and only
+    /// through the guard.
+    fn sessions(&self) -> &Arc<Sessions> {
+        &self.sessions
     }
 
     pub(super) fn subscribe(&self) -> broadcast::Receiver<Arc<str>> {
@@ -285,24 +310,6 @@ impl RemoteState {
         let name = serde_json::to_string(name).unwrap_or_else(|_| "\"\"".to_string());
         let frame = format!("{{\"event\":{name},\"payload\":{payload}}}");
         let _ = self.events.send(Arc::from(frame));
-    }
-
-    pub(super) fn mark_connected(&self, device_id: &str) {
-        *self
-            .connected
-            .lock()
-            .entry(device_id.to_string())
-            .or_insert(0) += 1;
-    }
-
-    pub(super) fn mark_disconnected(&self, device_id: &str) {
-        let mut connected = self.connected.lock();
-        if let Some(n) = connected.get_mut(device_id) {
-            *n = n.saturating_sub(1);
-            if *n == 0 {
-                connected.remove(device_id);
-            }
-        }
     }
 }
 

--- a/src-tauri/src/remote/mod.rs
+++ b/src-tauri/src/remote/mod.rs
@@ -218,6 +218,9 @@ impl RemoteState {
     }
 
     pub fn status(&self) -> RemoteStatus {
+        // Settings polls this, so it doubles as the retry point for a device
+        // store write that failed earlier (see `DeviceStore::flush`).
+        self.devices.flush();
         let inner = self.inner.lock();
         let connected = self.sessions.connected_devices();
         RemoteStatus {
@@ -238,7 +241,7 @@ impl RemoteState {
                     last_seen_at: d.last_seen_at,
                 })
                 .collect(),
-            error: self.devices.storage_error().map(str::to_string),
+            error: self.devices.storage_error(),
         }
     }
 
@@ -278,8 +281,9 @@ impl RemoteState {
     /// The hang-up does not depend on the disk write. The in-memory credential
     /// is gone the moment `revoke` returns, whether or not `devices.json` could
     /// be rewritten, so the live socket is closed either way and only then is
-    /// a persistence error reported — it means the revoke may not survive a
-    /// relaunch, not that it did not happen.
+    /// a persistence error reported. That error is also kept on the store
+    /// (`RemoteStatus.error`) and the write is retried from `status` until it
+    /// lands, so the on-disk record does not quietly outlive the revoke.
     pub fn revoke_device(&self, device_id: &str) -> Result<bool> {
         let persisted = self.devices.revoke(device_id);
         self.sessions.close_device(device_id, CLOSE_REVOKED);

--- a/src-tauri/src/remote/mod.rs
+++ b/src-tauri/src/remote/mod.rs
@@ -1,0 +1,375 @@
+//! Paired-device remote access: a phone acts as a control panel for the agents
+//! running on this Mac.
+//!
+//! The wire contract is `docs/remote-protocol.md` — every op mirrors an existing
+//! Tauri command by name, argument keys and result DTO, so the dispatcher calls
+//! the same supervisor/service functions the commands call and the phone can
+//! reuse the desktop's TypeScript DTOs unchanged.
+//!
+//! Layout: `auth` owns the two credentials, `server` the WebSocket listener,
+//! `dispatch` the op allowlist, `events` the Tauri event taps. This module owns
+//! the state those four share and the listener's lifecycle.
+
+mod auth;
+mod dispatch;
+mod events;
+mod server;
+#[cfg(test)]
+mod tests;
+
+pub use auth::{DeviceStore, PairingTokens};
+pub use dispatch::{Dispatch, DispatchResult, SupervisorDispatch};
+pub use events::install_taps;
+
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use serde::Serialize;
+use serde_json::Value;
+use tokio::sync::broadcast;
+
+use crate::error::{Error, Result};
+
+/// `settings` key mirroring whether the listener should run. Read once at
+/// launch and rewritten by `remote_set_enabled`.
+pub const ENABLED_SETTING: &str = "remote.enabled";
+/// `settings` key holding a TCP port override.
+pub const PORT_SETTING: &str = "remote.port";
+/// Default listen port (protocol doc).
+pub const DEFAULT_PORT: u16 = 47285;
+/// The only path the listener serves.
+pub const WS_PATH: &str = "/ws";
+
+/// How many event frames the fan-out buffers per connection. A phone that
+/// stalls past this is told it lagged and refetches, exactly as the desktop
+/// frontend does on focus — events are best effort by contract.
+const EVENT_BUFFER: usize = 256;
+
+/// Same shape as the other `settings`-mirrored booleans in the crate
+/// (`rpc::approval`, `codegraph`): anything but the literal `"true"` is off.
+pub fn parse_enabled(raw: Option<&str>) -> bool {
+    raw == Some("true")
+}
+
+/// A blank, absent or unparseable port setting falls back to the default rather
+/// than refusing to listen.
+pub fn parse_port(raw: Option<&str>) -> u16 {
+    raw.and_then(|s| s.trim().parse::<u16>().ok())
+        .filter(|p| *p != 0)
+        .unwrap_or(DEFAULT_PORT)
+}
+
+/// Who the phone is talking to, sent in the `pair` and `hello` results.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HostInfo {
+    pub name: String,
+    pub app_version: String,
+    pub os: String,
+}
+
+/// A paired device as Settings renders it.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteDevice {
+    pub device_id: String,
+    pub name: String,
+    pub platform: String,
+    pub created_at: String,
+    pub last_seen_at: Option<String>,
+    pub connected: bool,
+}
+
+/// `remote_status`' reply.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RemoteStatus {
+    pub enabled: bool,
+    pub listening: bool,
+    pub port: u16,
+    /// Every address a phone could reach this host on, best candidate first.
+    pub addresses: Vec<String>,
+    pub devices: Vec<RemoteDevice>,
+}
+
+/// `remote_begin_pairing`' reply: the code to read out and the deep link to
+/// encode as a QR.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PairingInvite {
+    pub token: String,
+    pub url: String,
+    pub expires_at: String,
+}
+
+struct Inner {
+    /// The user's intent, independent of whether a bind currently succeeds.
+    enabled: bool,
+    /// The configured port; `listening` reports the bound one.
+    port: u16,
+    server: Option<ServerHandle>,
+}
+
+struct ServerHandle {
+    port: u16,
+    /// Fires once to stop the accept loop and close live connections with 4004.
+    shutdown: broadcast::Sender<()>,
+}
+
+/// Everything the remote surface shares: credentials, the event fan-out, the
+/// live-session census and the listener handle. Held in Tauri managed state.
+pub struct RemoteState {
+    dispatch: Arc<dyn Dispatch>,
+    devices: Arc<DeviceStore>,
+    pairing: PairingTokens,
+    events: broadcast::Sender<Arc<str>>,
+    /// device id → live connection count, so `RemoteDevice::connected` is a
+    /// fact about sockets rather than about the last `hello`.
+    connected: Mutex<HashMap<String, usize>>,
+    inner: Mutex<Inner>,
+}
+
+impl RemoteState {
+    /// Build the state, loading `devices.json` from `<dir>` (which is
+    /// `<app_data_dir>/remote`). Does not start the listener.
+    pub fn new(dir: &std::path::Path, dispatch: Arc<dyn Dispatch>) -> Result<Arc<Self>> {
+        let (events, _) = broadcast::channel(EVENT_BUFFER);
+        Ok(Arc::new(Self {
+            dispatch,
+            devices: Arc::new(DeviceStore::load(dir)?),
+            pairing: PairingTokens::new(),
+            events,
+            connected: Mutex::new(HashMap::new()),
+            inner: Mutex::new(Inner {
+                enabled: false,
+                port: DEFAULT_PORT,
+                server: None,
+            }),
+        }))
+    }
+
+    pub fn devices(&self) -> &Arc<DeviceStore> {
+        &self.devices
+    }
+
+    pub fn pairing(&self) -> &PairingTokens {
+        &self.pairing
+    }
+
+    /// Start listening on `port` (0 binds an ephemeral one, which the socket
+    /// tests use). Returns the bound port. Idempotent: an already-running
+    /// listener is left alone.
+    ///
+    /// Must be called from inside the async runtime — the bind itself is
+    /// synchronous so that "port already in use" reaches the settings UI as an
+    /// error rather than a log line.
+    pub fn start(self: &Arc<Self>, port: u16) -> Result<u16> {
+        let mut inner = self.inner.lock();
+        if let Some(port) = inner.server.as_ref().map(|h| h.port) {
+            inner.enabled = true;
+            return Ok(port);
+        }
+
+        // Bind before recording the intent, so a port that cannot be opened
+        // leaves the toggle off and the error on screen rather than a switch
+        // that claims to be on.
+        let std_listener = std::net::TcpListener::bind((Ipv4Addr::UNSPECIFIED, port))
+            .map_err(|e| Error::Other(format!("remote: cannot listen on port {port}: {e}")))?;
+        std_listener.set_nonblocking(true)?;
+        let listener = tokio::net::TcpListener::from_std(std_listener)?;
+        let bound = listener.local_addr()?.port();
+
+        let (shutdown, stop) = broadcast::channel(1);
+        tokio::spawn(server::accept_loop(self.clone(), listener, stop));
+        inner.enabled = true;
+        inner.port = port;
+        inner.server = Some(ServerHandle {
+            port: bound,
+            shutdown,
+        });
+        tracing::info!(port = bound, "remote: listening");
+        Ok(bound)
+    }
+
+    /// Stop listening and close every live connection with 4004.
+    pub fn stop(&self) {
+        let mut inner = self.inner.lock();
+        inner.enabled = false;
+        if let Some(handle) = inner.server.take() {
+            let _ = handle.shutdown.send(());
+            tracing::info!(port = handle.port, "remote: stopped");
+        }
+    }
+
+    pub fn status(&self) -> RemoteStatus {
+        let inner = self.inner.lock();
+        let connected = self.connected.lock();
+        RemoteStatus {
+            enabled: inner.enabled,
+            listening: inner.server.is_some(),
+            port: inner.server.as_ref().map_or(inner.port, |h| h.port),
+            addresses: candidate_addresses(),
+            devices: self
+                .devices
+                .list()
+                .into_iter()
+                .map(|d| RemoteDevice {
+                    connected: connected.get(&d.device_id).copied().unwrap_or(0) > 0,
+                    device_id: d.device_id,
+                    name: d.name,
+                    platform: d.platform,
+                    created_at: d.created_at,
+                    last_seen_at: d.last_seen_at,
+                })
+                .collect(),
+        }
+    }
+
+    /// Mint a pairing token and the `fletch://pair` deep link that carries it.
+    pub fn begin_pairing(&self) -> PairingInvite {
+        let minted = self.pairing.mint();
+        let host = host_info();
+        let port = {
+            let inner = self.inner.lock();
+            inner.server.as_ref().map_or(inner.port, |h| h.port)
+        };
+        let addr = candidate_addresses()
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| "127.0.0.1".to_string());
+        let url = format!(
+            "fletch://pair?host={}&port={}&token={}&name={}",
+            urlencode(&addr),
+            port,
+            urlencode(&minted.token),
+            urlencode(&host.name),
+        );
+        PairingInvite {
+            token: minted.token,
+            url,
+            expires_at: minted.expires_at.to_rfc3339(),
+        }
+    }
+
+    /// Revoke a device. Its live connection (if any) is not torn down here —
+    /// the next `hello` fails with 4003, and the connection dies on its own
+    /// ping timeout. Keeping revoke a pure credential operation avoids reaching
+    /// into per-connection state for a case the user retries anyway.
+    pub fn revoke_device(&self, device_id: &str) -> Result<bool> {
+        self.devices.revoke(device_id)
+    }
+
+    pub(super) fn subscribe(&self) -> broadcast::Receiver<Arc<str>> {
+        self.events.subscribe()
+    }
+
+    pub(super) async fn dispatch(&self, op: &str, args: Value) -> DispatchResult {
+        self.dispatch.dispatch(op, args).await
+    }
+
+    /// Fan one Tauri event out to every authenticated connection.
+    ///
+    /// `payload_json` is spliced in rather than parsed and re-serialized, so the
+    /// phone receives byte-identical JSON to the desktop webview.
+    pub(super) fn forward_event(&self, name: &str, payload_json: &str) {
+        if self.events.receiver_count() == 0 {
+            return;
+        }
+        let payload = if payload_json.trim().is_empty() {
+            "null"
+        } else {
+            payload_json
+        };
+        let name = serde_json::to_string(name).unwrap_or_else(|_| "\"\"".to_string());
+        let frame = format!("{{\"event\":{name},\"payload\":{payload}}}");
+        let _ = self.events.send(Arc::from(frame));
+    }
+
+    pub(super) fn mark_connected(&self, device_id: &str) {
+        *self
+            .connected
+            .lock()
+            .entry(device_id.to_string())
+            .or_insert(0) += 1;
+    }
+
+    pub(super) fn mark_disconnected(&self, device_id: &str) {
+        let mut connected = self.connected.lock();
+        if let Some(n) = connected.get_mut(device_id) {
+            *n = n.saturating_sub(1);
+            if *n == 0 {
+                connected.remove(device_id);
+            }
+        }
+    }
+}
+
+/// Every IPv4 address a phone could dial this host on, best candidate first:
+/// RFC1918 LAN addresses, then everything else routable (which is where a
+/// Tailscale 100.64/10 address lands). Loopback and link-local are dropped —
+/// neither reaches a phone.
+pub fn candidate_addresses() -> Vec<String> {
+    let Ok(ifaces) = if_addrs::get_if_addrs() else {
+        return Vec::new();
+    };
+    let mut addrs: Vec<Ipv4Addr> = ifaces
+        .into_iter()
+        .filter_map(|i| match i.ip() {
+            std::net::IpAddr::V4(v4) => Some(v4),
+            std::net::IpAddr::V6(_) => None,
+        })
+        .filter(|v4| !v4.is_loopback() && !v4.is_link_local() && !v4.is_unspecified())
+        .collect();
+    addrs.sort();
+    addrs.dedup();
+    addrs.sort_by_key(|v4| !v4.is_private());
+    addrs.into_iter().map(|v4| v4.to_string()).collect()
+}
+
+/// Host identity for the pairing URL and the `hello` result.
+pub fn host_info() -> HostInfo {
+    HostInfo {
+        name: machine_name(),
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        os: std::env::consts::OS.to_string(),
+    }
+}
+
+/// The name a user would recognize in a device list. On macOS that is the
+/// Sharing pane's Computer Name ("Alex's MacBook Pro"), not the DNS hostname
+/// ("Alexs-MacBook-Pro.local"), so `scutil` is asked first. Cold path — called
+/// only when pairing or reading status.
+fn machine_name() -> String {
+    let candidates: &[(&str, &[&str])] = if cfg!(target_os = "macos") {
+        &[("scutil", &["--get", "ComputerName"]), ("hostname", &[])]
+    } else {
+        &[("hostname", &[])]
+    };
+    for (bin, args) in candidates {
+        if let Ok(out) = std::process::Command::new(bin).args(*args).output() {
+            let name = String::from_utf8_lossy(&out.stdout).trim().to_string();
+            if out.status.success() && !name.is_empty() {
+                return name;
+            }
+        }
+    }
+    "Fletch host".to_string()
+}
+
+/// Percent-encode a query-string value. Deliberately tiny: the only values
+/// encoded here are an IPv4 literal, an 8-character token and a machine name,
+/// so an allowlist of unreserved characters is the whole rule.
+fn urlencode(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(*byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
+}

--- a/src-tauri/src/remote/mod.rs
+++ b/src-tauri/src/remote/mod.rs
@@ -274,10 +274,16 @@ impl RemoteState {
     /// authenticating right now either fails `verify`, or registers itself and
     /// then finds itself gone from the store (see `server::read_loop`) — there
     /// is no interleaving that leaves an authorized socket behind.
+    ///
+    /// The hang-up does not depend on the disk write. The in-memory credential
+    /// is gone the moment `revoke` returns, whether or not `devices.json` could
+    /// be rewritten, so the live socket is closed either way and only then is
+    /// a persistence error reported — it means the revoke may not survive a
+    /// relaunch, not that it did not happen.
     pub fn revoke_device(&self, device_id: &str) -> Result<bool> {
-        let removed = self.devices.revoke(device_id)?;
+        let persisted = self.devices.revoke(device_id);
         self.sessions.close_device(device_id, CLOSE_REVOKED);
-        Ok(removed)
+        persisted
     }
 
     /// Private to this module tree: only `server` registers sessions, and only

--- a/src-tauri/src/remote/server.rs
+++ b/src-tauri/src/remote/server.rs
@@ -153,6 +153,10 @@ async fn drain(mut ws: Ws) {
 
 /// Reject anything but `/ws` at the handshake, so a stray browser hitting the
 /// port gets a 404 instead of an open socket.
+///
+/// The signature is tungstenite's `Callback` contract, so the large `Err`
+/// (`http::Response`) cannot be boxed away.
+#[allow(clippy::result_large_err)]
 fn check_path(req: &Request, response: Response) -> std::result::Result<Response, ErrorResponse> {
     if req.uri().path() == WS_PATH {
         return Ok(response);

--- a/src-tauri/src/remote/server.rs
+++ b/src-tauri/src/remote/server.rs
@@ -1,0 +1,447 @@
+//! The WebSocket listener: one task per connection, requests dispatched
+//! concurrently, events fanned out from the shared broadcast channel.
+//!
+//! Requests are answered off the reader loop on purpose. Some ops (`push_agent`,
+//! `create_pr`) take tens of seconds, and a reader that awaited them inline
+//! would stop reading pongs and hang up on a healthy phone mid-push.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::stream::SplitSink;
+use futures_util::{SinkExt, StreamExt};
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{broadcast, mpsc};
+use tokio_tungstenite::tungstenite::handshake::server::{ErrorResponse, Request, Response};
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::protocol::{CloseFrame, WebSocketConfig};
+use tokio_tungstenite::tungstenite::{http, Bytes, Error as WsError, Message};
+use tokio_tungstenite::WebSocketStream;
+
+use super::auth::DeviceRecord;
+use super::{RemoteState, WS_PATH};
+
+/// Largest frame/message the host accepts. tungstenite answers anything larger
+/// with close code 1009 on its own.
+const MAX_FRAME_BYTES: usize = 4 * 1024 * 1024;
+/// Ping cadence, and how many may go unanswered before the socket is dropped.
+const PING_INTERVAL: Duration = Duration::from_secs(20);
+const MAX_MISSED_PONGS: u32 = 2;
+/// How long a closing connection keeps reading (and discarding) the peer's
+/// bytes before the socket is dropped. See `drain`.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
+
+/// The first frame was neither `pair` nor `hello`.
+const CLOSE_BAD_FIRST_FRAME: CloseCode = CloseCode::Library(4001);
+/// Unauthenticated, or a bad/revoked credential.
+const CLOSE_UNAUTHENTICATED: CloseCode = CloseCode::Library(4003);
+/// The host turned remote access off under a live connection.
+const CLOSE_DISABLED: CloseCode = CloseCode::Library(4004);
+/// A frame past `MAX_FRAME_BYTES`. tungstenite surfaces this as a capacity
+/// error without closing, so the host sends the RFC's 1009 itself — the phone
+/// has no client-side cap and relies on this code to know what happened.
+const CLOSE_TOO_LARGE: CloseCode = CloseCode::Size;
+
+type Ws = WebSocketStream<TcpStream>;
+type Outbound = mpsc::UnboundedSender<Message>;
+
+pub(super) async fn accept_loop(
+    state: Arc<RemoteState>,
+    listener: TcpListener,
+    mut shutdown: broadcast::Receiver<()>,
+) {
+    loop {
+        tokio::select! {
+            _ = shutdown.recv() => return,
+            accepted = listener.accept() => match accepted {
+                Ok((stream, peer)) => {
+                    // Interactive control traffic: small frames, latency over
+                    // throughput.
+                    let _ = stream.set_nodelay(true);
+                    tokio::spawn(serve(state.clone(), stream, peer, shutdown.resubscribe()));
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "remote: accept failed");
+                }
+            },
+        }
+    }
+}
+
+async fn serve(
+    state: Arc<RemoteState>,
+    stream: TcpStream,
+    peer: SocketAddr,
+    shutdown: broadcast::Receiver<()>,
+) {
+    let mut config = WebSocketConfig::default();
+    config.max_message_size = Some(MAX_FRAME_BYTES);
+    config.max_frame_size = Some(MAX_FRAME_BYTES);
+    let ws = match tokio_tungstenite::accept_hdr_async_with_config(stream, check_path, Some(config))
+        .await
+    {
+        Ok(ws) => ws,
+        Err(e) => {
+            tracing::debug!(error = %e, %peer, "remote: handshake rejected");
+            return;
+        }
+    };
+
+    let (sink, stream) = ws.split();
+    let (tx, rx) = mpsc::unbounded_channel::<Message>();
+    let writer = tokio::spawn(pump(sink, rx));
+
+    let (device, stream) = read_loop(&state, stream, &tx, shutdown, peer).await;
+
+    if let Some(device) = &device {
+        state.mark_disconnected(&device.device_id);
+    }
+    // Closing `tx` lets the writer flush whatever is queued (a close frame
+    // last) and hand the sink back, so the socket can be drained before drop.
+    drop(tx);
+    if let Ok(sink) = writer.await {
+        if let Ok(ws) = stream.reunite(sink) {
+            drain(ws).await;
+        }
+    }
+}
+
+/// Read and discard whatever the peer is still sending, briefly, before the
+/// socket is dropped.
+///
+/// Dropping a TCP socket that still has unread inbound bytes makes the kernel
+/// send RST instead of FIN, and a reset discards anything the peer had not yet
+/// read — including the close frame that carries the code. The case that
+/// matters is the oversized frame: tungstenite rejects it on the header, so
+/// the host is closing while the phone is still writing the body, and without
+/// this the phone sees a broken pipe rather than 1009. The same applies, less
+/// often, to a client that keeps talking past a 4003. Raw reads, not WebSocket
+/// frames: after a capacity error the remaining bytes are payload, not frames.
+async fn drain(mut ws: Ws) {
+    use tokio::io::AsyncReadExt;
+    let tcp = ws.get_mut();
+    let mut buf = [0u8; 16 * 1024];
+    let _ = tokio::time::timeout(DRAIN_TIMEOUT, async {
+        while let Ok(n) = tcp.read(&mut buf).await {
+            if n == 0 {
+                break;
+            }
+        }
+    })
+    .await;
+}
+
+/// Reject anything but `/ws` at the handshake, so a stray browser hitting the
+/// port gets a 404 instead of an open socket.
+fn check_path(req: &Request, response: Response) -> std::result::Result<Response, ErrorResponse> {
+    if req.uri().path() == WS_PATH {
+        return Ok(response);
+    }
+    let mut err = ErrorResponse::new(Some(format!("only {WS_PATH} is served")));
+    *err.status_mut() = http::StatusCode::NOT_FOUND;
+    Err(err)
+}
+
+/// Serialize the outbound queue onto the socket. A `Close` is the last thing
+/// written; anything queued behind it is dropped. Hands the sink back so the
+/// caller can reunite it with the reader and drain the socket before drop.
+async fn pump(
+    mut sink: SplitSink<Ws, Message>,
+    mut rx: mpsc::UnboundedReceiver<Message>,
+) -> SplitSink<Ws, Message> {
+    while let Some(msg) = rx.recv().await {
+        let closing = matches!(msg, Message::Close(_));
+        if sink.send(msg).await.is_err() {
+            return sink;
+        }
+        if closing {
+            let _ = sink.close().await;
+            return sink;
+        }
+    }
+    let _ = sink.flush().await;
+    sink
+}
+
+/// The connection's state machine. Returns the authenticated device (if the
+/// connection ever got one) so the caller can drop it from the census, and
+/// the reader half so the socket can be reunited and drained.
+async fn read_loop(
+    state: &Arc<RemoteState>,
+    mut stream: futures_util::stream::SplitStream<Ws>,
+    tx: &Outbound,
+    mut shutdown: broadcast::Receiver<()>,
+    peer: SocketAddr,
+) -> (Option<DeviceRecord>, futures_util::stream::SplitStream<Ws>) {
+    let mut device: Option<DeviceRecord> = None;
+    let mut event_task: Option<tokio::task::JoinHandle<()>> = None;
+    let mut first_frame = true;
+    let mut missed_pongs = 0u32;
+    let mut ping = tokio::time::interval(PING_INTERVAL);
+    // `interval` fires immediately; the first real ping belongs one period out.
+    ping.tick().await;
+
+    loop {
+        tokio::select! {
+            _ = shutdown.recv() => {
+                send_close(tx, CLOSE_DISABLED, "remote access disabled");
+                break;
+            }
+            _ = ping.tick() => {
+                if missed_pongs >= MAX_MISSED_PONGS {
+                    tracing::debug!(%peer, "remote: pong timeout");
+                    break;
+                }
+                missed_pongs += 1;
+                if tx.send(Message::Ping(Bytes::new())).is_err() {
+                    break;
+                }
+            }
+            incoming = stream.next() => {
+                let msg = match incoming {
+                    Some(Ok(msg)) => msg,
+                    Some(Err(WsError::Capacity(e))) => {
+                        tracing::debug!(error = %e, %peer, "remote: frame over the 4 MiB cap");
+                        send_close(tx, CLOSE_TOO_LARGE, "frame too large");
+                        break;
+                    }
+                    // A protocol error or a dropped socket: nothing useful to
+                    // say back, and the peer is already gone or misbehaving.
+                    Some(Err(_)) | None => break,
+                };
+                match msg {
+                    Message::Pong(_) => missed_pongs = 0,
+                    Message::Close(_) => break,
+                    Message::Binary(_) => {
+                        // The protocol is text-only; a binary first frame is a
+                        // client that does not speak it at all.
+                        if first_frame {
+                            send_close(tx, CLOSE_BAD_FIRST_FRAME, "expected pair or hello");
+                            break;
+                        }
+                    }
+                    Message::Text(text) => {
+                        let frame: RequestFrame = match serde_json::from_str(&text) {
+                            Ok(frame) => frame,
+                            Err(e) => {
+                                if first_frame {
+                                    send_close(tx, CLOSE_BAD_FIRST_FRAME, "expected pair or hello");
+                                    break;
+                                }
+                                // No id to answer with; the client will time its
+                                // own request out.
+                                tracing::debug!(error = %e, %peer, "remote: unparseable frame");
+                                continue;
+                            }
+                        };
+                        let handshake = frame.op == "pair" || frame.op == "hello";
+                        if first_frame && !handshake {
+                            send_close(tx, CLOSE_BAD_FIRST_FRAME, "expected pair or hello");
+                            break;
+                        }
+                        first_frame = false;
+
+                        if device.is_none() {
+                            if !handshake {
+                                send_close(tx, CLOSE_UNAUTHENTICATED, "hello required");
+                                break;
+                            }
+                            match authenticate(state, &frame).await {
+                                Some((record, result)) => {
+                                    // Subscribe before the reply goes out: an
+                                    // event emitted in the gap would otherwise
+                                    // be lost, and the phone would render a
+                                    // snapshot it can't see the next change to.
+                                    event_task = Some(spawn_event_forwarder(state, tx.clone()));
+                                    state.devices().touch(&record.device_id);
+                                    state.mark_connected(&record.device_id);
+                                    // Reply last: the phone must not be able to
+                                    // observe itself as authenticated before it
+                                    // is on the fan-out and in the census.
+                                    send(tx, ok_frame(&frame.id, result));
+                                    tracing::info!(
+                                        device = %record.name,
+                                        platform = %record.platform,
+                                        "remote: device authenticated"
+                                    );
+                                    device = Some(record);
+                                }
+                                None => {
+                                    send_close(tx, CLOSE_UNAUTHENTICATED, "bad credential");
+                                    break;
+                                }
+                            }
+                            continue;
+                        }
+
+                        if handshake {
+                            // Already authenticated: the handshake ops are not
+                            // part of the dispatchable surface.
+                            send(tx, err_frame(&frame.id, super::dispatch::UNKNOWN_OP));
+                            continue;
+                        }
+
+                        let state = state.clone();
+                        let tx = tx.clone();
+                        let RequestFrame { id, op, args } = frame;
+                        tokio::spawn(async move {
+                            let outcome = state.dispatch(&op, args).await;
+                            let frame = match outcome {
+                                Ok(result) => ok_frame(&id, result),
+                                Err(error) => err_frame(&id, &error),
+                            };
+                            send(&tx, frame);
+                        });
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    if let Some(task) = event_task {
+        task.abort();
+    }
+    (device, stream)
+}
+
+/// Forward the shared event stream to one connection. Owned by a task rather
+/// than the reader's `select!` so a lagging phone can't stall request handling.
+fn spawn_event_forwarder(state: &Arc<RemoteState>, tx: Outbound) -> tokio::task::JoinHandle<()> {
+    // Subscribed here, not inside the task, so the connection is on the
+    // fan-out the instant this returns.
+    let mut rx = state.subscribe();
+    tokio::spawn(async move {
+        loop {
+            match rx.recv().await {
+                Ok(frame) => {
+                    if tx.send(Message::Text(frame.as_ref().into())).is_err() {
+                        return;
+                    }
+                }
+                // Best-effort delivery by contract: the phone refetches on
+                // reconnect and on returning to the foreground.
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::debug!(dropped = n, "remote: event fan-out lagged")
+                }
+                Err(broadcast::error::RecvError::Closed) => return,
+            }
+        }
+    })
+}
+
+/// Resolve a `pair`/`hello` frame into an authenticated device plus the result
+/// to answer with. `None` means close code 4003.
+async fn authenticate(
+    state: &Arc<RemoteState>,
+    frame: &RequestFrame,
+) -> Option<(DeviceRecord, Value)> {
+    let host = super::host_info();
+    match frame.op.as_str() {
+        "pair" => {
+            let args: PairArgs = serde_json::from_value(frame.args.clone()).ok()?;
+            if !state.pairing().consume(&args.token) {
+                return None;
+            }
+            let info = args.device.unwrap_or_default();
+            let (record, token) = state
+                .devices()
+                .register(&info.name(), &info.platform())
+                .map_err(|e| tracing::warn!(error = %e, "remote: pairing failed"))
+                .ok()?;
+            // No snapshot here, by contract: `pair` only authenticates and
+            // starts the event stream, and the client issues its own
+            // `get_workspace` next. Only `hello` carries a snapshot.
+            let result = json!({
+                "deviceId": record.device_id,
+                "deviceToken": token,
+                "host": host,
+            });
+            Some((record, result))
+        }
+        "hello" => {
+            let args: HelloArgs = serde_json::from_value(frame.args.clone()).ok()?;
+            let record = state.devices().verify(&args.device_token)?;
+            let workspace = state
+                .dispatch("get_workspace", json!({}))
+                .await
+                .unwrap_or(Value::Null);
+            let result = json!({ "host": host, "workspace": workspace });
+            Some((record, result))
+        }
+        _ => None,
+    }
+}
+
+fn send(tx: &Outbound, frame: String) {
+    let _ = tx.send(Message::Text(frame.into()));
+}
+
+fn send_close(tx: &Outbound, code: CloseCode, reason: &str) {
+    let _ = tx.send(Message::Close(Some(CloseFrame {
+        code,
+        reason: reason.into(),
+    })));
+}
+
+fn ok_frame(id: &str, result: Value) -> String {
+    json!({ "id": id, "ok": true, "result": result }).to_string()
+}
+
+fn err_frame(id: &str, error: &str) -> String {
+    json!({ "id": id, "ok": false, "error": error }).to_string()
+}
+
+#[derive(Deserialize)]
+struct RequestFrame {
+    id: String,
+    op: String,
+    #[serde(default = "empty_args")]
+    args: Value,
+}
+
+fn empty_args() -> Value {
+    json!({})
+}
+
+#[derive(Deserialize)]
+struct PairArgs {
+    token: String,
+    #[serde(default)]
+    device: Option<ClientInfo>,
+}
+
+/// `hello`'s documented `client` object is accepted and ignored: the device
+/// record already carries the name and platform from `pair`, and serde drops
+/// unknown keys.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HelloArgs {
+    device_token: String,
+}
+
+#[derive(Deserialize, Default)]
+struct ClientInfo {
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    platform: Option<String>,
+}
+
+impl ClientInfo {
+    fn name(&self) -> String {
+        self.name
+            .clone()
+            .filter(|n| !n.trim().is_empty())
+            .unwrap_or_else(|| "Unnamed device".to_string())
+    }
+
+    fn platform(&self) -> String {
+        self.platform
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string())
+    }
+}

--- a/src-tauri/src/remote/server.rs
+++ b/src-tauri/src/remote/server.rs
@@ -4,6 +4,11 @@
 //! Requests are answered off the reader loop on purpose. Some ops (`push_agent`,
 //! `create_pr`) take tens of seconds, and a reader that awaited them inline
 //! would stop reading pongs and hang up on a healthy phone mid-push.
+//!
+//! Everything a connection owns is bounded and ends with it: the outbound queue
+//! holds `OUTBOUND_BUFFER` frames, at most `MAX_IN_FLIGHT` dispatches run at
+//! once, and both the dispatch tasks and the registry entry are dropped on
+//! every exit path out of `serve`.
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -15,6 +20,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{broadcast, mpsc};
+use tokio::task::JoinSet;
 use tokio_tungstenite::tungstenite::handshake::server::{ErrorResponse, Request, Response};
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 use tokio_tungstenite::tungstenite::protocol::{CloseFrame, WebSocketConfig};
@@ -22,6 +28,7 @@ use tokio_tungstenite::tungstenite::{http, Bytes, Error as WsError, Message};
 use tokio_tungstenite::WebSocketStream;
 
 use super::auth::DeviceRecord;
+use super::session::{CloseRequest, SessionGuard};
 use super::{RemoteState, WS_PATH};
 
 /// Largest frame/message the host accepts. tungstenite answers anything larger
@@ -33,20 +40,26 @@ const MAX_MISSED_PONGS: u32 = 2;
 /// How long a closing connection keeps reading (and discarding) the peer's
 /// bytes before the socket is dropped. See `drain`.
 const DRAIN_TIMEOUT: Duration = Duration::from_secs(1);
+/// Frames one connection may have queued but not yet written. A control panel
+/// reads its own responses; a peer that lets this many pile up is either gone
+/// or not reading, and the session is dropped rather than buffered for.
+const OUTBOUND_BUFFER: usize = 64;
+/// Requests one connection may have in flight at once. The phone issues a
+/// handful per screen; past this the host answers `TOO_MANY_IN_FLIGHT` without
+/// dispatching, so a flood costs a response instead of a task and a `Supervisor`
+/// call each.
+const MAX_IN_FLIGHT: usize = 8;
 
 /// The first frame was neither `pair` nor `hello`.
 const CLOSE_BAD_FIRST_FRAME: CloseCode = CloseCode::Library(4001);
 /// Unauthenticated, or a bad/revoked credential.
 const CLOSE_UNAUTHENTICATED: CloseCode = CloseCode::Library(4003);
-/// The host turned remote access off under a live connection.
-const CLOSE_DISABLED: CloseCode = CloseCode::Library(4004);
 /// A frame past `MAX_FRAME_BYTES`. tungstenite surfaces this as a capacity
 /// error without closing, so the host sends the RFC's 1009 itself — the phone
 /// has no client-side cap and relies on this code to know what happened.
 const CLOSE_TOO_LARGE: CloseCode = CloseCode::Size;
 
 type Ws = WebSocketStream<TcpStream>;
-type Outbound = mpsc::UnboundedSender<Message>;
 
 pub(super) async fn accept_loop(
     state: Arc<RemoteState>,
@@ -61,7 +74,7 @@ pub(super) async fn accept_loop(
                     // Interactive control traffic: small frames, latency over
                     // throughput.
                     let _ = stream.set_nodelay(true);
-                    tokio::spawn(serve(state.clone(), stream, peer, shutdown.resubscribe()));
+                    tokio::spawn(serve(state.clone(), stream, peer));
                 }
                 Err(e) => {
                     tracing::warn!(error = %e, "remote: accept failed");
@@ -71,12 +84,7 @@ pub(super) async fn accept_loop(
     }
 }
 
-async fn serve(
-    state: Arc<RemoteState>,
-    stream: TcpStream,
-    peer: SocketAddr,
-    shutdown: broadcast::Receiver<()>,
-) {
+async fn serve(state: Arc<RemoteState>, stream: TcpStream, peer: SocketAddr) {
     let mut config = WebSocketConfig::default();
     config.max_message_size = Some(MAX_FRAME_BYTES);
     config.max_frame_size = Some(MAX_FRAME_BYTES);
@@ -91,17 +99,26 @@ async fn serve(
     };
 
     let (sink, stream) = ws.split();
-    let (tx, rx) = mpsc::unbounded_channel::<Message>();
+    let (tx, rx) = mpsc::channel::<Message>(OUTBOUND_BUFFER);
+    let (close_tx, close_rx) = mpsc::channel::<CloseRequest>(1);
+    // Registered before the first frame, so turning remote access off closes a
+    // socket that is still handshaking rather than leaving it free to pair
+    // against a stopped listener. The guard deregisters the session when it
+    // drops, which is every way out of this function.
+    let session = state.sessions().register(close_tx.clone());
+    let out = Outbox {
+        tx,
+        close: close_tx,
+    };
     let writer = tokio::spawn(pump(sink, rx));
 
-    let (device, stream) = read_loop(&state, stream, &tx, shutdown, peer).await;
+    let stream = read_loop(&state, stream, &out, close_rx, &session, peer).await;
 
-    if let Some(device) = &device {
-        state.mark_disconnected(&device.device_id);
-    }
-    // Closing `tx` lets the writer flush whatever is queued (a close frame
-    // last) and hand the sink back, so the socket can be drained before drop.
-    drop(tx);
+    // Dropping the guard and the outbox releases the last senders, which lets
+    // the writer flush whatever is queued (a close frame last) and hand the
+    // sink back, so the socket can be drained before drop.
+    drop(session);
+    drop(out);
     if let Ok(sink) = writer.await {
         if let Ok(ws) = stream.reunite(sink) {
             drain(ws).await;
@@ -145,12 +162,39 @@ fn check_path(req: &Request, response: Response) -> std::result::Result<Response
     Err(err)
 }
 
+/// One connection's outbound side: the bounded queue plus the switch that ends
+/// the session when that queue can no longer be written to.
+///
+/// Handed to the dispatch and event-forwarding tasks, which have no other way
+/// to stop a connection whose peer has stopped reading.
+#[derive(Clone)]
+struct Outbox {
+    tx: mpsc::Sender<Message>,
+    close: mpsc::Sender<CloseRequest>,
+}
+
+impl Outbox {
+    /// Queue a message. `false` means the session is over — the socket is gone,
+    /// or the peer let `OUTBOUND_BUFFER` frames pile up unread — and the
+    /// connection has been asked to close, so a caller in a loop should stop.
+    ///
+    /// A backpressure kill asks for a close with no frame: the queue a close
+    /// frame would travel through is exactly what is full.
+    fn send(&self, msg: Message) -> bool {
+        if self.tx.try_send(msg).is_ok() {
+            return true;
+        }
+        let _ = self.close.try_send(None);
+        false
+    }
+}
+
 /// Serialize the outbound queue onto the socket. A `Close` is the last thing
 /// written; anything queued behind it is dropped. Hands the sink back so the
 /// caller can reunite it with the reader and drain the socket before drop.
 async fn pump(
     mut sink: SplitSink<Ws, Message>,
-    mut rx: mpsc::UnboundedReceiver<Message>,
+    mut rx: mpsc::Receiver<Message>,
 ) -> SplitSink<Ws, Message> {
     while let Some(msg) = rx.recv().await {
         let closing = matches!(msg, Message::Close(_));
@@ -166,18 +210,21 @@ async fn pump(
     sink
 }
 
-/// The connection's state machine. Returns the authenticated device (if the
-/// connection ever got one) so the caller can drop it from the census, and
-/// the reader half so the socket can be reunited and drained.
+/// The connection's state machine. Returns the reader half so the socket can be
+/// reunited and drained.
 async fn read_loop(
     state: &Arc<RemoteState>,
     mut stream: futures_util::stream::SplitStream<Ws>,
-    tx: &Outbound,
-    mut shutdown: broadcast::Receiver<()>,
+    out: &Outbox,
+    mut close_rx: mpsc::Receiver<CloseRequest>,
+    session: &SessionGuard,
     peer: SocketAddr,
-) -> (Option<DeviceRecord>, futures_util::stream::SplitStream<Ws>) {
-    let mut device: Option<DeviceRecord> = None;
+) -> futures_util::stream::SplitStream<Ws> {
+    let mut authenticated = false;
     let mut event_task: Option<tokio::task::JoinHandle<()>> = None;
+    // Owns the dispatch tasks, so they are aborted when this loop ends instead
+    // of outliving the socket they were going to answer on.
+    let mut in_flight: JoinSet<()> = JoinSet::new();
     let mut first_frame = true;
     let mut missed_pongs = 0u32;
     let mut ping = tokio::time::interval(PING_INTERVAL);
@@ -186,8 +233,13 @@ async fn read_loop(
 
     loop {
         tokio::select! {
-            _ = shutdown.recv() => {
-                send_close(tx, CLOSE_DISABLED, "remote access disabled");
+            request = close_rx.recv() => {
+                // The host is hanging up: remote access was disabled, this
+                // device was revoked, or the outbound queue backed up (which
+                // is the `None` case — no frame can be written).
+                if let Some(Some(reason)) = request {
+                    out.send(close_frame(CloseCode::Library(reason.code), reason.reason));
+                }
                 break;
             }
             _ = ping.tick() => {
@@ -196,7 +248,7 @@ async fn read_loop(
                     break;
                 }
                 missed_pongs += 1;
-                if tx.send(Message::Ping(Bytes::new())).is_err() {
+                if !out.send(Message::Ping(Bytes::new())) {
                     break;
                 }
             }
@@ -205,7 +257,7 @@ async fn read_loop(
                     Some(Ok(msg)) => msg,
                     Some(Err(WsError::Capacity(e))) => {
                         tracing::debug!(error = %e, %peer, "remote: frame over the 4 MiB cap");
-                        send_close(tx, CLOSE_TOO_LARGE, "frame too large");
+                        out.send(close_frame(CLOSE_TOO_LARGE, "frame too large"));
                         break;
                     }
                     // A protocol error or a dropped socket: nothing useful to
@@ -219,7 +271,7 @@ async fn read_loop(
                         // The protocol is text-only; a binary first frame is a
                         // client that does not speak it at all.
                         if first_frame {
-                            send_close(tx, CLOSE_BAD_FIRST_FRAME, "expected pair or hello");
+                            out.send(close_frame(CLOSE_BAD_FIRST_FRAME, "expected pair or hello"));
                             break;
                         }
                     }
@@ -228,7 +280,7 @@ async fn read_loop(
                             Ok(frame) => frame,
                             Err(e) => {
                                 if first_frame {
-                                    send_close(tx, CLOSE_BAD_FIRST_FRAME, "expected pair or hello");
+                                    out.send(close_frame(CLOSE_BAD_FIRST_FRAME, "expected pair or hello"));
                                     break;
                                 }
                                 // No id to answer with; the client will time its
@@ -239,14 +291,14 @@ async fn read_loop(
                         };
                         let handshake = frame.op == "pair" || frame.op == "hello";
                         if first_frame && !handshake {
-                            send_close(tx, CLOSE_BAD_FIRST_FRAME, "expected pair or hello");
+                            out.send(close_frame(CLOSE_BAD_FIRST_FRAME, "expected pair or hello"));
                             break;
                         }
                         first_frame = false;
 
-                        if device.is_none() {
+                        if !authenticated {
                             if !handshake {
-                                send_close(tx, CLOSE_UNAUTHENTICATED, "hello required");
+                                out.send(close_frame(CLOSE_UNAUTHENTICATED, "hello required"));
                                 break;
                             }
                             match authenticate(state, &frame).await {
@@ -255,22 +307,33 @@ async fn read_loop(
                                     // event emitted in the gap would otherwise
                                     // be lost, and the phone would render a
                                     // snapshot it can't see the next change to.
-                                    event_task = Some(spawn_event_forwarder(state, tx.clone()));
+                                    event_task = Some(spawn_event_forwarder(state, out.clone()));
+                                    // Makes this socket revocable and visible
+                                    // as `connected`.
+                                    session.bind_device(&record.device_id);
+                                    // The credential could have been revoked
+                                    // between `verify` above and the line
+                                    // above, in which case `revoke_device`
+                                    // found no session to close and this is
+                                    // where that is caught.
+                                    if !state.devices().contains(&record.device_id) {
+                                        out.send(close_frame(CLOSE_UNAUTHENTICATED, "bad credential"));
+                                        break;
+                                    }
                                     state.devices().touch(&record.device_id);
-                                    state.mark_connected(&record.device_id);
                                     // Reply last: the phone must not be able to
                                     // observe itself as authenticated before it
-                                    // is on the fan-out and in the census.
-                                    send(tx, ok_frame(&frame.id, result));
+                                    // is on the fan-out and in the registry.
+                                    out.send(text_frame(ok_frame(&frame.id, result)));
                                     tracing::info!(
                                         device = %record.name,
                                         platform = %record.platform,
                                         "remote: device authenticated"
                                     );
-                                    device = Some(record);
+                                    authenticated = true;
                                 }
                                 None => {
-                                    send_close(tx, CLOSE_UNAUTHENTICATED, "bad credential");
+                                    out.send(close_frame(CLOSE_UNAUTHENTICATED, "bad credential"));
                                     break;
                                 }
                             }
@@ -280,20 +343,28 @@ async fn read_loop(
                         if handshake {
                             // Already authenticated: the handshake ops are not
                             // part of the dispatchable surface.
-                            send(tx, err_frame(&frame.id, super::dispatch::UNKNOWN_OP));
+                            out.send(text_frame(err_frame(&frame.id, super::dispatch::UNKNOWN_OP)));
+                            continue;
+                        }
+
+                        // Reap finished dispatches before counting, so the cap
+                        // is on work actually outstanding.
+                        while in_flight.try_join_next().is_some() {}
+                        if in_flight.len() >= MAX_IN_FLIGHT {
+                            out.send(text_frame(err_frame(&frame.id, super::dispatch::TOO_MANY_IN_FLIGHT)));
                             continue;
                         }
 
                         let state = state.clone();
-                        let tx = tx.clone();
+                        let out = out.clone();
                         let RequestFrame { id, op, args } = frame;
-                        tokio::spawn(async move {
+                        in_flight.spawn(async move {
                             let outcome = state.dispatch(&op, args).await;
                             let frame = match outcome {
                                 Ok(result) => ok_frame(&id, result),
                                 Err(error) => err_frame(&id, &error),
                             };
-                            send(&tx, frame);
+                            out.send(text_frame(frame));
                         });
                     }
                     _ => {}
@@ -302,15 +373,22 @@ async fn read_loop(
         }
     }
 
+    // Nothing this connection started may outlive it. Git ops run inside
+    // `spawn_blocking` and run to completion regardless; aborting only stops
+    // the host from waiting for them and from answering into a dead socket.
+    in_flight.shutdown().await;
     if let Some(task) = event_task {
         task.abort();
+        // Awaited so the task's `Outbox` clone is gone before the caller drops
+        // its own and waits for the writer.
+        let _ = task.await;
     }
-    (device, stream)
+    stream
 }
 
 /// Forward the shared event stream to one connection. Owned by a task rather
 /// than the reader's `select!` so a lagging phone can't stall request handling.
-fn spawn_event_forwarder(state: &Arc<RemoteState>, tx: Outbound) -> tokio::task::JoinHandle<()> {
+fn spawn_event_forwarder(state: &Arc<RemoteState>, out: Outbox) -> tokio::task::JoinHandle<()> {
     // Subscribed here, not inside the task, so the connection is on the
     // fan-out the instant this returns.
     let mut rx = state.subscribe();
@@ -318,7 +396,7 @@ fn spawn_event_forwarder(state: &Arc<RemoteState>, tx: Outbound) -> tokio::task:
         loop {
             match rx.recv().await {
                 Ok(frame) => {
-                    if tx.send(Message::Text(frame.as_ref().into())).is_err() {
+                    if !out.send(Message::Text(frame.as_ref().into())) {
                         return;
                     }
                 }
@@ -376,15 +454,15 @@ async fn authenticate(
     }
 }
 
-fn send(tx: &Outbound, frame: String) {
-    let _ = tx.send(Message::Text(frame.into()));
+fn text_frame(frame: String) -> Message {
+    Message::Text(frame.into())
 }
 
-fn send_close(tx: &Outbound, code: CloseCode, reason: &str) {
-    let _ = tx.send(Message::Close(Some(CloseFrame {
+fn close_frame(code: CloseCode, reason: &str) -> Message {
+    Message::Close(Some(CloseFrame {
         code,
         reason: reason.into(),
-    })));
+    }))
 }
 
 fn ok_frame(id: &str, result: Value) -> String {

--- a/src-tauri/src/remote/session.rs
+++ b/src-tauri/src/remote/session.rs
@@ -1,0 +1,133 @@
+//! The live-connection registry.
+//!
+//! A connected phone is addressable state, not just a row in `devices.json`:
+//! revoking a device or turning remote access off has to reach the socket that
+//! is already authenticated. Every accepted connection registers a
+//! `SessionGuard` here for its whole life, and the guard's `Drop` is the only
+//! place a session leaves the registry — so no exit path out of the connection
+//! task can leak one, and `RemoteDevice::connected` is derived from this map
+//! rather than from a second census that could disagree with it.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use tokio::sync::mpsc;
+
+/// Identifies one connection for the lifetime of the process.
+pub(super) type SessionId = u64;
+
+/// The close frame the host wants written before a socket goes away.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CloseReason {
+    /// WebSocket close code, per `docs/remote-protocol.md` → "Errors".
+    pub code: u16,
+    pub reason: &'static str,
+}
+
+/// What the host asks a live connection to do. `None` means "drop the socket
+/// without a close frame": the only case is outbound backpressure, where the
+/// queue a close frame would have to travel through is precisely what is full.
+pub(super) type CloseRequest = Option<CloseReason>;
+
+/// A device's credential was revoked under a live connection.
+pub(super) const CLOSE_REVOKED: CloseReason = CloseReason {
+    code: 4003,
+    reason: "device revoked",
+};
+
+/// The host turned remote access off under a live connection.
+pub(super) const CLOSE_DISABLED: CloseReason = CloseReason {
+    code: 4004,
+    reason: "remote access disabled",
+};
+
+struct Session {
+    /// `None` until `pair`/`hello` succeeds. Pre-auth connections are tracked
+    /// too, so disabling remote access closes a socket that is mid-handshake
+    /// instead of leaving it free to finish pairing against a stopped listener.
+    device_id: Option<String>,
+    /// Capacity 1: one close request is all a connection can act on.
+    close: mpsc::Sender<CloseRequest>,
+}
+
+/// Every live connection, keyed by an id that is never reused.
+pub(super) struct Sessions {
+    next_id: AtomicU64,
+    live: Mutex<HashMap<SessionId, Session>>,
+}
+
+impl Sessions {
+    pub(super) fn new() -> Self {
+        Self {
+            next_id: AtomicU64::new(1),
+            live: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Register a connection. The returned guard must be held for as long as
+    /// the connection lives; dropping it deregisters the session.
+    pub(super) fn register(self: &Arc<Self>, close: mpsc::Sender<CloseRequest>) -> SessionGuard {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        self.live.lock().insert(
+            id,
+            Session {
+                device_id: None,
+                close,
+            },
+        );
+        SessionGuard {
+            sessions: self.clone(),
+            id,
+        }
+    }
+
+    /// Ask every session authenticated as `device_id` to close. Non-blocking:
+    /// a session that already has a close queued needs no second one.
+    pub(super) fn close_device(&self, device_id: &str, reason: CloseReason) {
+        for session in self.live.lock().values() {
+            if session.device_id.as_deref() == Some(device_id) {
+                let _ = session.close.try_send(Some(reason));
+            }
+        }
+    }
+
+    /// Ask every session to close, authenticated or not.
+    pub(super) fn close_all(&self, reason: CloseReason) {
+        for session in self.live.lock().values() {
+            let _ = session.close.try_send(Some(reason));
+        }
+    }
+
+    /// The devices with at least one live authenticated connection.
+    pub(super) fn connected_devices(&self) -> HashSet<String> {
+        self.live
+            .lock()
+            .values()
+            .filter_map(|s| s.device_id.clone())
+            .collect()
+    }
+}
+
+/// A connection's handle on its own registration. Owned by the connection task.
+pub(super) struct SessionGuard {
+    sessions: Arc<Sessions>,
+    id: SessionId,
+}
+
+impl SessionGuard {
+    /// Record which device this connection authenticated as, which is what
+    /// makes it reachable by `close_device` and visible as `connected`.
+    pub(super) fn bind_device(&self, device_id: &str) {
+        if let Some(session) = self.sessions.live.lock().get_mut(&self.id) {
+            session.device_id = Some(device_id.to_string());
+        }
+    }
+}
+
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        self.sessions.live.lock().remove(&self.id);
+    }
+}

--- a/src-tauri/src/remote/tests.rs
+++ b/src-tauri/src/remote/tests.rs
@@ -7,7 +7,8 @@ use tokio::net::TcpStream;
 use tokio_tungstenite::tungstenite::Message;
 use tokio_tungstenite::WebSocketStream;
 
-use super::dispatch::{self, Dispatch, DispatchFuture, UNKNOWN_OP};
+use super::auth::DeviceRecord;
+use super::dispatch::{self, Dispatch, DispatchFuture, TOO_MANY_IN_FLIGHT, UNKNOWN_OP};
 use super::{DeviceStore, PairingTokens, RemoteState};
 
 // ---------------------------------------------------------------------------
@@ -64,7 +65,7 @@ fn minting_does_not_invalidate_an_outstanding_token() {
 #[test]
 fn device_token_verifies_until_revoked() {
     let dir = tempfile::tempdir().unwrap();
-    let store = DeviceStore::load(dir.path()).unwrap();
+    let store = DeviceStore::load(dir.path());
     let (record, token) = store.register("Alex's iPhone", "ios").unwrap();
 
     assert_eq!(token.len(), 43, "32 random bytes as base64url");
@@ -82,7 +83,7 @@ fn device_token_verifies_until_revoked() {
 #[test]
 fn unknown_device_token_is_rejected() {
     let dir = tempfile::tempdir().unwrap();
-    let store = DeviceStore::load(dir.path()).unwrap();
+    let store = DeviceStore::load(dir.path());
     store.register("phone", "ios").unwrap();
     assert!(store.verify("not-a-real-token").is_none());
 }
@@ -90,7 +91,7 @@ fn unknown_device_token_is_rejected() {
 #[test]
 fn devices_json_holds_no_plaintext_token_and_is_owner_only() {
     let dir = tempfile::tempdir().unwrap();
-    let store = DeviceStore::load(dir.path()).unwrap();
+    let store = DeviceStore::load(dir.path());
     let (_, token) = store.register("phone", "ios").unwrap();
 
     let path = dir.path().join("devices.json");
@@ -113,12 +114,73 @@ fn devices_json_holds_no_plaintext_token_and_is_owner_only() {
 fn devices_survive_a_reload() {
     let dir = tempfile::tempdir().unwrap();
     let token = {
-        let store = DeviceStore::load(dir.path()).unwrap();
+        let store = DeviceStore::load(dir.path());
         store.register("phone", "ios").unwrap().1
     };
-    let reopened = DeviceStore::load(dir.path()).unwrap();
+    let reopened = DeviceStore::load(dir.path());
     assert!(reopened.verify(&token).is_some());
     assert_eq!(reopened.list().len(), 1);
+}
+
+#[test]
+fn concurrent_writers_leave_the_file_agreeing_with_memory() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = Arc::new(DeviceStore::load(dir.path()));
+
+    // Every writer persists the whole list, so two of them racing used to be
+    // able to rename each other's temp file and land out of order —
+    // resurrecting a revoked credential at the next launch.
+    let workers: Vec<_> = (0..8)
+        .map(|w| {
+            let store = store.clone();
+            std::thread::spawn(move || {
+                for i in 0..20 {
+                    let (record, _) = store.register(&format!("phone-{w}-{i}"), "ios").unwrap();
+                    store.touch(&record.device_id);
+                    if i % 2 == 0 {
+                        assert!(store.revoke(&record.device_id).unwrap());
+                    }
+                }
+            })
+        })
+        .collect();
+    for worker in workers {
+        worker.join().unwrap();
+    }
+
+    let in_memory: Vec<String> = store.list().into_iter().map(|d| d.device_id).collect();
+    let raw = std::fs::read(dir.path().join("devices.json")).unwrap();
+    let on_disk: Vec<String> = serde_json::from_slice::<Vec<DeviceRecord>>(&raw)
+        .unwrap()
+        .into_iter()
+        .map(|d| d.device_id)
+        .collect();
+
+    assert_eq!(in_memory.len(), 8 * 10, "half of each worker's are revoked");
+    assert_eq!(on_disk, in_memory, "devices.json diverged from memory");
+    assert!(
+        !dir.path().join("devices.json.tmp").exists(),
+        "a temp file outlived its rename"
+    );
+}
+
+#[test]
+fn an_unusable_device_store_becomes_a_status_error() {
+    let dir = tempfile::tempdir().unwrap();
+    // A path already occupied by a regular file: `create_dir_all` cannot make
+    // the store directory, which used to leave `RemoteState` unmanaged and
+    // panic `remote_status` the moment Settings opened.
+    let occupied = dir.path().join("remote");
+    std::fs::write(&occupied, b"not a directory").unwrap();
+
+    let state = RemoteState::new(&occupied, Arc::new(StubDispatch));
+    let status = state.status();
+    assert!(
+        status.error.is_some(),
+        "an unusable device store must surface an error"
+    );
+    assert!(status.devices.is_empty());
+    assert!(!status.listening);
 }
 
 // ---------------------------------------------------------------------------
@@ -212,6 +274,21 @@ impl Dispatch for StubDispatch {
     }
 }
 
+/// Answers the `hello` snapshot and then never answers anything, so a
+/// connection can be driven past its in-flight cap.
+struct HangingDispatch;
+
+impl Dispatch for HangingDispatch {
+    fn dispatch<'a>(&'a self, op: &'a str, _args: Value) -> DispatchFuture<'a> {
+        Box::pin(async move {
+            match op {
+                "get_workspace" => Ok(json!({ "projects": [], "agents": [] })),
+                _ => std::future::pending().await,
+            }
+        })
+    }
+}
+
 struct Host {
     _dir: tempfile::TempDir,
     state: Arc<RemoteState>,
@@ -219,8 +296,12 @@ struct Host {
 }
 
 fn boot() -> Host {
+    boot_with(Arc::new(StubDispatch))
+}
+
+fn boot_with(dispatch: Arc<dyn Dispatch>) -> Host {
     let dir = tempfile::tempdir().unwrap();
-    let state = RemoteState::new(dir.path(), Arc::new(StubDispatch)).unwrap();
+    let state = RemoteState::new(dir.path(), dispatch);
     let port = state.start(0).unwrap();
     Host {
         _dir: dir,
@@ -407,6 +488,77 @@ async fn disabling_remote_access_closes_live_connections_4004() {
     host.state.stop();
     assert_eq!(close_code(&mut ws).await, 4004);
     assert!(!host.state.status().listening);
+}
+
+#[tokio::test]
+async fn revoking_a_device_closes_its_live_connection_4003() {
+    let host = boot();
+    let (record, token) = host.state.devices().register("phone", "ios").unwrap();
+    let mut ws = connect(host.port).await;
+    request(&mut ws, "1", "hello", json!({ "deviceToken": token })).await;
+    assert_eq!(next_json(&mut ws).await["ok"], true);
+    assert!(host.state.status().devices[0].connected);
+
+    // The credential is gone *and* the socket that was using it is hung up on:
+    // an already-authenticated connection is not re-checked per request.
+    host.state.revoke_device(&record.device_id).unwrap();
+    assert_eq!(close_code(&mut ws).await, 4003);
+    assert!(host.state.status().devices.is_empty());
+}
+
+#[tokio::test]
+async fn revoking_one_device_leaves_another_connected() {
+    let host = boot();
+    let (first, first_token) = host.state.devices().register("phone", "ios").unwrap();
+    let (_, second_token) = host.state.devices().register("tablet", "android").unwrap();
+
+    let mut doomed = connect(host.port).await;
+    request(
+        &mut doomed,
+        "1",
+        "hello",
+        json!({ "deviceToken": first_token }),
+    )
+    .await;
+    assert_eq!(next_json(&mut doomed).await["ok"], true);
+    let mut kept = connect(host.port).await;
+    request(
+        &mut kept,
+        "1",
+        "hello",
+        json!({ "deviceToken": second_token }),
+    )
+    .await;
+    assert_eq!(next_json(&mut kept).await["ok"], true);
+
+    host.state.revoke_device(&first.device_id).unwrap();
+    assert_eq!(close_code(&mut doomed).await, 4003);
+
+    request(&mut kept, "2", "get_workspace", json!({})).await;
+    let reply = next_json(&mut kept).await;
+    assert_eq!(reply["id"], "2");
+    assert_eq!(reply["ok"], true);
+}
+
+#[tokio::test]
+async fn requests_past_the_in_flight_cap_are_refused_without_dispatching() {
+    let host = boot_with(Arc::new(HangingDispatch));
+    let (_, token) = host.state.devices().register("phone", "ios").unwrap();
+    let mut ws = connect(host.port).await;
+    request(&mut ws, "0", "hello", json!({ "deviceToken": token })).await;
+    assert_eq!(next_json(&mut ws).await["ok"], true);
+
+    // Eight ops that never answer fill the connection's slots; the reader
+    // handles frames in order, so the ninth is over the cap by construction.
+    for i in 1..=8 {
+        request(&mut ws, &i.to_string(), "get_git_state", json!({})).await;
+    }
+    request(&mut ws, "9", "get_git_state", json!({})).await;
+
+    let refused = next_json(&mut ws).await;
+    assert_eq!(refused["id"], "9");
+    assert_eq!(refused["ok"], false);
+    assert_eq!(refused["error"], TOO_MANY_IN_FLIGHT);
 }
 
 #[tokio::test]

--- a/src-tauri/src/remote/tests.rs
+++ b/src-tauri/src/remote/tests.rs
@@ -1,0 +1,462 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::{SinkExt, StreamExt};
+use serde_json::{json, Value};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::Message;
+use tokio_tungstenite::WebSocketStream;
+
+use super::dispatch::{self, Dispatch, DispatchFuture, UNKNOWN_OP};
+use super::{DeviceStore, PairingTokens, RemoteState};
+
+// ---------------------------------------------------------------------------
+// Pairing tokens
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pairing_token_uses_the_documented_alphabet() {
+    let minted = PairingTokens::new().mint();
+    assert_eq!(minted.token.len(), 8);
+    assert!(
+        minted
+            .token
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || ('2'..='9').contains(&c)),
+        "token {} left the A-Z2-9 alphabet",
+        minted.token
+    );
+}
+
+#[test]
+fn pairing_token_is_single_use() {
+    let tokens = PairingTokens::new();
+    let minted = tokens.mint();
+    assert!(tokens.consume(&minted.token));
+    assert!(!tokens.consume(&minted.token));
+}
+
+#[test]
+fn pairing_token_expires() {
+    let tokens = PairingTokens::new();
+    let minted = tokens.mint_with_ttl(Duration::ZERO);
+    assert!(!tokens.consume(&minted.token));
+}
+
+#[test]
+fn unminted_pairing_token_is_rejected() {
+    assert!(!PairingTokens::new().consume("AAAAAAAA"));
+}
+
+#[test]
+fn minting_does_not_invalidate_an_outstanding_token() {
+    let tokens = PairingTokens::new();
+    let first = tokens.mint();
+    let second = tokens.mint();
+    assert!(tokens.consume(&first.token));
+    assert!(tokens.consume(&second.token));
+}
+
+// ---------------------------------------------------------------------------
+// Device credentials
+// ---------------------------------------------------------------------------
+
+#[test]
+fn device_token_verifies_until_revoked() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = DeviceStore::load(dir.path()).unwrap();
+    let (record, token) = store.register("Alex's iPhone", "ios").unwrap();
+
+    assert_eq!(token.len(), 43, "32 random bytes as base64url");
+    let found = store.verify(&token).expect("fresh token verifies");
+    assert_eq!(found.device_id, record.device_id);
+
+    assert!(store.revoke(&record.device_id).unwrap());
+    assert!(store.verify(&token).is_none(), "revoked token still works");
+    assert!(
+        !store.revoke(&record.device_id).unwrap(),
+        "revoke is idempotent"
+    );
+}
+
+#[test]
+fn unknown_device_token_is_rejected() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = DeviceStore::load(dir.path()).unwrap();
+    store.register("phone", "ios").unwrap();
+    assert!(store.verify("not-a-real-token").is_none());
+}
+
+#[test]
+fn devices_json_holds_no_plaintext_token_and_is_owner_only() {
+    let dir = tempfile::tempdir().unwrap();
+    let store = DeviceStore::load(dir.path()).unwrap();
+    let (_, token) = store.register("phone", "ios").unwrap();
+
+    let path = dir.path().join("devices.json");
+    let raw = std::fs::read_to_string(&path).unwrap();
+    assert!(!raw.contains(&token), "plaintext token reached disk");
+    assert!(raw.contains("tokenHash"));
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o600,
+            "devices.json should not be group/world readable"
+        );
+    }
+}
+
+#[test]
+fn devices_survive_a_reload() {
+    let dir = tempfile::tempdir().unwrap();
+    let token = {
+        let store = DeviceStore::load(dir.path()).unwrap();
+        store.register("phone", "ios").unwrap().1
+    };
+    let reopened = DeviceStore::load(dir.path()).unwrap();
+    assert!(reopened.verify(&token).is_some());
+    assert_eq!(reopened.list().len(), 1);
+}
+
+// ---------------------------------------------------------------------------
+// Op allowlist
+// ---------------------------------------------------------------------------
+
+#[test]
+fn allowlist_matches_the_protocol_table() {
+    // The 26 rows of docs/remote-protocol.md's op table, spelled out here so a
+    // silent widening of the wire surface fails this test.
+    let documented = [
+        "get_workspace",
+        "allocate_draft_name",
+        "spawn_agent",
+        "send_user_message",
+        "answer_tool_use",
+        "stop_agent",
+        "resume_agent",
+        "archive_agent",
+        "set_agent_model",
+        "set_agent_effort",
+        "read_session_records",
+        "read_user_turns",
+        "get_git_state",
+        "get_agent_diff_stats",
+        "list_checkout_tree",
+        "read_checkout_file",
+        "get_file_diff",
+        "commit_agent",
+        "push_agent",
+        "create_pr",
+        "get_pr_state",
+        "get_pr_checks",
+        "get_pr_live",
+        "list_repo_branches",
+        "repo_default_branch",
+        "discover_supported_models",
+    ];
+    assert_eq!(dispatch::OPS, documented.as_slice());
+}
+
+#[test]
+fn never_exposed_ops_are_not_dispatchable() {
+    // One per family from the doc's "never exposed, by design" paragraph.
+    for op in [
+        "db_select",
+        "db_insert",
+        "db_query",
+        "write_checkout_file",
+        "rename_checkout_path",
+        "delete_checkout_path",
+        "create_checkout_file",
+        "copy_checkout_file",
+        "open_agent_shell",
+        "write_to_shell",
+        "write_to_agent",
+        "open_in_editor",
+        "reveal_logs",
+        "track_event",
+        "install_agent",
+        "wf_start_run",
+        "roadmap_enqueue",
+        "run_start",
+        "fork_agent",
+        "merge_pr",
+        "delete_project",
+        "",
+        "hello",
+        "pair",
+    ] {
+        assert!(!dispatch::is_allowed(op), "{op} must not be dispatchable");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Socket-level behaviour
+// ---------------------------------------------------------------------------
+
+/// Answers only `get_workspace`, so the server can be exercised without a live
+/// `Supervisor`. Production runs `SupervisorDispatch`.
+struct StubDispatch;
+
+impl Dispatch for StubDispatch {
+    fn dispatch<'a>(&'a self, op: &'a str, _args: Value) -> DispatchFuture<'a> {
+        Box::pin(async move {
+            match op {
+                "get_workspace" => Ok(json!({ "projects": [], "agents": [] })),
+                _ => Err(UNKNOWN_OP.to_string()),
+            }
+        })
+    }
+}
+
+struct Host {
+    _dir: tempfile::TempDir,
+    state: Arc<RemoteState>,
+    port: u16,
+}
+
+fn boot() -> Host {
+    let dir = tempfile::tempdir().unwrap();
+    let state = RemoteState::new(dir.path(), Arc::new(StubDispatch)).unwrap();
+    let port = state.start(0).unwrap();
+    Host {
+        _dir: dir,
+        state,
+        port,
+    }
+}
+
+async fn connect_path(port: u16, path: &str) -> std::io::Result<WebSocketStream<TcpStream>> {
+    let tcp = TcpStream::connect(("127.0.0.1", port)).await?;
+    tokio_tungstenite::client_async(format!("ws://127.0.0.1:{port}{path}"), tcp)
+        .await
+        .map(|(ws, _)| ws)
+        .map_err(|e| std::io::Error::other(e.to_string()))
+}
+
+async fn connect(port: u16) -> WebSocketStream<TcpStream> {
+    connect_path(port, "/ws").await.expect("handshake")
+}
+
+async fn request(ws: &mut WebSocketStream<TcpStream>, id: &str, op: &str, args: Value) {
+    let frame = json!({ "id": id, "op": op, "args": args }).to_string();
+    ws.send(Message::Text(frame.into())).await.unwrap();
+}
+
+/// Next application frame, skipping the ping/pong keepalive traffic.
+async fn next_json(ws: &mut WebSocketStream<TcpStream>) -> Value {
+    loop {
+        match ws
+            .next()
+            .await
+            .expect("stream ended")
+            .expect("socket error")
+        {
+            Message::Text(text) => return serde_json::from_str(&text).unwrap(),
+            Message::Ping(_) | Message::Pong(_) => continue,
+            other => panic!("expected a text frame, got {other:?}"),
+        }
+    }
+}
+
+async fn close_code(ws: &mut WebSocketStream<TcpStream>) -> u16 {
+    while let Some(msg) = ws.next().await {
+        match msg {
+            Ok(Message::Close(Some(frame))) => return u16::from(frame.code),
+            Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => continue,
+            Ok(other) => panic!("expected a close frame, got {other:?}"),
+            Err(e) => panic!("expected a close frame, got error {e}"),
+        }
+    }
+    panic!("stream ended with no close frame");
+}
+
+#[tokio::test]
+async fn pair_then_hello_then_op_then_event_fanout() {
+    let host = boot();
+    let minted = host.state.pairing().mint();
+
+    // pair
+    let mut ws = connect(host.port).await;
+    request(
+        &mut ws,
+        "1",
+        "pair",
+        json!({
+            "token": minted.token,
+            "device": { "name": "Alex's iPhone", "platform": "ios", "appVersion": "0.1.0" }
+        }),
+    )
+    .await;
+    let paired = next_json(&mut ws).await;
+    assert_eq!(paired["id"], "1");
+    assert_eq!(paired["ok"], true);
+    let device_token = paired["result"]["deviceToken"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert_eq!(device_token.len(), 43);
+    assert!(paired["result"]["deviceId"].is_string());
+    assert_eq!(paired["result"]["host"]["os"], std::env::consts::OS);
+    // `pair` authenticates and opens the event stream; it never pushes a
+    // snapshot. The client calls `get_workspace` itself.
+    assert!(paired["result"].get("workspace").is_none());
+
+    // The pairing token is spent, and the device is now in the census.
+    assert!(!host.state.pairing().consume(&minted.token));
+    let status = host.state.status();
+    assert_eq!(status.devices.len(), 1);
+    assert!(status.devices[0].connected);
+    assert!(status.devices[0].last_seen_at.is_some());
+
+    // Events reach the paired connection.
+    host.state
+        .forward_event("agent:status", r#"{"agentId":"arabia","status":"running"}"#);
+    let event = next_json(&mut ws).await;
+    assert_eq!(event["event"], "agent:status");
+    assert_eq!(event["payload"]["agentId"], "arabia");
+    assert!(event.get("id").is_none(), "events carry no id");
+
+    drop(ws);
+
+    // hello on a fresh connection, with the token pair handed out.
+    let mut ws = connect(host.port).await;
+    request(
+        &mut ws,
+        "2",
+        "hello",
+        json!({
+            "deviceToken": device_token,
+            "client": { "name": "Alex's iPhone", "platform": "ios", "appVersion": "0.1.0" }
+        }),
+    )
+    .await;
+    let hello = next_json(&mut ws).await;
+    assert_eq!(hello["id"], "2");
+    assert_eq!(hello["ok"], true);
+    assert!(hello["result"]["workspace"].is_object());
+
+    request(&mut ws, "3", "get_workspace", json!({})).await;
+    let reply = next_json(&mut ws).await;
+    assert_eq!(reply["id"], "3");
+    assert_eq!(reply["ok"], true);
+    assert_eq!(reply["result"]["agents"], json!([]));
+
+    request(&mut ws, "4", "db_select", json!({ "table": "settings" })).await;
+    let denied = next_json(&mut ws).await;
+    assert_eq!(denied["id"], "4");
+    assert_eq!(denied["ok"], false);
+    assert_eq!(denied["error"], UNKNOWN_OP);
+}
+
+#[tokio::test]
+async fn first_frame_other_than_pair_or_hello_closes_4001() {
+    let host = boot();
+    let mut ws = connect(host.port).await;
+    request(&mut ws, "1", "get_workspace", json!({})).await;
+    assert_eq!(close_code(&mut ws).await, 4001);
+}
+
+#[tokio::test]
+async fn unparseable_first_frame_closes_4001() {
+    let host = boot();
+    let mut ws = connect(host.port).await;
+    ws.send(Message::Text("not json".into())).await.unwrap();
+    assert_eq!(close_code(&mut ws).await, 4001);
+}
+
+#[tokio::test]
+async fn bad_device_token_closes_4003() {
+    let host = boot();
+    let mut ws = connect(host.port).await;
+    request(&mut ws, "1", "hello", json!({ "deviceToken": "nope" })).await;
+    assert_eq!(close_code(&mut ws).await, 4003);
+}
+
+#[tokio::test]
+async fn revoked_device_token_closes_4003() {
+    let host = boot();
+    let (record, token) = host.state.devices().register("phone", "ios").unwrap();
+    host.state.revoke_device(&record.device_id).unwrap();
+
+    let mut ws = connect(host.port).await;
+    request(&mut ws, "1", "hello", json!({ "deviceToken": token })).await;
+    assert_eq!(close_code(&mut ws).await, 4003);
+}
+
+#[tokio::test]
+async fn bad_pairing_token_closes_4003() {
+    let host = boot();
+    let mut ws = connect(host.port).await;
+    request(&mut ws, "1", "pair", json!({ "token": "ZZZZZZZZ" })).await;
+    assert_eq!(close_code(&mut ws).await, 4003);
+    assert!(host.state.status().devices.is_empty());
+}
+
+#[tokio::test]
+async fn disabling_remote_access_closes_live_connections_4004() {
+    let host = boot();
+    let (_, token) = host.state.devices().register("phone", "ios").unwrap();
+    let mut ws = connect(host.port).await;
+    request(&mut ws, "1", "hello", json!({ "deviceToken": token })).await;
+    assert_eq!(next_json(&mut ws).await["ok"], true);
+
+    host.state.stop();
+    assert_eq!(close_code(&mut ws).await, 4004);
+    assert!(!host.state.status().listening);
+}
+
+#[tokio::test]
+async fn oversized_frame_is_rejected_and_never_dispatched() {
+    let host = boot();
+    let (_, token) = host.state.devices().register("phone", "ios").unwrap();
+    let mut ws = connect(host.port).await;
+    request(&mut ws, "1", "hello", json!({ "deviceToken": token })).await;
+    assert_eq!(next_json(&mut ws).await["ok"], true);
+
+    // Past the 4 MiB cap. tungstenite rejects on the frame *header*, while the
+    // client is still writing the body; the host drains the socket before it
+    // drops it (see `server::drain`), which is what makes the 1009 deliverable
+    // instead of being destroyed by a reset. The phone has no client-side cap,
+    // so this code is the only thing that tells it why the socket went away.
+    let huge = json!({ "id": "2", "op": "get_workspace", "args": { "pad": "x".repeat(5 << 20) } });
+    ws.send(Message::Text(huge.to_string().into()))
+        .await
+        .expect("host keeps reading until the client is done writing");
+    loop {
+        match ws.next().await {
+            Some(Ok(Message::Close(Some(frame)))) => {
+                assert_eq!(u16::from(frame.code), 1009);
+                break;
+            }
+            Some(Ok(Message::Text(text))) => panic!("host answered an oversized frame: {text}"),
+            Some(Ok(_)) => continue,
+            Some(Err(e)) => panic!("expected a 1009 close frame, got error {e}"),
+            None => panic!("stream ended with no close frame"),
+        }
+    }
+    wait_disconnected(&host.state).await;
+}
+
+/// Wait for the host to drop every device from its census — the connection task
+/// does that as it unwinds, so it lands just after the socket dies.
+async fn wait_disconnected(state: &Arc<RemoteState>) {
+    for _ in 0..100 {
+        if state.status().devices.iter().all(|d| !d.connected) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("device stayed marked connected after the socket died");
+}
+
+#[tokio::test]
+async fn only_the_ws_path_is_served() {
+    let host = boot();
+    assert!(connect_path(host.port, "/").await.is_err());
+    assert!(connect_path(host.port, "/admin").await.is_err());
+    assert!(connect_path(host.port, "/ws").await.is_ok());
+}

--- a/src-tauri/src/remote/tests.rs
+++ b/src-tauri/src/remote/tests.rs
@@ -505,6 +505,9 @@ async fn revoking_a_device_closes_its_live_connection_4003() {
 /// The hang-up must not hinge on the disk write: with `devices.json`
 /// unwritable, revoke reports the persistence error, but the credential is
 /// gone from memory and the socket that was using it is closed all the same.
+/// The failure then stays visible in `status().error` and the write is retried
+/// from `status` until it lands, so the stale on-disk record cannot bring the
+/// device back at the next launch once the disk recovers.
 #[cfg(unix)]
 #[tokio::test]
 async fn revoking_closes_the_live_connection_even_when_persisting_fails() {
@@ -521,12 +524,29 @@ async fn revoking_closes_the_live_connection_even_when_persisting_fails() {
     let writable = std::fs::metadata(dir).unwrap().permissions();
     std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o500)).unwrap();
     let outcome = host.state.revoke_device(&record.device_id);
-    std::fs::set_permissions(dir, writable).unwrap();
 
     assert!(outcome.is_err(), "the persistence failure is reported");
     assert_eq!(close_code(&mut ws).await, 4003);
     assert!(host.state.devices().verify(&token).is_none());
-    assert!(host.state.status().devices.is_empty());
+    let status = host.state.status();
+    assert!(status.devices.is_empty());
+    assert!(
+        status
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("could not be saved")),
+        "the failed write stays visible, not just the Err of the one call"
+    );
+    // While the disk is unwritable the old record is still there, which is
+    // exactly what a relaunch would reload.
+    assert!(DeviceStore::load(dir).verify(&token).is_some());
+
+    // Disk recovers: the next status poll retries the write, clears the error,
+    // and the record is gone from disk too.
+    std::fs::set_permissions(dir, writable).unwrap();
+    let status = host.state.status();
+    assert_eq!(status.error, None);
+    assert!(DeviceStore::load(dir).verify(&token).is_none());
 }
 
 #[tokio::test]

--- a/src-tauri/src/remote/tests.rs
+++ b/src-tauri/src/remote/tests.rs
@@ -290,7 +290,7 @@ impl Dispatch for HangingDispatch {
 }
 
 struct Host {
-    _dir: tempfile::TempDir,
+    dir: tempfile::TempDir,
     state: Arc<RemoteState>,
     port: u16,
 }
@@ -303,11 +303,7 @@ fn boot_with(dispatch: Arc<dyn Dispatch>) -> Host {
     let dir = tempfile::tempdir().unwrap();
     let state = RemoteState::new(dir.path(), dispatch);
     let port = state.start(0).unwrap();
-    Host {
-        _dir: dir,
-        state,
-        port,
-    }
+    Host { dir, state, port }
 }
 
 async fn connect_path(port: u16, path: &str) -> std::io::Result<WebSocketStream<TcpStream>> {
@@ -503,6 +499,33 @@ async fn revoking_a_device_closes_its_live_connection_4003() {
     // an already-authenticated connection is not re-checked per request.
     host.state.revoke_device(&record.device_id).unwrap();
     assert_eq!(close_code(&mut ws).await, 4003);
+    assert!(host.state.status().devices.is_empty());
+}
+
+/// The hang-up must not hinge on the disk write: with `devices.json`
+/// unwritable, revoke reports the persistence error, but the credential is
+/// gone from memory and the socket that was using it is closed all the same.
+#[cfg(unix)]
+#[tokio::test]
+async fn revoking_closes_the_live_connection_even_when_persisting_fails() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let host = boot();
+    let (record, token) = host.state.devices().register("phone", "ios").unwrap();
+    let mut ws = connect(host.port).await;
+    request(&mut ws, "1", "hello", json!({ "deviceToken": token })).await;
+    assert_eq!(next_json(&mut ws).await["ok"], true);
+
+    // Read-only store directory: the tmp file for the rewrite cannot be created.
+    let dir = host.dir.path();
+    let writable = std::fs::metadata(dir).unwrap().permissions();
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+    let outcome = host.state.revoke_device(&record.device_id);
+    std::fs::set_permissions(dir, writable).unwrap();
+
+    assert!(outcome.is_err(), "the persistence failure is reported");
+    assert_eq!(close_code(&mut ws).await, 4003);
+    assert!(host.state.devices().verify(&token).is_none());
     assert!(host.state.status().devices.is_empty());
 }
 

--- a/src/api/domains/remote.ts
+++ b/src/api/domains/remote.ts
@@ -1,0 +1,16 @@
+import { invoke } from "../invoke";
+import type { PairingInvite, RemoteStatus } from "../types/remote";
+
+/** Host-side control of the paired-device remote server. These are not remote
+ *  ops — they are how the desktop turns the listener on, mints pairing codes
+ *  and revokes devices. The mutating three answer with the resulting status so
+ *  the pane never has to re-read (and never renders a state in between). */
+export const remoteApi = {
+  remoteStatus: () => invoke<RemoteStatus>("remote_status"),
+  remoteSetEnabled: (enabled: boolean) => invoke<RemoteStatus>("remote_set_enabled", { enabled }),
+  /** Rejects while the listener is down: a code nothing can be typed into is
+   *  worse than an error. */
+  remoteBeginPairing: () => invoke<PairingInvite>("remote_begin_pairing"),
+  remoteRevokeDevice: (deviceId: string) =>
+    invoke<RemoteStatus>("remote_revoke_device", { deviceId }),
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -7,6 +7,7 @@ import { githubApi } from "./domains/github";
 import { issuesApi } from "./domains/issues";
 import { miscApi } from "./domains/misc";
 import { providersApi } from "./domains/providers";
+import { remoteApi } from "./domains/remote";
 import { roadmapApi } from "./domains/roadmap";
 import { runApi } from "./domains/run";
 import { sandboxApi } from "./domains/sandbox";
@@ -26,6 +27,7 @@ export * from "./types/git";
 export * from "./types/issues";
 export * from "./types/pr";
 export * from "./types/providers";
+export * from "./types/remote";
 export * from "./types/roadmap";
 export * from "./types/run";
 export * from "./types/sandbox";
@@ -51,6 +53,7 @@ export const api = {
   ...commandsApi,
   ...dictationApi,
   ...providersApi,
+  ...remoteApi,
   ...workflowsApi,
   ...roadmapApi,
 };

--- a/src/api/types/remote.ts
+++ b/src/api/types/remote.ts
@@ -1,0 +1,36 @@
+/** DTOs for the paired-device remote server (Settings › Mobile devices).
+ *  Mirrors the Rust types in `src-tauri/src/remote/`; the wire contract is
+ *  `docs/remote-protocol.md`. */
+
+/** One device paired with this host. */
+export interface RemoteDevice {
+  deviceId: string;
+  name: string;
+  platform: string;
+  /** RFC3339. */
+  createdAt: string;
+  /** RFC3339 of the last successful `hello`/`pair`; null if it never connected. */
+  lastSeenAt: string | null;
+  /** Whether a WebSocket from this device is open right now — a fact about
+   *  sockets, not about the last `hello`. */
+  connected: boolean;
+}
+
+export interface RemoteStatus {
+  /** The user's intent, independent of whether the bind currently holds. */
+  enabled: boolean;
+  listening: boolean;
+  port: number;
+  /** Every IPv4 a phone could dial, best candidate (LAN) first. */
+  addresses: string[];
+  devices: RemoteDevice[];
+}
+
+/** A minted pairing code: 8 characters from `A-Z2-9`, single use, five minutes. */
+export interface PairingInvite {
+  token: string;
+  /** `fletch://pair?host=…&port=…&token=…&name=…` — what the QR encodes. */
+  url: string;
+  /** RFC3339. */
+  expiresAt: string;
+}

--- a/src/api/types/remote.ts
+++ b/src/api/types/remote.ts
@@ -24,6 +24,10 @@ export interface RemoteStatus {
   /** Every IPv4 a phone could dial, best candidate (LAN) first. */
   addresses: string[];
   devices: RemoteDevice[];
+  /** A standing problem with the remote surface itself, shown inline in the
+   *  pane. Currently only one: paired devices cannot be stored, which also
+   *  makes `remoteBeginPairing` refuse. */
+  error: string | null;
 }
 
 /** A minted pairing code: 8 characters from `A-Z2-9`, single use, five minutes. */

--- a/src/components/SettingsScreen/GeneralPane.tsx
+++ b/src/components/SettingsScreen/GeneralPane.tsx
@@ -8,6 +8,7 @@ import { useAppStore } from "@/store";
 import { IS_MAC } from "@/util/platform";
 import { ContainerAuth } from "./ContainerAuth";
 import { DictationSection } from "./DictationSection";
+import { MobileDevices } from "./MobileDevices";
 import { type FeatureItem, SetGroup, SetHead, SetRow, SetSeg, SetToggle } from "./primitives";
 
 // A container runtime can start or stop while this pane stays open, so we
@@ -253,6 +254,8 @@ export function GeneralPane() {
         )}
         <ContainerAuth />
       </SetGroup>
+
+      <MobileDevices />
 
       <SetGroup label="Diagnostics" last>
         <SetRow

--- a/src/components/SettingsScreen/MobileDevices/DeviceRow.tsx
+++ b/src/components/SettingsScreen/MobileDevices/DeviceRow.tsx
@@ -1,0 +1,47 @@
+import type { RemoteDevice } from "@/api";
+import { Button } from "@/components/ui/Button";
+import { formatAge } from "@/util/format";
+
+const PLATFORM_LABELS: Record<string, string> = {
+  ios: "iOS",
+  android: "Android",
+  macos: "macOS",
+};
+
+/** One paired device: name, platform, whether it is connected right now, and
+ *  the credential's revoke. Revoking drops the stored token hash — the phone's
+ *  next `hello` is refused, and it has to be paired again. */
+export function DeviceRow({
+  device,
+  disabled,
+  onRevoke,
+}: {
+  device: RemoteDevice;
+  disabled?: boolean;
+  onRevoke: () => void;
+}) {
+  const platform = PLATFORM_LABELS[device.platform] ?? device.platform;
+  const seen = device.lastSeenAt ? formatAge(device.lastSeenAt, Date.now()) : null;
+  const sub = device.connected
+    ? `${platform} · connected`
+    : seen
+      ? `${platform} · last seen ${seen} ago`
+      : `${platform} · never connected`;
+
+  return (
+    <div className="set-row flex-center">
+      <div className="set-row-l">
+        <div className="set-row-t text-base flex-center">
+          <i className="set-dev-dot" data-on={device.connected ? "1" : "0"} />
+          {device.name}
+        </div>
+        <div className="set-row-s text-sm">{sub}</div>
+      </div>
+      <div className="set-row-c flex-center">
+        <Button variant="outline" size="sm" danger disabled={disabled} onClick={onRevoke}>
+          Revoke
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/MobileDevices/PairingCard.tsx
+++ b/src/components/SettingsScreen/MobileDevices/PairingCard.tsx
@@ -1,0 +1,74 @@
+import { QRCodeSVG } from "qrcode.react";
+import { useEffect, useState } from "react";
+import type { PairingInvite } from "@/api";
+import { Button } from "@/components/ui/Button";
+import { CopyButton } from "@/components/ui/CopyButton";
+
+const QR_SIZE = 148;
+
+/** Seconds left before `iso` lapses, floored at zero. */
+function secondsLeft(iso: string): number {
+  const at = Date.parse(iso);
+  if (Number.isNaN(at)) return 0;
+  return Math.max(0, Math.floor((at - Date.now()) / 1000));
+}
+
+function useCountdown(iso: string): number {
+  const [left, setLeft] = useState(() => secondsLeft(iso));
+  useEffect(() => {
+    setLeft(secondsLeft(iso));
+    const timer = setInterval(() => setLeft(secondsLeft(iso)), 1000);
+    return () => clearInterval(timer);
+  }, [iso]);
+  return left;
+}
+
+/** The live pairing code: readable text for manual entry (v1 phones have no
+ *  scanner) plus the same `fletch://pair` deep link as a QR for the ones that
+ *  do. Single use and five minutes, so the countdown is part of the affordance
+ *  rather than decoration. */
+export function PairingCard({
+  invite,
+  onRegenerate,
+  onDismiss,
+}: {
+  invite: PairingInvite;
+  onRegenerate: () => void;
+  onDismiss: () => void;
+}) {
+  const left = useCountdown(invite.expiresAt);
+  const expired = left === 0;
+  const mmss = `${Math.floor(left / 60)}:${String(left % 60).padStart(2, "0")}`;
+
+  return (
+    <div className="set-pair" data-expired={expired ? "1" : "0"}>
+      <div className="set-pair-main">
+        <div className="set-pair-code mono">{invite.token}</div>
+        <div className="set-pair-copy text-sm">
+          {expired
+            ? "This code has expired. Generate a new one."
+            : "Enter this code in Fletch on your phone, or scan the code."}
+        </div>
+        <div className="set-pair-meta text-xs flex-center">
+          <span className={`set-pair-clock mono ${left <= 30 ? "urgent" : ""}`}>
+            {expired ? "expired" : `expires in ${mmss}`}
+          </span>
+          <CopyButton text={invite.url} tip="Copy pairing link" />
+        </div>
+        <div className="set-pair-actions flex-center">
+          <Button variant="outline" size="sm" onClick={onRegenerate}>
+            New code
+          </Button>
+          <Button variant="ghost" size="sm" onClick={onDismiss}>
+            Done
+          </Button>
+        </div>
+      </div>
+      {!expired && (
+        <div className="set-pair-qr">
+          <QRCodeSVG value={invite.url} size={QR_SIZE} level="M" marginSize={2} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/MobileDevices/index.tsx
+++ b/src/components/SettingsScreen/MobileDevices/index.tsx
@@ -44,6 +44,10 @@ export function MobileDevices() {
         {listening && <span className="set-remote-port mono text-sm">port {status?.port}</span>}
       </SetRow>
 
+      {/* The host's own standing problem (an unwritable device store, which
+          also blocks pairing) first, then whatever the last command failed
+          with. */}
+      {status?.error && <div className="set-inline-warn">{status.error}</div>}
       {error && <div className="set-inline-warn">{error}</div>}
 
       {listening && !invite && (
@@ -51,7 +55,7 @@ export function MobileDevices() {
           title="Pair a device"
           sub="Generates a one-time code, good for five minutes. Enter it in Fletch on your phone."
         >
-          <Button variant="primary" onClick={() => void beginPairing()}>
+          <Button variant="primary" disabled={!!status?.error} onClick={() => void beginPairing()}>
             Pair a device
           </Button>
         </SetRow>

--- a/src/components/SettingsScreen/MobileDevices/index.tsx
+++ b/src/components/SettingsScreen/MobileDevices/index.tsx
@@ -1,0 +1,82 @@
+import { Button } from "@/components/ui/Button";
+import { SetGroup, SetRow, SetToggle } from "../primitives";
+import { DeviceRow } from "./DeviceRow";
+import { PairingCard } from "./PairingCard";
+import { useRemote } from "./useRemote";
+
+/** Settings › General › Mobile devices: run the paired-device WebSocket server
+ *  so a phone can drive the agents on this Mac.
+ *
+ *  LAN (or Tailscale) only and unencrypted in v1 — hence the plain statement of
+ *  what the switch opens, and pairing that is an explicit, expiring, single-use
+ *  act rather than a standing invitation. */
+export function MobileDevices() {
+  const { status, invite, error, busy, setEnabled, beginPairing, revoke, clearInvite } =
+    useRemote();
+
+  const enabled = !!status?.enabled;
+  const listening = !!status?.listening;
+  const devices = status?.devices ?? [];
+  const addresses = status?.addresses ?? [];
+
+  const reach = listening
+    ? addresses.length > 0
+      ? addresses.map((a) => `${a}:${status?.port}`).join(" · ")
+      : "No network address found — connect this Mac to Wi-Fi or Ethernet."
+    : enabled
+      ? "On, but the port could not be opened."
+      : "Off. No port is open.";
+
+  return (
+    <SetGroup label="Mobile devices">
+      <SetRow
+        title="Remote control from your phone"
+        sub="Opens a local WebSocket port so a paired phone can watch and steer your agents. Unencrypted, so keep it to networks you trust — your own Wi-Fi or a Tailscale network. Only paired devices are ever answered."
+      >
+        <SetToggle
+          on={enabled}
+          disabled={busy || !status}
+          onClick={() => void setEnabled(!enabled)}
+        />
+      </SetRow>
+
+      <SetRow title="Reachable at" sub={reach} align="start">
+        {listening && <span className="set-remote-port mono text-sm">port {status?.port}</span>}
+      </SetRow>
+
+      {error && <div className="set-inline-warn">{error}</div>}
+
+      {listening && !invite && (
+        <SetRow
+          title="Pair a device"
+          sub="Generates a one-time code, good for five minutes. Enter it in Fletch on your phone."
+        >
+          <Button variant="primary" onClick={() => void beginPairing()}>
+            Pair a device
+          </Button>
+        </SetRow>
+      )}
+
+      {invite && (
+        <PairingCard
+          invite={invite}
+          onRegenerate={() => void beginPairing()}
+          onDismiss={clearInvite}
+        />
+      )}
+
+      {devices.length === 0 ? (
+        <SetRow title="Paired devices" sub="None yet." />
+      ) : (
+        devices.map((device) => (
+          <DeviceRow
+            key={device.deviceId}
+            device={device}
+            disabled={busy}
+            onRevoke={() => void revoke(device.deviceId)}
+          />
+        ))
+      )}
+    </SetGroup>
+  );
+}

--- a/src/components/SettingsScreen/MobileDevices/useRemote.ts
+++ b/src/components/SettingsScreen/MobileDevices/useRemote.ts
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useState } from "react";
+import { api, type PairingInvite, type RemoteStatus } from "@/api";
+
+/** How often the pane re-reads status. A phone connecting or dropping produces
+ *  no Tauri event (the remote server is the thing being observed, not an agent),
+ *  so the connected dot is a poll. Only while Settings is open. */
+const POLL_MS = 4_000;
+
+export interface Remote {
+  status: RemoteStatus | null;
+  invite: PairingInvite | null;
+  error: string | null;
+  busy: boolean;
+  setEnabled: (enabled: boolean) => Promise<void>;
+  beginPairing: () => Promise<void>;
+  revoke: (deviceId: string) => Promise<void>;
+  clearInvite: () => void;
+}
+
+/** Server state for the Mobile devices section. Deliberately local rather than
+ *  a store slice: nothing outside this pane reads it, and it is only live while
+ *  the pane is mounted. */
+export function useRemote(): Remote {
+  const [status, setStatus] = useState<RemoteStatus | null>(null);
+  const [invite, setInvite] = useState<PairingInvite | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      setStatus(await api.remoteStatus());
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const timer = setInterval(() => void refresh(), POLL_MS);
+    return () => clearInterval(timer);
+  }, [refresh]);
+
+  /** Run a mutating command; all three answer with the fresh status. */
+  const mutate = useCallback(async (call: () => Promise<RemoteStatus>) => {
+    setBusy(true);
+    setError(null);
+    try {
+      setStatus(await call());
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  const setEnabled = useCallback(
+    async (enabled: boolean) => {
+      // A code minted against a listener that is going away is unusable.
+      if (!enabled) setInvite(null);
+      await mutate(() => api.remoteSetEnabled(enabled));
+    },
+    [mutate],
+  );
+
+  const beginPairing = useCallback(async () => {
+    setError(null);
+    try {
+      setInvite(await api.remoteBeginPairing());
+    } catch (e) {
+      setError(String(e));
+    }
+  }, []);
+
+  const revoke = useCallback(
+    (deviceId: string) => mutate(() => api.remoteRevokeDevice(deviceId)),
+    [mutate],
+  );
+
+  const clearInvite = useCallback(() => setInvite(null), []);
+
+  return { status, invite, error, busy, setEnabled, beginPairing, revoke, clearInvite };
+}

--- a/src/components/SettingsScreen/SettingsScreen.css
+++ b/src/components/SettingsScreen/SettingsScreen.css
@@ -494,7 +494,10 @@
    persisted Docker choice whose daemon is down): new agents would fail to
    launch until it's resolved, so surface it rather than let the Select read as
    active. Warn-tinted like the other inline banners. */
-.set-sandbox-warn {
+/* Inline warning box. Named for its first caller; `.set-inline-warn` is the
+   neutral alias new panes use. */
+.set-sandbox-warn,
+.set-inline-warn {
   margin-top: 10px;
   padding: 8px 10px;
   background: color-mix(in srgb, var(--warn), var(--bg-0) 86%);
@@ -831,6 +834,83 @@
   to {
     transform: translateX(350%);
   }
+}
+
+/* ── MOBILE DEVICES ──────────────────────────────────────────────────── */
+/* The listen port sits beside a wrapping address list, so it reads as a label
+   rather than a control. */
+.set-remote-port {
+  color: var(--fg-3);
+  white-space: nowrap;
+}
+
+/* Live pairing code. Its own block rather than a `set-row`: the code is the
+   content, not a control on the right of a label. */
+.set-pair {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--bd-soft);
+}
+.set-rows .set-pair:last-child {
+  border-bottom: 0;
+}
+.set-pair-main {
+  flex: 1;
+  min-width: 0;
+}
+.set-pair-code {
+  font-size: 30px;
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  color: var(--fg-0);
+  line-height: 1.1;
+}
+.set-pair[data-expired="1"] .set-pair-code {
+  color: var(--fg-3);
+  text-decoration: line-through;
+}
+.set-pair-copy {
+  color: var(--fg-2);
+  margin-top: 6px;
+  max-width: 44ch;
+  text-wrap: pretty;
+}
+.set-pair-meta {
+  gap: 6px;
+  margin-top: 8px;
+}
+.set-pair-clock {
+  color: var(--fg-3);
+}
+.set-pair-clock.urgent {
+  color: var(--warn);
+}
+.set-pair-actions {
+  gap: 8px;
+  margin-top: 12px;
+}
+/* White quiet zone regardless of theme — a dark-on-dark QR does not scan. */
+.set-pair-qr {
+  flex-shrink: 0;
+  padding: 8px;
+  background: #fff;
+  border-radius: var(--r-md);
+  line-height: 0;
+}
+
+/* Connected indicator on a paired device row. */
+.set-dev-dot {
+  width: 7px;
+  height: 7px;
+  margin-right: 8px;
+  border-radius: 50%;
+  background: var(--fg-3);
+  flex-shrink: 0;
+}
+.set-dev-dot[data-on="1"] {
+  background: var(--success);
 }
 
 /* ── quick-popover "All settings" footer button ──────────────────────── */


### PR DESCRIPTION
## Summary

Adds a desktop-only `remote` module so a paired phone (the mobile companion app, separate PR) can watch and steer agents running on this Mac. Code and agents never leave the host; the phone only sends operations and receives events.

Contract: `docs/remote-protocol.md`. Every remote op mirrors an existing Tauri command by name, camelCase argument keys and result DTO, so the dispatcher calls the same supervisor functions the commands do and the phone reuses the desktop DTOs unchanged.

## What's in it

- **Server** (`src-tauri/src/remote/server.rs`): WebSocket listener on `0.0.0.0:47285`, `/ws` only, 4 MiB frame cap, 20 s ping with two missed pongs, close codes 4001 / 4003 / 4004 / 1009. The socket is drained before drop so a close code survives an oversized frame instead of being destroyed by an RST.
- **Auth** (`auth.rs`): single-use 8-char pairing codes (`A-Z2-9`, 5 min TTL, monotonic deadline). Device tokens are 32 random bytes; only the sha256 is persisted to `<app_data>/remote/devices.json` at 0600.
- **Dispatcher** (`dispatch.rs`): explicit allowlist of 26 ops. Nothing else is reachable: `db_*`, file mutations, shell, raw PTY input, editor/telemetry/provider-install, workflow/roadmap/run. Adding an op is one doc row plus one match arm.
- **Events** (`events.rs`): one `listen_any` tap per whitelisted event name, payload forwarded as raw JSON so the phone gets byte-identical payloads. `agent:output` / `shell:output` never leave the host.
- **Command extractions**: twelve commands had inline logic pulled into shared `*_impl` functions that both the command and the dispatcher call. Command behaviour is unchanged.
- **Settings › General › Mobile devices**: enable toggle (persisted only after a successful bind), reachable addresses, pairing code as text and QR (`qrcode.react`, zero transitive deps), countdown, paired-device list with revoke.
- **`scripts/remote-smoke.ts`**: pairs or says hello, prints the workspace, tails events for 20 s.

## Verification

- `cargo test remote`: 40 passed (token lifecycle, allowlist matches the doc, 24 denylisted names rejected, socket-level pair → hello → op → event fan-out, every close code, `/ws` only). Ran 3× for flakiness.
- Full crate suite: 1522 passed. `cargo fmt --check` clean.
- `bun run check`, `bun run lint`, `bun run test` (1102) clean.
- Not done: smoke script against a live dev build (sandbox cannot run the app). Please run `bun scripts/remote-smoke.ts` after enabling the toggle in Settings.

## Deliberately out of scope (v1)

TLS or a relay for off-network access, push notifications, tearing down a revoked device's live socket (its next `hello` fails; ping timeout ends the connection), a top-level Settings nav entry (it lives as a group in General for now).