### PR TITLE
feat(remote): Cloudflare relay for off-network access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ mobile/src-tauri/target/
 # tauri-build regenerates these schemas on every build; the Xcode project that
 # `tauri ios init` puts beside them is committed once it exists.
 mobile/src-tauri/gen/schemas/
+
+# Remote relay Worker (relay/). Same story as mobile/: the root-anchored
+# entries above do not reach into it.
+relay/node_modules/
+relay/.wrangler/
+relay/dist/

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -23,8 +23,8 @@ adapters (`src/adapters/*`) unchanged.
 - Host listens on TCP port `47285` by default (setting `remote.port`), all
   interfaces, path `/ws`. `ws://<host>:<port>/ws`. The WebSocket is a plain
   carrier: the secure channel, not the transport, provides confidentiality and
-  authentication, so the same frames travel unchanged through the relay that
-  the next contract revision adds. v2 is reachable over LAN and Tailscale.
+  authentication, so the same frames travel unchanged through the relay (see
+  "Relay"). The phone dials the LAN address first and falls back to the relay.
 - Host sends a WebSocket ping every 20 s and closes the connection after two
   missed pongs. Client reconnects with exponential backoff (1 s, 2 s, 4 s … 30 s).
 - WebSocket messages larger than 4 MiB are rejected (close code 1009).
@@ -88,6 +88,89 @@ ciphertext.
   the browser dev loop (`bun run dev` outside Tauri) can only reach the mock
   host.
 
+## Relay
+
+Off-network access goes through a relay that both ends dial outbound. The
+relay is a dumb pipe: it routes by host ID and sees nothing but the ciphertext
+the secure channel already produces. The reference implementation is a
+Cloudflare Worker fronting one Durable Object per host ID (`relay/` in this
+repo); anyone can run their own and point both apps at it.
+
+- **Base URL.** Host setting `remote.relay_url`; absent or empty means no
+  relay. The desktop's suggested default is `wss://relay.fletch.app`. The
+  pairing link carries the URL as `relay=<url-encoded>` when set, and the phone
+  persists it with the host.
+- **Endpoints.** `wss://<relay>/v1/host/<hostId>` for the Mac,
+  `wss://<relay>/v1/device/<hostId>` for a phone. `hostId` is the host public
+  key, base64url. Anything else is `404`.
+- **Host link authentication** proves possession of the host key with a DH
+  challenge, as three JSON text frames within 10 s of the upgrade:
+  1. relay → host `{ "type": "challenge", "nonce": "<base64url, 32 bytes>", "relayKey": "<base64url X25519 public key>" }`
+  2. host → relay `{ "type": "proof", "proof": "<base64url SHA-256( shared || nonce || hostKey )>" }`
+     where `shared = X25519(hostPrivate, relayKey)`, `nonce` and `hostKey` are
+     the raw 32-byte values, and `||` is concatenation.
+  3. relay → host `{ "type": "ready" }`, or close `4003` on a bad proof, a
+     malformed or non-text proof frame, or no proof within the 10 s.
+  The relay stores nothing: the host ID *is* the public key it verifies
+  against. A second host link for the same ID replaces the first, which is
+  closed with `4409`; devices attached to it are closed with `4404`. A known-
+  answer vector for the proof lives in `relay/test-vector.json`; both the
+  relay's and the host's implementations are tested against it.
+- **Device link.** No relay-level authentication: the Noise handshake is the
+  authentication, end to end. The phone speaks to the relay exactly as it
+  would to the host on the LAN — same handshake, same frames, same close codes
+  from the host. The relay closes a device link with `4404` ("host offline")
+  when no host link is attached, `4429` when the host already has 8 device
+  links, `1009` for a message over 4 MiB, and `1008` for more than 100
+  messages in 10 s.
+- **Multiplexing on the host link.** Every device link becomes a numbered
+  virtual connection on the one host link. Binary frames on the host link are
+  `type (1 byte) || connId (u32 big-endian) || payload`:
+
+  | type | direction | payload |
+  |---|---|---|
+  | `0x01` OPEN | relay → host | empty; a device link attached |
+  | `0x02` DATA | both | one device WebSocket **binary** message, verbatim |
+  | `0x03` CLOSE | both | `code (u16 big-endian) || reason (UTF-8)`; the link is over |
+  | `0x04` TEXT | relay → host | one device WebSocket **text** message, verbatim, so the host can apply its own `4001` rule |
+
+  A host-sent CLOSE makes the relay close the device link with that code and
+  reason. A device link that drops produces a CLOSE toward the host with
+  `1006`, and a device link the relay closed itself (`1008`, `1009`) produces
+  a CLOSE with that code, so the host always frees the virtual connection.
+  Frames the relay does not understand (unknown connId, truncated, a text
+  frame on the host link after `ready`) are ignored, not fatal. The host link
+  accepts messages up to 4 MiB + 5 bytes, so a legal 4 MiB device message fits
+  inside a DATA frame. The host serves each virtual connection through the
+  same code path as a LAN socket; WebSocket ping/pong is per hop (host↔relay
+  and relay↔device), never forwarded, and the host answers its own liveness
+  pings to a virtual connection locally. The relay originates no pings of its
+  own (they would keep the Durable Object awake); the host pings the relay,
+  and the runtime answers device pings without waking the object.
+- **Host side.** The Mac keeps the host link up whenever remote access is
+  enabled and a relay URL is set, reconnecting with backoff (1 s … 60 s) when
+  it drops, `4409` included: two Macs sharing one host key is a
+  misconfiguration, and the alternating link surfaces it in `relay.error`
+  rather than silently picking a winner. `remote_status.relay` reports the
+  link (see host commands). The host hashes the nonce it is given whatever its
+  length (the relay always sends 32 bytes), ignores frames for a connId it
+  does not know, and closes a single virtual connection with `1008` if that
+  device outruns the host's inbound queue for it. Disabling
+  remote access drops the link, which closes every relayed device with `4404`
+  from the relay's side; the host's own `4004` goes out first over the virtual
+  connections, as on the LAN.
+- **Phone side.** Connection candidates in order: `addr` over `ws://` with a
+  3 s open timeout, then `wss://<relay>/v1/device/<hostId>` with no extra
+  timeout (it is the last resort; the platform's TCP/TLS timeout applies). The
+  relay candidate exists only when the phone holds both the relay URL and the
+  host key, since the key is the route. A host-key mismatch on either path
+  stops the list at once and is not retried: an impostor must not be able to
+  steer the phone onto the other path. The relay URL arrives in the pairing
+  link and can be added or changed later in the phone's host sheet without
+  re-pairing. The Noise handshake and everything after it are identical on
+  both paths, so the app above the transport cannot tell which one it is on
+  and does not need to.
+
 ## Threat model (v2)
 
 A passive observer of the network sees the WebSocket upgrade, ping/pong timing
@@ -107,6 +190,15 @@ Still in place from v1: pairing needs a single-use code, minted on the desktop
 and valid five minutes; turning remote access off closes every connection with
 `4004`; ops are an explicit allowlist with no shell, no file writes and no raw
 PTY, and events are a whitelist that excludes PTY output.
+
+The relay adds a party that sees metadata but no content: which host IDs are
+online, when devices connect, and ciphertext sizes and timing. It cannot read
+or forge frames, and it cannot impersonate a host, because attaching a host
+link requires the host's private key. Anyone who learns a host ID can open
+device links to that host and make it run Noise handshakes that fail, which is
+why device links per host are capped and rate-limited; a host ID is a random
+public key, so it cannot be guessed or enumerated. A hostile relay operator
+can deny service and nothing more.
 
 ## Envelope
 
@@ -149,14 +241,15 @@ Desktop Settings → "Mobile devices" → "Pair a device" calls the Tauri comman
 as text and as a QR code encoding:
 
 ```
-fletch://pair?host=<host public key, base64url>&addr=<ip>:<port>&token=<code>&name=<url-encoded host name>
+fletch://pair?host=<host public key, base64url>&addr=<ip>:<port>&relay=<url-encoded relay base URL>&token=<code>&name=<url-encoded host name>
 ```
 
 `host` is the host ID (its public key) and is the phone's authentication of
-the Mac. `addr` is the best address to dial right now; when the relay arrives
-the link may add other ways to reach the host, but `host` stays the identity.
-A hand-typed pairing supplies only `addr` and `token`, and pins the host key it
-meets (see "Secure channel").
+the Mac. `addr` is the best LAN address to dial right now; `relay` is present
+only when the host has a relay configured (see "Relay"). `host` stays the
+identity whichever path is used. A hand-typed pairing supplies only `addr` and
+`token`, and pins the host key it meets (see "Secure channel"); it cannot use
+the relay until a later QR pairing or manual entry supplies the relay URL.
 
 Client request (first encrypted frame after the handshake):
 
@@ -284,17 +377,29 @@ connection is authenticated as, and `4004` when the host turns remote access
 off — in both cases the credential is gone or dormant, so the client should
 stop reconnecting until it is paired or the host is enabled again.
 
+Relay close codes reach the phone on the device link and are all retryable
+with the normal backoff — the condition is on the host's or relay's side and
+may clear: `4404` the Mac is not connected to the relay ("Your Mac is
+offline"), `4429` the Mac already has its 8 relayed devices, `1008` the relay
+throttled this connection, `1009` a message was over 4 MiB. `4409` is sent
+only on the host link (a newer host link replaced this one) and never reaches
+a phone.
+
 ## Host-side settings and commands (desktop Tauri commands, not remote ops)
 
 | command | purpose |
 |---|---|
-| `remote_status` | `{ enabled, listening, port, hostId, addresses: string[], devices: RemoteDevice[], error: string \| null }` — `hostId` is the host public key, base64url |
-| `remote_set_enabled` | `{ enabled }` start/stop the listener; persists setting `remote.enabled`; disabling closes live connections with `4004` |
+| `remote_status` | `{ enabled, listening, port, hostId, addresses: string[], devices: RemoteDevice[], relay: RelayStatus, error: string \| null }` — `hostId` is the host public key, base64url |
+| `remote_set_enabled` | `{ enabled }` start/stop the listener and the relay link; persists setting `remote.enabled`; disabling closes live connections with `4004` |
+| `remote_set_relay` | `{ url: string \| null }` persist setting `remote.relay_url` (null/empty clears it) and connect or drop the host link accordingly; returns `RemoteStatus` |
 | `remote_begin_pairing` | `{ token, url, expiresAt }`; refused while the listener is down or `error` is set |
 | `remote_revoke_device` | `{ deviceId }`; drops the credential and closes that device's live connections with `4003` |
 
 `RemoteDevice = { deviceId, name, platform, createdAt, lastSeenAt, connected }`,
 where `connected` is derived from the live connections, not from `lastSeenAt`.
+`RelayStatus = { url: string | null, state: "off" | "connecting" | "connected" | "error", error: string | null }`;
+`off` when no URL is set or remote access is disabled, `error` with the last
+failure while the link is between reconnect attempts.
 `error` is a standing problem with the remote surface itself — "`devices.json`
 could not be read or written", or "`host_key` could not be created or read";
 either blocks pairing, and without a host key no connection can be served
@@ -304,12 +409,10 @@ error stays in `error`, and every `remote_status` retries the write until it
 lands, so the stale file cannot quietly bring a revoked device back at the next
 launch once the disk recovers.
 
-## Out of scope for v2 (tracked, not built)
+## Out of scope (tracked, not built)
 
-The relay for off-network access (next revision: both ends connect outbound to
-a Cloudflare Durable Object keyed by host ID, which pipes these same encrypted
-frames; the phone tries `addr` first and falls back to the relay), push
-notifications (needs the relay and APNs), QR scanning on the phone (manual
-entry of address and code, plus `fletch://pair` deep-link parsing, in v2), Add
-project / clone, voice, attachments, Run scripts, Keychain storage of the
-device key on the phone (v2 stores it in the app data dir).
+Push notifications (the host sends the relay a content-free wake hint, the
+relay calls APNs, the phone connects and fetches), QR scanning on the phone
+(manual entry of address and code, plus `fletch://pair` deep-link parsing, for
+now), Add project / clone, voice, attachments, Run scripts, Keychain storage of
+the device key on the phone (it lives in the app data dir).

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -112,8 +112,13 @@ repo); anyone can run their own and point both apps at it.
   3. relay → host `{ "type": "ready" }`, or close `4003` on a bad proof, a
      malformed or non-text proof frame, or no proof within the 10 s.
   The relay stores nothing: the host ID *is* the public key it verifies
-  against. A second host link for the same ID replaces the first, which is
-  closed with `4409`; devices attached to it are closed with `4404`. A known-
+  against. A second host link for the same ID replaces the first — closed with
+  `4409`, its devices closed with `4404` — but only once the newcomer's proof
+  has verified. An unauthenticated link is a claim, not a host: it changes
+  nothing for the current host and its devices, and it alone is closed if it
+  fails or times out. The host ID is public, so anything less would let anyone
+  who knows it knock the real host offline. The deadline is enforced when the
+  proof arrives as well as by the alarm. A known-
   answer vector for the proof lives in `relay/test-vector.json`; both the
   relay's and the host's implementations are tested against it.
 - **Device link.** No relay-level authentication: the Noise handshake is the

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -115,9 +115,10 @@ repo); anyone can run their own and point both apps at it.
   against. A second host link for the same ID replaces the first — closed with
   `4409`, its devices closed with `4404` — but only once the newcomer's proof
   has verified. An unauthenticated link is a claim, not a host: it changes
-  nothing for the current host and its devices, and it alone is closed if it
-  fails or times out. The host ID is public, so anything less would let anyone
-  who knows it knock the real host offline. The deadline is enforced when the
+  nothing for the current host and its devices, whether it fails, times out,
+  hangs up or is cut for breaking a limit; only the authenticated host's
+  departure closes devices with `4404`. The host ID is public, so anything less
+  would let anyone who knows it knock the real host or its devices offline. The deadline is enforced when the
   proof arrives as well as by the alarm. A known-
   answer vector for the proof lives in `relay/test-vector.json`; both the
   relay's and the host's implementations are tested against it.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -19,6 +19,20 @@ also why the browser dev loop can only reach the mock host: outside Tauri there
 is no Rust layer to hold the device key, so `?mock=1` is the only way to run
 `bun run dev` in a desktop browser.
 
+## LAN first, relay second
+
+A connection attempt walks two candidates in order: the host's LAN address over
+`ws://` with a 3 s open timeout, then `wss://<relay>/v1/device/<hostId>` if that
+did not answer. The relay base URL comes from `relay=` in the pairing link (the
+desktop puts it there when it has a relay configured) and is persisted with the
+host; it can also be typed into the Host sheet later, which is the only way a
+hand-typed pairing gets one. The relay needs the host's public key, since that
+key is its route, so a target without one is LAN-only. Both paths carry the same
+Noise handshake and the same frames, so nothing above the transport can tell
+them apart or needs to — the path is reported in the Host sheet and that is all
+it is used for. The open timeout is enforced in Rust, inside `remote_connect`,
+so a candidate the client has moved past is really closed.
+
 ## Web dev loop
 
 ```sh

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -29,12 +29,16 @@ tauri-plugin-deep-link = "2"
 # wss:// relay works on iOS without an OpenSSL build.
 snow = "0.10"
 tokio-tungstenite = { version = "0.27", features = ["rustls-tls-webpki-roots"] }
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["sync", "time"] }
 futures-util = "0.3"
 base64 = "0.22"
 serde = { version = "1", features = ["derive"] }
 # `generate_context!` expands to serde_json for the capability scopes.
 serde_json = "1"
+
+[dev-dependencies]
+# The connect budget is async, so the test that drives it needs a runtime.
+tokio = { version = "1", features = ["rt", "time"] }
 
 [features]
 default = ["custom-protocol"]

--- a/mobile/src-tauri/src/remote/mod.rs
+++ b/mobile/src-tauri/src/remote/mod.rs
@@ -17,9 +17,11 @@ use secure::{Channel, DeviceKey, Handshake, HOST_KEY_MISMATCH};
 use serde::Serialize;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::net::TcpStream;
 use tokio::sync::Mutex;
+use tokio::time::Instant;
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 use tokio_tungstenite::tungstenite::Message;
@@ -113,24 +115,41 @@ struct ErrorPayload {
 /// Open a socket, run the Noise handshake and start reading. Supersedes any
 /// connection already open or still handshaking: the newest attempt owns the
 /// slot, and an older one that finishes later discards its socket.
+///
+/// `timeout_ms` bounds the dial and the handshake together. It is the only
+/// timeout: the caller walks a list of candidates (LAN, then relay) and needs
+/// a candidate it has given up on to be really gone, which a timer on the
+/// webview side could not deliver — so the budget is enforced here, where the
+/// socket is, and expiring closes it.
 #[tauri::command]
 pub async fn remote_connect(
     app: AppHandle,
     state: State<'_, Remote>,
     url: String,
     host_key: Option<String>,
+    timeout_ms: Option<u64>,
 ) -> Result<ConnectResult, String> {
     // Claim the id first, so a concurrent attempt can tell who is newer.
     let id = state.latest.fetch_add(1, Ordering::AcqRel) + 1;
     close_current(&state.slot).await;
     let key = device_key(&app, &state)?;
-    let (mut ws, _) = connect_async(&url)
+    let deadline = timeout_ms.map(|ms| Instant::now() + Duration::from_millis(ms));
+    let dialled = within(deadline, connect_async(&url))
         .await
-        .map_err(|e| format!("cannot reach {url}: {e}"))?;
-    let channel = match handshake(&mut ws, &key, host_key.as_deref()).await {
-        Ok(channel) => channel,
-        Err(e) => {
+        .ok_or_else(|| timed_out(&url, timeout_ms))?;
+    let (mut ws, _) = dialled.map_err(|e| format!("cannot reach {url}: {e}"))?;
+    // The borrow of `ws` ends with the statement, so the socket is ours again
+    // whether the handshake finished, failed or ran out of time.
+    let handshaken = within(deadline, handshake(&mut ws, &key, host_key.as_deref())).await;
+    let channel = match handshaken {
+        Some(Ok(channel)) => channel,
+        Some(Err(e)) => {
             close_ws(&mut ws, CLOSE_BAD_FRAME, &e).await;
+            return Err(e);
+        }
+        None => {
+            let e = timed_out(&url, timeout_ms);
+            close_ws(&mut ws, u16::from(CloseCode::Normal), &e).await;
             return Err(e);
         }
     };
@@ -209,6 +228,25 @@ pub fn remote_device_public_key(
 }
 
 // --- internals ---------------------------------------------------------------
+
+/// Run `fut` under `deadline`, or unbounded when there is none. `None` means it
+/// ran out of time and the future has been dropped.
+async fn within<F: std::future::Future>(deadline: Option<Instant>, fut: F) -> Option<F::Output> {
+    match deadline {
+        Some(at) => tokio::time::timeout_at(at, fut).await.ok(),
+        None => Some(fut.await),
+    }
+}
+
+/// The error a caller sees when opening a connection overran its budget. The
+/// wording matters only in that it says "timed out": that is what tells a
+/// candidate that did not answer from one that refused.
+fn timed_out(url: &str, timeout_ms: Option<u64>) -> String {
+    match timeout_ms {
+        Some(ms) => format!("cannot reach {url}: timed out after {ms} ms"),
+        None => format!("cannot reach {url}: timed out"),
+    }
+}
 
 /// The process-wide device identity (see `Remote::identity`).
 fn device_key(app: &AppHandle, state: &Remote) -> Result<Arc<DeviceKey>, String> {
@@ -433,5 +471,36 @@ mod tests {
         let persisted = DeviceKey::load_or_create(&dir).unwrap().public_base64();
         assert!(seen.contains(&persisted), "and it is the one on disk");
         assert!(!dir.join("device_key.tmp").exists());
+    }
+
+    /// A candidate that never answers has to be distinguishable from one that
+    /// refused, since the caller walks a list and reports the last failure.
+    #[test]
+    fn a_timeout_says_so_and_names_the_url() {
+        let with_budget = timed_out("ws://192.168.1.24:47285/ws", Some(3000));
+        assert!(with_budget.contains("timed out"), "{with_budget}");
+        assert!(with_budget.contains("3000 ms"), "{with_budget}");
+        assert!(with_budget.contains("ws://192.168.1.24:47285/ws"));
+        assert!(timed_out("wss://relay.fletch.app/v1/device/k", None).contains("timed out"));
+    }
+
+    /// `within` is what makes the budget real: a future that has not finished
+    /// is dropped, which is what closes a half-open socket.
+    #[test]
+    fn within_bounds_a_future_and_passes_one_through_unbounded() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let deadline = Some(Instant::now() + Duration::from_millis(5));
+            assert_eq!(within(deadline, async { 7 }).await, Some(7));
+            assert_eq!(
+                within(deadline, tokio::time::sleep(Duration::from_secs(30))).await,
+                None,
+                "an overrunning future is abandoned"
+            );
+            assert_eq!(within(None, async { 7 }).await, Some(7));
+        });
     }
 }

--- a/mobile/src/remote/candidates.ts
+++ b/mobile/src/remote/candidates.ts
@@ -1,0 +1,30 @@
+// Where to dial, and in which order: the LAN address first with a short open
+// timeout, then the relay (docs/remote-protocol.md, "Relay" → "Phone side").
+// The Noise handshake and every frame after it are identical on both paths, so
+// this is the only place that knows there is more than one.
+
+import { relayDeviceUrl, wsUrl } from "./pairing";
+import type { HostTarget, Via } from "./types";
+
+/** How long to wait for the LAN socket to open before moving on. The timeout
+ *  is enforced by the transport, not by a timer on this side. */
+export const LAN_OPEN_TIMEOUT_MS = 3000;
+
+export interface Candidate {
+  url: string;
+  via: Via;
+  /** Absent means "no bound" — the relay is the last resort, so waiting on it
+   *  is waiting on the only path left. */
+  timeoutMs?: number;
+}
+
+/** The dial list for `target`. The relay is only reachable with the host key,
+ *  which is also its route on the relay, so a hand-typed target (no key yet)
+ *  is LAN-only until a pairing link supplies both. */
+export function candidatesFor(target: HostTarget, lanTimeoutMs = LAN_OPEN_TIMEOUT_MS): Candidate[] {
+  const list: Candidate[] = [{ url: wsUrl(target), via: "lan", timeoutMs: lanTimeoutMs }];
+  if (target.relay && target.hostKey) {
+    list.push({ url: relayDeviceUrl(target.relay, target.hostKey), via: "relay" });
+  }
+  return list;
+}

--- a/mobile/src/remote/client.ts
+++ b/mobile/src/remote/client.ts
@@ -4,8 +4,8 @@
 // mock host and the real WebSocket share every line of this.
 
 import { backoffDelay } from "./backoff";
-import { wsUrl } from "./pairing";
-import type { Socket, SocketFactory } from "./socket";
+import { type Candidate, candidatesFor } from "./candidates";
+import type { Socket, SocketFactory, SocketHandlers } from "./socket";
 import {
   CLOSE_REASONS,
   CLOSE_REMOTE_DISABLED,
@@ -25,6 +25,7 @@ import {
   type RemoteClient,
   type RequestFrame,
   type StateHandler,
+  type Via,
 } from "./types";
 
 /** Close codes that mean "do not retry" — the device has to be paired again,
@@ -45,6 +46,9 @@ export interface ClientOptions {
   clearTimer?: (handle: unknown) => void;
   baseDelay?: number;
   maxDelay?: number;
+  /** Open timeout for the LAN candidate, in ms (see `LAN_OPEN_TIMEOUT_MS`).
+   *  Lowered in tests so a hanging dial does not cost three seconds. */
+  openTimeout?: number;
 }
 
 /** The transport's mismatch marker carries the two keys, which is right for a
@@ -73,6 +77,7 @@ export class ProtocolClient implements RemoteClient {
   private closedByUs = false;
   private _state: ConnectionState = "disconnected";
   private _host: HostInfo | null = null;
+  private _via: Via | null = null;
   private readonly newId: () => string;
   private readonly setTimer: (fn: () => void, ms: number) => unknown;
   private readonly clearTimer: (handle: unknown) => void;
@@ -95,6 +100,19 @@ export class ProtocolClient implements RemoteClient {
    *  or pinned on first contact. */
   get hostKey(): string | null {
     return this._target?.hostKey ?? null;
+  }
+
+  /** Which candidate the live socket came from. Reported for the Host sheet;
+   *  nothing in the protocol depends on it. */
+  get via(): Via | null {
+    return this.socket ? this._via : null;
+  }
+
+  /** Add or change the relay on the held target. Nothing reconnects: the next
+   *  attempt picks up the new dial list. */
+  setRelay(relay: string | null): void {
+    if (!this._target) return;
+    this._target = { ...this._target, relay: relay?.trim() || undefined };
   }
 
   /** Where this client is (or was last) pointed. The client owns it: after a
@@ -189,8 +207,8 @@ export class ProtocolClient implements RemoteClient {
   }
 
   /** One connection attempt: open the socket, then run the first frame
-   *  (`pair` or `hello`). Every failure inside it — the open rejecting, the
-   *  handshake being refused — goes through `fail`, so the client is never
+   *  (`pair` or `hello`). Every failure inside it — every candidate rejecting,
+   *  the handshake being refused — goes through `fail`, so the client is never
    *  left sitting in `connecting` with nothing scheduled. */
   private async attemptConnect(): Promise<HelloResult> {
     let target = this._target;
@@ -198,28 +216,14 @@ export class ProtocolClient implements RemoteClient {
     const gen = ++this.gen;
     this.setState(target.pairingToken ? "pairing" : "connecting");
     try {
-      const socket = await this.opts.openSocket(
-        wsUrl(target),
-        {
-          onOpen: () => {},
-          onMessage: (text) => {
-            if (this.current(gen)) this.onMessage(text);
-          },
-          onClose: (code, reason) => {
-            if (this.current(gen)) this.onClose(code, reason);
-          },
-          onError: (message) => {
-            if (this.current(gen)) this.onSocketError(message);
-          },
-        },
-        { hostKey: target.hostKey },
-      );
+      const socket = await this.openFirstReachable(target, gen);
       if (!this.current(gen)) {
         // A newer attempt (or a disconnect) landed while the socket opened.
         socket.close();
         throw new Error("Connection superseded");
       }
       this.socket = socket;
+      this._via = socket.via;
       // Trust on first use: a hand-typed pairing has no key to compare, so the
       // one the handshake authenticated becomes the pinned identity. A target
       // that did have a key never gets here with a different one — the
@@ -243,6 +247,50 @@ export class ProtocolClient implements RemoteClient {
 
   private current(gen: number): boolean {
     return gen === this.gen;
+  }
+
+  /** Try the dial list in order within this one attempt: LAN, then the relay
+   *  (docs/remote-protocol.md, "Relay" → "Phone side"). The first candidate
+   *  that opens *is* the connection; the rest are never dialled. A candidate
+   *  that rejects — refused, unreachable, or timed out by the transport —
+   *  hands over to the next, and when none is left the attempt fails through
+   *  `fail` with the last error, retryable as before.
+   *
+   *  A host-key mismatch is the exception and stops the list at once: the
+   *  host's identity is wrong, not the path. Falling through to the relay
+   *  would let an impostor on the LAN quietly move the phone onto the relay
+   *  (and a hostile relay push it back onto the LAN), turning an alarm the
+   *  user must see into a silent path switch. */
+  private async openFirstReachable(target: HostTarget, gen: number): Promise<Socket> {
+    const handlers: SocketHandlers = {
+      onOpen: () => {},
+      onMessage: (text) => {
+        if (this.current(gen)) this.onMessage(text);
+      },
+      onClose: (code, reason) => {
+        if (this.current(gen)) this.onClose(code, reason);
+      },
+      onError: (message) => {
+        if (this.current(gen)) this.onSocketError(message);
+      },
+    };
+    const list: Candidate[] = candidatesFor(target, this.opts.openTimeout);
+    let last = new Error("no address to dial");
+    for (const candidate of list) {
+      try {
+        return await this.opts.openSocket(candidate.url, handlers, {
+          hostKey: target.hostKey,
+          timeoutMs: candidate.timeoutMs,
+          via: candidate.via,
+        });
+      } catch (e) {
+        last = e instanceof Error ? e : new Error(String(e));
+        if (last.message.includes(HOST_KEY_MISMATCH)) throw last;
+        // Superseded mid-list: the newer attempt owns the dialling now.
+        if (!this.current(gen)) throw last;
+      }
+    }
+    throw last;
   }
 
   /** The first frame on a fresh socket: `pair` when a pairing code is held,

--- a/mobile/src/remote/index.ts
+++ b/mobile/src/remote/index.ts
@@ -3,8 +3,9 @@ import { mockSocket } from "./mock";
 import type { DeviceInfo, RemoteClient } from "./types";
 import { openWebSocket } from "./ws";
 
+export { type Candidate, candidatesFor, LAN_OPEN_TIMEOUT_MS } from "./candidates";
 export { ProtocolClient } from "./client";
-export { parseAddress, parsePairUrl, wsUrl } from "./pairing";
+export { parseAddress, parsePairUrl, relayDeviceUrl, wsUrl } from "./pairing";
 export * from "./types";
 
 const search = () =>

--- a/mobile/src/remote/mock/index.ts
+++ b/mobile/src/remote/mock/index.ts
@@ -389,6 +389,8 @@ export function mockSocket(opts: MockOptions = {}): SocketFactory {
     handlers.onOpen();
     const socket: Socket = {
       hostKey: MOCK_HOST_KEY,
+      // There is no network under the mock host, so it is always the near path.
+      via: "lan",
       send: (text) => host.receive(text),
       close: () => host.close(),
     };

--- a/mobile/src/remote/pairing.ts
+++ b/mobile/src/remote/pairing.ts
@@ -15,8 +15,9 @@ export function parseAddress(input: string): { host: string; port: number } | nu
   return { host, port: Number(port) || DEFAULT_PORT };
 }
 
-/** Parse a `fletch://pair?host=<host public key>&addr=<ip>:<port>&token=<code>
- *  &name=<name>` deep link into a connect target. Returns null when it isn't
+/** Parse a `fletch://pair?host=<host public key>&addr=<ip>:<port>
+ *  &relay=<url-encoded relay base URL>&token=<code>&name=<name>` deep link into
+ *  a connect target. Returns null when it isn't
  *  one — the deep-link handler connects on anything this accepts, so a bare
  *  address is `parseAddress`'s business, not this one's.
  *
@@ -41,6 +42,10 @@ export function parsePairUrl(input: string): HostTarget | null {
   if (token) target.pairingToken = token;
   const name = params.get("name")?.trim();
   if (name) target.name = name;
+  // `relay=` is url-encoded in the link and present only when the host has a
+  // relay configured; `URLSearchParams` has already decoded it.
+  const relay = params.get("relay")?.trim();
+  if (relay) target.relay = relay;
   return target;
 }
 
@@ -48,4 +53,11 @@ export function parsePairUrl(input: string): HostTarget | null {
 export function wsUrl(target: Pick<HostTarget, "host" | "port">): string {
   const host = target.host.includes(":") ? `[${target.host}]` : target.host;
   return `ws://${host}:${target.port}/ws`;
+}
+
+/** `<relay>/v1/device/<hostKey>` — the phone's endpoint on the relay
+ *  (docs/remote-protocol.md, "Relay"). The host key is the route, and it is
+ *  already base64url, so nothing needs encoding. */
+export function relayDeviceUrl(relay: string, hostKey: string): string {
+  return `${relay.trim().replace(/\/+$/, "")}/v1/device/${hostKey}`;
 }

--- a/mobile/src/remote/socket.ts
+++ b/mobile/src/remote/socket.ts
@@ -3,12 +3,16 @@
 // Everything above it (envelopes, request matching, pairing, reconnect) lives
 // in client.ts and is therefore identical for both.
 
+import type { Via } from "./types";
+
 export interface Socket {
   send(text: string): void | Promise<void>;
   close(): void;
   /** The host public key the handshake authenticated, base64url. The client
    *  pins this when it had none to compare against. */
   readonly hostKey: string;
+  /** Which path this socket took — reported for the UI only. */
+  readonly via: Via;
 }
 
 export interface SocketHandlers {
@@ -24,6 +28,12 @@ export interface SocketOptions {
    *  host presents a different one; absent, any key is accepted and reported
    *  for pinning. */
   hostKey?: string;
+  /** Bound on opening the socket — dial plus handshake — after which the
+   *  attempt fails with a "timed out" error. Enforced inside the transport, so
+   *  the attempt is really cancelled and nothing races it from this side. */
+  timeoutMs?: number;
+  /** Which candidate this URL came from; echoed back as `Socket.via`. */
+  via?: Via;
 }
 
 /** Opens a socket to `url`. Rejecting is equivalent to `onError` + `onClose`;

--- a/mobile/src/remote/types.ts
+++ b/mobile/src/remote/types.ts
@@ -60,21 +60,41 @@ export interface HostTarget {
    *  pairing link, absent for hand-typed entry until the first connection
    *  pins the key it meets. */
   hostKey?: string;
+  /** Relay base URL, e.g. `wss://relay.fletch.app` — the fallback path when the
+   *  LAN address cannot be reached. Comes from `relay=` in the pairing link, or
+   *  is entered later in the Host sheet; absent means LAN only. */
+  relay?: string;
   /** Display name from the pairing URL, before `hello` reports the real one. */
   name?: string;
   pairingToken?: string;
 }
+
+/** Which path a connection took. The protocol is identical on both, so nothing
+ *  above the transport branches on this — it is reported, not acted on. */
+export type Via = "lan" | "relay";
 
 /** Auth-related close codes the host uses instead of error responses. */
 export const CLOSE_BAD_FIRST_FRAME = 4001;
 export const CLOSE_UNAUTHENTICATED = 4003;
 export const CLOSE_REMOTE_DISABLED = 4004;
 
+/** Codes the *relay* closes a device link with (docs/remote-protocol.md,
+ *  "Relay" and "Errors"). None of them says the credential is gone, so all are
+ *  retryable on the normal backoff — they are conditions that clear on their
+ *  own: the Mac comes back, a device slot frees up, the rate window passes. */
+export const CLOSE_HOST_OFFLINE = 4404;
+export const CLOSE_TOO_MANY_DEVICES = 4429;
+export const CLOSE_RELAY_THROTTLED = 1008;
+export const CLOSE_FRAME_TOO_LARGE = 1009;
+
 export const CLOSE_REASONS: Record<number, string> = {
   [CLOSE_BAD_FIRST_FRAME]: "Host rejected the handshake",
   [CLOSE_UNAUTHENTICATED]: "This device is not paired with the host any more",
   [CLOSE_REMOTE_DISABLED]: "Remote access is switched off on the host",
-  1009: "Frame too large",
+  [CLOSE_HOST_OFFLINE]: "Your Mac is offline",
+  [CLOSE_TOO_MANY_DEVICES]: "This Mac already has its 8 remote devices connected",
+  [CLOSE_RELAY_THROTTLED]: "The relay throttled this connection",
+  [CLOSE_FRAME_TOO_LARGE]: "Frame too large",
 };
 
 /** The marker the Rust transport puts in front of a pinned-key mismatch. It
@@ -113,6 +133,11 @@ export interface RemoteClient {
   /** The host key in use: the one the target carried, or the one pinned on
    *  first contact. */
   readonly hostKey: string | null;
+  /** Which candidate the live connection is on, or null when not connected. */
+  readonly via: Via | null;
+  /** Point the held target at a relay (or none) without re-pairing. It takes
+   *  effect on the next connection attempt. */
+  setRelay(relay: string | null): void;
   /** Where the client is pointed, with any spent pairing token stripped and
    *  the host key it authenticated pinned in. */
   readonly target: Readonly<HostTarget> | null;

--- a/mobile/src/remote/ws.ts
+++ b/mobile/src/remote/ws.ts
@@ -1,7 +1,8 @@
 // The secure transport, which is a thin shell over the app's own Rust layer:
 // `remote_connect` opens the WebSocket, runs the Noise handshake and reports
 // the host's identity key, then every frame travels encrypted. This side only
-// ever sees plaintext JSON (docs/remote-protocol.md, "Secure channel").
+// ever sees plaintext JSON (docs/remote-protocol.md, "Secure channel"). The
+// URL may be a LAN `ws://` or a relay `wss://` — same call, same handshake.
 //
 // Every connection has an id the Rust layer hands back and stamps on every
 // event, and `remote_send`/`remote_close` take it. This wrapper only ever acts
@@ -71,6 +72,10 @@ const secureSocket: SocketFactory = async (url, handlers, opts) => {
     result = await invoke<ConnectResult>("remote_connect", {
       url,
       hostKey: opts?.hostKey ?? null,
+      // One timeout, and it lives in Rust: it bounds the dial and the
+      // handshake together and closes the socket when it expires, so a
+      // candidate this side has given up on is really gone.
+      timeoutMs: opts?.timeoutMs ?? null,
     });
   } catch (e) {
     stop();
@@ -82,6 +87,7 @@ const secureSocket: SocketFactory = async (url, handlers, opts) => {
 
   const socket: Socket = {
     hostKey: result.hostKey,
+    via: opts?.via ?? "lan",
     send: (text) => invoke<void>("remote_send", { connectionId: id, text }),
     close: () => {
       done = true;

--- a/mobile/src/screens/Pair/index.tsx
+++ b/mobile/src/screens/Pair/index.tsx
@@ -6,9 +6,12 @@ import { Wordmark } from "../Home/Wordmark";
 
 /** Manual pairing: the host's address and the one-time code from the desktop's
  *  Settings → Mobile devices. A pasted `fletch://pair?…` link fills both and
- *  brings the host's public key with it, which is what authenticates the Mac;
- *  hand-typed entry has no key and pins the one it meets on first contact
- *  (docs/remote-protocol.md, "Secure channel"). */
+ *  brings the host's public key with it, which is what authenticates the Mac,
+ *  plus the relay URL when the host has one; hand-typed entry has no key and
+ *  pins the one it meets on first contact, and has no relay until a link
+ *  supplies one or it is entered in the Host sheet later
+ *  (docs/remote-protocol.md, "Secure channel" and "Authentication and
+ *  pairing"). */
 export function PairScreen() {
   const connect = useStore((s) => s.connect);
   const connection = useStore((s) => s.connection);
@@ -16,6 +19,7 @@ export function PairScreen() {
   const [address, setAddress] = useState("");
   const [token, setToken] = useState("");
   const [hostKey, setHostKey] = useState<string | undefined>(undefined);
+  const [relay, setRelay] = useState<string | undefined>(undefined);
   const busy = connection === "connecting" || connection === "pairing";
   const parsed = parseAddress(address);
 
@@ -25,6 +29,7 @@ export function PairScreen() {
     if (!link) return fallback(value);
     setAddress(`${link.host}:${link.port}`);
     setHostKey(link.hostKey);
+    setRelay(link.relay);
     if (link.pairingToken) setToken(link.pairingToken);
   };
 
@@ -33,6 +38,7 @@ export function PairScreen() {
     void connect({
       ...parsed,
       hostKey,
+      relay,
       pairingToken: token.trim().toUpperCase(),
     }).catch(() => {});
   };
@@ -82,8 +88,9 @@ export function PairScreen() {
         {busy ? "Pairing…" : "Pair"}
       </button>
       <div className="hint">
-        The code is valid for five minutes and can be used once. Everything stays on your network —
-        there is no relay in this version — and the link is end-to-end encrypted.
+        The code is valid for five minutes and can be used once. The link is end-to-end encrypted,
+        and the app talks to your Mac directly on your network — a pasted pairing link can also
+        bring a relay URL for when you are away from it.
       </div>
     </div>
   );

--- a/mobile/src/sheets/HostSheet.tsx
+++ b/mobile/src/sheets/HostSheet.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { Icon } from "../components/Icon";
 import { Segmented, Sheet } from "../components/ui";
 import { ignore } from "../lib/ignore";
@@ -11,6 +12,14 @@ const CONNECTION_TEXT: Record<string, string> = {
   error: "Disconnected",
 };
 
+/** Which candidate the live link is on. Both paths carry the same protocol, so
+ *  this is information, not a setting. */
+const VIA_TEXT: Record<string, string> = { lan: "Local network", relay: "Relay" };
+
+/** Long enough to recognise the host, short enough for the value column. */
+const abbreviate = (url: string, max = 30) =>
+  url.length <= max ? url : `${url.slice(0, max - 1)}…`;
+
 export function HostSheet({ open, onClose }: { open: boolean; onClose: () => void }) {
   const host = useStore((s) => s.hostInfo);
   const connection = useStore((s) => s.connection);
@@ -19,11 +28,21 @@ export function HostSheet({ open, onClose }: { open: boolean; onClose: () => voi
   const reconnect = useStore((s) => s.reconnect);
   const unpair = useStore((s) => s.unpair);
   const hostKey = useStore((s) => s.hostKey);
+  const relay = useStore((s) => s.relay);
+  const via = useStore((s) => s.via);
+  const setRelay = useStore((s) => s.setRelay);
   const projects = useStore((s) => s.workspace?.projects.length ?? 0);
   const agents = useStore((s) => s.workspace?.agents.length ?? 0);
   // The client owns the target; this re-reads it on every render, which the
   // connection-state subscription above already drives.
   const address = client.target ? `${client.target.host}:${client.target.port}` : "";
+  const [draft, setDraft] = useState(relay ?? "");
+  // Follow the stored value when it changes elsewhere (a fresh pairing link
+  // brings one), but never fight the user's typing.
+  useEffect(() => setDraft(relay ?? ""), [relay]);
+  const commitRelay = () => {
+    if ((draft.trim() || null) !== relay) void setRelay(draft).catch(ignore);
+  };
 
   return (
     <Sheet
@@ -76,6 +95,18 @@ export function HostSheet({ open, onClose }: { open: boolean; onClose: () => voi
               one Settings shows on the Mac. */}
           <span>{hostKey ? `${hostKey.slice(0, 12)}…` : "—"}</span>
         </div>
+        {relay && (
+          <div className="kv">
+            <span>Relay</span>
+            <span>{abbreviate(relay)}</span>
+          </div>
+        )}
+        {via && connection === "connected" && (
+          <div className="kv">
+            <span>Connected over</span>
+            <span>{VIA_TEXT[via]}</span>
+          </div>
+        )}
         <div className="kv">
           <span>Projects</span>
           <span>{projects}</span>
@@ -97,6 +128,26 @@ export function HostSheet({ open, onClose }: { open: boolean; onClose: () => voi
               onChange={(id) => setTheme(id as "system" | "light" | "dark")}
             />
           </span>
+        </div>
+      </div>
+      <div className="relay-field">
+        <label htmlFor="host-relay">Relay URL</label>
+        <input
+          id="host-relay"
+          value={draft}
+          placeholder="wss://relay.fletch.app"
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commitRelay}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") e.currentTarget.blur();
+          }}
+        />
+        <div className="hint">
+          Used only when your Mac's local address does not answer. Leave empty for local network
+          only.
         </div>
       </div>
       <div style={{ display: "flex", gap: 10, marginTop: 18 }}>

--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -13,6 +13,7 @@ import {
   type HostInfo,
   type HostTarget,
   mockEnabled,
+  type Via,
 } from "../remote";
 import { registerRemoteEvents } from "./events";
 import { clearHost, loadSettings, saveSettings } from "./persist";
@@ -46,6 +47,11 @@ export interface MobileState {
   /** The paired host's public key — pinned on first contact, and what makes
    *  the app paired at all. */
   hostKey: string | null;
+  /** The host's relay base URL, when it has one; the fallback path. */
+  relay: string | null;
+  /** Which path the live connection took — mirrored from the client for the
+   *  Host sheet, and null when there is no connection. */
+  via: Via | null;
 
   workspace: Workspace | null;
   logs: Record<string, ChatItem[]>;
@@ -69,6 +75,8 @@ export interface MobileState {
   connect(target: HostTarget): Promise<void>;
   reconnect(): Promise<void>;
   unpair(): Promise<void>;
+  /** Add or change the relay for the paired host without re-pairing. */
+  setRelay(url: string | null): Promise<void>;
   setTheme(theme: ThemeMode): void;
   setSystemTheme(t: "light" | "dark"): void;
   clearError(): void;
@@ -161,6 +169,8 @@ export const useStore = create<MobileState>()((set, get) => ({
   connectionError: null,
   hostInfo: null,
   hostKey: null,
+  relay: null,
+  via: null,
 
   workspace: null,
   logs: {},
@@ -186,7 +196,12 @@ export const useStore = create<MobileState>()((set, get) => ({
     initialized = true;
     registerRemoteEvents(client, set, get);
     client.onState((state, error) =>
-      set({ connection: state, connectionError: error ?? null, hostInfo: client.host }),
+      set({
+        connection: state,
+        connectionError: error ?? null,
+        hostInfo: client.host,
+        via: client.via,
+      }),
     );
     client.onSnapshot((snapshot) => {
       set({ hostInfo: snapshot.host });
@@ -199,7 +214,7 @@ export const useStore = create<MobileState>()((set, get) => ({
       });
     }
     const saved = await loadSettings();
-    set({ ready: true, theme: saved.theme ?? "dark" });
+    set({ ready: true, theme: saved.theme ?? "dark", relay: saved.relay ?? null });
     if (mockEnabled()) {
       // The mock host has no pairing step worth clicking through every reload;
       // its fixed key is pinned by `connect` like any other.
@@ -216,6 +231,8 @@ export const useStore = create<MobileState>()((set, get) => ({
           port: saved.port ?? DEFAULT_PORT,
           name: saved.hostName,
           hostKey: saved.hostKey,
+          // The relay is dialled only if the LAN address does not answer.
+          relay: saved.relay,
         })
         .catch(ignore);
     }
@@ -229,10 +246,13 @@ export const useStore = create<MobileState>()((set, get) => ({
       const snapshot = await client.connect(target);
       // Either the key the target carried, or the one just pinned.
       const hostKey = client.hostKey ?? target.hostKey ?? get().hostKey;
+      const relay = client.target?.relay ?? null;
       set({
         hostInfo: snapshot.host,
         workspace: snapshot.workspace,
         hostKey,
+        relay,
+        via: client.via,
         nav: [{ key: Date.now(), screen: "home", props: {}, phase: "idle" }],
       });
       // Mock mode must not leave a "mock" host behind for the next real run.
@@ -241,6 +261,7 @@ export const useStore = create<MobileState>()((set, get) => ({
           host: target.host,
           port: target.port,
           hostName: snapshot.host.name,
+          relay: relay ?? undefined,
           ...(hostKey ? { hostKey } : {}),
         });
       }
@@ -266,12 +287,24 @@ export const useStore = create<MobileState>()((set, get) => ({
     await clearHost();
     set({
       hostKey: null,
+      relay: null,
+      via: null,
       workspace: null,
       hostInfo: null,
       logs: {},
       sheet: null,
       nav: [{ key: Date.now(), screen: "home", props: {}, phase: "idle" }],
     });
+  },
+
+  /** The relay is a property of the paired host, not of a pairing: a link that
+   *  never carried one (or a hand-typed pairing) can be given one here, and it
+   *  applies from the next connection attempt on. */
+  async setRelay(url) {
+    const relay = url?.trim() || null;
+    client.setRelay(relay);
+    set({ relay });
+    if (!mockEnabled()) await saveSettings({ relay: relay ?? undefined });
   },
 
   setTheme(theme) {

--- a/mobile/src/store/persist.ts
+++ b/mobile/src/store/persist.ts
@@ -1,5 +1,5 @@
-// Small key/value store for the last host — its address, name and public key —
-// and the theme. App data dir via the fs plugin inside Tauri, localStorage in a
+// Small key/value store for the last host — its address, name, public key and
+// relay URL — and the theme. App data dir via the fs plugin inside Tauri, localStorage in a
 // browser. There is no credential here: the device's identity is the Noise
 // static key, which lives in the Rust layer's app data dir.
 
@@ -16,6 +16,8 @@ export interface Persisted {
   hostName?: string;
   /** The host's public key. Its presence is what "paired" means. */
   hostKey?: string;
+  /** Relay base URL for this host, from the pairing link or the Host sheet. */
+  relay?: string;
   theme?: "system" | "light" | "dark";
 }
 
@@ -65,7 +67,8 @@ export async function saveSettings(patch: Persisted): Promise<Persisted> {
   return next;
 }
 
-/** Forget the paired host — address, name and pinned key — and keep the rest. */
+/** Forget the paired host — address, name, pinned key and relay — and keep the
+ *  rest. */
 export async function clearHost(): Promise<void> {
   const { theme } = await readAll();
   await writeAll(theme ? { theme } : {});

--- a/mobile/src/styles/screens.css
+++ b/mobile/src/styles/screens.css
@@ -621,7 +621,8 @@
   color: var(--fg-2);
   line-height: 1.5;
 }
-.pair label {
+.pair label,
+.relay-field label {
   display: block;
   font-size: 11px;
   font-weight: 600;
@@ -633,7 +634,8 @@
 .pair .field {
   margin-top: 2px;
 }
-.pair input {
+.pair input,
+.relay-field input {
   width: 100%;
   background: var(--bg-2);
   border: 1px solid var(--bd-soft);
@@ -644,8 +646,20 @@
   font-family: var(--font-mono);
   transition: border-color 0.2s;
 }
-.pair input:focus {
+.pair input:focus,
+.relay-field input:focus {
   border-color: var(--accent-line);
+}
+/* Relay URL in the host sheet: the same field as pairing, one row down from
+   the values above it. */
+.relay-field {
+  margin-top: 16px;
+}
+.relay-field .hint {
+  font-size: 12px;
+  color: var(--fg-3);
+  line-height: 1.45;
+  margin-top: 6px;
 }
 .pair .grid {
   display: grid;

--- a/mobile/tests/protocol.test.ts
+++ b/mobile/tests/protocol.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it, vi } from "vitest";
 import { backoffDelay } from "../src/remote/backoff";
+import { candidatesFor, LAN_OPEN_TIMEOUT_MS } from "../src/remote/candidates";
 import { ProtocolClient } from "../src/remote/client";
-import { parseAddress, parsePairUrl, wsUrl } from "../src/remote/pairing";
+import { parseAddress, parsePairUrl, relayDeviceUrl, wsUrl } from "../src/remote/pairing";
 import type { Socket, SocketHandlers, SocketOptions } from "../src/remote/socket";
 import {
+  CLOSE_HOST_OFFLINE,
+  CLOSE_REASONS,
+  CLOSE_RELAY_THROTTLED,
+  CLOSE_TOO_MANY_DEVICES,
   CLOSE_UNAUTHENTICATED,
   type DeviceInfo,
   HOST_KEY_MISMATCH,
@@ -16,25 +21,41 @@ const HOST_KEY = "hostkey-aaa";
 
 /** A socket the test drives by hand: it records every frame the client sends,
  *  reports a host key the way the secure transport does, and lets the test
- *  push frames and closes back. */
-function fakeSocket(hostKey = HOST_KEY) {
+ *  push frames and closes back.
+ *
+ *  `unreachable` marks URLs that must not open: `"reject"` refuses at once,
+ *  `"hang"` never answers and is abandoned by the transport's own open
+ *  timeout — the two ways a candidate can fail. */
+function fakeSocket(hostKey = HOST_KEY, unreachable: Record<string, "reject" | "hang"> = {}) {
   const sent: Record<string, unknown>[] = [];
   const asked: (string | undefined)[] = [];
+  const urls: string[] = [];
+  const budgets: (number | undefined)[] = [];
   let handlers: SocketHandlers | null = null;
-  const socket: Socket = {
-    hostKey,
-    send: (text) => {
-      sent.push(JSON.parse(text));
-    },
-    close: () => {},
-  };
   return {
     sent,
     /** The expected host key handed to the factory on each attempt. */
     asked,
-    factory: async (_url: string, h: SocketHandlers, opts?: SocketOptions) => {
-      handlers = h;
+    /** Every URL dialled, in order. */
+    urls,
+    /** The open timeout each dial was given. */
+    budgets,
+    factory: async (url: string, h: SocketHandlers, opts?: SocketOptions): Promise<Socket> => {
+      urls.push(url);
       asked.push(opts?.hostKey);
+      budgets.push(opts?.timeoutMs);
+      const mode = unreachable[url];
+      if (mode === "reject") throw new Error(`Cannot reach ${url}`);
+      if (mode === "hang") {
+        // The open timeout lives in the transport (`remote_connect` in Rust),
+        // so a dial that never answers fails here, not on a timer above.
+        await new Promise((_resolve, reject) => {
+          setTimeout(
+            () => reject(new Error(`cannot reach ${url}: timed out`)),
+            opts?.timeoutMs ?? 20,
+          );
+        });
+      }
       // A real transport aborts the handshake itself when the host presents a
       // key other than the pinned one.
       if (opts?.hostKey && opts.hostKey !== hostKey) {
@@ -42,8 +63,16 @@ function fakeSocket(hostKey = HOST_KEY) {
           `${HOST_KEY_MISMATCH}: expected ${opts.hostKey}, host presented ${hostKey}`,
         );
       }
+      handlers = h;
       h.onOpen();
-      return socket;
+      return {
+        hostKey,
+        via: opts?.via ?? "lan",
+        send: (text) => {
+          sent.push(JSON.parse(text));
+        },
+        close: () => {},
+      };
     },
     reply: (frame: unknown) => handlers?.onMessage(JSON.stringify(frame)),
     hangup: (code: number) => handlers?.onClose(code),
@@ -107,6 +136,53 @@ describe("pairing URL", () => {
   it("brackets an IPv6 literal in the ws URL", () => {
     expect(wsUrl({ host: "fe80::1", port: 47285 })).toBe("ws://[fe80::1]:47285/ws");
     expect(wsUrl({ host: "mac.local", port: 1 })).toBe("ws://mac.local:1/ws");
+  });
+
+  it("parses relay= url-decoded, and leaves it out when the host has none", () => {
+    expect(
+      parsePairUrl(
+        "fletch://pair?host=Zm9vYmFy&addr=192.168.1.24:47285&relay=wss%3A%2F%2Frelay.fletch.app&token=K7PQ2M9X",
+      ),
+    ).toEqual({
+      host: "192.168.1.24",
+      port: 47285,
+      hostKey: "Zm9vYmFy",
+      relay: "wss://relay.fletch.app",
+      pairingToken: "K7PQ2M9X",
+    });
+    expect(
+      parsePairUrl("fletch://pair?host=Zm9vYmFy&addr=192.168.1.24:47285&token=K7PQ2M9X")?.relay,
+    ).toBeUndefined();
+  });
+
+  it("builds the device endpoint and tolerates a trailing slash on the base", () => {
+    expect(relayDeviceUrl("wss://relay.fletch.app", "Zm9vYmFy")).toBe(
+      "wss://relay.fletch.app/v1/device/Zm9vYmFy",
+    );
+    expect(relayDeviceUrl("wss://relay.fletch.app/", "Zm9vYmFy")).toBe(
+      "wss://relay.fletch.app/v1/device/Zm9vYmFy",
+    );
+    expect(relayDeviceUrl(" wss://relay.fletch.app// ", "Zm9vYmFy")).toBe(
+      "wss://relay.fletch.app/v1/device/Zm9vYmFy",
+    );
+  });
+});
+
+describe("connection candidates", () => {
+  it("dials the LAN address first, with a 3 s open budget, then the relay", () => {
+    expect(
+      candidatesFor({ host: "h", port: 1, hostKey: HOST_KEY, relay: "wss://relay.test" }),
+    ).toEqual([
+      { url: "ws://h:1/ws", via: "lan", timeoutMs: LAN_OPEN_TIMEOUT_MS },
+      { url: `wss://relay.test/v1/device/${HOST_KEY}`, via: "relay" },
+    ]);
+  });
+
+  it("is LAN-only without a relay, and without a host key to route on", () => {
+    const lanOnly = [{ url: "ws://h:1/ws", via: "lan", timeoutMs: LAN_OPEN_TIMEOUT_MS }];
+    expect(candidatesFor({ host: "h", port: 1, hostKey: HOST_KEY })).toEqual(lanOnly);
+    // Hand-typed entry has no key yet, and the key *is* the relay's route.
+    expect(candidatesFor({ host: "h", port: 1, relay: "wss://relay.test" })).toEqual(lanOnly);
   });
 });
 
@@ -269,9 +345,9 @@ describe("connection lifecycle", () => {
     expect(client.state).toBe("error");
     expect(timers.map((t) => t.ms)).toEqual([1000]);
     timers[0].fn();
-    await vi.waitFor(() => expect(attempts()).toBe(2));
-    // The retry failed the same way, so the next one is already scheduled.
-    expect(timers.map((t) => t.ms)).toEqual([1000, 2000]);
+    // The retry failed the same way, so the next one is scheduled after it.
+    await vi.waitFor(() => expect(timers.map((t) => t.ms)).toEqual([1000, 2000]));
+    expect(attempts()).toBe(2);
   });
 
   it("leaves a failed pairing attempt in error for the user to retry", async () => {
@@ -349,6 +425,36 @@ describe("reconnect", () => {
     expect(timers.map((t) => t.ms)).toEqual([1000, 1000]);
   });
 
+  it("retries a relay 4404 and says what it means: the Mac is offline", async () => {
+    const fake = fakeSocket();
+    const timers: { fn: () => void; ms: number }[] = [];
+    const client = new ProtocolClient({
+      openSocket: fake.factory,
+      device: DEVICE,
+      setTimer: (fn, ms) => {
+        timers.push({ fn, ms });
+        return timers.length;
+      },
+      clearTimer: () => {},
+    });
+    const reported: (string | undefined)[] = [];
+    client.onState((_state, error) => reported.push(error));
+    const connected = client.connect({ host: "h", port: 1, hostKey: HOST_KEY });
+    await vi.waitFor(() => expect(fake.sent.length).toBe(1));
+    fake.reply(helloOk(fake.sent[0].id as string));
+    await connected;
+
+    // The relay closes the device link when no host link is attached. Nothing
+    // about the credential is wrong, so it retries like any dropped link.
+    fake.hangup(CLOSE_HOST_OFFLINE);
+    expect(client.state).toBe("error");
+    expect(reported.at(-1)).toBe("Your Mac is offline");
+    expect(timers.map((t) => t.ms)).toEqual([1000]);
+    // The relay's other device-link closes are readable too, not bare codes.
+    expect(CLOSE_REASONS[CLOSE_TOO_MANY_DEVICES]).toContain("8 remote devices");
+    expect(CLOSE_REASONS[CLOSE_RELAY_THROTTLED]).toContain("throttled");
+  });
+
   it("does not retry after a 4003 close — the device has to be paired again", async () => {
     const fake = fakeSocket();
     const timers: { fn: () => void; ms: number }[] = [];
@@ -385,6 +491,113 @@ describe("reconnect", () => {
     const pending = client.call("get_workspace");
     fake.hangup(1006);
     await expect(pending).rejects.toThrow();
+  });
+});
+
+/** docs/remote-protocol.md, "Relay" → "Phone side": the LAN address with a
+ *  short open timeout, then the relay, within one attempt. */
+describe("relay fallback", () => {
+  const LAN = "ws://h:1/ws";
+  const RELAY = `wss://relay.test/v1/device/${HOST_KEY}`;
+  const PAIRED = { host: "h", port: 1, hostKey: HOST_KEY, relay: "wss://relay.test" };
+
+  /** A client with a tiny open budget and captured timers, so a hanging dial
+   *  and a scheduled retry are both observable without real waiting. */
+  function relayClient(fake: ReturnType<typeof fakeSocket>) {
+    const timers: { fn: () => void; ms: number }[] = [];
+    const client = new ProtocolClient({
+      openSocket: fake.factory,
+      device: DEVICE,
+      openTimeout: 5,
+      setTimer: (fn, ms) => {
+        timers.push({ fn, ms });
+        return timers.length;
+      },
+      clearTimer: () => {},
+    });
+    return { client, timers };
+  }
+
+  it("dials the LAN address only, when it opens", async () => {
+    const fake = fakeSocket();
+    const { client } = relayClient(fake);
+    const connected = client.connect(PAIRED);
+    await vi.waitFor(() => expect(fake.sent.length).toBe(1));
+    fake.reply(helloOk(fake.sent[0].id as string));
+    await connected;
+    expect(fake.urls).toEqual([LAN]);
+    expect(fake.budgets).toEqual([5]);
+    expect(client.via).toBe("lan");
+    client.disconnect();
+    expect(client.via).toBeNull();
+  });
+
+  it("moves to the relay when the LAN dial is refused", async () => {
+    const fake = fakeSocket(HOST_KEY, { [LAN]: "reject" });
+    const { client } = relayClient(fake);
+    const connected = client.connect(PAIRED);
+    await vi.waitFor(() => expect(fake.sent.length).toBe(1));
+    fake.reply(helloOk(fake.sent[0].id as string));
+    await connected;
+    // Both, in order, on the one attempt — and the relay carries the same
+    // `hello` on the same pinned key.
+    expect(fake.urls).toEqual([LAN, RELAY]);
+    expect(fake.asked).toEqual([HOST_KEY, HOST_KEY]);
+    expect(fake.budgets).toEqual([5, undefined]);
+    expect(client.via).toBe("relay");
+  });
+
+  it("moves to the relay when the LAN dial times out", async () => {
+    const fake = fakeSocket(HOST_KEY, { [LAN]: "hang" });
+    const { client } = relayClient(fake);
+    const connected = client.connect(PAIRED);
+    await vi.waitFor(() => expect(fake.sent.length).toBe(1));
+    fake.reply(helloOk(fake.sent[0].id as string));
+    await connected;
+    expect(fake.urls).toEqual([LAN, RELAY]);
+    expect(client.via).toBe("relay");
+  });
+
+  it("fails the attempt with the last error, and retries, when neither opens", async () => {
+    const fake = fakeSocket(HOST_KEY, { [LAN]: "hang", [RELAY]: "reject" });
+    const { client, timers } = relayClient(fake);
+    await expect(client.connect(PAIRED)).rejects.toThrow(`Cannot reach ${RELAY}`);
+    expect(fake.urls).toEqual([LAN, RELAY]);
+    expect(client.state).toBe("error");
+    expect(client.via).toBeNull();
+    // One attempt, one retry — not one per candidate.
+    expect(timers.map((t) => t.ms)).toEqual([1000]);
+  });
+
+  it("has nothing to fall back to without a relay on the target", async () => {
+    const fake = fakeSocket(HOST_KEY, { [LAN]: "reject" });
+    const { client } = relayClient(fake);
+    await expect(client.connect({ host: "h", port: 1, hostKey: HOST_KEY })).rejects.toThrow(
+      "Cannot reach",
+    );
+    expect(fake.urls).toEqual([LAN]);
+  });
+
+  it("skips the relay without a host key to route on", async () => {
+    const fake = fakeSocket(HOST_KEY, { [LAN]: "reject" });
+    const { client } = relayClient(fake);
+    // Hand-typed pairing: a relay URL is useless until a link brings the key.
+    await expect(client.connect({ host: "h", port: 1, relay: "wss://relay.test" })).rejects.toThrow(
+      "Cannot reach",
+    );
+    expect(fake.urls).toEqual([LAN]);
+  });
+
+  it("stops the list on a host-key mismatch, and never retries", async () => {
+    const fake = fakeSocket("hostkey-bbb");
+    const { client, timers } = relayClient(fake);
+    await expect(client.connect(PAIRED)).rejects.toThrow(HOST_KEY_MISMATCH_REASON);
+    // An impostor on the LAN must not push the phone quietly onto the relay:
+    // the identity is wrong, not the path.
+    expect(fake.urls).toEqual([LAN]);
+    expect(client.state).toBe("error");
+    expect(timers).toHaveLength(0);
+    expect(client.hostKey).toBe(HOST_KEY);
   });
 });
 

--- a/mobile/tests/store.test.ts
+++ b/mobile/tests/store.test.ts
@@ -5,7 +5,8 @@
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { MOCK_HOST_KEY } from "../src/remote/mock";
 import { PENDING_REQUEST_ID, PENDING_TOOL_USE_ID } from "../src/remote/mock/fixtures";
-import { agentOf, api, useStore } from "../src/store";
+import { agentOf, api, client, useStore } from "../src/store";
+import { clearHost, loadSettings, saveSettings } from "../src/store/persist";
 
 const state = () => useStore.getState();
 
@@ -25,12 +26,46 @@ describe("connection and snapshot", () => {
     expect(state().workspace?.agents).toHaveLength(4);
   });
 
+  it("mirrors which path the connection is on", () => {
+    // The mock host has no network under it, so it is the near path.
+    expect(state().via).toBe("lan");
+  });
+
   it("covers a running, a waiting, a finished and an errored agent", () => {
     const byId = Object.fromEntries((state().workspace?.agents ?? []).map((a) => [a.id, a]));
     expect(byId.arabia.status).toBe("running");
     expect(byId.kamakura.status).toBe("idle");
     expect(byId.caspian.status).toBe("error");
     expect(byId.caspian.last_error).toContain("429");
+  });
+});
+
+describe("relay setting", () => {
+  it("keeps the relay next to the host, and forgets it with the host", async () => {
+    await saveSettings({
+      host: "192.168.1.24",
+      port: 47285,
+      hostKey: "k",
+      relay: "wss://relay.test",
+      theme: "dark",
+    });
+    expect((await loadSettings()).relay).toBe("wss://relay.test");
+    await clearHost();
+    const after = await loadSettings();
+    expect(after.relay).toBeUndefined();
+    expect(after.host).toBeUndefined();
+    expect(after.theme).toBe("dark");
+  });
+
+  it("can be added later without re-pairing, and lands on the held target", async () => {
+    await state().setRelay(" wss://relay.test ");
+    expect(state().relay).toBe("wss://relay.test");
+    // It applies from the next attempt on; nothing reconnects here.
+    expect(client.target?.relay).toBe("wss://relay.test");
+    expect(state().connection).toBe("connected");
+    await state().setRelay(null);
+    expect(state().relay).toBeNull();
+    expect(client.target?.relay).toBeUndefined();
   });
 });
 

--- a/relay/README.md
+++ b/relay/README.md
@@ -1,0 +1,147 @@
+# Fletch Relay
+
+The reference relay for the Fletch remote protocol: a Cloudflare Worker
+fronting one Durable Object per host ID. It exists so a phone can reach its Mac
+when the two are not on the same network.
+
+It is a dumb pipe. The Noise channel between phone and Mac is end to end, so
+everything the relay carries is already ciphertext — it routes by host ID,
+verifies one Diffie-Hellman proof to decide who may claim a host ID, and
+multiplexes device links onto the single host link. It stores nothing but a
+connection-id counter. The contract is `../docs/remote-protocol.md`, section
+"Relay"; that document is the source of truth and this code follows it.
+
+## Endpoints
+
+| route | who | behaviour |
+|---|---|---|
+| `GET /v1/host/<hostId>` | the Mac | challenge / proof / ready, then multiplexed frames |
+| `GET /v1/device/<hostId>` | a phone | a plain WebSocket, exactly as the LAN host would serve |
+
+Anything else is `404`, as is a `hostId` that is not 43 base64url characters
+decoding to exactly 32 bytes. A valid route without `Upgrade: websocket` is
+`426`.
+
+Close codes: `4003` host authentication failed, `4404` host offline, `4409`
+host link replaced, `4429` more than 8 device links, `1009` message over
+4 MiB, `1008` more than 100 messages in 10 s on one device link.
+
+## Host link authentication
+
+The host ID *is* the host's X25519 public key, so nothing has to be
+registered in advance and nothing is stored. On upgrade the relay mints a
+throwaway X25519 keypair and a 32-byte nonce and sends
+
+```json
+{ "type": "challenge", "nonce": "<base64url>", "relayKey": "<base64url>" }
+```
+
+The host answers within 10 s with
+
+```json
+{ "type": "proof", "proof": "<base64url SHA-256( shared || nonce || hostKey )>" }
+```
+
+where `shared = X25519(hostPrivate, relayKey)` and `hostKey` is the raw 32
+bytes of the host ID. The relay recomputes it as
+`X25519(relayPrivate, hostKey)`, compares in constant time, and replies
+`{ "type": "ready" }` or closes `4003`. X25519 and SHA-256 both come from
+WebCrypto (`crypto.subtle`); there is no third-party crypto dependency.
+
+## Test vector
+
+A known-answer vector for that proof, so the desktop's Rust implementation can
+be checked against the same numbers. It was produced with Node's `crypto`
+(`crypto.diffieHellman` for X25519) and is verified against this Worker's
+WebCrypto code by `test/auth.test.ts`. It also lives in `test-vector.json`.
+All values are unpadded base64url of raw bytes.
+
+```
+hostPrivate   OqU0-7cJg-RJvvrbEO7QdOhyDkXsLgpcep6iAuRBhyM
+hostId        CByil-LnR3Z4wv604Br29p6iHZu2cmhqy35dlKs7Ojg   (= X25519 public of hostPrivate)
+relayPrivate  X3dswLZDY6e6AswL_bcW6V13_XV_3NnBcXngrkpTn38
+relayKey      9ULx3HxJf-CwYQMXrrUbub-mLokcC6O-EkH1Uv0bcR8   (= X25519 public of relayPrivate)
+nonce         91SDD6qePWgyP4B77YoYcp5T7H2CVoihopcC_iVs13U
+shared        3eRCj5nchCI2rpYP7m4yUk_eYadXHnLE8SIcsIEg82U
+proof         hVOvHwh5XlYzm95Ts3hqD2J6OAVe6lIt1wRxGMN30CM
+```
+
+`proof = SHA-256( X25519(hostPrivate, relayKey) || nonce || hostId )` over the
+raw 32-byte decodings. The private values are unclamped random bytes, which is
+what both `crypto.diffieHellman` and `x25519-dalek`'s `StaticSecret::from`
+accept.
+
+## Multiplexing
+
+Every device link becomes a numbered virtual connection on the one host link.
+Binary messages on the host link are `type (1) || connId (u32 BE) || payload`:
+`0x01` OPEN, `0x02` DATA, `0x03` CLOSE (`code (u16 BE) || reason`), `0x04`
+TEXT. A device's binary message becomes DATA, its text message becomes TEXT
+(verbatim, so the host applies its own `4001` rule), and a device that goes
+away becomes CLOSE. Host DATA goes back out as a binary message to that
+device; host CLOSE closes it with that code and reason. Frames naming an
+unknown `connId` are dropped. `connId` is a u32 that is never reused for the
+life of a Durable Object; the counter is the object's only stored value.
+
+## Hibernation
+
+The object uses the WebSocket Hibernation API, so it is evicted while its
+sockets are idle and rebuilt on the next message — which means no socket
+bookkeeping can live in instance fields. `ctx.getWebSockets(tag)` is the only
+source of truth for who is attached, and each socket's own attachment
+(`serializeAttachment` / `deserializeAttachment`) carries its role, connection
+id, authentication stage, challenge keypair and rate-limit window. The 10 s
+proof deadline is a storage alarm rather than a `setTimeout`, for the same
+reason.
+
+## Develop
+
+```sh
+bun install
+bun run dev            # wrangler dev
+bun run check          # tsc --noEmit
+bun run lint           # biome
+bun run test           # vitest in workerd, via @cloudflare/vitest-pool-workers
+```
+
+The tests run the real Durable Object inside workerd, so hibernation, WebCrypto
+and close-code handling behave as they do in production. Keep
+`compatibility_date` in `wrangler.toml` at or below the newest date the bundled
+workerd supports, or the test runtime refuses to start.
+
+## Deploy
+
+```sh
+bunx wrangler login
+bunx wrangler deploy
+```
+
+That publishes to `https://fletch-relay.<subdomain>.workers.dev`. For a custom
+domain, add the zone to the same Cloudflare account and give the Worker a
+route — either in the dashboard (Workers & Pages → the Worker → Settings →
+Domains & Routes → Add custom domain) or in `wrangler.toml`:
+
+```toml
+[[routes]]
+pattern = "relay.example.com"
+custom_domain = true
+```
+
+Cloudflare provisions the certificate; WebSockets need no extra configuration.
+
+## Pointing the apps at it
+
+The relay is opt-in and per host. On the Mac, Settings → Mobile devices sets
+`remote.relay_url` (Tauri command `remote_set_relay`) to the base URL, e.g.
+`wss://relay.example.com` — no path, the app appends `/v1/host/<hostId>`. Empty
+or absent means no relay, and the Mac only dials LAN. With it set, the desktop
+keeps a host link up whenever remote access is enabled, reconnecting with
+backoff, and reports it in `remote_status.relay`.
+
+The phone learns the URL from the pairing link, which carries
+`relay=<url-encoded>` when the host has one, and persists it with the host.
+A phone then tries the LAN address first and the relay second. A hand-typed
+pairing has no `relay=`, so it stays LAN-only until the URL is entered by hand.
+
+Anyone can run their own relay: it holds no keys and no accounts, and both ends
+only need to agree on the base URL.

--- a/relay/biome.json
+++ b/relay/biome.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
+  "root": false,
+  "extends": ["../biome.json"],
+  "vcs": {
+    "enabled": false
+  },
+  "files": {
+    "includes": ["!bun.lock", "!.wrangler", "!dist", "!worker-configuration.d.ts"]
+  }
+}

--- a/relay/bun.lock
+++ b/relay/bun.lock
@@ -1,0 +1,386 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "fletch-relay",
+      "devDependencies": {
+        "@biomejs/biome": "^2.5.1",
+        "@cloudflare/vitest-pool-workers": "^0.22.0",
+        "@cloudflare/workers-types": "^4.20260101.0",
+        "typescript": "~5.7.3",
+        "vitest": "^4.1.9",
+        "wrangler": "^4.129.1",
+      },
+    },
+  },
+  "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.5.12", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.12", "@biomejs/cli-darwin-x64": "2.5.12", "@biomejs/cli-linux-arm64": "2.5.12", "@biomejs/cli-linux-arm64-musl": "2.5.12", "@biomejs/cli-linux-x64": "2.5.12", "@biomejs/cli-linux-x64-musl": "2.5.12", "@biomejs/cli-win32-arm64": "2.5.12", "@biomejs/cli-win32-x64": "2.5.12" }, "bin": { "biome": "bin/biome" } }, "sha512-Lw4VHZRebrReBBnlHa12JQjnIBm3JJAA55PDB9LbBVBF0q4RYphm6KfmIjqtPhf61MxZ5Q9KoK8R8x+7per5Aw=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-lCRY1rwgNeWNgTr4DI/u6ZwXTRwRLHAvbaio1YLLGS+4r1nhvB2ssyPqIpfUSmRveNfv0fn/N58C7CAdK2XVrg=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-vhPgwnh+6tN3ArdAXuET99xaNbFt7CG82Bqn+omHVLC5xdVx45JsYjGPmUIGNzjDek5XdNCP1HKksK7fn8+3bQ=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-2gp8aVwXYKdAtmBfRFCUuyDMcfN1ahHqUkGfLYrZlNRFmryMATLVvJgWKvyA8wu4Rwn5OSxM1UcUmOuOFNGeBQ=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-couHYjFLL5uuI8ne6zhT7KwEsXo5YP7ry/2xmEqah7qanu0YmfDi3mwJg47YXSuv/NpZj22CZzcRH/5c4gjPSQ=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.12", "", { "os": "linux", "cpu": "x64" }, "sha512-SnvOs3TSTiuia4SQOUNe1aWC9RT4+YkjcKnOhL/nsKOV0k5ycgBkDzF0lUxKn1V7Q8CLTRq6iV23ZAivHomRoA=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.12", "", { "os": "linux", "cpu": "x64" }, "sha512-8A0oDW58/w9f/PQNYuq0sGUZtGtGrkNF4Z6n0PUoXpLCshi85vtKTv1XSznQawhdE4MXJ8ufpzHXyLFe87M/+w=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-b9vtoZFsuZt1pdjNwJvXl0f+BpayRzV008uS2+JpmwIKdSE2qdu4A/l04FESwLoou5g2E/Qlec0xwJydZplH+A=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.12", "", { "os": "win32", "cpu": "x64" }, "sha512-B1R/l+CwEpKFSuqiwePzPNRk1EiJN8kc0UhdafNz6MZN9v5OFP9HYP1irptvWzHrwVI4blVNGMbxc5zt70m3IA=="],
+
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/vitest-pool-workers": ["@cloudflare/vitest-pool-workers@0.22.0", "", { "dependencies": { "cjs-module-lexer": "1.2.3", "esbuild": "0.28.1", "miniflare": "5.20260815.0-alpha", "wrangler": "4.124.0", "zod": "4.4.3" }, "peerDependencies": { "@vitest/runner": "^4.1.0", "@vitest/snapshot": "^4.1.0", "vitest": "^4.1.0" } }, "sha512-OJv/qikkOgxnKxJ5xrLS7zuOLZhc/6iziU+llqZm4tiQf2CJUYwlMuXN68VaWIQebORd1AUx4w6A0oy8XRbuaQ=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260907.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-Xaum46kviN8xixl0axXm7mfLTf2GAG+baotnEIv8M5EbvyHxHagvS5Z8bU5B/WJlTWwwvGzItFfKZvga78o3ew=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260907.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-P2o7xpZbxvoES9xY5uHqJPXvsWBWi0w1STCGoYLqxI1rh1gSUdlr4HruMiWq/TA94PPoQCg0eUfoshyQxMdGpA=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260907.1", "", { "os": "linux", "cpu": "x64" }, "sha512-4aXjFMtD76FgVmDm7vUtl96LWNmFScfrYZ9lA6JpP5+svRfUQOYaJKcYK4g9IVmAxemItJizTTIA8jhEZaw0vg=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260907.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-nex+emDfyOYnQlhfPoCfLYQN6L+Ng0fVg5f3+8Ot4XRZaKJUzpiBFiRkgpoUuEN47U8Pm8BwhhOK2dQwtKwivQ=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260907.1", "", { "os": "win32", "cpu": "x64" }, "sha512-/ZHtEmpdSUKZyQCBUSqmGp+I7GwWVR2eUaGE5NzFJIu31HBsoQEakXaDpTrbwXydpBzpI9N0DC83W7qekkGPMQ=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260702.1", "", {}, "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.3.1" }, "os": "darwin", "cpu": "arm64" }, "sha512-eEieHsMksAW4IiO5NzauESRl2D2qz3J/kwUxUrSfV06A93eEaRfMpHXyUb1mAqrR7i8U9A0GRqE9pjn6u1Jjpg=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.3.1" }, "os": "darwin", "cpu": "x64" }, "sha512-BaktuGPCeHJMARpodR8jK4uKiZrPAy9WrfQW0sdI37clracq8Bp01AYS3SZgi5FS/y5twa9t4+LIuuxQjqRrWw=="],
+
+    "@img/sharp-freebsd-wasm32": ["@img/sharp-freebsd-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "os": "freebsd" }, "sha512-YoAxdnd8hPUkvLHd3bWY+YA8nw3xM/RyRopYucNsWHVSan8NLVM3X2volsfoRDcXdUJPg6tXahSd7HXPK7lRnw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.3.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-4V/M3roRMTYjiwZY9IOVQOE8OyeCxFAkYmyZDrZl51uOKjibm3oeEJ4WAmLxutAfzFbC9jqUiPs2gbnGflH+7g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.3.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-c0/DxItpJv2+dGhgycJBBgotdqruGYDvA79drdh0MD1dFpy7JzJ/PlXwi1H4rFf0eTy8tgbI91aHDnZIceY3jQ=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.3.1", "", { "os": "linux", "cpu": "arm" }, "sha512-aGGy9aWzXgHBG7HNyQPWorZthlp7+x6fDRoPAQbGO3ThcttuTyKIx3NuSHb6zb4gBNq6/yNn9f1cy9nFKS/Vmg=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-JznefmcK9j1JKPz8AkQDh89kjojubyfOasWBPKfzMIhPwsgDy9evpE/naJTXXXmghS1iFwR8u/kTwh/I2/+GCw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.3.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1EkwGNCZk6iWNCMWqrvdJ+r1j0PT1zIz60CNPhYnJlK/zyeWqlsPZIe+ocBVqPF8k/Ssee/NCk+tE9Ryrko6ng=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.3.1", "", { "os": "linux", "cpu": "none" }, "sha512-Ilays+w2bXdnxzxtQdmXR62u8o8GYa3eL4+Gr+1KiE4xperMZUslRaVPJwwPkzlHEjGfXAfRVAa/7CYCtSqsBw=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.3.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-VfBwVHQTbRoj4XlpA/KLZ7ltgMpz+4WSejFzQ+GnoImjo1PtEJ59QB2qR1xQEeRPYIkNrPIm2L4cICMvz4C2ew=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-+c8ukgwU62DS54nCAjw7keOfHUkmr0B5QHEdcOqRnodF/MNXJbVI8Eopoj4B/0H8Asr65I+A4Amrn7a85/md6A=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.3.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-qlKb/pwbkAi1WMsJrYHk7CuDrd12s27U2QnRhFYUoJNrRCmkosMTttuRFat/DDB3IlDm5qE1TJgZ4JDnHX8Ldw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.3.1", "", { "os": "linux", "cpu": "x64" }, "sha512-yO21HwoUVLN8Qa+/SBjQLMYwBWAVJjeGPNe+hc0OUeMeifEtJqu5a1c4HayE1nNpDih9y3/KkoltfkDodmKAlg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.3.1" }, "os": "linux", "cpu": "arm" }, "sha512-SE4kzF2mepn6z+6E7L6lsV8FzuLL6IPQdyX8ZiwROAG/G8td+hP/m7FsFPwidtrF19gvajuC9l6TxAVcsA4S7A=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-af12Pnd0ZGu2HfP8NayB0kk6eC/lrfbQE6HlR4jD+34wdJ1Vw9TF6TMn6ZvffT+WgqVsl0hRbmNvz2u/23VmwA=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.3.1" }, "os": "linux", "cpu": "ppc64" }, "sha512-hYSBm7zcNtDCozCxQHYZJiu63b/bXsgRZuOxCIBZsStMM9Vap47iFHdbX4kCvQsblPB/k+clhELpdQJHQLSHvg=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.3.1" }, "os": "linux", "cpu": "none" }, "sha512-qQt0Kc13+Hoan/Awq/qMSQw3L+RI1NCRPgD5cUJ/1WSSmIoysLOc72jlRM3E0OHN9Yr313jgeQ2T+zW+F03QFA=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.3.1" }, "os": "linux", "cpu": "s390x" }, "sha512-E4fLLfRPzDLlEeDaTzI98OFLcv++WL5ChLLMwPoVd0CIoZQqupBSNbOisPL5am9XsbQ9T84+iiMpUvbFtkunbA=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-gi0zFJJRLswfCZmHtJdikXPOc5u7qamSOS3NHedLqLd4W8Q0NqjdBr6TTRIgsfFjqfTsHFgdfvJ9LwqSgcHiAA=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.3.1" }, "os": "linux", "cpu": "arm64" }, "sha512-siWbOW1u6HFnFLrp0waKyW7VEf7jYvcDWdrXEFa8AkdAQgEvuu5Fz8/Y70w9EeqAdwDtfU012BhEHHaDqvQNzg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.35.2", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.3.1" }, "os": "linux", "cpu": "x64" }, "sha512-YBqMMcjDi4QGYiSn4vNOYBhmlC4z5AXqkOUUqI2e0AFA4urNv4ESgOgwNl3K+4etQhha0twXlzeF20bbULm9Yg=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.35.2", "", { "dependencies": { "@emnapi/runtime": "^1.11.1" } }, "sha512-Mrv4JQNYVQ94xH+jzZ9r+gowleN8mv2FTgKT+PI6bx5C0G8TdNYndu161pg2i7uoBwxy2ImPMHrJOM2LZef7Bw=="],
+
+    "@img/sharp-webcontainers-wasm32": ["@img/sharp-webcontainers-wasm32@0.35.2", "", { "dependencies": { "@img/sharp-wasm32": "0.35.2" }, "cpu": "none" }, "sha512-QNV27pxs9wpApEiCfvHM1RDoP1w1+2KrUWWDPEhEwg+latvOrfuhWrHWZKwdSFwU6jh3myjw/yOCRsUIuOft3g=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.35.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-BiVRYc/t6/Vl3e1hBx0hugG4oN9Pydf4fgMSpxTQJmwGUg/YoXTWHiFeRymHfCZzifxu4F4rpk/I67D0LQ20wQ=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.35.2", "", { "os": "win32", "cpu": "ia32" }, "sha512-YYEhx9PImCC7T0tI8JDMi4DB9LwLCXCU5OWNYEXAxh5Q1ShKkyC6byxzoBJ3gEFDnH2lQckWuDe70G7mB2XJog=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.35.2", "", { "os": "win32", "cpu": "x64" }, "sha512-imoOyBcoM/iiUr4J6VPpCNjPnjvP/Gks95898yB8YqoGGYmHYbOyCuNv9FMhFgtaiHFGbHW8bxKqRV6VjtXThQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.6.0", "", {}, "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.148.0", "", {}, "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A=="],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@rolldown/binding-android-arm-eabi": ["@rolldown/binding-android-arm-eabi@1.2.7", "", { "os": "android", "cpu": "arm" }, "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.7", "", { "os": "android", "cpu": "arm64" }, "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.7", "", { "os": "linux", "cpu": "arm" }, "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.7", "", { "os": "linux", "cpu": "x64" }, "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.7", "", { "os": "linux", "cpu": "x64" }, "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.7", "", { "os": "none", "cpu": "arm64" }, "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.7", "", { "os": "win32", "cpu": "x64" }, "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.24", "", {}, "sha512-qeW2e1l78afw8VhRPfPQ1Gjj+KU5XFQ/OFV5ti6eTa9bruO7mJyZtA4vw0ofqmA3tKCkROE9xLk3VZoeRc98nw=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@vitest/expect": ["@vitest/expect@4.1.11", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.11", "", { "dependencies": { "@vitest/spy": "4.1.11", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.11", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.11", "", { "dependencies": { "@vitest/utils": "4.1.11", "pathe": "^2.0.3" } }, "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.11", "", { "dependencies": { "@vitest/pretty-format": "4.1.11", "@vitest/utils": "4.1.11", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.11", "", {}, "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.11", "", { "dependencies": { "@vitest/pretty-format": "4.1.11", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@1.2.3", "", {}, "sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ=="],
+
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
+
+    "es-module-lexer": ["es-module-lexer@2.3.2", "", {}, "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw=="],
+
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "miniflare": ["miniflare@5.20260815.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260815.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ=="],
+
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
+
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.7", "", {}, "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA=="],
+
+    "postcss": ["postcss@8.5.28", "", { "dependencies": { "nanoid": "^3.3.18", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A=="],
+
+    "rolldown": ["rolldown@1.2.7", "", { "dependencies": { "@oxc-project/types": "=0.148.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm-eabi": "1.2.7", "@rolldown/binding-android-arm64": "1.2.7", "@rolldown/binding-darwin-arm64": "1.2.7", "@rolldown/binding-darwin-x64": "1.2.7", "@rolldown/binding-freebsd-x64": "1.2.7", "@rolldown/binding-linux-arm-gnueabihf": "1.2.7", "@rolldown/binding-linux-arm64-gnu": "1.2.7", "@rolldown/binding-linux-arm64-musl": "1.2.7", "@rolldown/binding-linux-ppc64-gnu": "1.2.7", "@rolldown/binding-linux-s390x-gnu": "1.2.7", "@rolldown/binding-linux-x64-gnu": "1.2.7", "@rolldown/binding-linux-x64-musl": "1.2.7", "@rolldown/binding-openharmony-arm64": "1.2.7", "@rolldown/binding-win32-arm64-msvc": "1.2.7", "@rolldown/binding-win32-x64-msvc": "1.2.7" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "sharp": ["sharp@0.35.2", "", { "dependencies": { "@img/colour": "^1.1.0", "detect-libc": "^2.1.2", "semver": "^7.8.4" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.35.2", "@img/sharp-darwin-x64": "0.35.2", "@img/sharp-freebsd-wasm32": "0.35.2", "@img/sharp-libvips-darwin-arm64": "1.3.1", "@img/sharp-libvips-darwin-x64": "1.3.1", "@img/sharp-libvips-linux-arm": "1.3.1", "@img/sharp-libvips-linux-arm64": "1.3.1", "@img/sharp-libvips-linux-ppc64": "1.3.1", "@img/sharp-libvips-linux-riscv64": "1.3.1", "@img/sharp-libvips-linux-s390x": "1.3.1", "@img/sharp-libvips-linux-x64": "1.3.1", "@img/sharp-libvips-linuxmusl-arm64": "1.3.1", "@img/sharp-libvips-linuxmusl-x64": "1.3.1", "@img/sharp-linux-arm": "0.35.2", "@img/sharp-linux-arm64": "0.35.2", "@img/sharp-linux-ppc64": "0.35.2", "@img/sharp-linux-riscv64": "0.35.2", "@img/sharp-linux-s390x": "0.35.2", "@img/sharp-linux-x64": "0.35.2", "@img/sharp-linuxmusl-arm64": "0.35.2", "@img/sharp-linuxmusl-x64": "0.35.2", "@img/sharp-webcontainers-wasm32": "0.35.2", "@img/sharp-win32-arm64": "0.35.2", "@img/sharp-win32-ia32": "0.35.2", "@img/sharp-win32-x64": "0.35.2" } }, "sha512-FVtFjtBCMiJS6yb5CX7Sop45WFMpeGw6oRKuJnXYgf/f1ms/D7LE/ZUSNxnW7rZ/dbslQWYkoqFHGPaDBtaK4w=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
+
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.3.1", "", {}, "sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
+
+    "undici": ["undici@7.29.0", "", {}, "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
+    "vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
+
+    "vitest": ["vitest@4.1.11", "", { "dependencies": { "@vitest/expect": "4.1.11", "@vitest/mocker": "4.1.11", "@vitest/pretty-format": "4.1.11", "@vitest/runner": "4.1.11", "@vitest/snapshot": "4.1.11", "@vitest/spy": "4.1.11", "@vitest/utils": "4.1.11", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.11", "@vitest/browser-preview": "4.1.11", "@vitest/browser-webdriverio": "4.1.11", "@vitest/coverage-istanbul": "4.1.11", "@vitest/coverage-v8": "4.1.11", "@vitest/ui": "4.1.11", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "workerd": ["workerd@1.20260907.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260907.1", "@cloudflare/workerd-darwin-arm64": "1.20260907.1", "@cloudflare/workerd-linux-64": "1.20260907.1", "@cloudflare/workerd-linux-arm64": "1.20260907.1", "@cloudflare/workerd-windows-64": "1.20260907.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-MN/jgZkg2y9ZOOXdN9ecYynRFaqTCRkmpt3jS6LQNPoSx8HxTgcG947SduxJEB38YisB7RJ3Gu/y7fpd7fZ5bA=="],
+
+    "wrangler": ["wrangler@4.129.1", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260907.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260907.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260907.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-u1Q8dMAczlmj41K0xk5LkfcHHmbwq5xZRctlyrErVqpcoGsSIW07i74phv3B9xt6mTEO1dX3U5d9WVxR3GFRfA=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler": ["wrangler@4.124.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "5.20260815.0-alpha", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260815.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260815.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog=="],
+
+    "miniflare/workerd": ["workerd@1.20260815.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260815.1", "@cloudflare/workerd-darwin-arm64": "1.20260815.1", "@cloudflare/workerd-linux-64": "1.20260815.1", "@cloudflare/workerd-linux-arm64": "1.20260815.1", "@cloudflare/workerd-windows-64": "1.20260815.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg=="],
+
+    "wrangler/miniflare": ["miniflare@5.20260907.0-alpha", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.35.2", "undici": "7.29.0", "workerd": "1.20260907.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" } }, "sha512-56F13BeJQuDbTxcoGGN4MGxN8oNNIH3pK48VyJ1JGmjbzE9MMu6S2kxoON3nOBHlLdNjXyzg1Rz3jdHx+JpuZA=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd": ["workerd@1.20260815.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260815.1", "@cloudflare/workerd-darwin-arm64": "1.20260815.1", "@cloudflare/workerd-linux-64": "1.20260815.1", "@cloudflare/workerd-linux-arm64": "1.20260815.1", "@cloudflare/workerd-windows-64": "1.20260815.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg=="],
+
+    "miniflare/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260815.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-7PsLdcz6pT9EMd1EJGZEgMyYRfs0CHxGs62PS2L1w3s6+xGmQcRXKm/zoMftmqZF45JBa4MzFeownRKbRt/x5g=="],
+
+    "miniflare/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260815.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw=="],
+
+    "miniflare/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260815.1", "", { "os": "linux", "cpu": "x64" }, "sha512-MuqKIHPo0Qyo8MZMmy0lP2B5PeAL7f4T9Fu4Usk3QdbV4JIrKG/OoybN3Ign7m/Dff+L1Oo/ZHydB+hEg1ueFw=="],
+
+    "miniflare/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260815.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-XNFtJ5rIqJxnY6ISjkfbhT/ODiWJ6LcBvNbntuPD6I/F2k7aZeKgPaXrvWvKde66LXyzFKzc8Hn+Ydx4shevQg=="],
+
+    "miniflare/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260815.1", "", { "os": "win32", "cpu": "x64" }, "sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260815.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-7PsLdcz6pT9EMd1EJGZEgMyYRfs0CHxGs62PS2L1w3s6+xGmQcRXKm/zoMftmqZF45JBa4MzFeownRKbRt/x5g=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260815.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260815.1", "", { "os": "linux", "cpu": "x64" }, "sha512-MuqKIHPo0Qyo8MZMmy0lP2B5PeAL7f4T9Fu4Usk3QdbV4JIrKG/OoybN3Ign7m/Dff+L1Oo/ZHydB+hEg1ueFw=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260815.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-XNFtJ5rIqJxnY6ISjkfbhT/ODiWJ6LcBvNbntuPD6I/F2k7aZeKgPaXrvWvKde66LXyzFKzc8Hn+Ydx4shevQg=="],
+
+    "@cloudflare/vitest-pool-workers/wrangler/workerd/@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260815.1", "", { "os": "win32", "cpu": "x64" }, "sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw=="],
+  }
+}

--- a/relay/package.json
+++ b/relay/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "fletch-relay",
+  "private": true,
+  "version": "0.1.0",
+  "license": "AGPL-3.0-only",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "check": "tsc --noEmit",
+    "lint": "biome check",
+    "lint:fix": "biome check --write",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.5.1",
+    "@cloudflare/vitest-pool-workers": "^0.22.0",
+    "@cloudflare/workers-types": "^4.20260101.0",
+    "typescript": "~5.7.3",
+    "vitest": "^4.1.9",
+    "wrangler": "^4.129.1"
+  }
+}

--- a/relay/src/auth.ts
+++ b/relay/src/auth.ts
@@ -1,0 +1,208 @@
+// Host-link authentication: one X25519 DH proof, no stored secrets. The host
+// ID *is* the public key the relay verifies against.
+//
+//   relay -> host  { type: "challenge", nonce, relayKey }
+//   host  -> relay { type: "proof", proof }   proof = SHA-256(shared||nonce||hostKey)
+//   relay -> host  { type: "ready" }          or close 4003
+//
+// See ../../docs/remote-protocol.md, "Host link authentication".
+//
+// X25519 comes from WebCrypto (`crypto.subtle`), which workerd supports for
+// generateKey/importKey/deriveBits — verified by the known-answer test in
+// test/auth.test.ts against a vector produced by Node's `crypto`. No
+// third-party curve library is needed.
+
+const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+const REVERSE = (() => {
+  const table = new Int8Array(128).fill(-1);
+  for (let i = 0; i < ALPHABET.length; i++) table[ALPHABET.charCodeAt(i)] = i;
+  return table;
+})();
+
+export const HOST_ID_LENGTH = 43;
+export const KEY_BYTES = 32;
+export const NONCE_BYTES = 32;
+
+export function b64urlEncode(bytes: Uint8Array): string {
+  let out = "";
+  const full = bytes.length - (bytes.length % 3);
+  for (let i = 0; i < full; i += 3) {
+    const n = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+    out += ALPHABET[(n >> 18) & 63] + ALPHABET[(n >> 12) & 63];
+    out += ALPHABET[(n >> 6) & 63] + ALPHABET[n & 63];
+  }
+  const rest = bytes.length - full;
+  if (rest === 1) {
+    const n = bytes[full] << 16;
+    out += ALPHABET[(n >> 18) & 63] + ALPHABET[(n >> 12) & 63];
+  } else if (rest === 2) {
+    const n = (bytes[full] << 16) | (bytes[full + 1] << 8);
+    out += ALPHABET[(n >> 18) & 63] + ALPHABET[(n >> 12) & 63] + ALPHABET[(n >> 6) & 63];
+  }
+  return out;
+}
+
+/**
+ * Strict, unpadded base64url. Returns null for a bad character, an impossible
+ * length, or non-canonical trailing bits, so each byte string has exactly one
+ * accepted spelling and a host ID cannot be written two ways.
+ */
+export function b64urlDecode(text: string): Uint8Array | null {
+  if (text.length % 4 === 1) return null;
+  const out = new Uint8Array((text.length * 3) >> 2);
+  let acc = 0;
+  let bits = 0;
+  let written = 0;
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code > 127) return null;
+    const value = REVERSE[code];
+    if (value < 0) return null;
+    acc = (acc << 6) | value;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      out[written++] = (acc >> bits) & 0xff;
+    }
+  }
+  if (bits > 0 && (acc & ((1 << bits) - 1)) !== 0) return null;
+  return written === out.length ? out : out.subarray(0, written);
+}
+
+/** A host ID is 43 base64url characters decoding to exactly 32 bytes. */
+export function decodeHostKey(hostId: string): Uint8Array | null {
+  if (hostId.length !== HOST_ID_LENGTH) return null;
+  const raw = b64urlDecode(hostId);
+  return raw && raw.length === KEY_BYTES ? raw : null;
+}
+
+/**
+ * An X25519 keypair in its only JSON-serialisable form: the JWK `d` (private
+ * scalar) and `x` (public key), both raw 32 bytes as base64url. WebCrypto has
+ * no "raw" export for X25519 private keys and no way to derive a public key
+ * from a bare scalar, so both halves are carried together — which is also
+ * what lets the challenge keypair ride along in a hibernating socket's
+ * attachment.
+ */
+export interface X25519Keypair {
+  d: string;
+  x: string;
+}
+
+export async function generateKeypair(): Promise<X25519Keypair> {
+  const pair = (await crypto.subtle.generateKey({ name: "X25519" }, true, [
+    "deriveBits",
+  ])) as CryptoKeyPair;
+  const jwk = (await crypto.subtle.exportKey("jwk", pair.privateKey)) as JsonWebKey;
+  if (!jwk.d || !jwk.x) throw new Error("X25519 private key export lacks d/x");
+  return { d: jwk.d, x: jwk.x };
+}
+
+export function publicKeyOf(keypair: X25519Keypair): string {
+  return keypair.x;
+}
+
+/** Builds a keypair from a raw 32-byte private scalar (test vectors only). */
+export async function keypairFromPrivate(privateKey: Uint8Array): Promise<X25519Keypair> {
+  if (privateKey.length !== KEY_BYTES) throw new Error("X25519 private key must be 32 bytes");
+  // WebCrypto needs `x` to import, and cannot compute it, so round-trip
+  // through PKCS#8, which carries only the scalar.
+  const pkcs8 = new Uint8Array(PKCS8_X25519_PREFIX.length + KEY_BYTES);
+  pkcs8.set(PKCS8_X25519_PREFIX, 0);
+  pkcs8.set(privateKey, PKCS8_X25519_PREFIX.length);
+  const key = await crypto.subtle.importKey("pkcs8", toBuffer(pkcs8), { name: "X25519" }, true, [
+    "deriveBits",
+  ]);
+  const jwk = (await crypto.subtle.exportKey("jwk", key)) as JsonWebKey;
+  if (!jwk.d || !jwk.x) throw new Error("X25519 private key export lacks d/x");
+  return { d: jwk.d, x: jwk.x };
+}
+
+// SEQUENCE { INTEGER 0, SEQUENCE { OID 1.3.101.110 }, OCTET STRING { OCTET
+// STRING (32) } } — the fixed 16-byte header of a PKCS#8 X25519 private key.
+const PKCS8_X25519_PREFIX = new Uint8Array([
+  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x6e, 0x04, 0x22, 0x04, 0x20,
+]);
+
+/** X25519(private, peerPublic). Null when the peer key is unusable. */
+export async function sharedSecret(
+  keypair: X25519Keypair,
+  peerPublic: Uint8Array,
+): Promise<Uint8Array | null> {
+  if (peerPublic.length !== KEY_BYTES) return null;
+  try {
+    const priv = await crypto.subtle.importKey(
+      "jwk",
+      { kty: "OKP", crv: "X25519", d: keypair.d, x: keypair.x },
+      { name: "X25519" },
+      false,
+      ["deriveBits"],
+    );
+    const pub = await crypto.subtle.importKey(
+      "raw",
+      toBuffer(peerPublic),
+      { name: "X25519" },
+      false,
+      [],
+    );
+    // @cloudflare/workers-types spells the peer key `$public` because its
+    // codegen escapes TS keywords; the property workerd reads is `public`.
+    const algorithm = { name: "X25519", public: pub } as unknown as SubtleCryptoDeriveKeyAlgorithm;
+    return new Uint8Array(await crypto.subtle.deriveBits(algorithm, priv, 256));
+  } catch {
+    // A low-order peer key gives an all-zero shared secret, which WebCrypto
+    // rejects outright. That is a failed proof, not a relay error.
+    return null;
+  }
+}
+
+/**
+ * SHA-256(shared || nonce || hostKey).
+ *
+ * The DH peer and the trailing hash input are different values, and which is
+ * which depends on the side: the relay derives against the host key (its DH
+ * peer *is* the host key), while the host derives against the relay key but
+ * still hashes its own public key at the end. Hence the two parameters.
+ */
+export async function proofBytes(
+  keypair: X25519Keypair,
+  peerPublic: Uint8Array,
+  nonce: Uint8Array,
+  hostKey: Uint8Array,
+): Promise<Uint8Array | null> {
+  const shared = await sharedSecret(keypair, peerPublic);
+  if (!shared) return null;
+  const input = new Uint8Array(shared.length + nonce.length + hostKey.length);
+  input.set(shared, 0);
+  input.set(nonce, shared.length);
+  input.set(hostKey, shared.length + nonce.length);
+  return new Uint8Array(await crypto.subtle.digest("SHA-256", toBuffer(input)));
+}
+
+/** The relay's side: its DH peer is the host key it is verifying against. */
+export function expectedProof(
+  keypair: X25519Keypair,
+  hostKey: Uint8Array,
+  nonce: Uint8Array,
+): Promise<Uint8Array | null> {
+  return proofBytes(keypair, hostKey, nonce, hostKey);
+}
+
+/** Compares in constant time, so a wrong proof leaks no prefix length. */
+export function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a[i] ^ b[i];
+  return diff === 0;
+}
+
+export function randomBytes(length: number): Uint8Array {
+  return crypto.getRandomValues(new Uint8Array(length));
+}
+
+export function toBuffer(bytes: Uint8Array): ArrayBuffer {
+  return bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
+    ? (bytes.buffer as ArrayBuffer)
+    : (bytes.slice().buffer as ArrayBuffer);
+}

--- a/relay/src/frames.ts
+++ b/relay/src/frames.ts
@@ -1,0 +1,63 @@
+// Host-link frame codec. Every device link becomes a numbered virtual
+// connection on the one host link, and every binary message on that link is
+//
+//     type (1 byte) || connId (u32 big-endian) || payload
+//
+// See ../../docs/remote-protocol.md, "Multiplexing on the host link". This
+// module is pure: no sockets, no state, so it can be unit-tested directly.
+
+export const FRAME_OPEN = 0x01;
+export const FRAME_DATA = 0x02;
+export const FRAME_CLOSE = 0x03;
+export const FRAME_TEXT = 0x04;
+
+export const HEADER_BYTES = 5;
+
+export interface Frame {
+  type: number;
+  connId: number;
+  payload: Uint8Array;
+}
+
+const EMPTY = new Uint8Array(0);
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+
+export function encode(type: number, connId: number, payload: Uint8Array = EMPTY): Uint8Array {
+  const out = new Uint8Array(HEADER_BYTES + payload.length);
+  out[0] = type & 0xff;
+  out[1] = (connId >>> 24) & 0xff;
+  out[2] = (connId >>> 16) & 0xff;
+  out[3] = (connId >>> 8) & 0xff;
+  out[4] = connId & 0xff;
+  out.set(payload, HEADER_BYTES);
+  return out;
+}
+
+/** Returns null for anything too short to hold a header. */
+export function decode(data: ArrayBuffer | Uint8Array): Frame | null {
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+  if (bytes.length < HEADER_BYTES) return null;
+  const connId = ((bytes[1] << 24) | (bytes[2] << 16) | (bytes[3] << 8) | bytes[4]) >>> 0;
+  // Copy, so the payload can be handed to `send()` without dragging the rest
+  // of the frame's buffer along with it.
+  return { type: bytes[0], connId, payload: bytes.slice(HEADER_BYTES) };
+}
+
+/** CLOSE payload is `code (u16 big-endian) || reason (UTF-8)`. */
+export function encodeClose(connId: number, code: number, reason = ""): Uint8Array {
+  const text = encoder.encode(reason);
+  const payload = new Uint8Array(2 + text.length);
+  payload[0] = (code >>> 8) & 0xff;
+  payload[1] = code & 0xff;
+  payload.set(text, 2);
+  return encode(FRAME_CLOSE, connId, payload);
+}
+
+export function decodeClose(payload: Uint8Array): { code: number; reason: string } | null {
+  if (payload.length < 2) return null;
+  return {
+    code: (payload[0] << 8) | payload[1],
+    reason: decoder.decode(payload.subarray(2)),
+  };
+}

--- a/relay/src/host-relay.ts
+++ b/relay/src/host-relay.ts
@@ -110,10 +110,10 @@ export class HostRelay {
   private async attachHost(hostId: string): Promise<Response> {
     if (!decodeHostKey(hostId)) return new Response("not found", { status: 404 });
 
-    // "A second host link for the same ID replaces the first, which is closed
-    // with 4409; devices attached to it are closed with 4404."
-    this.evictHostLinks(CLOSE_REPLACED, "replaced by a newer host link");
-
+    // Nothing happens to the current host here. A new link is only a claim
+    // until its proof verifies (`promoteHost`); the host ID is public, so an
+    // unauthenticated claim must not be able to evict the real host or drop
+    // its devices. Several pending claims may coexist; each times out alone.
     const pair = new WebSocketPair();
     const server = pair[1];
     const keypair = await generateKeypair();
@@ -142,6 +142,9 @@ export class HostRelay {
     state: HostState,
     message: string | ArrayBuffer,
   ): Promise<void> {
+    // The deadline is enforced where the proof arrives, not only by the alarm:
+    // an alarm can run late, and a late alarm must not extend the window.
+    if (Date.now() > state.deadline) return this.failHostAuth(ws, state);
     if (typeof message !== "string") return this.failHostAuth(ws, state);
     let parsed: unknown;
     try {
@@ -157,6 +160,15 @@ export class HostRelay {
     const want = await expectedProof(state.keypair, hostKey, nonce);
     if (!want || !equalBytes(want, offered)) return this.failHostAuth(ws, state);
 
+    this.promoteHost(ws, state);
+  }
+
+  /** The one transition to "the host": only a verified proof gets here, and
+   *  only here does the previous host lose its link and its devices. "A second
+   *  host link for the same ID replaces the first, which is closed with 4409;
+   *  devices attached to it are closed with 4404." */
+  private promoteHost(ws: WebSocket, state: HostState): void {
+    this.evictReadyHosts(ws, CLOSE_REPLACED, "replaced by a newer host link");
     state.stage = "ready";
     writeState(ws, state);
     trySend(ws, JSON.stringify({ type: "ready" }));
@@ -177,15 +189,21 @@ export class HostRelay {
     return null;
   }
 
-  private evictHostLinks(code: number, reason: string): void {
+  /** Close every *authenticated* host link other than `keep`, and the devices
+   *  that were attached to it. Pending (unproven) links are left alone: they
+   *  prove themselves or time out. */
+  private evictReadyHosts(keep: WebSocket, code: number, reason: string): void {
+    let evicted = false;
     for (const ws of this.ctx.getWebSockets(TAG_HOST)) {
+      if (ws === keep) continue;
       const state = readState(ws);
-      if (state?.role !== "host" || state.stage === "gone") continue;
+      if (state?.role !== "host" || state.stage !== "ready") continue;
       state.stage = "gone";
       writeState(ws, state);
       closeSocket(ws, code, reason);
+      evicted = true;
     }
-    this.closeAllDevices();
+    if (evicted) this.closeAllDevices();
   }
 
   private closeAllDevices(): void {

--- a/relay/src/host-relay.ts
+++ b/relay/src/host-relay.ts
@@ -175,9 +175,25 @@ export class HostRelay {
   }
 
   private failHostAuth(ws: WebSocket, state: HostState): void {
+    this.retireHost(ws, state, { code: CLOSE_BAD_PROOF, reason: "host authentication failed" });
+  }
+
+  /** The one exit for a host link, however it ends: proof failure, eviction,
+   *  a relay-enforced limit, or the peer hanging up. Devices are dropped only
+   *  when the departing link was *the* authenticated host. A pending claim
+   *  never owned a device, so its departure disturbs nothing — otherwise
+   *  anyone who learns the host ID could knock every device offline by
+   *  opening the host route and closing it. */
+  private retireHost(
+    ws: WebSocket,
+    state: HostState,
+    close?: { code: number; reason: string },
+  ): void {
+    const wasReady = state.stage === "ready";
     state.stage = "gone";
     writeState(ws, state);
-    closeSocket(ws, CLOSE_BAD_PROOF, "host authentication failed");
+    if (close) closeSocket(ws, close.code, close.reason);
+    if (wasReady) this.closeAllDevices();
   }
 
   /** The one authenticated host link, or null. */
@@ -193,17 +209,12 @@ export class HostRelay {
    *  that were attached to it. Pending (unproven) links are left alone: they
    *  prove themselves or time out. */
   private evictReadyHosts(keep: WebSocket, code: number, reason: string): void {
-    let evicted = false;
     for (const ws of this.ctx.getWebSockets(TAG_HOST)) {
       if (ws === keep) continue;
       const state = readState(ws);
       if (state?.role !== "host" || state.stage !== "ready") continue;
-      state.stage = "gone";
-      writeState(ws, state);
-      closeSocket(ws, code, reason);
-      evicted = true;
+      this.retireHost(ws, state, { code, reason });
     }
-    if (evicted) this.closeAllDevices();
   }
 
   private closeAllDevices(): void {
@@ -306,9 +317,7 @@ export class HostRelay {
     if (!state) return;
 
     if (state.role === "host") {
-      state.stage = "gone";
-      writeState(ws, state);
-      this.closeAllDevices();
+      this.retireHost(ws, state);
       return;
     }
 
@@ -343,10 +352,7 @@ export class HostRelay {
   /** Relay-initiated end of a link; tells the host when it was a device. */
   private closeLink(ws: WebSocket, state: SocketState, code: number, reason: string): void {
     if (state.role === "host") {
-      state.stage = "gone";
-      writeState(ws, state);
-      closeSocket(ws, code, reason);
-      this.closeAllDevices();
+      this.retireHost(ws, state, { code, reason });
       return;
     }
     if (state.closed) return;

--- a/relay/src/host-relay.ts
+++ b/relay/src/host-relay.ts
@@ -1,0 +1,453 @@
+// One Durable Object per host ID. It holds at most one authenticated host
+// link and up to 8 device links, and copies bytes between them. It never
+// decrypts anything: the Noise channel is end to end, so everything below is
+// framing and bookkeeping.
+//
+// Everything here is written against the WebSocket Hibernation API. The object
+// is evicted while its sockets are idle and rebuilt from scratch on the next
+// message, so there is no reliable in-memory map of sockets: `getWebSockets`
+// is the only source of truth for who is attached, and each socket's own
+// attachment (`serializeAttachment` / `deserializeAttachment`) is the only
+// place per-socket state survives. That is why every handler starts by
+// reading state off the socket and writes it back after any change.
+
+import {
+  b64urlDecode,
+  b64urlEncode,
+  decodeHostKey,
+  equalBytes,
+  expectedProof,
+  generateKeypair,
+  NONCE_BYTES,
+  publicKeyOf,
+  randomBytes,
+  toBuffer,
+  type X25519Keypair,
+} from "./auth";
+import {
+  decode,
+  decodeClose,
+  encode,
+  encodeClose,
+  FRAME_CLOSE,
+  FRAME_DATA,
+  FRAME_OPEN,
+  FRAME_TEXT,
+  HEADER_BYTES,
+} from "./frames";
+
+export const MAX_DEVICES = 8;
+export const MAX_MESSAGE_BYTES = 4 * 1024 * 1024;
+export const RATE_LIMIT_MESSAGES = 100;
+export const RATE_LIMIT_WINDOW_MS = 10_000;
+export const HOST_AUTH_TIMEOUT_MS = 10_000;
+
+/** 4003 unauthenticated, 4404 host offline, 4409 replaced, 4429 too many. */
+export const CLOSE_BAD_PROOF = 4003;
+export const CLOSE_NO_HOST = 4404;
+export const CLOSE_REPLACED = 4409;
+export const CLOSE_TOO_MANY = 4429;
+const CLOSE_TOO_BIG = 1009;
+const CLOSE_RATE_LIMIT = 1008;
+
+const TAG_HOST = "host";
+const TAG_DEVICE = "device";
+const KEY_NEXT_CONN_ID = "nextConnId";
+const MAX_CONN_ID = 0xffffffff;
+
+interface RateWindow {
+  start: number;
+  count: number;
+}
+
+interface HostState {
+  role: "host";
+  /** `gone` marks a socket already closed but possibly still in getWebSockets. */
+  stage: "await-proof" | "ready" | "gone";
+  hostId: string;
+  keypair: X25519Keypair;
+  nonce: string;
+  deadline: number;
+  rate: RateWindow;
+}
+
+interface DeviceState {
+  role: "device";
+  connId: number;
+  closed: boolean;
+  rate: RateWindow;
+}
+
+type SocketState = HostState | DeviceState;
+
+export class HostRelay {
+  private readonly ctx: DurableObjectState;
+  private nextConnId = 1;
+
+  constructor(ctx: DurableObjectState) {
+    this.ctx = ctx;
+    // connIds must never repeat for the object's life, and the object is
+    // rebuilt on every wake, so the counter lives in storage and is read once
+    // here behind the input gate.
+    ctx.blockConcurrencyWhile(async () => {
+      this.nextConnId = (await ctx.storage.get<number>(KEY_NEXT_CONN_ID)) ?? 1;
+    });
+  }
+
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    // Both are set by the Worker with `set`, which overwrites anything a
+    // client tried to smuggle in.
+    const role = url.searchParams.get("role");
+    const hostId = url.searchParams.get("hostId") ?? "";
+    if (role === "host") return this.attachHost(hostId);
+    if (role === "device") return this.attachDevice();
+    return new Response("not found", { status: 404 });
+  }
+
+  // -- host link ------------------------------------------------------------
+
+  private async attachHost(hostId: string): Promise<Response> {
+    if (!decodeHostKey(hostId)) return new Response("not found", { status: 404 });
+
+    // "A second host link for the same ID replaces the first, which is closed
+    // with 4409; devices attached to it are closed with 4404."
+    this.evictHostLinks(CLOSE_REPLACED, "replaced by a newer host link");
+
+    const pair = new WebSocketPair();
+    const server = pair[1];
+    const keypair = await generateKeypair();
+    const nonce = b64urlEncode(randomBytes(NONCE_BYTES));
+    const state: HostState = {
+      role: "host",
+      stage: "await-proof",
+      hostId,
+      keypair,
+      nonce,
+      deadline: Date.now() + HOST_AUTH_TIMEOUT_MS,
+      rate: { start: Date.now(), count: 0 },
+    };
+    this.ctx.acceptWebSocket(server, [TAG_HOST]);
+    writeState(server, state);
+    trySend(server, JSON.stringify({ type: "challenge", nonce, relayKey: publicKeyOf(keypair) }));
+    // An alarm, not a timer: the object may hibernate during the 10 s window
+    // (the socket is already accepted, so nothing keeps it awake), and a
+    // `setTimeout` would die with it.
+    await this.scheduleAuthDeadline(state.deadline);
+    return new Response(null, { status: 101, webSocket: pair[0] });
+  }
+
+  private async handleProof(
+    ws: WebSocket,
+    state: HostState,
+    message: string | ArrayBuffer,
+  ): Promise<void> {
+    if (typeof message !== "string") return this.failHostAuth(ws, state);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(message);
+    } catch {
+      return this.failHostAuth(ws, state);
+    }
+    const offered = readProofField(parsed);
+    const nonce = b64urlDecode(state.nonce);
+    const hostKey = decodeHostKey(state.hostId);
+    if (!offered || !nonce || !hostKey) return this.failHostAuth(ws, state);
+
+    const want = await expectedProof(state.keypair, hostKey, nonce);
+    if (!want || !equalBytes(want, offered)) return this.failHostAuth(ws, state);
+
+    state.stage = "ready";
+    writeState(ws, state);
+    trySend(ws, JSON.stringify({ type: "ready" }));
+  }
+
+  private failHostAuth(ws: WebSocket, state: HostState): void {
+    state.stage = "gone";
+    writeState(ws, state);
+    closeSocket(ws, CLOSE_BAD_PROOF, "host authentication failed");
+  }
+
+  /** The one authenticated host link, or null. */
+  private hostSocket(): WebSocket | null {
+    for (const ws of this.ctx.getWebSockets(TAG_HOST)) {
+      const state = readState(ws);
+      if (state?.role === "host" && state.stage === "ready") return ws;
+    }
+    return null;
+  }
+
+  private evictHostLinks(code: number, reason: string): void {
+    for (const ws of this.ctx.getWebSockets(TAG_HOST)) {
+      const state = readState(ws);
+      if (state?.role !== "host" || state.stage === "gone") continue;
+      state.stage = "gone";
+      writeState(ws, state);
+      closeSocket(ws, code, reason);
+    }
+    this.closeAllDevices();
+  }
+
+  private closeAllDevices(): void {
+    for (const ws of this.ctx.getWebSockets(TAG_DEVICE)) {
+      const state = readState(ws);
+      if (state?.role !== "device" || state.closed) continue;
+      state.closed = true;
+      writeState(ws, state);
+      closeSocket(ws, CLOSE_NO_HOST, "host offline");
+    }
+  }
+
+  // -- device links ---------------------------------------------------------
+
+  private async attachDevice(): Promise<Response> {
+    const host = this.hostSocket();
+    if (!host) return refuse(CLOSE_NO_HOST, "host offline");
+    if (this.liveDeviceCount() >= MAX_DEVICES)
+      return refuse(CLOSE_TOO_MANY, "too many device links");
+    const connId = await this.allocateConnId();
+    if (connId === null) return refuse(CLOSE_TOO_MANY, "connection ids exhausted");
+
+    const pair = new WebSocketPair();
+    const server = pair[1];
+    this.ctx.acceptWebSocket(server, [TAG_DEVICE]);
+    writeState(server, {
+      role: "device",
+      connId,
+      closed: false,
+      rate: { start: Date.now(), count: 0 },
+    });
+    trySend(host, toBuffer(encode(FRAME_OPEN, connId)));
+    return new Response(null, { status: 101, webSocket: pair[0] });
+  }
+
+  private liveDeviceCount(): number {
+    let n = 0;
+    for (const ws of this.ctx.getWebSockets(TAG_DEVICE)) {
+      const state = readState(ws);
+      if (state?.role === "device" && !state.closed) n++;
+    }
+    return n;
+  }
+
+  private deviceSocket(connId: number): WebSocket | null {
+    for (const ws of this.ctx.getWebSockets(TAG_DEVICE)) {
+      const state = readState(ws);
+      if (state?.role === "device" && !state.closed && state.connId === connId) return ws;
+    }
+    return null;
+  }
+
+  private async allocateConnId(): Promise<number | null> {
+    if (this.nextConnId > MAX_CONN_ID) return null;
+    const connId = this.nextConnId++;
+    await this.ctx.storage.put(KEY_NEXT_CONN_ID, this.nextConnId);
+    return connId;
+  }
+
+  // -- hibernation handlers -------------------------------------------------
+
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    const state = readState(ws);
+    if (!state) return;
+
+    // 4 MiB per device message. A host DATA frame carrying a 4 MiB device
+    // message is 4 MiB + 5, so the host link's cap includes the frame header.
+    const limit = state.role === "host" ? MAX_MESSAGE_BYTES + HEADER_BYTES : MAX_MESSAGE_BYTES;
+    if (messageBytes(message) > limit) {
+      this.closeLink(ws, state, CLOSE_TOO_BIG, "message too large");
+      return;
+    }
+
+    if (state.role === "host") {
+      if (state.stage === "await-proof") return this.handleProof(ws, state, message);
+      if (state.stage !== "ready") return;
+      // After `ready` the host link carries only binary frames.
+      if (typeof message !== "string") this.routeHostFrame(message);
+      return;
+    }
+
+    if (!this.allowRate(ws, state)) {
+      this.closeLink(ws, state, CLOSE_RATE_LIMIT, "rate limit exceeded");
+      return;
+    }
+    const host = this.hostSocket();
+    if (!host) {
+      this.closeLink(ws, state, CLOSE_NO_HOST, "host offline");
+      return;
+    }
+    const frame =
+      typeof message === "string"
+        ? encode(FRAME_TEXT, state.connId, new TextEncoder().encode(message))
+        : encode(FRAME_DATA, state.connId, new Uint8Array(message));
+    trySend(host, toBuffer(frame));
+  }
+
+  webSocketClose(ws: WebSocket, code: number, reason: string, wasClean: boolean): void {
+    const state = readState(ws);
+    if (!state) return;
+
+    if (state.role === "host") {
+      state.stage = "gone";
+      writeState(ws, state);
+      this.closeAllDevices();
+      return;
+    }
+
+    if (state.closed) return;
+    state.closed = true;
+    writeState(ws, state);
+    const host = this.hostSocket();
+    if (host) {
+      trySend(host, toBuffer(encodeClose(state.connId, hostFacingCode(code, wasClean), reason)));
+    }
+  }
+
+  webSocketError(ws: WebSocket): void {
+    // An error ends the link exactly as an unclean close does.
+    this.webSocketClose(ws, 1006, "", false);
+  }
+
+  async alarm(): Promise<void> {
+    const now = Date.now();
+    let next = Number.POSITIVE_INFINITY;
+    for (const ws of this.ctx.getWebSockets(TAG_HOST)) {
+      const state = readState(ws);
+      if (state?.role !== "host" || state.stage !== "await-proof") continue;
+      if (state.deadline <= now) this.failHostAuth(ws, state);
+      else next = Math.min(next, state.deadline);
+    }
+    if (next !== Number.POSITIVE_INFINITY) await this.ctx.storage.setAlarm(next);
+  }
+
+  // -- helpers --------------------------------------------------------------
+
+  /** Relay-initiated end of a link; tells the host when it was a device. */
+  private closeLink(ws: WebSocket, state: SocketState, code: number, reason: string): void {
+    if (state.role === "host") {
+      state.stage = "gone";
+      writeState(ws, state);
+      closeSocket(ws, code, reason);
+      this.closeAllDevices();
+      return;
+    }
+    if (state.closed) return;
+    state.closed = true;
+    writeState(ws, state);
+    const host = this.hostSocket();
+    if (host) trySend(host, toBuffer(encodeClose(state.connId, code, reason)));
+    closeSocket(ws, code, reason);
+  }
+
+  private routeHostFrame(message: ArrayBuffer): void {
+    const frame = decode(message);
+    if (!frame) return;
+    const device = this.deviceSocket(frame.connId);
+    // "Frames from the host with an unknown connId are ignored."
+    if (!device) return;
+
+    if (frame.type === FRAME_DATA) {
+      trySend(device, toBuffer(frame.payload));
+      return;
+    }
+    if (frame.type === FRAME_CLOSE) {
+      const parsed = decodeClose(frame.payload);
+      const state = readState(device);
+      if (state?.role === "device") {
+        state.closed = true;
+        writeState(device, state);
+      }
+      closeSocket(device, parsed?.code ?? 1000, parsed?.reason ?? "");
+    }
+    // OPEN and TEXT are relay -> host only; anything else is unknown. Ignored.
+  }
+
+  /** Fixed 10 s window, 100 messages. The 101st in a window trips 1008. */
+  private allowRate(ws: WebSocket, state: DeviceState): boolean {
+    const now = Date.now();
+    if (now - state.rate.start >= RATE_LIMIT_WINDOW_MS) state.rate = { start: now, count: 1 };
+    else state.rate.count += 1;
+    writeState(ws, state);
+    return state.rate.count <= RATE_LIMIT_MESSAGES;
+  }
+
+  private async scheduleAuthDeadline(at: number): Promise<void> {
+    const current = await this.ctx.storage.getAlarm();
+    if (current === null || current > at) await this.ctx.storage.setAlarm(at);
+  }
+}
+
+function readState(ws: WebSocket): SocketState | null {
+  const raw = ws.deserializeAttachment();
+  return raw ? (raw as SocketState) : null;
+}
+
+function writeState(ws: WebSocket, state: SocketState): void {
+  ws.serializeAttachment(state);
+}
+
+function readProofField(parsed: unknown): Uint8Array | null {
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const body = parsed as { type?: unknown; proof?: unknown };
+  if (body.type !== "proof" || typeof body.proof !== "string") return null;
+  const bytes = b64urlDecode(body.proof);
+  return bytes && bytes.length === 32 ? bytes : null;
+}
+
+function messageBytes(message: string | ArrayBuffer): number {
+  if (typeof message !== "string") return message.byteLength;
+  // One char is at least one UTF-8 byte and at most three (a surrogate pair
+  // is two chars and four bytes), so only the ambiguous band needs encoding.
+  if (message.length > MAX_MESSAGE_BYTES) return message.length;
+  if (message.length * 3 <= MAX_MESSAGE_BYTES) return message.length;
+  return new TextEncoder().encode(message).length;
+}
+
+/** The code the host sees in a CLOSE frame for a device link that ended. */
+function hostFacingCode(code: number, wasClean: boolean): number {
+  if (!wasClean) return 1006;
+  if (code < 1000 || code > 4999 || code === 1005 || code === 1006) return 1006;
+  return code;
+}
+
+/** Accepts the upgrade only to deliver a close code, as the doc specifies. */
+function refuse(code: number, reason: string): Response {
+  const pair = new WebSocketPair();
+  const server = pair[1];
+  // Deliberately not `acceptWebSocket`: this socket never hibernates and must
+  // not show up in `getWebSockets`.
+  server.accept();
+  server.close(code, reason);
+  return new Response(null, { status: 101, webSocket: pair[0] });
+}
+
+function closeSocket(ws: WebSocket, code: number, reason: string): void {
+  const text = truncateReason(reason);
+  try {
+    ws.close(code, text);
+  } catch {
+    // The code came from the host, which may send one the runtime refuses
+    // (1005/1006, or out of range), and the socket may already be gone.
+    try {
+      ws.close(1000, text);
+    } catch {
+      /* already closed */
+    }
+  }
+}
+
+function trySend(ws: WebSocket, data: string | ArrayBuffer): void {
+  try {
+    ws.send(data);
+  } catch {
+    // The peer can go away between the lookup and the send; its own close
+    // handler does the cleanup.
+  }
+}
+
+/** A close reason is capped at 123 UTF-8 bytes by the WebSocket protocol. */
+function truncateReason(reason: string): string {
+  const bytes = new TextEncoder().encode(reason);
+  if (bytes.length <= 123) return reason;
+  return new TextDecoder().decode(bytes.subarray(0, 123)).replace(/�$/, "");
+}

--- a/relay/src/index.ts
+++ b/relay/src/index.ts
@@ -1,0 +1,43 @@
+// The Fletch remote relay. A dumb pipe: it routes by host ID, verifies one
+// DH proof on the host link, and multiplexes device links onto it. Everything
+// it carries is already ciphertext from the end-to-end Noise channel.
+//
+// See ../../docs/remote-protocol.md, section "Relay".
+
+import { decodeHostKey, HOST_ID_LENGTH } from "./auth";
+import { HostRelay } from "./host-relay";
+
+export { HostRelay };
+
+export interface Env {
+  HOSTS: DurableObjectNamespace;
+}
+
+// `wss://<relay>/v1/host/<hostId>` and `wss://<relay>/v1/device/<hostId>`.
+// Anything else is 404.
+const ROUTE = new RegExp(`^/v1/(host|device)/([A-Za-z0-9_-]{${HOST_ID_LENGTH}})$`);
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+    const match = ROUTE.exec(url.pathname);
+    if (!match) return new Response("not found", { status: 404 });
+
+    const role = match[1];
+    const hostId = match[2];
+    // The charset and length are in the pattern; this rejects the remaining
+    // 43-character strings whose trailing bits are non-canonical, so one host
+    // ID cannot be spelled two ways and land in two Durable Objects.
+    if (!decodeHostKey(hostId)) return new Response("not found", { status: 404 });
+
+    if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("expected a websocket upgrade", { status: 426 });
+    }
+
+    const target = new URL(request.url);
+    // `set` overwrites, so a client cannot smuggle in its own role.
+    target.searchParams.set("role", role);
+    target.searchParams.set("hostId", hostId);
+    return env.HOSTS.get(env.HOSTS.idFromName(hostId)).fetch(new Request(target, request));
+  },
+};

--- a/relay/test-vector.json
+++ b/relay/test-vector.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Known-answer vector for the relay's host-link DH proof. Produced with Node's crypto (x25519 via crypto.diffieHellman) and verified against the Worker's WebCrypto implementation in test/auth.test.ts. The desktop's Rust host should reproduce `proof` from `hostPrivate`, `relayKey` and `nonce`. All values are unpadded base64url of raw bytes.",
+  "algorithm": "proof = SHA-256( X25519(hostPrivate, relayKey) || nonce || hostId ), on the raw 32-byte decodings of relayKey, nonce and hostId; hostId is the X25519 public key of hostPrivate",
+  "hostPrivate": "OqU0-7cJg-RJvvrbEO7QdOhyDkXsLgpcep6iAuRBhyM",
+  "hostId": "CByil-LnR3Z4wv604Br29p6iHZu2cmhqy35dlKs7Ojg",
+  "relayPrivate": "X3dswLZDY6e6AswL_bcW6V13_XV_3NnBcXngrkpTn38",
+  "relayKey": "9ULx3HxJf-CwYQMXrrUbub-mLokcC6O-EkH1Uv0bcR8",
+  "nonce": "91SDD6qePWgyP4B77YoYcp5T7H2CVoihopcC_iVs13U",
+  "shared": "3eRCj5nchCI2rpYP7m4yUk_eYadXHnLE8SIcsIEg82U",
+  "proof": "hVOvHwh5XlYzm95Ts3hqD2J6OAVe6lIt1wRxGMN30CM"
+}

--- a/relay/test/auth.test.ts
+++ b/relay/test/auth.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest";
+import {
+  b64urlDecode,
+  b64urlEncode,
+  decodeHostKey,
+  equalBytes,
+  expectedProof,
+  generateKeypair,
+  keypairFromPrivate,
+  proofBytes,
+  sharedSecret,
+} from "../src/auth";
+import vector from "../test-vector.json";
+
+const decode = (text: string): Uint8Array => {
+  const bytes = b64urlDecode(text);
+  if (!bytes) throw new Error(`not base64url: ${text}`);
+  return bytes;
+};
+
+describe("base64url", () => {
+  it("round-trips every byte value", () => {
+    const bytes = new Uint8Array(256);
+    for (let i = 0; i < 256; i++) bytes[i] = i;
+    expect([...decode(b64urlEncode(bytes))]).toEqual([...bytes]);
+  });
+
+  it("round-trips every length up to 8, unpadded", () => {
+    for (let length = 0; length <= 8; length++) {
+      const bytes = new Uint8Array(length).fill(0xab);
+      const text = b64urlEncode(bytes);
+      expect(text).not.toContain("=");
+      expect([...decode(text)]).toEqual([...bytes]);
+    }
+  });
+
+  it("uses the URL alphabet, never + or /", () => {
+    const text = b64urlEncode(new Uint8Array([0xfb, 0xff, 0xbf]));
+    expect(text).toBe("-_-_");
+  });
+
+  it("rejects padding, non-alphabet characters and impossible lengths", () => {
+    for (const bad of ["A", "AAAAA", "AA=", "AAA=", "A+AA", "A/AA", "AA A", "AAAÿ"]) {
+      expect(b64urlDecode(bad)).toBeNull();
+    }
+  });
+
+  it("rejects non-canonical trailing bits", () => {
+    // "AB" would decode to one byte but drops a set bit; "AA" is the canonical
+    // spelling of that byte, so only it is accepted.
+    expect(b64urlDecode("AA")).toEqual(new Uint8Array(1));
+    expect(b64urlDecode("AB")).toBeNull();
+    expect(b64urlDecode("AAA")).toEqual(new Uint8Array(2));
+    expect(b64urlDecode("AAB")).toBeNull();
+  });
+});
+
+describe("host IDs", () => {
+  it("accepts the 43-character public key of a fresh keypair", async () => {
+    const keypair = await generateKeypair();
+    expect(keypair.x).toHaveLength(43);
+    expect(decodeHostKey(keypair.x)).toHaveLength(32);
+  });
+
+  it("accepts the vector's host ID", () => {
+    expect(decodeHostKey(vector.hostId)).toHaveLength(32);
+  });
+
+  it("rejects wrong lengths and non-canonical spellings", () => {
+    expect(decodeHostKey("")).toBeNull();
+    expect(decodeHostKey(vector.hostId.slice(0, 42))).toBeNull();
+    expect(decodeHostKey(`${vector.hostId}A`)).toBeNull();
+    // Same 43 characters, last one carrying trailing bits that must be zero.
+    expect(decodeHostKey(`${vector.hostId.slice(0, 42)}h`)).toBeNull();
+  });
+});
+
+describe("X25519", () => {
+  it("agrees in both directions", async () => {
+    const host = await generateKeypair();
+    const relay = await generateKeypair();
+    const fromRelay = await sharedSecret(relay, decode(host.x));
+    const fromHost = await sharedSecret(host, decode(relay.x));
+    expect(fromRelay).not.toBeNull();
+    expect(equalBytes(fromRelay as Uint8Array, fromHost as Uint8Array)).toBe(true);
+  });
+
+  it("rejects a peer key of the wrong length", async () => {
+    const relay = await generateKeypair();
+    expect(await sharedSecret(relay, new Uint8Array(31))).toBeNull();
+    expect(await sharedSecret(relay, new Uint8Array(33))).toBeNull();
+  });
+
+  it("returns null for an all-zero (low-order) peer key", async () => {
+    const relay = await generateKeypair();
+    expect(await sharedSecret(relay, new Uint8Array(32))).toBeNull();
+  });
+
+  it("rebuilds a keypair from a raw private scalar", async () => {
+    const keypair = await keypairFromPrivate(decode(vector.hostPrivate));
+    expect(keypair.x).toBe(vector.hostId);
+  });
+});
+
+describe("proof (known-answer vector from Node's crypto)", () => {
+  it("derives the vector's shared secret", async () => {
+    const relay = await keypairFromPrivate(decode(vector.relayPrivate));
+    expect(relay.x).toBe(vector.relayKey);
+    const shared = await sharedSecret(relay, decode(vector.hostId));
+    expect(b64urlEncode(shared as Uint8Array)).toBe(vector.shared);
+  });
+
+  it("computes the vector's proof from the relay side", async () => {
+    const relay = await keypairFromPrivate(decode(vector.relayPrivate));
+    const proof = await expectedProof(relay, decode(vector.hostId), decode(vector.nonce));
+    expect(b64urlEncode(proof as Uint8Array)).toBe(vector.proof);
+  });
+
+  it("computes the vector's proof from the host side", async () => {
+    const host = await keypairFromPrivate(decode(vector.hostPrivate));
+    const proof = await proofBytes(
+      host,
+      decode(vector.relayKey),
+      decode(vector.nonce),
+      decode(vector.hostId),
+    );
+    expect(b64urlEncode(proof as Uint8Array)).toBe(vector.proof);
+  });
+
+  it("changes the proof when the nonce changes", async () => {
+    const relay = await keypairFromPrivate(decode(vector.relayPrivate));
+    const nonce = decode(vector.nonce);
+    nonce[0] ^= 1;
+    const proof = await expectedProof(relay, decode(vector.hostId), nonce);
+    expect(b64urlEncode(proof as Uint8Array)).not.toBe(vector.proof);
+  });
+});
+
+describe("equalBytes", () => {
+  it("compares contents, not identity", () => {
+    expect(equalBytes(new Uint8Array([1, 2]), new Uint8Array([1, 2]))).toBe(true);
+    expect(equalBytes(new Uint8Array([1, 2]), new Uint8Array([1, 3]))).toBe(false);
+    expect(equalBytes(new Uint8Array([1]), new Uint8Array([1, 2]))).toBe(false);
+  });
+});

--- a/relay/test/frames.test.ts
+++ b/relay/test/frames.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import {
+  decode,
+  decodeClose,
+  encode,
+  encodeClose,
+  FRAME_CLOSE,
+  FRAME_DATA,
+  FRAME_OPEN,
+  HEADER_BYTES,
+} from "../src/frames";
+
+describe("frames", () => {
+  it("encodes type, connId big-endian and payload", () => {
+    const frame = encode(FRAME_DATA, 0x01020304, new Uint8Array([9, 8]));
+    expect([...frame]).toEqual([FRAME_DATA, 0x01, 0x02, 0x03, 0x04, 9, 8]);
+  });
+
+  it("encodes an empty payload as a bare header", () => {
+    expect([...encode(FRAME_OPEN, 1)]).toEqual([FRAME_OPEN, 0, 0, 0, 1]);
+  });
+
+  it("round-trips every frame type", () => {
+    const payload = new Uint8Array([1, 2, 3, 250, 255]);
+    for (const type of [0x01, 0x02, 0x03, 0x04]) {
+      const frame = decode(encode(type, 7, payload));
+      expect(frame).toEqual({ type, connId: 7, payload });
+    }
+  });
+
+  it("treats connId as unsigned", () => {
+    const frame = decode(encode(FRAME_DATA, 0xffffffff));
+    expect(frame?.connId).toBe(0xffffffff);
+  });
+
+  it("accepts an ArrayBuffer as well as a view", () => {
+    const bytes = encode(FRAME_DATA, 42, new Uint8Array([7]));
+    expect(decode(bytes.buffer as ArrayBuffer)).toEqual(decode(bytes));
+  });
+
+  it("rejects anything shorter than a header", () => {
+    for (let length = 0; length < HEADER_BYTES; length++) {
+      expect(decode(new Uint8Array(length))).toBeNull();
+    }
+    expect(decode(new Uint8Array(HEADER_BYTES))?.payload.length).toBe(0);
+  });
+
+  it("does not carry the frame's buffer along in the payload", () => {
+    const frame = decode(encode(FRAME_DATA, 1, new Uint8Array([5, 6])));
+    expect(frame?.payload.byteOffset).toBe(0);
+    expect(frame?.payload.buffer.byteLength).toBe(2);
+  });
+
+  it("round-trips a CLOSE code and UTF-8 reason", () => {
+    const frame = decode(encodeClose(3, 4404, "host offline — göne"));
+    expect(frame?.type).toBe(FRAME_CLOSE);
+    expect(frame?.connId).toBe(3);
+    expect(decodeClose(frame?.payload as Uint8Array)).toEqual({
+      code: 4404,
+      reason: "host offline — göne",
+    });
+  });
+
+  it("round-trips a CLOSE with no reason", () => {
+    const frame = decode(encodeClose(1, 1006));
+    expect(decodeClose(frame?.payload as Uint8Array)).toEqual({ code: 1006, reason: "" });
+  });
+
+  it("encodes a CLOSE code big-endian", () => {
+    const frame = decode(encodeClose(1, 4409));
+    // 4409 = 0x1139
+    expect(frame && [...frame.payload]).toEqual([0x11, 0x39]);
+  });
+
+  it("rejects a CLOSE payload with no room for a code", () => {
+    expect(decodeClose(new Uint8Array(0))).toBeNull();
+    expect(decodeClose(new Uint8Array(1))).toBeNull();
+  });
+});

--- a/relay/test/harness.ts
+++ b/relay/test/harness.ts
@@ -1,0 +1,172 @@
+// Test-side WebSocket client. `SELF.fetch` with an Upgrade header gives back
+// the client half of the pair; this wraps it in a queue so a test can await
+// the next message or the close code without racing the event listeners.
+
+import { SELF } from "cloudflare:test";
+import { expect } from "vitest";
+import {
+  b64urlDecode,
+  b64urlEncode,
+  decodeHostKey,
+  generateKeypair,
+  proofBytes,
+  type X25519Keypair,
+} from "../src/auth";
+
+const ORIGIN = "https://relay.test";
+const TIMEOUT_MS = 5_000;
+
+export interface CloseInfo {
+  code: number;
+  reason: string;
+}
+
+export interface Link {
+  ws: WebSocket;
+  next(): Promise<string | ArrayBuffer>;
+  nextJson(): Promise<Record<string, unknown>>;
+  nextBinary(): Promise<Uint8Array>;
+  closed(): Promise<CloseInfo>;
+}
+
+export async function upgrade(path: string): Promise<Link> {
+  const response = await SELF.fetch(`${ORIGIN}${path}`, { headers: { Upgrade: "websocket" } });
+  expect(response.status).toBe(101);
+  const ws = response.webSocket;
+  if (!ws) throw new Error("no webSocket on the 101 response");
+
+  // A pull queue: messages buffer until something awaits them, and awaiting
+  // waiters are settled in order. Anything simpler drops messages that arrive
+  // while no test is looking.
+  const messages: unknown[] = [];
+  const waiters: { resolve(v: unknown): void; reject(e: Error): void }[] = [];
+  const closeWaiters: ((info: CloseInfo) => void)[] = [];
+  let closeInfo: CloseInfo | null = null;
+
+  const deliver = () => {
+    while (waiters.length > 0 && messages.length > 0) {
+      const waiter = waiters.shift();
+      const message = messages.shift();
+      if (waiter && message !== undefined) waiter.resolve(message);
+    }
+    if (!closeInfo) return;
+    const info = closeInfo;
+    while (waiters.length > 0) {
+      waiters.shift()?.reject(new Error(`closed with ${info.code} while awaiting a message`));
+    }
+    while (closeWaiters.length > 0) closeWaiters.shift()?.(info);
+  };
+
+  ws.addEventListener("message", (event) => {
+    messages.push(event.data);
+    deliver();
+  });
+  ws.addEventListener("close", (event) => {
+    closeInfo ??= { code: event.code, reason: event.reason };
+    deliver();
+  });
+  ws.addEventListener("error", () => {
+    closeInfo ??= { code: 1006, reason: "" };
+    deliver();
+  });
+  // Listeners first, then accept, or a message already queued on the pair is
+  // dropped.
+  ws.accept();
+
+  const next = async (): Promise<string | ArrayBuffer> =>
+    normalize(
+      await withTimeout<unknown>("message", (resolve, reject) => {
+        waiters.push({ resolve, reject });
+        deliver();
+      }),
+    );
+
+  return {
+    ws,
+    next,
+    async nextJson() {
+      const value = await next();
+      if (typeof value !== "string") throw new Error("expected a text message");
+      return JSON.parse(value) as Record<string, unknown>;
+    },
+    async nextBinary() {
+      const value = await next();
+      if (typeof value === "string") throw new Error(`expected binary, got text: ${value}`);
+      return new Uint8Array(value);
+    },
+    closed: () =>
+      withTimeout<CloseInfo>("close", (resolve) => {
+        closeWaiters.push(resolve);
+        deliver();
+      }),
+  };
+}
+
+/**
+ * The client half of a WebSocketPair delivers binary as a Blob in the test
+ * isolate, while the Durable Object's hibernation handler gets an ArrayBuffer.
+ * Tests only care about the bytes.
+ */
+async function normalize(value: unknown): Promise<string | ArrayBuffer> {
+  if (typeof value === "string" || value instanceof ArrayBuffer) return value;
+  if (value instanceof Blob) return await value.arrayBuffer();
+  throw new Error(`unexpected message type: ${Object.prototype.toString.call(value)}`);
+}
+
+function withTimeout<T>(
+  what: string,
+  body: (resolve: (v: T) => void, reject: (e: Error) => void) => void,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`timed out waiting for ${what}`)), TIMEOUT_MS);
+    body(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
+export interface TestHost {
+  hostId: string;
+  keypair: X25519Keypair;
+}
+
+/** A fresh host identity, so each test gets its own Durable Object. */
+export async function newHost(): Promise<TestHost> {
+  const keypair = await generateKeypair();
+  return { hostId: keypair.x, keypair };
+}
+
+/** Answers a challenge the way the desktop host will. */
+export async function answerChallenge(
+  host: TestHost,
+  challenge: Record<string, unknown>,
+): Promise<string> {
+  const relayKey = b64urlDecode(String(challenge.relayKey));
+  const nonce = b64urlDecode(String(challenge.nonce));
+  const hostKey = decodeHostKey(host.hostId);
+  if (!relayKey || !nonce || !hostKey) throw new Error("malformed challenge");
+  const proof = await proofBytes(host.keypair, relayKey, nonce, hostKey);
+  if (!proof) throw new Error("could not compute a proof");
+  return b64urlEncode(proof);
+}
+
+/** Opens a host link and drives it to `ready`. */
+export async function attachHost(host: TestHost): Promise<Link> {
+  const link = await upgrade(`/v1/host/${host.hostId}`);
+  const challenge = await link.nextJson();
+  expect(challenge.type).toBe("challenge");
+  link.ws.send(JSON.stringify({ type: "proof", proof: await answerChallenge(host, challenge) }));
+  expect(await link.nextJson()).toEqual({ type: "ready" });
+  return link;
+}
+
+export function attachDevice(host: TestHost): Promise<Link> {
+  return upgrade(`/v1/device/${host.hostId}`);
+}

--- a/relay/test/relay.test.ts
+++ b/relay/test/relay.test.ts
@@ -216,6 +216,41 @@ describe("host link authentication", () => {
     expect(frame?.type).toBe(FRAME_DATA);
     expect(Array.from(frame?.payload ?? [])).toEqual([1, 2, 3]);
   });
+
+  it("keeps the devices when an unauthenticated claim hangs up", async () => {
+    const host = await newHost();
+    const real = await attachHost(host);
+    const device = await attachDevice(host);
+    expect(decode(await real.nextBinary())?.type).toBe(FRAME_OPEN);
+
+    // Only the authenticated host's departure means "host offline". A claim
+    // that leaves without proving itself never owned the devices.
+    const impostor = await upgrade(`/v1/host/${host.hostId}`);
+    expect((await impostor.nextJson()).type).toBe("challenge");
+    impostor.ws.close(1000, "never mind");
+
+    device.ws.send(new Uint8Array([4, 5, 6]));
+    const frame = decode(await real.nextBinary());
+    expect(frame?.type).toBe(FRAME_DATA);
+    expect(Array.from(frame?.payload ?? [])).toEqual([4, 5, 6]);
+  });
+
+  it("keeps the devices when an unauthenticated claim is cut for an oversized message", async () => {
+    const host = await newHost();
+    const real = await attachHost(host);
+    const device = await attachDevice(host);
+    expect(decode(await real.nextBinary())?.type).toBe(FRAME_OPEN);
+
+    const impostor = await upgrade(`/v1/host/${host.hostId}`);
+    expect((await impostor.nextJson()).type).toBe("challenge");
+    impostor.ws.send(new Uint8Array(MAX_MESSAGE_BYTES + 6));
+    expect((await impostor.closed()).code).toBe(1009);
+
+    device.ws.send(new Uint8Array([7, 8, 9]));
+    const frame = decode(await real.nextBinary());
+    expect(frame?.type).toBe(FRAME_DATA);
+    expect(Array.from(frame?.payload ?? [])).toEqual([7, 8, 9]);
+  });
 });
 
 describe("device links", () => {

--- a/relay/test/relay.test.ts
+++ b/relay/test/relay.test.ts
@@ -1,0 +1,374 @@
+import { env, runDurableObjectAlarm, runInDurableObject, SELF } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import {
+  decode,
+  decodeClose,
+  encode,
+  encodeClose,
+  FRAME_DATA,
+  FRAME_OPEN,
+  FRAME_TEXT,
+} from "../src/frames";
+import {
+  HOST_AUTH_TIMEOUT_MS,
+  MAX_DEVICES,
+  MAX_MESSAGE_BYTES,
+  RATE_LIMIT_MESSAGES,
+} from "../src/host-relay";
+import { answerChallenge, attachDevice, attachHost, newHost, upgrade } from "./harness";
+
+const ORIGIN = "https://relay.test";
+const UPGRADE = { headers: { Upgrade: "websocket" } };
+const VALID_ID = "CByil-LnR3Z4wv604Br29p6iHZu2cmhqy35dlKs7Ojg";
+
+describe("routing", () => {
+  it("404s a bad host ID", async () => {
+    const paths = [
+      "/v1/host/short",
+      `/v1/host/${VALID_ID}A`,
+      `/v1/host/${VALID_ID.slice(0, 42)}`,
+      // 43 valid characters, but non-canonical trailing bits.
+      `/v1/host/${VALID_ID.slice(0, 42)}h`,
+      // Not base64url.
+      `/v1/host/${VALID_ID.slice(0, 42)}+`,
+      `/v1/device/${VALID_ID}A`,
+    ];
+    for (const path of paths) {
+      const response = await SELF.fetch(`${ORIGIN}${path}`, UPGRADE);
+      expect([path, response.status]).toEqual([path, 404]);
+    }
+  });
+
+  it("404s an unknown route", async () => {
+    for (const path of [
+      "/",
+      "/v1",
+      `/v1/nope/${VALID_ID}`,
+      `/v2/host/${VALID_ID}`,
+      `/v1/host/${VALID_ID}/x`,
+    ]) {
+      const response = await SELF.fetch(`${ORIGIN}${path}`, UPGRADE);
+      expect([path, response.status]).toEqual([path, 404]);
+    }
+  });
+
+  it("426s a valid route without an upgrade header", async () => {
+    for (const path of [`/v1/host/${VALID_ID}`, `/v1/device/${VALID_ID}`]) {
+      const response = await SELF.fetch(`${ORIGIN}${path}`);
+      expect(response.status).toBe(426);
+    }
+  });
+
+  it("ignores a client-supplied role", async () => {
+    // The Worker overwrites `role`, so this must still be treated as a device
+    // link and refused with 4404 rather than served a challenge.
+    const host = await newHost();
+    const link = await upgrade(`/v1/device/${host.hostId}?role=host`);
+    expect((await link.closed()).code).toBe(4404);
+  });
+});
+
+describe("host link authentication", () => {
+  it("challenges, accepts a valid proof and replies ready", async () => {
+    const host = await newHost();
+    const link = await upgrade(`/v1/host/${host.hostId}`);
+    const challenge = await link.nextJson();
+    expect(challenge.type).toBe("challenge");
+    expect(String(challenge.nonce)).toHaveLength(43);
+    expect(String(challenge.relayKey)).toHaveLength(43);
+    link.ws.send(JSON.stringify({ type: "proof", proof: await answerChallenge(host, challenge) }));
+    expect(await link.nextJson()).toEqual({ type: "ready" });
+  });
+
+  it("issues a fresh nonce and relay key per host link", async () => {
+    const first = await attachHost(await newHost());
+    const second = await upgrade(`/v1/host/${(await newHost()).hostId}`);
+    const challenge = await second.nextJson();
+    expect(challenge.nonce).toBeTypeOf("string");
+    first.ws.close(1000, "done");
+    const third = await upgrade(`/v1/host/${(await newHost()).hostId}`);
+    const other = await third.nextJson();
+    expect(other.nonce).not.toBe(challenge.nonce);
+    expect(other.relayKey).not.toBe(challenge.relayKey);
+  });
+
+  it("closes 4003 on a bad proof", async () => {
+    const host = await newHost();
+    const link = await upgrade(`/v1/host/${host.hostId}`);
+    const challenge = await link.nextJson();
+    // Well formed, right length, but computed for a different host key.
+    const wrong = await answerChallenge(await newHost(), challenge);
+    link.ws.send(JSON.stringify({ type: "proof", proof: wrong }));
+    expect((await link.closed()).code).toBe(4003);
+  });
+
+  it("closes 4003 on a malformed proof frame", async () => {
+    for (const body of [
+      "not json",
+      JSON.stringify({ type: "ready" }),
+      JSON.stringify({ type: "proof" }),
+      JSON.stringify({ type: "proof", proof: 7 }),
+      // Right shape, wrong length once decoded.
+      JSON.stringify({ type: "proof", proof: "AAAA" }),
+    ]) {
+      const host = await newHost();
+      const link = await upgrade(`/v1/host/${host.hostId}`);
+      await link.nextJson();
+      link.ws.send(body);
+      expect([body, (await link.closed()).code]).toEqual([body, 4003]);
+    }
+  });
+
+  it("closes 4003 when the proof arrives as a binary frame", async () => {
+    const host = await newHost();
+    const link = await upgrade(`/v1/host/${host.hostId}`);
+    await link.nextJson();
+    link.ws.send(new Uint8Array([1, 2, 3]));
+    expect((await link.closed()).code).toBe(4003);
+  });
+
+  it("arms a storage alarm for the 10 s proof deadline", async () => {
+    const host = await newHost();
+    const link = await upgrade(`/v1/host/${host.hostId}`);
+    await link.nextJson();
+    const stub = env.HOSTS.get(env.HOSTS.idFromName(host.hostId));
+    const at = await runInDurableObject(stub, (_instance, state) => state.storage.getAlarm());
+    expect(at).not.toBeNull();
+    expect(at as number).toBeLessThanOrEqual(Date.now() + HOST_AUTH_TIMEOUT_MS);
+  });
+
+  it("closes 4003 when the proof deadline passes", async () => {
+    const host = await newHost();
+    const link = await upgrade(`/v1/host/${host.hostId}`);
+    await link.nextJson();
+    const stub = env.HOSTS.get(env.HOSTS.idFromName(host.hostId));
+    // Backdate the deadline rather than wait 10 s. It lives in the socket's
+    // attachment, which is exactly where hibernation would have left it.
+    await runInDurableObject(stub, (_instance, state) => {
+      for (const ws of state.getWebSockets("host")) {
+        ws.serializeAttachment({
+          ...(ws.deserializeAttachment() as Record<string, unknown>),
+          deadline: 1,
+        });
+      }
+    });
+    expect(await runDurableObjectAlarm(stub)).toBe(true);
+    expect((await link.closed()).code).toBe(4003);
+  });
+
+  it("replaces an earlier host link with 4409 and its devices with 4404", async () => {
+    const host = await newHost();
+    const first = await attachHost(host);
+    const device = await attachDevice(host);
+    expect(decode(await first.nextBinary())?.type).toBe(FRAME_OPEN);
+
+    const second = await upgrade(`/v1/host/${host.hostId}`);
+    expect((await first.closed()).code).toBe(4409);
+    expect((await device.closed()).code).toBe(4404);
+    // The replacement still has to authenticate from scratch.
+    expect((await second.nextJson()).type).toBe("challenge");
+  });
+});
+
+describe("device links", () => {
+  it("closes 4404 when no host link is attached", async () => {
+    const host = await newHost();
+    const device = await attachDevice(host);
+    expect((await device.closed()).code).toBe(4404);
+  });
+
+  it("closes 4404 while the host link is still authenticating", async () => {
+    const host = await newHost();
+    const link = await upgrade(`/v1/host/${host.hostId}`);
+    await link.nextJson();
+    const device = await attachDevice(host);
+    expect((await device.closed()).code).toBe(4404);
+  });
+
+  it("closes the ninth device with 4429", async () => {
+    const host = await newHost();
+    const hostLink = await attachHost(host);
+    const connIds: number[] = [];
+    for (let i = 0; i < MAX_DEVICES; i++) {
+      await attachDevice(host);
+      const frame = decode(await hostLink.nextBinary());
+      expect(frame?.type).toBe(FRAME_OPEN);
+      connIds.push(frame?.connId as number);
+    }
+    // connIds are unique and never reused within the object's life.
+    expect(new Set(connIds).size).toBe(MAX_DEVICES);
+
+    const ninth = await attachDevice(host);
+    expect((await ninth.closed()).code).toBe(4429);
+  });
+
+  it("frees a slot when a device leaves", async () => {
+    const host = await newHost();
+    const hostLink = await attachHost(host);
+    const devices = [];
+    for (let i = 0; i < MAX_DEVICES; i++) {
+      devices.push(await attachDevice(host));
+      await hostLink.nextBinary();
+    }
+    expect((await (await attachDevice(host)).closed()).code).toBe(4429);
+
+    devices[0].ws.close(1000, "bye");
+    const close = decode(await hostLink.nextBinary());
+    expect(decodeClose(close?.payload as Uint8Array)?.code).toBe(1000);
+
+    await attachDevice(host);
+    expect(decode(await hostLink.nextBinary())?.type).toBe(FRAME_OPEN);
+  });
+});
+
+describe("the pipe", () => {
+  it("carries OPEN, DATA both ways, TEXT, and CLOSE from either end", async () => {
+    const host = await newHost();
+    const hostLink = await attachHost(host);
+    const device = await attachDevice(host);
+
+    const open = decode(await hostLink.nextBinary());
+    expect(open?.type).toBe(FRAME_OPEN);
+    expect(open?.payload.length).toBe(0);
+    const connId = open?.connId as number;
+
+    // device binary -> DATA
+    device.ws.send(new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+    const data = decode(await hostLink.nextBinary());
+    expect(data?.type).toBe(FRAME_DATA);
+    expect(data?.connId).toBe(connId);
+    expect(data && [...data.payload]).toEqual([0xde, 0xad, 0xbe, 0xef]);
+
+    // device text -> TEXT (verbatim, so the host can apply its own 4001 rule)
+    device.ws.send("hello ☃");
+    const text = decode(await hostLink.nextBinary());
+    expect(text?.type).toBe(FRAME_TEXT);
+    expect(new TextDecoder().decode(text?.payload)).toBe("hello ☃");
+
+    // host DATA -> device binary
+    hostLink.ws.send(encode(FRAME_DATA, connId, new Uint8Array([1, 2, 3])));
+    expect([...(await device.nextBinary())]).toEqual([1, 2, 3]);
+
+    // host CLOSE -> device sees the code and reason
+    hostLink.ws.send(encodeClose(connId, 4004, "remote access disabled"));
+    expect(await device.closed()).toEqual({ code: 4004, reason: "remote access disabled" });
+  });
+
+  it("reports a device that drops to the host as CLOSE 1006", async () => {
+    const host = await newHost();
+    const hostLink = await attachHost(host);
+    const device = await attachDevice(host);
+    const open = decode(await hostLink.nextBinary());
+    const connId = open?.connId as number;
+
+    // No close frame at all: an abrupt drop, which the doc maps to 1006.
+    device.ws.close();
+    const frame = decode(await hostLink.nextBinary());
+    expect(frame?.connId).toBe(connId);
+    expect(decodeClose(frame?.payload as Uint8Array)?.code).toBe(1006);
+  });
+
+  it("forwards a device's own close code to the host", async () => {
+    const host = await newHost();
+    const hostLink = await attachHost(host);
+    const device = await attachDevice(host);
+    await hostLink.nextBinary();
+    device.ws.close(4001, "bad frame");
+    const frame = decode(await hostLink.nextBinary());
+    expect(decodeClose(frame?.payload as Uint8Array)).toEqual({
+      code: 4001,
+      reason: "bad frame",
+    });
+  });
+
+  it("ignores host frames for an unknown connId", async () => {
+    const host = await newHost();
+    const hostLink = await attachHost(host);
+    const device = await attachDevice(host);
+    const connId = decode(await hostLink.nextBinary())?.connId as number;
+
+    hostLink.ws.send(encode(FRAME_DATA, connId + 999, new Uint8Array([7])));
+    hostLink.ws.send(encodeClose(connId + 999, 4004, "nobody"));
+    // Still alive, and the real connId still works.
+    hostLink.ws.send(encode(FRAME_DATA, connId, new Uint8Array([8])));
+    expect([...(await device.nextBinary())]).toEqual([8]);
+  });
+
+  it("ignores a truncated host frame and a relay-only frame type", async () => {
+    const host = await newHost();
+    const hostLink = await attachHost(host);
+    const device = await attachDevice(host);
+    const connId = decode(await hostLink.nextBinary())?.connId as number;
+
+    hostLink.ws.send(new Uint8Array([FRAME_DATA, 0, 0]));
+    hostLink.ws.send(encode(FRAME_OPEN, connId));
+    hostLink.ws.send(encode(FRAME_TEXT, connId, new TextEncoder().encode("nope")));
+    hostLink.ws.send(encode(FRAME_DATA, connId, new Uint8Array([9])));
+    expect([...(await device.nextBinary())]).toEqual([9]);
+  });
+
+  it("closes every device with 4404 when the host link drops", async () => {
+    const host = await newHost();
+    const hostLink = await attachHost(host);
+    const first = await attachDevice(host);
+    await hostLink.nextBinary();
+    const second = await attachDevice(host);
+    await hostLink.nextBinary();
+
+    hostLink.ws.close(1000, "disabled");
+    expect((await first.closed()).code).toBe(4404);
+    expect((await second.closed()).code).toBe(4404);
+  });
+});
+
+describe("limits", () => {
+  it("closes 1009 for a message over 4 MiB", async () => {
+    const host = await newHost();
+    await attachHost(host);
+    const device = await attachDevice(host);
+    device.ws.send(new Uint8Array(MAX_MESSAGE_BYTES + 16));
+    expect((await device.closed()).code).toBe(1009);
+  });
+
+  it("passes a message of exactly 4 MiB through", async () => {
+    const host = await newHost();
+    const hostLink = await attachHost(host);
+    const device = await attachDevice(host);
+    const connId = decode(await hostLink.nextBinary())?.connId as number;
+
+    device.ws.send(new Uint8Array(MAX_MESSAGE_BYTES));
+    const frame = decode(await hostLink.nextBinary());
+    expect(frame?.type).toBe(FRAME_DATA);
+    expect(frame?.connId).toBe(connId);
+    expect(frame?.payload.length).toBe(MAX_MESSAGE_BYTES);
+
+    // And back, as a DATA frame of 4 MiB + the 5-byte header.
+    hostLink.ws.send(encode(FRAME_DATA, connId, new Uint8Array(MAX_MESSAGE_BYTES)));
+    expect((await device.nextBinary()).length).toBe(MAX_MESSAGE_BYTES);
+  });
+
+  it("closes 1008 after more than 100 messages in 10 s", async () => {
+    const host = await newHost();
+    const hostLink = await attachHost(host);
+    const device = await attachDevice(host);
+    await hostLink.nextBinary();
+    for (let i = 0; i <= RATE_LIMIT_MESSAGES; i++) device.ws.send(new Uint8Array([i & 0xff]));
+    const close = await device.closed();
+    expect(close.code).toBe(1008);
+    // The host is told the virtual connection ended, with the same code.
+    let frame = decode(await hostLink.nextBinary());
+    while (frame?.type === FRAME_DATA) frame = decode(await hostLink.nextBinary());
+    expect(decodeClose(frame?.payload as Uint8Array)?.code).toBe(1008);
+  });
+
+  it("allows exactly 100 messages in a window", async () => {
+    const host = await newHost();
+    const hostLink = await attachHost(host);
+    const device = await attachDevice(host);
+    await hostLink.nextBinary();
+    for (let i = 0; i < RATE_LIMIT_MESSAGES; i++) device.ws.send(new Uint8Array([1]));
+    for (let i = 0; i < RATE_LIMIT_MESSAGES; i++) {
+      expect(decode(await hostLink.nextBinary())?.type).toBe(FRAME_DATA);
+    }
+  });
+});

--- a/relay/test/relay.test.ts
+++ b/relay/test/relay.test.ts
@@ -156,17 +156,65 @@ describe("host link authentication", () => {
     expect((await link.closed()).code).toBe(4003);
   });
 
-  it("replaces an earlier host link with 4409 and its devices with 4404", async () => {
+  it("refuses a valid proof that arrives after the deadline, alarm or no alarm", async () => {
+    const host = await newHost();
+    const link = await upgrade(`/v1/host/${host.hostId}`);
+    const challenge = await link.nextJson();
+    const stub = env.HOSTS.get(env.HOSTS.idFromName(host.hostId));
+    // The alarm has not fired (nobody ran it); the deadline alone must refuse.
+    await runInDurableObject(stub, (_instance, state) => {
+      for (const ws of state.getWebSockets("host")) {
+        ws.serializeAttachment({
+          ...(ws.deserializeAttachment() as Record<string, unknown>),
+          deadline: 1,
+        });
+      }
+    });
+    link.ws.send(JSON.stringify({ type: "proof", proof: await answerChallenge(host, challenge) }));
+    expect((await link.closed()).code).toBe(4003);
+  });
+
+  it("replaces an earlier host link with 4409 and its devices with 4404, once the newcomer has proved itself", async () => {
     const host = await newHost();
     const first = await attachHost(host);
     const device = await attachDevice(host);
     expect(decode(await first.nextBinary())?.type).toBe(FRAME_OPEN);
 
+    // The replacement has to authenticate from scratch, and until it does the
+    // first link and its device are untouched.
     const second = await upgrade(`/v1/host/${host.hostId}`);
+    const challenge = await second.nextJson();
+    expect(challenge.type).toBe("challenge");
+    device.ws.send(new Uint8Array([7, 7, 7]));
+    expect(decode(await first.nextBinary())?.type).toBe(FRAME_DATA);
+
+    second.ws.send(
+      JSON.stringify({ type: "proof", proof: await answerChallenge(host, challenge) }),
+    );
+    expect(await second.nextJson()).toEqual({ type: "ready" });
     expect((await first.closed()).code).toBe(4409);
     expect((await device.closed()).code).toBe(4404);
-    // The replacement still has to authenticate from scratch.
-    expect((await second.nextJson()).type).toBe("challenge");
+  });
+
+  it("lets an unauthenticated claim on the host ID disturb nothing", async () => {
+    const host = await newHost();
+    const real = await attachHost(host);
+    const device = await attachDevice(host);
+    expect(decode(await real.nextBinary())?.type).toBe(FRAME_OPEN);
+
+    // Anyone can learn the host ID; opening the host route with it, and even
+    // sending garbage, must not evict the real host or its devices.
+    const impostor = await upgrade(`/v1/host/${host.hostId}`);
+    expect((await impostor.nextJson()).type).toBe("challenge");
+    impostor.ws.send(
+      JSON.stringify({ type: "proof", proof: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" }),
+    );
+    expect((await impostor.closed()).code).toBe(4003);
+
+    device.ws.send(new Uint8Array([1, 2, 3]));
+    const frame = decode(await real.nextBinary());
+    expect(frame?.type).toBe(FRAME_DATA);
+    expect(Array.from(frame?.payload ?? [])).toEqual([1, 2, 3]);
   });
 });
 

--- a/relay/tsconfig.json
+++ b/relay/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "isolatedModules": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "types": ["@cloudflare/workers-types/experimental", "@cloudflare/vitest-pool-workers/types"]
+  },
+  "include": ["src", "test", "vitest.config.ts", "worker-env.d.ts"]
+}

--- a/relay/vitest.config.ts
+++ b/relay/vitest.config.ts
@@ -1,0 +1,10 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+// Tests run inside the same workerd that serves the Worker, so the Durable
+// Object, the WebSocket Hibernation API and WebCrypto behave exactly as they
+// do in production. `cloudflareTest` is the vitest 4 / pool-workers 0.22
+// plugin form of what used to be `defineWorkersConfig`.
+export default defineConfig({
+  plugins: [cloudflareTest({ wrangler: { configPath: "./wrangler.toml" } })],
+});

--- a/relay/worker-env.d.ts
+++ b/relay/worker-env.d.ts
@@ -1,0 +1,9 @@
+// `cloudflare:test` and `cloudflare:workers` type their `env` as
+// `Cloudflare.Env`, which `wrangler types` would normally generate into a
+// megabyte of bindings. The relay has exactly one binding, so it is declared
+// by hand here instead.
+declare namespace Cloudflare {
+  interface Env {
+    HOSTS: DurableObjectNamespace;
+  }
+}

--- a/relay/wrangler.toml
+++ b/relay/wrangler.toml
@@ -1,0 +1,23 @@
+# Fletch remote relay — a dumb pipe between a Mac ("host") and its phones
+# ("devices"). See ../docs/remote-protocol.md, section "Relay".
+name = "fletch-relay"
+main = "src/index.ts"
+# Keep at or below the newest date the bundled workerd (via miniflare, used by
+# `bun run test`) supports, or the test runtime refuses to start.
+compatibility_date = "2026-08-22"
+
+# One Durable Object per host ID (`idFromName(hostId)`) holds the single host
+# link and its device links.
+[[durable_objects.bindings]]
+name = "HOSTS"
+class_name = "HostRelay"
+
+# SQLite-backed Durable Objects are the only kind available on the free plan,
+# and they are what the WebSocket Hibernation API is billed against, so the
+# object can sleep while a host link sits idle.
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["HostRelay"]
+
+[observability]
+enabled = true

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2033,7 +2033,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -3898,7 +3898,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -5587,8 +5587,12 @@ checksum = "489a59b6730eda1b0171fcfda8b121f4bee2b35cba8645ca35c5f7ba3eb736c1"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5883,6 +5887,8 @@ dependencies = [
  "httparse",
  "log",
  "rand",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -6023,7 +6029,7 @@ dependencies = [
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
- "webpki-roots",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -6365,6 +6371,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -68,14 +68,21 @@ base64 = "0.22"
 sha2 = "0.10"
 flate2 = "1"
 tar = "0.4"
-# Paired-device remote access (`remote/`). Server side only: `handshake` is the
-# one feature needed, and no TLS backend is pulled in — confidentiality comes
-# from the Noise channel inside the WebSocket, not from the transport, so the
-# same frames survive the relay (see docs/remote-protocol.md). Pinned to
-# 0.27 rather than 0.30 deliberately: 0.30 moves to sha1 0.11 / digest 0.11 and
-# rand 0.10, which would add a second copy of the whole hashing and RNG stack
-# next to the sha2 0.10 and rand 0.9 already in the tree.
-tokio-tungstenite = { version = "0.27", default-features = false, features = ["handshake"] }
+# Paired-device remote access (`remote/`). `handshake` for the LAN listener,
+# `connect` + `rustls-tls-webpki-roots` for the outbound relay link
+# (`remote/relay.rs`), which dials a `wss://` URL and therefore does need a TLS
+# backend — webpki roots rather than the platform store so the link behaves the
+# same on every OS. The *payload* is still end-to-end encrypted by the Noise
+# channel inside the WebSocket, not by TLS, so the same frames survive the relay
+# unchanged (see docs/remote-protocol.md). Pinned to 0.27 rather than 0.30
+# deliberately: 0.30 moves to sha1 0.11 / digest 0.11 and rand 0.10, which would
+# add a second copy of the whole hashing and RNG stack next to the sha2 0.10 and
+# rand 0.9 already in the tree.
+tokio-tungstenite = { version = "0.27", default-features = false, features = [
+  "handshake",
+  "connect",
+  "rustls-tls-webpki-roots",
+] }
 # The remote secure channel (`remote/secure.rs`):
 # `Noise_XX_25519_ChaChaPoly_BLAKE2s`, the pattern the protocol doc fixes.
 snow = "0.10"

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -49,6 +49,31 @@ pub async fn remote_set_enabled(
     Ok(remote.status())
 }
 
+/// Set or clear the relay base URL: the host link comes up (or goes away)
+/// immediately, and the setting is persisted so the next launch agrees.
+///
+/// Persisted only after `set_relay` accepted the URL, for the same reason
+/// `remote_set_enabled` persists after the bind: a value the link could never
+/// use should not survive the restart. Clearing is stored as an empty string,
+/// which is what "no relay" reads as at launch.
+#[tauri::command]
+pub async fn remote_set_relay(
+    remote: State<'_, Arc<RemoteState>>,
+    db: State<'_, DbState>,
+    url: Option<String>,
+) -> Result<RemoteStatus> {
+    remote.inner().set_relay(url.clone())?;
+    {
+        let conn = db.lock();
+        database::set_setting(
+            &conn,
+            crate::remote::RELAY_URL_SETTING,
+            url.as_deref().unwrap_or("").trim(),
+        )?;
+    }
+    Ok(remote.status())
+}
+
 /// Mint a single-use pairing code and the `fletch://pair` deep link that
 /// carries it. Refuses while the listener is down — a code nothing can be typed
 /// into is worse than an error — and while the device store is unwritable,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1678,7 +1678,7 @@ pub fn run() {
                 // failure travels as `RemoteStatus::error` instead.
                 let state = remote::RemoteState::new(&data_dir.join("remote"), dispatch);
                 remote::install_taps(app.handle(), state.clone());
-                let (enabled, port) = {
+                let (enabled, port, relay_url) = {
                     let conn = db_for_remote.lock();
                     (
                         remote::parse_enabled(
@@ -1687,8 +1687,16 @@ pub fn run() {
                         remote::parse_port(
                             database::get_setting(&conn, remote::PORT_SETTING).as_deref(),
                         ),
+                        database::get_setting(&conn, remote::RELAY_URL_SETTING),
                     )
                 };
+                // The URL is stored before the autostart, so `start` brings the
+                // host link up with the listener. Safe outside the async
+                // runtime: nothing is enabled yet, so this cannot spawn the
+                // link task here.
+                if let Err(e) = state.set_relay(relay_url) {
+                    tracing::warn!(error = %e, "remote: stored relay url rejected");
+                }
                 if enabled {
                     // `start` binds synchronously but spawns onto the async
                     // runtime, so it has to run inside it.
@@ -1969,6 +1977,7 @@ pub fn run() {
             // is the only target this app ships for.
             commands::remote_status,
             commands::remote_set_enabled,
+            commands::remote_set_relay,
             commands::remote_begin_pairing,
             commands::remote_revoke_device,
             dictation::dictation_availability,

--- a/src-tauri/src/remote/mod.rs
+++ b/src-tauri/src/remote/mod.rs
@@ -8,13 +8,17 @@
 //!
 //! Layout: `secure` owns the Noise channel and the host identity, `auth` the
 //! pairing codes and the device registry, `server` the WebSocket listener,
-//! `session` the live-connection registry, `dispatch` the op allowlist,
-//! `events` the Tauri event taps. This module owns the state those six share
-//! and the listener's lifecycle.
+//! `relay` the outbound host link that carries off-LAN devices, `session` the
+//! live-connection registry, `dispatch` the op allowlist, `events` the Tauri
+//! event taps. This module owns the state those seven share and the lifecycle
+//! of the listener and the relay link.
 
 mod auth;
 mod dispatch;
 mod events;
+mod relay;
+#[cfg(test)]
+mod relay_tests;
 mod secure;
 mod server;
 mod session;
@@ -24,6 +28,7 @@ mod tests;
 pub use auth::{DeviceStore, PairingTokens};
 pub use dispatch::{Dispatch, DispatchResult, SupervisorDispatch};
 pub use events::install_taps;
+pub use relay::RelayStatus;
 pub use secure::HostKey;
 
 use std::net::Ipv4Addr;
@@ -34,6 +39,7 @@ use serde::Serialize;
 use serde_json::Value;
 use tokio::sync::broadcast;
 
+use self::relay::{RelayLink, RelayTiming};
 use self::session::{Sessions, CLOSE_DISABLED, CLOSE_REVOKED};
 use crate::error::{Error, Result};
 
@@ -42,6 +48,18 @@ use crate::error::{Error, Result};
 pub const ENABLED_SETTING: &str = "remote.enabled";
 /// `settings` key holding a TCP port override.
 pub const PORT_SETTING: &str = "remote.port";
+/// `settings` key holding the relay base URL. Absent or empty means no relay:
+/// the setting has no default, since a host that is only ever on its own LAN
+/// should not be dialling anything outbound.
+pub const RELAY_URL_SETTING: &str = "remote.relay_url";
+/// The URL the settings pane offers when the user turns the relay on. Only a
+/// suggestion — the setting is what decides, and anyone can run their own.
+///
+/// The canonical copy: the pane sends this string down from TypeScript
+/// (`src/api/types/remote.ts`), so nothing in Rust reads it outside the tests
+/// that check it is a URL `set_relay` accepts.
+#[cfg_attr(not(test), allow(dead_code))]
+pub const DEFAULT_RELAY_URL: &str = "wss://relay.fletch.app";
 /// Default listen port (protocol doc).
 pub const DEFAULT_PORT: u16 = 47285;
 /// The only path the listener serves.
@@ -101,6 +119,9 @@ pub struct RemoteStatus {
     /// Every address a phone could reach this host on, best candidate first.
     pub addresses: Vec<String>,
     pub devices: Vec<RemoteDevice>,
+    /// The outbound relay link: the configured URL and how the link to it is
+    /// doing. `off` when no URL is set or remote access is disabled.
+    pub relay: RelayStatus,
     /// A standing problem with the remote surface itself, for the pane to show
     /// inline. Currently only one: `devices.json` is not writable, so pairing
     /// is refused because the credential would not survive a restart.
@@ -123,6 +144,14 @@ struct Inner {
     /// The configured port; `listening` reports the bound one.
     port: u16,
     server: Option<ServerHandle>,
+    /// The configured relay base URL, normalized. `None` is "no relay", and is
+    /// also what the status reports whether or not the link is running.
+    relay_url: Option<String>,
+    /// The live host link. `Some` only while remote access is on *and* a URL is
+    /// set; dropping it asks the link to wind down.
+    relay: Option<RelayLink>,
+    /// Injectable so the relay tests do not sleep.
+    relay_timing: RelayTiming,
 }
 
 struct ServerHandle {
@@ -182,8 +211,18 @@ impl RemoteState {
                 enabled: false,
                 port: DEFAULT_PORT,
                 server: None,
+                relay_url: None,
+                relay: None,
+                relay_timing: RelayTiming::default(),
             }),
         })
+    }
+
+    /// Shorten every relay wait, so the reconnect and wind-down paths can be
+    /// tested without sleeping. Must be called before the link starts.
+    #[cfg(test)]
+    pub(in crate::remote) fn set_relay_timing(&self, timing: RelayTiming) {
+        self.inner.lock().relay_timing = timing;
     }
 
     pub fn devices(&self) -> &Arc<DeviceStore> {
@@ -206,8 +245,8 @@ impl RemoteState {
     }
 
     /// Start listening on `port` (0 binds an ephemeral one, which the socket
-    /// tests use). Returns the bound port. Idempotent: an already-running
-    /// listener is left alone.
+    /// tests use), and bring the relay link up if a URL is configured. Returns
+    /// the bound port. Idempotent: an already-running listener is left alone.
     ///
     /// Must be called from inside the async runtime — the bind itself is
     /// synchronous so that "port already in use" reaches the settings UI as an
@@ -216,6 +255,7 @@ impl RemoteState {
         let mut inner = self.inner.lock();
         if let Some(port) = inner.server.as_ref().map(|h| h.port) {
             inner.enabled = true;
+            self.spawn_relay(&mut inner);
             return Ok(port);
         }
 
@@ -236,11 +276,22 @@ impl RemoteState {
             port: bound,
             shutdown,
         });
+        self.spawn_relay(&mut inner);
         tracing::info!(port = bound, "remote: listening");
         Ok(bound)
     }
 
-    /// Stop listening and close every live connection with 4004.
+    /// Stop listening, close every live connection with 4004, and drop the
+    /// relay link.
+    ///
+    /// Order matters. `close_all` only *queues* a close on each session, and a
+    /// relayed session's close frame travels out over the link — so the
+    /// sessions are asked to close while the link is still up, and the link
+    /// handle is dropped after, which asks the link task to flush what those
+    /// sessions queued (bounded by `RelayTiming::shutdown_grace`) before it
+    /// hangs up. The doc's ordering: the host's own 4004 goes out first over
+    /// the virtual connections, and the relay's own 4404 follows from the link
+    /// dropping.
     pub fn stop(&self) {
         let mut inner = self.inner.lock();
         inner.enabled = false;
@@ -248,8 +299,52 @@ impl RemoteState {
             let _ = handle.shutdown.send(());
             tracing::info!(port = handle.port, "remote: stopped");
         }
+        let link = inner.relay.take();
         drop(inner);
         self.sessions.close_all(CLOSE_DISABLED);
+        drop(link);
+    }
+
+    /// Set (or clear) the relay base URL and bring the link in line with it.
+    ///
+    /// Normalizes as the doc does: trimmed, empty means no relay, and only
+    /// `ws://`/`wss://` are accepted — a typo is worth an error in Settings
+    /// rather than a link that can never connect.
+    pub fn set_relay(self: &Arc<Self>, url: Option<String>) -> Result<()> {
+        let url = match url.as_deref().map(str::trim).filter(|u| !u.is_empty()) {
+            None => None,
+            Some(url) if url.starts_with("ws://") || url.starts_with("wss://") => {
+                Some(url.trim_end_matches('/').to_string())
+            }
+            Some(url) => {
+                return Err(Error::Other(format!(
+                    "A relay URL has to start with ws:// or wss:// — {url} does not."
+                )))
+            }
+        };
+        let mut inner = self.inner.lock();
+        inner.relay_url = url;
+        // The old link goes first: two links for one host ID make the relay
+        // close one with 4409, and the one it keeps should be the new one.
+        drop(inner.relay.take());
+        if inner.enabled {
+            self.spawn_relay(&mut inner);
+        }
+        Ok(())
+    }
+
+    /// Start the host link if remote access is on, a URL is set and no link is
+    /// running. Called from every place that changes one of those three.
+    ///
+    /// Must run inside the async runtime, like `start`.
+    fn spawn_relay(self: &Arc<Self>, inner: &mut Inner) {
+        if !inner.enabled || inner.relay.is_some() {
+            return;
+        }
+        let Some(url) = inner.relay_url.clone() else {
+            return;
+        };
+        inner.relay = Some(RelayLink::spawn(self.clone(), url, inner.relay_timing));
     }
 
     pub fn status(&self) -> RemoteStatus {
@@ -264,6 +359,19 @@ impl RemoteState {
             port: inner.server.as_ref().map_or(inner.port, |h| h.port),
             host_id: self.host_id(),
             addresses: candidate_addresses(),
+            relay: match inner.relay.as_ref() {
+                Some(link) => {
+                    let (state, error) = link.snapshot();
+                    RelayStatus {
+                        url: inner.relay_url.clone(),
+                        state,
+                        error,
+                    }
+                }
+                // No link: either no URL, or remote access is off. The URL is
+                // still reported, so the pane can show what is configured.
+                None => RelayStatus::off(inner.relay_url.clone()),
+            },
             devices: self
                 .devices
                 .list()
@@ -291,9 +399,12 @@ impl RemoteState {
     pub fn begin_pairing(&self) -> PairingInvite {
         let minted = self.pairing.mint();
         let host = host_info();
-        let port = {
+        let (port, relay_url) = {
             let inner = self.inner.lock();
-            inner.server.as_ref().map_or(inner.port, |h| h.port)
+            (
+                inner.server.as_ref().map_or(inner.port, |h| h.port),
+                inner.relay_url.clone(),
+            )
         };
         let addr = candidate_addresses()
             .into_iter()
@@ -305,11 +416,19 @@ impl RemoteState {
         // The colon in `addr` is left literal, as the doc writes it; the values
         // around it are an IPv4 literal, a port, an 8-character code and a
         // machine name.
+        // `relay` is present only when one is configured, and the phone dials
+        // it only after `addr` fails — the same host key authenticates both
+        // paths, so which one the phone lands on changes nothing above the
+        // transport.
+        let relay = relay_url
+            .map(|url| format!("&relay={}", urlencode(&url)))
+            .unwrap_or_default();
         let url = format!(
-            "fletch://pair?host={}&addr={}:{}&token={}&name={}",
+            "fletch://pair?host={}&addr={}:{}{}&token={}&name={}",
             urlencode(&self.host_id()),
             urlencode(&addr),
             port,
+            relay,
             urlencode(&minted.token),
             urlencode(&host.name),
         );

--- a/src-tauri/src/remote/relay.rs
+++ b/src-tauri/src/remote/relay.rs
@@ -1,0 +1,973 @@
+//! The host link: one outbound WebSocket to the relay, carrying every off-LAN
+//! device as a numbered virtual connection.
+//!
+//! The contract is `docs/remote-protocol.md` → "Relay". The relay is a dumb
+//! pipe that routes on the host ID and sees only the ciphertext the secure
+//! channel already produces, so nothing here touches the protocol above the
+//! transport: a virtual connection is handed to the same `server::serve` a LAN
+//! socket is, and that state machine cannot tell the difference.
+//!
+//! Three pieces:
+//!
+//! - [`Frame`], the multiplexing codec (`type || connId || payload`).
+//! - [`VirtualConn`], a `server::WsTransport` whose inbound side is fed by the
+//!   demux and whose outbound side writes DATA/CLOSE frames onto the link's
+//!   shared queue.
+//! - [`RelayLink`], the task that dials, proves possession of the host key,
+//!   demultiplexes, and reconnects with backoff.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::net::{Ipv4Addr, SocketAddr};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use base64::Engine;
+use futures_util::stream::SplitSink;
+use futures_util::{Sink, SinkExt, Stream, StreamExt};
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tokio::sync::{broadcast, mpsc};
+use tokio::task::JoinSet;
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::protocol::{CloseFrame, WebSocketConfig};
+use tokio_tungstenite::tungstenite::{Bytes, Error as WsError, Message};
+use tracing::Instrument;
+
+use super::secure::HostKey;
+use super::server;
+use super::RemoteState;
+
+// ---------------------------------------------------------------------------
+// The multiplexing codec
+// ---------------------------------------------------------------------------
+
+const TYPE_OPEN: u8 = 0x01;
+const TYPE_DATA: u8 = 0x02;
+const TYPE_CLOSE: u8 = 0x03;
+const TYPE_TEXT: u8 = 0x04;
+
+/// Length of the fixed header: `type (1) || connId (u32 big-endian)`.
+const HEADER_LEN: usize = 5;
+
+/// One frame on the host link. `OPEN` and `TEXT` only ever arrive; `DATA` and
+/// `CLOSE` travel both ways.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum Frame {
+    /// A device link attached; payload is empty.
+    Open { conn: u32 },
+    /// One device WebSocket binary message, verbatim.
+    Data { conn: u32, payload: Bytes },
+    /// The virtual connection is over: `code (u16 big-endian) || reason`.
+    Close {
+        conn: u32,
+        code: u16,
+        reason: String,
+    },
+    /// One device WebSocket *text* message, verbatim, so the host can apply its
+    /// own 4001 rule to it rather than the relay guessing.
+    Text { conn: u32, text: String },
+}
+
+impl Frame {
+    pub(super) fn conn(&self) -> u32 {
+        match self {
+            Frame::Open { conn }
+            | Frame::Data { conn, .. }
+            | Frame::Close { conn, .. }
+            | Frame::Text { conn, .. } => *conn,
+        }
+    }
+
+    pub(super) fn encode(&self) -> Bytes {
+        let mut out = Vec::with_capacity(HEADER_LEN + 32);
+        out.push(match self {
+            Frame::Open { .. } => TYPE_OPEN,
+            Frame::Data { .. } => TYPE_DATA,
+            Frame::Close { .. } => TYPE_CLOSE,
+            Frame::Text { .. } => TYPE_TEXT,
+        });
+        out.extend_from_slice(&self.conn().to_be_bytes());
+        match self {
+            Frame::Open { .. } => {}
+            Frame::Data { payload, .. } => out.extend_from_slice(payload),
+            Frame::Close { code, reason, .. } => {
+                out.extend_from_slice(&code.to_be_bytes());
+                out.extend_from_slice(reason.as_bytes());
+            }
+            Frame::Text { text, .. } => out.extend_from_slice(text.as_bytes()),
+        }
+        Bytes::from(out)
+    }
+
+    /// Decode one frame. `Err` carries what was wrong with it, for the log; a
+    /// frame the host cannot parse is dropped, not fatal, since the relay is
+    /// free to add frame types the host does not know yet.
+    pub(super) fn decode(bytes: &[u8]) -> std::result::Result<Self, String> {
+        if bytes.len() < HEADER_LEN {
+            return Err(format!("frame of {} bytes has no header", bytes.len()));
+        }
+        let conn = u32::from_be_bytes([bytes[1], bytes[2], bytes[3], bytes[4]]);
+        let body = &bytes[HEADER_LEN..];
+        match bytes[0] {
+            TYPE_OPEN => Ok(Frame::Open { conn }),
+            TYPE_DATA => Ok(Frame::Data {
+                conn,
+                payload: Bytes::copy_from_slice(body),
+            }),
+            TYPE_CLOSE => {
+                if body.len() < 2 {
+                    return Err("close frame without a code".to_string());
+                }
+                Ok(Frame::Close {
+                    conn,
+                    code: u16::from_be_bytes([body[0], body[1]]),
+                    reason: String::from_utf8_lossy(&body[2..]).into_owned(),
+                })
+            }
+            TYPE_TEXT => Ok(Frame::Text {
+                conn,
+                text: String::from_utf8_lossy(body).into_owned(),
+            }),
+            other => Err(format!("unknown frame type {other:#04x}")),
+        }
+    }
+
+    fn into_message(self) -> Message {
+        Message::Binary(self.encode())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Status
+// ---------------------------------------------------------------------------
+
+/// What `remote_status.relay.state` reports. `off` covers both "no URL set" and
+/// "remote access is disabled"; `error` stands between reconnect attempts and
+/// carries the last failure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RelayState {
+    Off,
+    Connecting,
+    Connected,
+    Error,
+}
+
+/// `remote_status.relay`.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelayStatus {
+    /// The configured base URL, reported whether or not the link is running.
+    pub url: Option<String>,
+    pub state: RelayState,
+    pub error: Option<String>,
+}
+
+impl RelayStatus {
+    /// No URL configured, or remote access is off.
+    pub(super) fn off(url: Option<String>) -> Self {
+        Self {
+            url,
+            state: RelayState::Off,
+            error: None,
+        }
+    }
+}
+
+/// The link task's published state, read by `remote_status`.
+struct Published {
+    state: RelayState,
+    error: Option<String>,
+}
+
+impl Published {
+    fn set(&mut self, state: RelayState, error: Option<String>) {
+        self.state = state;
+        self.error = error;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Timing
+// ---------------------------------------------------------------------------
+
+/// Everything the link waits on, in one place so tests do not sleep.
+#[derive(Debug, Clone, Copy)]
+pub(super) struct RelayTiming {
+    /// First reconnect delay, doubled per failure up to `backoff_max` and reset
+    /// by a successful `ready`.
+    pub backoff_initial: Duration,
+    pub backoff_max: Duration,
+    /// How long the relay has to complete challenge → proof → ready.
+    pub auth_timeout: Duration,
+    /// Host↔relay keepalive. This hop has its own ping/pong, never forwarded.
+    pub ping_interval: Duration,
+    /// How long a link that has been asked to go away keeps writing, so the
+    /// 4004 its virtual connections just queued actually reaches the relay.
+    pub shutdown_grace: Duration,
+}
+
+impl Default for RelayTiming {
+    fn default() -> Self {
+        Self {
+            backoff_initial: Duration::from_secs(1),
+            backoff_max: Duration::from_secs(60),
+            auth_timeout: Duration::from_secs(10),
+            ping_interval: Duration::from_secs(20),
+            shutdown_grace: Duration::from_secs(2),
+        }
+    }
+}
+
+/// Two missed pongs drop the link, as on the LAN path.
+const MAX_MISSED_PONGS: u32 = 2;
+/// Frames queued for the relay across every virtual connection. Each virtual
+/// connection already has its own 64-frame outbox inside `serve`; this is the
+/// one hop after it, so it only fills when the relay itself stops reading.
+const LINK_OUTBOUND_BUFFER: usize = 256;
+/// Messages queued *into* one virtual connection. `serve` reads continuously
+/// and dispatches off its reader loop, so this only fills for a device that is
+/// flooding, which costs that device its link and nothing else.
+const CONN_INBOUND_BUFFER: usize = 64;
+/// The device message cap (4 MiB, protocol doc) plus room for the mux header.
+const MAX_LINK_MESSAGE: usize = 4 * 1024 * 1024 + 1024;
+
+// ---------------------------------------------------------------------------
+// The link handle
+// ---------------------------------------------------------------------------
+
+/// A running host link. Dropping it asks the task to wind down — it does not
+/// abort, so the CLOSE frames the virtual connections queued on the way out
+/// still reach the relay (see `RemoteState::stop`).
+pub(super) struct RelayLink {
+    published: Arc<Mutex<Published>>,
+    shutdown: broadcast::Sender<()>,
+}
+
+impl RelayLink {
+    /// Dial `url` and keep the link up until this handle is dropped.
+    ///
+    /// Must be called from inside the async runtime. The task holds an
+    /// `Arc<RemoteState>`, so the state outlives the link rather than the other
+    /// way round; every path that stops caring about the link drops this handle,
+    /// which is what lets the task (and that `Arc`) go.
+    pub(super) fn spawn(state: Arc<RemoteState>, url: String, timing: RelayTiming) -> Self {
+        let published = Arc::new(Mutex::new(Published {
+            state: RelayState::Connecting,
+            error: None,
+        }));
+        let (shutdown, stop) = broadcast::channel(1);
+        tokio::spawn(run(state, url, timing, published.clone(), stop));
+        Self {
+            published,
+            shutdown,
+        }
+    }
+
+    pub(super) fn snapshot(&self) -> (RelayState, Option<String>) {
+        let published = self.published.lock();
+        (published.state, published.error.clone())
+    }
+}
+
+impl Drop for RelayLink {
+    fn drop(&mut self) {
+        let _ = self.shutdown.send(());
+    }
+}
+
+/// `<base>/v1/host/<hostId>`, per the doc's endpoint table.
+pub(super) fn host_endpoint(base: &str, host_id: &str) -> String {
+    format!("{}/v1/host/{host_id}", base.trim_end_matches('/'))
+}
+
+/// Reconnect forever: dial, authenticate, demultiplex, back off, repeat.
+async fn run(
+    state: Arc<RemoteState>,
+    url: String,
+    timing: RelayTiming,
+    published: Arc<Mutex<Published>>,
+    mut shutdown: broadcast::Receiver<()>,
+) {
+    let mut backoff = timing.backoff_initial;
+    loop {
+        published.lock().set(RelayState::Connecting, None);
+        match attempt(&state, &url, &timing, &published, &mut shutdown).await {
+            Outcome::Done => {
+                published.lock().set(RelayState::Off, None);
+                return;
+            }
+            Outcome::Retry { error, connected } => {
+                tracing::info!(%url, %error, "remote: relay link down, retrying");
+                published.lock().set(RelayState::Error, Some(error));
+                // A link that got as far as `ready` proved the URL and the key
+                // are good, so the next failure starts from the short delay.
+                if connected {
+                    backoff = timing.backoff_initial;
+                }
+                tokio::select! {
+                    _ = shutdown.recv() => {
+                        published.lock().set(RelayState::Off, None);
+                        return;
+                    }
+                    _ = tokio::time::sleep(backoff) => {}
+                }
+                backoff = (backoff * 2).min(timing.backoff_max);
+            }
+        }
+    }
+}
+
+enum Outcome {
+    /// The handle was dropped: stop reconnecting.
+    Done,
+    /// Reconnect. `connected` records whether this attempt ever reached
+    /// `ready`, which is what resets the backoff.
+    Retry { error: String, connected: bool },
+}
+
+fn retry(error: impl Into<String>) -> Outcome {
+    Outcome::Retry {
+        error: error.into(),
+        connected: false,
+    }
+}
+
+/// One connection attempt, from the dial to the link going away.
+async fn attempt(
+    state: &Arc<RemoteState>,
+    url: &str,
+    timing: &RelayTiming,
+    published: &Arc<Mutex<Published>>,
+    shutdown: &mut broadcast::Receiver<()>,
+) -> Outcome {
+    let Some(host_id) = state.host_key().map(HostKey::host_id) else {
+        // No identity: nothing to route on and nothing to prove. The same
+        // condition already stands in `RemoteStatus::error`.
+        return retry("this host has no key, so it cannot attach to a relay");
+    };
+    let endpoint = host_endpoint(url, &host_id);
+
+    let mut config = WebSocketConfig::default();
+    config.max_message_size = Some(MAX_LINK_MESSAGE);
+    config.max_frame_size = Some(MAX_LINK_MESSAGE);
+    let dial = tokio_tungstenite::connect_async_with_config(&endpoint, Some(config), true);
+    let mut ws = tokio::select! {
+        _ = shutdown.recv() => return Outcome::Done,
+        dialed = dial => match dialed {
+            Ok((ws, _)) => ws,
+            Err(e) => return retry(format!("{url} could not be reached: {e}")),
+        },
+    };
+
+    let authenticated = tokio::select! {
+        _ = shutdown.recv() => return Outcome::Done,
+        outcome = tokio::time::timeout(timing.auth_timeout, authenticate(&mut ws, state)) => outcome,
+    };
+    match authenticated {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => return retry(e),
+        Err(_) => return retry("the relay did not finish the challenge in time"),
+    }
+
+    tracing::info!(%endpoint, "remote: relay link up");
+    published.lock().set(RelayState::Connected, None);
+    match demux(state, ws, timing, shutdown).await {
+        Outcome::Done => Outcome::Done,
+        Outcome::Retry { error, .. } => Outcome::Retry {
+            error,
+            connected: true,
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Host link authentication
+// ---------------------------------------------------------------------------
+
+/// What the relay says before the link carries frames.
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+enum RelayHello {
+    Challenge {
+        nonce: String,
+        #[serde(rename = "relayKey")]
+        relay_key: String,
+    },
+    Ready,
+}
+
+/// Prove possession of the host key: read the challenge, answer with
+/// `SHA-256(shared || nonce || hostKey)`, and wait for `ready`.
+///
+/// `shared` is `X25519(host private, relayKey)`, so a relay that does not hold
+/// the private half of `relayKey` cannot verify the proof and one that does
+/// still learns nothing it could replay against another relay — the host public
+/// key is hashed in, and it is the ID the relay routes on anyway.
+async fn authenticate<S>(ws: &mut S, state: &Arc<RemoteState>) -> std::result::Result<(), String>
+where
+    S: Stream<Item = std::result::Result<Message, WsError>>
+        + Sink<Message, Error = WsError>
+        + Unpin,
+{
+    let (nonce, relay_key) = match next_text(ws).await? {
+        RelayHello::Challenge { nonce, relay_key } => (nonce, relay_key),
+        RelayHello::Ready => return Err("the relay sent ready before a challenge".to_string()),
+    };
+    let nonce = B64
+        .decode(nonce)
+        .map_err(|e| format!("the relay's nonce is not base64url: {e}"))?;
+    let relay_key: [u8; 32] = B64
+        .decode(relay_key)
+        .map_err(|e| format!("the relay's key is not base64url: {e}"))?
+        .try_into()
+        .map_err(|_| "the relay's key is not 32 bytes".to_string())?;
+
+    let host = state
+        .host_key()
+        .ok_or_else(|| "this host has no key".to_string())?;
+    let proof = challenge_proof(host, &relay_key, &nonce).map_err(|e| e.to_string())?;
+    let answer = format!("{{\"type\":\"proof\",\"proof\":\"{}\"}}", B64.encode(proof));
+    ws.send(Message::Text(answer.into()))
+        .await
+        .map_err(|e| format!("the proof could not be sent: {e}"))?;
+
+    match next_text(ws).await? {
+        RelayHello::Ready => Ok(()),
+        RelayHello::Challenge { .. } => Err("the relay challenged twice".to_string()),
+    }
+}
+
+/// `SHA-256( X25519(hostPrivate, relayKey) || nonce || hostKey )`, raw bytes
+/// throughout (`docs/remote-protocol.md` → "Relay").
+pub(super) fn challenge_proof(
+    host: &HostKey,
+    relay_key: &[u8; 32],
+    nonce: &[u8],
+) -> crate::error::Result<[u8; 32]> {
+    let shared = host.diffie_hellman(relay_key)?;
+    let mut digest = Sha256::new();
+    digest.update(shared);
+    digest.update(nonce);
+    digest.update(host.public_bytes());
+    Ok(digest.finalize().into())
+}
+
+/// The next JSON text frame of the authentication exchange. Ping/pong are the
+/// transport's business and can interleave; anything else ends the attempt.
+async fn next_text<S>(ws: &mut S) -> std::result::Result<RelayHello, String>
+where
+    S: Stream<Item = std::result::Result<Message, WsError>> + Unpin,
+{
+    loop {
+        let msg = ws
+            .next()
+            .await
+            .ok_or_else(|| "the relay closed the link during the challenge".to_string())?
+            .map_err(|e| format!("the relay link failed during the challenge: {e}"))?;
+        match msg {
+            Message::Text(text) => {
+                return serde_json::from_str(&text)
+                    .map_err(|e| format!("the relay sent {text}, which is not a challenge: {e}"))
+            }
+            Message::Ping(_) | Message::Pong(_) => continue,
+            Message::Close(frame) => {
+                let code = frame.as_ref().map_or(0, |f| u16::from(f.code));
+                return Err(match code {
+                    4003 => "the relay rejected this host's proof".to_string(),
+                    4409 => "another link for this host replaced this one".to_string(),
+                    0 => "the relay closed the link during the challenge".to_string(),
+                    other => format!("the relay closed the link with {other}"),
+                });
+            }
+            other => return Err(format!("the relay sent an unexpected frame: {other:?}")),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Demultiplexing
+// ---------------------------------------------------------------------------
+
+type LinkWs =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+/// One virtual connection's registration on the link.
+struct Registered {
+    /// The demux's end of the connection's inbound queue. Dropping it ends the
+    /// `Stream`, which is how a CLOSE turns into end-of-stream for `serve`.
+    inbound: mpsc::Sender<std::result::Result<Message, WsError>>,
+    shared: Arc<ConnShared>,
+}
+
+/// The one bit of state the demux and a virtual connection both touch: whether
+/// a CLOSE has already gone out for this connection, so it is sent exactly once
+/// no matter which end finished first.
+struct ConnShared {
+    closed: AtomicBool,
+}
+
+/// Read the link until it goes away, routing frames to virtual connections and
+/// keeping the hop alive with its own ping/pong.
+async fn demux(
+    state: &Arc<RemoteState>,
+    ws: LinkWs,
+    timing: &RelayTiming,
+    shutdown: &mut broadcast::Receiver<()>,
+) -> Outcome {
+    let (sink, mut stream) = ws.split();
+    let (out_tx, out_rx) = mpsc::channel::<Message>(LINK_OUTBOUND_BUFFER);
+    let writer = tokio::spawn(write_loop(sink, out_rx));
+
+    let mut conns: HashMap<u32, Registered> = HashMap::new();
+    // Owns the per-connection `serve` tasks, so winding the link down can wait
+    // for their close frames instead of cutting them off.
+    let mut serving: JoinSet<()> = JoinSet::new();
+    let mut missed_pongs = 0u32;
+    let mut ping = tokio::time::interval(timing.ping_interval);
+    // `interval` fires immediately; the first real ping belongs one period out.
+    ping.tick().await;
+
+    let outcome = loop {
+        tokio::select! {
+            biased;
+            _ = shutdown.recv() => break Outcome::Done,
+            _ = ping.tick() => {
+                if missed_pongs >= MAX_MISSED_PONGS {
+                    break retry("the relay stopped answering pings");
+                }
+                missed_pongs += 1;
+                // `try_send`, not `send`: a full queue means the relay has
+                // stopped reading, and awaiting a slot here would park the
+                // demux — pongs included — so the link could never time out.
+                if out_tx.try_send(Message::Ping(Bytes::new())).is_err() {
+                    break retry("the relay stopped reading");
+                }
+            }
+            incoming = stream.next() => {
+                let msg = match incoming {
+                    Some(Ok(msg)) => msg,
+                    Some(Err(e)) => break retry(format!("the relay link failed: {e}")),
+                    None => break retry("the relay closed the link"),
+                };
+                match msg {
+                    Message::Binary(bytes) => match Frame::decode(&bytes) {
+                        Ok(frame) => route(state, frame, &mut conns, &mut serving, &out_tx),
+                        Err(e) => tracing::debug!(error = %e, "remote: undecodable relay frame"),
+                    },
+                    Message::Pong(_) => missed_pongs = 0,
+                    Message::Close(frame) => {
+                        let code = frame.as_ref().map_or(0, |f| u16::from(f.code));
+                        break retry(format!("the relay closed the link with {code}"));
+                    }
+                    // Text after `ready` is not part of the contract. Ignored
+                    // rather than fatal, so a relay that grows a control
+                    // message does not knock older hosts off.
+                    Message::Text(text) => {
+                        tracing::debug!(%text, "remote: unexpected text frame on the relay link");
+                    }
+                    _ => {}
+                }
+            }
+            // Reaped so a long-lived link does not accumulate finished tasks.
+            Some(_) = serving.join_next(), if !serving.is_empty() => {}
+        }
+    };
+
+    // Wind-down. The virtual connections have been asked to close by whoever
+    // is taking the link away (`stop` closes every session with 4004 before
+    // dropping this handle), and their close frames are still travelling
+    // through `out_tx`; give them a bounded moment to land before the socket
+    // goes. Then drop the senders so the writer flushes and finishes.
+    drop(conns);
+    let _ = tokio::time::timeout(timing.shutdown_grace, async {
+        while serving.join_next().await.is_some() {}
+    })
+    .await;
+    serving.shutdown().await;
+    drop(out_tx);
+    let _ = tokio::time::timeout(timing.shutdown_grace, writer).await;
+    outcome
+}
+
+/// Serialize the link's outbound queue onto the socket. One task, so the frames
+/// of every virtual connection interleave in exactly the order they were queued.
+async fn write_loop(mut sink: SplitSink<LinkWs, Message>, mut rx: mpsc::Receiver<Message>) {
+    while let Some(msg) = rx.recv().await {
+        if sink.send(msg).await.is_err() {
+            return;
+        }
+    }
+    let _ = sink.close().await;
+}
+
+/// Route one inbound frame. OPEN creates a virtual connection; DATA/TEXT/CLOSE
+/// for a connection the host does not know are ignored, which is what the doc
+/// asks for — the relay may still be forwarding a device's last message when
+/// the host has already finished with it.
+fn route(
+    state: &Arc<RemoteState>,
+    frame: Frame,
+    conns: &mut HashMap<u32, Registered>,
+    serving: &mut JoinSet<()>,
+    out_tx: &mpsc::Sender<Message>,
+) {
+    let conn = frame.conn();
+    match frame {
+        Frame::Open { .. } => {
+            if conns.contains_key(&conn) {
+                tracing::warn!(conn_id = conn, "remote: relay reopened a live connection");
+                return;
+            }
+            let (inbound_tx, inbound_rx) = mpsc::channel(CONN_INBOUND_BUFFER);
+            let shared = Arc::new(ConnShared {
+                closed: AtomicBool::new(false),
+            });
+            let virtual_conn = VirtualConn {
+                conn,
+                inbound: inbound_rx,
+                self_inbound: inbound_tx.clone(),
+                out: Outbound::Idle(out_tx.clone()),
+                shared: shared.clone(),
+                done: false,
+            };
+            conns.insert(
+                conn,
+                Registered {
+                    inbound: inbound_tx,
+                    shared: shared.clone(),
+                },
+            );
+            let state = state.clone();
+            let out_tx = out_tx.clone();
+            serving.spawn(async move {
+                // A synthetic peer: there is no socket address behind a virtual
+                // connection, so the identifiable part is the span's `conn_id`.
+                let peer = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 0);
+                let span = tracing::info_span!("relay_conn", conn_id = conn);
+                // The `Option<S>` is for the TCP path's drain, which has no
+                // meaning here: there is no socket under this to reset.
+                let _ = server::serve(state, virtual_conn, peer)
+                    .instrument(span)
+                    .await;
+                // `serve` is done and never sent a close of its own (a dropped
+                // socket, on the LAN). The relay still has a device link open,
+                // so it needs to be told.
+                if !shared.closed.swap(true, Ordering::SeqCst) {
+                    let _ = out_tx
+                        .send(
+                            Frame::Close {
+                                conn,
+                                code: 1000,
+                                reason: String::new(),
+                            }
+                            .into_message(),
+                        )
+                        .await;
+                }
+            });
+        }
+        Frame::Data { payload, .. } => {
+            deliver(conns, conn, out_tx, Ok(Message::Binary(payload)));
+        }
+        Frame::Text { text, .. } => {
+            deliver(conns, conn, out_tx, Ok(Message::Text(text.into())));
+        }
+        Frame::Close { code, reason, .. } => {
+            if let Some(registered) = conns.remove(&conn) {
+                // The relay has already closed the device link, so nothing more
+                // may be sent for this connection.
+                registered.shared.closed.store(true, Ordering::SeqCst);
+                let frame = CloseFrame {
+                    code: CloseCode::from(code),
+                    reason: reason.into(),
+                };
+                let _ = registered.inbound.try_send(Ok(Message::Close(Some(frame))));
+                // Dropping the sender ends the connection's inbound stream.
+            }
+        }
+    }
+}
+
+/// Hand one message to a virtual connection. A full inbound queue means the
+/// device is talking faster than the host can read it, which costs that one
+/// connection: it is closed with 1008 and its stream ends.
+fn deliver(
+    conns: &mut HashMap<u32, Registered>,
+    conn: u32,
+    out_tx: &mpsc::Sender<Message>,
+    msg: std::result::Result<Message, WsError>,
+) {
+    let Some(registered) = conns.get(&conn) else {
+        tracing::debug!(
+            conn_id = conn,
+            "remote: relay frame for an unknown connection"
+        );
+        return;
+    };
+    if registered.inbound.try_send(msg).is_err() {
+        tracing::warn!(
+            conn_id = conn,
+            "remote: relayed device outran its inbound queue"
+        );
+        if let Some(registered) = conns.remove(&conn) {
+            if !registered.shared.closed.swap(true, Ordering::SeqCst) {
+                let _ = out_tx.try_send(
+                    Frame::Close {
+                        conn,
+                        code: 1008,
+                        reason: "inbound backlog".to_string(),
+                    }
+                    .into_message(),
+                );
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The virtual connection
+// ---------------------------------------------------------------------------
+
+/// One device link as a `WsTransport`: inbound comes from the demux, outbound
+/// becomes DATA and CLOSE frames on the link's shared queue.
+///
+/// This is the whole of the relay's intrusion into the server. `serve` sees a
+/// WebSocket; the frames inside it are the same end-to-end encrypted frames a
+/// LAN socket carries.
+struct VirtualConn {
+    conn: u32,
+    inbound: mpsc::Receiver<std::result::Result<Message, WsError>>,
+    /// Our own inbound sender, so a liveness ping can be answered locally: the
+    /// doc keeps ping/pong per hop, so a `Ping` the host writes to a virtual
+    /// connection must never reach the relay.
+    self_inbound: mpsc::Sender<std::result::Result<Message, WsError>>,
+    out: Outbound,
+    shared: Arc<ConnShared>,
+    /// Set once a CLOSE has been queued: the sink is finished, and anything
+    /// after it is dropped rather than reordered past the close.
+    done: bool,
+}
+
+/// The outbound half's permit machinery. `tokio_util::sync::PollSender` is
+/// exactly this, but `tokio-util` is not a direct dependency of this crate and
+/// one small `Sink` impl is cheaper than one more crate.
+enum Outbound {
+    Idle(mpsc::Sender<Message>),
+    Reserving(Reserving),
+    Ready(mpsc::OwnedPermit<Message>),
+    Gone,
+}
+
+/// `Sender::reserve_owned` in flight: the one thing that can be `Pending` here,
+/// and the whole reason this is a state machine rather than a `try_send`.
+type Reserving = Pin<
+    Box<
+        dyn Future<
+                Output = std::result::Result<
+                    mpsc::OwnedPermit<Message>,
+                    mpsc::error::SendError<()>,
+                >,
+            > + Send,
+    >,
+>;
+
+fn link_gone() -> WsError {
+    WsError::Io(std::io::Error::other("the relay link is gone"))
+}
+
+impl Stream for VirtualConn {
+    type Item = std::result::Result<Message, WsError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inbound.poll_recv(cx)
+    }
+}
+
+impl Sink<Message> for VirtualConn {
+    type Error = WsError;
+
+    fn poll_ready(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), WsError>> {
+        loop {
+            match std::mem::replace(&mut self.out, Outbound::Gone) {
+                Outbound::Idle(tx) => self.out = Outbound::Reserving(Box::pin(tx.reserve_owned())),
+                Outbound::Reserving(mut reserving) => match reserving.as_mut().poll(cx) {
+                    Poll::Ready(Ok(permit)) => {
+                        self.out = Outbound::Ready(permit);
+                        return Poll::Ready(Ok(()));
+                    }
+                    Poll::Ready(Err(_)) => return Poll::Ready(Err(link_gone())),
+                    Poll::Pending => {
+                        self.out = Outbound::Reserving(reserving);
+                        return Poll::Pending;
+                    }
+                },
+                Outbound::Ready(permit) => {
+                    self.out = Outbound::Ready(permit);
+                    return Poll::Ready(Ok(()));
+                }
+                Outbound::Gone => return Poll::Ready(Err(link_gone())),
+            }
+        }
+    }
+
+    fn start_send(mut self: Pin<&mut Self>, msg: Message) -> Result<(), WsError> {
+        if self.done {
+            return Ok(());
+        }
+        let conn = self.conn;
+        let frame = match msg {
+            Message::Binary(payload) => Frame::Data { conn, payload },
+            Message::Close(frame) => {
+                self.done = true;
+                // Exactly one CLOSE per connection: if the demux already saw one
+                // from the relay, the device link is gone and this is a no-op.
+                if self.shared.closed.swap(true, Ordering::SeqCst) {
+                    return Ok(());
+                }
+                let (code, reason) = frame
+                    .map(|f| (u16::from(f.code), f.reason.to_string()))
+                    .unwrap_or((1000, String::new()));
+                Frame::Close { conn, code, reason }
+            }
+            // Per the doc, liveness pings to a virtual connection are answered
+            // locally; this hop's own ping/pong is the link's, not a device's.
+            Message::Ping(payload) => {
+                let _ = self.self_inbound.try_send(Ok(Message::Pong(payload)));
+                return Ok(());
+            }
+            Message::Pong(_) | Message::Frame(_) => return Ok(()),
+            // Unreachable: past the handshake `pump` encrypts every protocol
+            // frame into a binary message, and the handshake itself is binary
+            // too. A text frame here would be a host bug, and forwarding it as
+            // DATA would show the phone plaintext where it expects ciphertext —
+            // so the connection ends instead.
+            Message::Text(_) => {
+                tracing::error!(
+                    conn_id = conn,
+                    "remote: a text frame reached the relay link"
+                );
+                return Err(WsError::Io(std::io::Error::other(
+                    "a text frame cannot travel over the relay",
+                )));
+            }
+        };
+        match std::mem::replace(&mut self.out, Outbound::Gone) {
+            Outbound::Ready(permit) => {
+                self.out = Outbound::Idle(permit.send(frame.into_message()));
+                Ok(())
+            }
+            // `Sink`'s contract is `poll_ready` before every `start_send`; being
+            // here means the queue is gone (or the caller broke the contract),
+            // and either way the frame cannot be written.
+            other => {
+                self.out = other;
+                Err(link_gone())
+            }
+        }
+    }
+
+    /// Nothing is buffered here: `start_send` hands the frame straight to the
+    /// link's queue, and the writer task is what flushes it.
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), WsError>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), WsError>> {
+        self.done = true;
+        self.out = Outbound::Gone;
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod codec_tests {
+    use super::*;
+
+    fn roundtrip(frame: Frame) {
+        let encoded = frame.encode();
+        assert_eq!(Frame::decode(&encoded).unwrap(), frame, "{frame:?}");
+    }
+
+    #[test]
+    fn every_frame_type_roundtrips() {
+        roundtrip(Frame::Open { conn: 0 });
+        roundtrip(Frame::Open { conn: u32::MAX });
+        roundtrip(Frame::Data {
+            conn: 7,
+            payload: Bytes::from_static(&[0, 1, 2, 255]),
+        });
+        roundtrip(Frame::Data {
+            conn: 7,
+            payload: Bytes::new(),
+        });
+        roundtrip(Frame::Close {
+            conn: 9,
+            code: 4004,
+            reason: "remote access disabled".to_string(),
+        });
+        roundtrip(Frame::Close {
+            conn: 9,
+            code: 1000,
+            reason: String::new(),
+        });
+        roundtrip(Frame::Text {
+            conn: 3,
+            text: "{\"op\":\"hello\"}".to_string(),
+        });
+    }
+
+    /// The header the doc fixes: `type (1) || connId (u32 big-endian)`, then the
+    /// payload, and for CLOSE a `u16` big-endian code before the reason.
+    #[test]
+    fn the_wire_layout_is_the_documented_one() {
+        assert_eq!(
+            Frame::Data {
+                conn: 0x01020304,
+                payload: Bytes::from_static(b"hi"),
+            }
+            .encode()
+            .as_ref(),
+            &[0x02, 0x01, 0x02, 0x03, 0x04, b'h', b'i']
+        );
+        assert_eq!(
+            Frame::Close {
+                conn: 1,
+                code: 4004,
+                reason: "x".to_string(),
+            }
+            .encode()
+            .as_ref(),
+            &[0x03, 0, 0, 0, 1, 0x0f, 0xa4, b'x']
+        );
+        assert_eq!(
+            Frame::Open { conn: 1 }.encode().as_ref(),
+            &[0x01, 0, 0, 0, 1]
+        );
+    }
+
+    #[test]
+    fn malformed_frames_are_rejected_not_guessed() {
+        for bytes in [
+            vec![],
+            vec![0x02],
+            vec![0x02, 0, 0, 0],
+            // CLOSE without room for a code.
+            vec![0x03, 0, 0, 0, 1],
+            vec![0x03, 0, 0, 0, 1, 0x0f],
+            // A type the host does not know.
+            vec![0x09, 0, 0, 0, 1],
+        ] {
+            assert!(
+                Frame::decode(&bytes).is_err(),
+                "{bytes:?} should not decode"
+            );
+        }
+    }
+}

--- a/src-tauri/src/remote/relay_tests.rs
+++ b/src-tauri/src/remote/relay_tests.rs
@@ -1,0 +1,815 @@
+//! The host link, exercised against a fake relay.
+//!
+//! The fake relay is the other half of `docs/remote-protocol.md` → "Relay":
+//! it accepts `/v1/host/<hostId>`, runs the DH challenge, and then speaks the
+//! multiplexing codec, wrapping a real Noise initiator inside DATA frames. So
+//! these tests drive the same code path a phone on the far side of a Cloudflare
+//! Worker would, minus the Worker.
+
+use std::collections::VecDeque;
+use std::future::Future;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
+use base64::Engine;
+use futures_util::{SinkExt, StreamExt};
+use parking_lot::Mutex;
+use serde_json::{json, Value};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::handshake::server::{ErrorResponse, Request, Response};
+use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
+use tokio_tungstenite::tungstenite::protocol::CloseFrame;
+use tokio_tungstenite::tungstenite::{Bytes, Message};
+use tokio_tungstenite::WebSocketStream;
+
+use super::relay::{self, Frame, RelayState, RelayTiming};
+use super::secure::{self, HostKey, SecureChannel};
+use super::tests::{device, Device, StubDispatch};
+use super::{RemoteState, DEFAULT_RELAY_URL};
+
+/// Every await in these tests is bounded: a link that never arrives should fail
+/// the test, not hang the suite.
+const PATIENCE: Duration = Duration::from_secs(5);
+
+async fn within<F: Future>(what: &str, f: F) -> F::Output {
+    tokio::time::timeout(PATIENCE, f)
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {what}"))
+}
+
+/// Short enough that the reconnect and wind-down paths run inside a test, long
+/// enough that the `error` window between attempts is observable by a poll.
+fn fast() -> RelayTiming {
+    RelayTiming {
+        backoff_initial: Duration::from_millis(100),
+        backoff_max: Duration::from_millis(100),
+        auth_timeout: Duration::from_secs(2),
+        // Longer than any test: the host↔relay keepalive is not what these
+        // exercise, and a stray ping would only add noise to the frame stream.
+        ping_interval: Duration::from_secs(30),
+        shutdown_grace: Duration::from_millis(500),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The fake relay
+// ---------------------------------------------------------------------------
+
+/// How the fake relay answers the host's proof.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Verdict {
+    /// Verify the proof exactly as the doc specifies, then send `ready`.
+    Accept,
+    /// Close 4003 without looking, as the relay does for a bad proof.
+    Reject,
+}
+
+struct FakeRelay {
+    url: String,
+    links: mpsc::Receiver<HostLink>,
+    /// Upgrades accepted, so a reconnect can be asserted even when the link
+    /// never gets as far as `ready`.
+    attempts: Arc<AtomicU32>,
+}
+
+impl FakeRelay {
+    async fn start(verdict: Verdict) -> Self {
+        let listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let (tx, links) = mpsc::channel(4);
+        let attempts = Arc::new(AtomicU32::new(0));
+        tokio::spawn(accept_loop(listener, verdict, tx, attempts.clone()));
+        Self {
+            url: format!("ws://127.0.0.1:{port}"),
+            links,
+            attempts,
+        }
+    }
+
+    async fn next_link(&mut self) -> HostLink {
+        within("a host link", self.links.recv())
+            .await
+            .expect("the relay's accept loop died")
+    }
+}
+
+/// The relay's own static key. Fixed rather than random so a failing test can
+/// be replayed, and so the proof vector below is reproducible.
+const RELAY_PRIVATE: [u8; 32] = [
+    0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+    0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02, 0x02,
+];
+const RELAY_NONCE: [u8; 32] = [
+    0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
+    0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03, 0x03,
+];
+
+/// The `Err` of tungstenite's upgrade callback is an `http::Response`, which
+/// clippy finds large; it is the crate's signature, not ours (see
+/// `server::check_path`, which carries the same allow).
+#[allow(clippy::result_large_err)]
+async fn accept_loop(
+    listener: TcpListener,
+    verdict: Verdict,
+    links: mpsc::Sender<HostLink>,
+    attempts: Arc<AtomicU32>,
+) {
+    let relay_key = HostKey::from_private(RELAY_PRIVATE).unwrap();
+    while let Ok((tcp, _)) = listener.accept().await {
+        attempts.fetch_add(1, Ordering::SeqCst);
+        let seen = Arc::new(Mutex::new(String::new()));
+        let path = seen.clone();
+        let capture = move |req: &Request, response: Response| -> Result<Response, ErrorResponse> {
+            *path.lock() = req.uri().path().to_string();
+            Ok(response)
+        };
+        let Ok(mut ws) = tokio_tungstenite::accept_hdr_async(tcp, capture).await else {
+            continue;
+        };
+        let path = seen.lock().clone();
+
+        // 1. challenge
+        let challenge = json!({
+            "type": "challenge",
+            "nonce": B64.encode(RELAY_NONCE),
+            "relayKey": B64.encode(relay_key.public_bytes()),
+        });
+        ws.send(Message::Text(challenge.to_string().into()))
+            .await
+            .unwrap();
+
+        // 2. proof, verified from the relay's side of the same DH: the host ID
+        //    in the path *is* the public key to check against, so the relay
+        //    stores nothing.
+        let proof = match next_text(&mut ws).await {
+            Some(text) => text,
+            None => continue,
+        };
+        let host_public: [u8; 32] = B64
+            .decode(path.rsplit('/').next().unwrap_or_default())
+            .expect("the host id in the path is base64url")
+            .try_into()
+            .expect("the host id is 32 bytes");
+        let shared = relay_key.diffie_hellman(&host_public).unwrap();
+        let mut digest = <sha2::Sha256 as sha2::Digest>::new();
+        sha2::Digest::update(&mut digest, shared);
+        sha2::Digest::update(&mut digest, RELAY_NONCE);
+        sha2::Digest::update(&mut digest, host_public);
+        let expected = B64.encode(sha2::Digest::finalize(digest));
+        let offered: Value = serde_json::from_str(&proof).expect("the proof frame is JSON");
+        let good = offered["type"] == "proof" && offered["proof"] == expected;
+
+        // 3. ready, or 4003
+        if verdict == Verdict::Reject || !good {
+            let _ = ws
+                .send(Message::Close(Some(CloseFrame {
+                    code: CloseCode::Library(4003),
+                    reason: "bad proof".into(),
+                })))
+                .await;
+            continue;
+        }
+        ws.send(Message::Text("{\"type\":\"ready\"}".into()))
+            .await
+            .unwrap();
+        if links
+            .send(HostLink {
+                ws,
+                path,
+                pending: VecDeque::new(),
+            })
+            .await
+            .is_err()
+        {
+            return;
+        }
+    }
+}
+
+async fn next_text(ws: &mut WebSocketStream<TcpStream>) -> Option<String> {
+    while let Some(Ok(msg)) = ws.next().await {
+        match msg {
+            Message::Text(text) => return Some(text.to_string()),
+            Message::Ping(_) | Message::Pong(_) => continue,
+            _ => return None,
+        }
+    }
+    None
+}
+
+/// One accepted host link, from the relay's side.
+struct HostLink {
+    ws: WebSocketStream<TcpStream>,
+    path: String,
+    /// Frames for a connection other than the one currently being read, kept
+    /// so two devices can be driven in any order.
+    pending: VecDeque<Frame>,
+}
+
+impl HostLink {
+    async fn send(&mut self, frame: Frame) {
+        self.ws
+            .send(Message::Binary(frame.encode()))
+            .await
+            .expect("the host link accepts frames");
+    }
+
+    /// The next frame, or `None` once the link is over.
+    async fn read(&mut self) -> Option<Frame> {
+        loop {
+            match within("a link frame", self.ws.next()).await {
+                Some(Ok(Message::Binary(bytes))) => {
+                    return Some(Frame::decode(&bytes).expect("a decodable frame"))
+                }
+                Some(Ok(Message::Ping(_))) | Some(Ok(Message::Pong(_))) => continue,
+                Some(Ok(Message::Close(_))) | None => return None,
+                Some(Ok(other)) => panic!("unexpected message on the link: {other:?}"),
+                Some(Err(_)) => return None,
+            }
+        }
+    }
+
+    /// The next frame belonging to `conn`, buffering the others.
+    async fn read_for(&mut self, conn: u32) -> Frame {
+        if let Some(i) = self.pending.iter().position(|f| f.conn() == conn) {
+            return self.pending.remove(i).unwrap();
+        }
+        loop {
+            let frame = self.read().await.expect("the link ended early");
+            if frame.conn() == conn {
+                return frame;
+            }
+            self.pending.push_back(frame);
+        }
+    }
+
+    async fn data_for(&mut self, conn: u32) -> Bytes {
+        match self.read_for(conn).await {
+            Frame::Data { payload, .. } => payload,
+            other => panic!("expected DATA for {conn}, got {other:?}"),
+        }
+    }
+
+    async fn close_for(&mut self, conn: u32) -> (u16, String) {
+        match self.read_for(conn).await {
+            Frame::Close { code, reason, .. } => (code, reason),
+            other => panic!("expected CLOSE for {conn}, got {other:?}"),
+        }
+    }
+
+    /// Every frame until the link goes away, so a wind-down can be asserted in
+    /// full without depending on the order two connections finish in.
+    async fn drain(&mut self) -> Vec<Frame> {
+        let mut frames: Vec<Frame> = self.pending.drain(..).collect();
+        while let Some(frame) = self.read().await {
+            frames.push(frame);
+        }
+        frames
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A phone on the far side of the relay
+// ---------------------------------------------------------------------------
+
+/// A device link as the relay presents it: one virtual connection carrying the
+/// same Noise channel a LAN socket would.
+struct Phone {
+    conn: u32,
+    channel: SecureChannel,
+}
+
+impl Phone {
+    /// OPEN the connection and run the initiator's half of the handshake, each
+    /// message wrapped in a DATA frame.
+    async fn open(link: &mut HostLink, conn: u32, phone: &Device) -> Self {
+        link.send(Frame::Open { conn }).await;
+        let mut handshake = secure::initiator(&phone.private).unwrap();
+        let mut buf = [0u8; 65535];
+
+        let n = handshake.write_message(&[], &mut buf).unwrap();
+        link.send(Frame::Data {
+            conn,
+            payload: Bytes::copy_from_slice(&buf[..n]),
+        })
+        .await;
+
+        let second = link.data_for(conn).await;
+        handshake.read_message(&second, &mut buf).unwrap();
+
+        let n = handshake.write_message(&[], &mut buf).unwrap();
+        link.send(Frame::Data {
+            conn,
+            payload: Bytes::copy_from_slice(&buf[..n]),
+        })
+        .await;
+
+        Self {
+            conn,
+            channel: SecureChannel::new(handshake.into_transport_mode().unwrap()),
+        }
+    }
+
+    async fn request(&mut self, link: &mut HostLink, id: &str, op: &str, args: Value) {
+        let frame = json!({ "id": id, "op": op, "args": args }).to_string();
+        let payload = self.channel.encrypt_frame(frame.as_bytes()).unwrap();
+        link.send(Frame::Data {
+            conn: self.conn,
+            payload: Bytes::from(payload),
+        })
+        .await;
+    }
+
+    async fn next_json(&mut self, link: &mut HostLink) -> Value {
+        let payload = link.data_for(self.conn).await;
+        let plaintext = self.channel.decrypt_frame(&payload).unwrap();
+        serde_json::from_slice(&plaintext).unwrap()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// A host with a relay configured
+// ---------------------------------------------------------------------------
+
+struct Host {
+    _dir: tempfile::TempDir,
+    state: Arc<RemoteState>,
+}
+
+/// A started host pointed at `url`, with the relay's waits shortened.
+fn boot(url: &str) -> Host {
+    let dir = tempfile::tempdir().unwrap();
+    let state = RemoteState::new(dir.path(), Arc::new(StubDispatch));
+    state.set_relay_timing(fast());
+    state.set_relay(Some(url.to_string())).unwrap();
+    state.start(0).unwrap();
+    Host { _dir: dir, state }
+}
+
+/// Poll `status()` until `check` holds. The link is a task, so everything it
+/// publishes lands a moment after the call that caused it.
+async fn until(state: &Arc<RemoteState>, what: &str, check: impl Fn(&super::RemoteStatus) -> bool) {
+    for _ in 0..500 {
+        if check(&state.status()) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("{what} never happened: {:?}", state.status().relay);
+}
+
+// ---------------------------------------------------------------------------
+// Authentication
+// ---------------------------------------------------------------------------
+
+/// The known-answer vector for the host link challenge, from fixed keys, so the
+/// relay implementation can be checked against exactly these bytes:
+///
+/// - host private  `AQEB…` (32 × 0x01)
+/// - relay private `AgIC…` (32 × 0x02)
+/// - nonce         `AwMD…` (32 × 0x03)
+///
+/// `proof = base64url( SHA-256( X25519(hostPrivate, relayPublic) || nonce || hostPublic ) )`.
+///
+/// The relay's own published vector (`relay/test-vector.json`, produced with
+/// Node's crypto and verified in workerd) must come out of this implementation
+/// byte for byte — the one place the two codebases are checked against the
+/// same numbers rather than each against itself. The fixed-key test below it
+/// is the desktop's own vector, printed for comparison.
+#[test]
+fn the_challenge_proof_matches_the_relays_published_vector() {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/../relay/test-vector.json");
+    let raw = std::fs::read_to_string(path).expect("relay/test-vector.json is in the repo");
+    let vector: serde_json::Value = serde_json::from_str(&raw).unwrap();
+    let field = |name: &str| -> [u8; 32] {
+        B64.decode(vector[name].as_str().unwrap())
+            .unwrap()
+            .try_into()
+            .unwrap_or_else(|_| panic!("{name} is not 32 bytes"))
+    };
+
+    let host = HostKey::from_private(field("hostPrivate")).unwrap();
+    assert_eq!(*host.public_bytes(), field("hostId"), "host public key");
+    let relay_key = field("relayKey");
+    assert_eq!(
+        host.diffie_hellman(&relay_key).unwrap(),
+        field("shared"),
+        "X25519 shared secret"
+    );
+    let proof = relay::challenge_proof(&host, &relay_key, &field("nonce")).unwrap();
+    assert_eq!(proof, field("proof"), "proof");
+}
+
+#[test]
+fn the_challenge_proof_matches_a_known_answer_vector() {
+    let host = HostKey::from_private([0x01; 32]).unwrap();
+    let relay = HostKey::from_private([0x02; 32]).unwrap();
+    let nonce = [0x03u8; 32];
+
+    // Both ends must reach the same secret from opposite sides, which is the
+    // whole point of the challenge: the relay verifies with its own private key
+    // against the host ID it is routing on.
+    let from_host = host.diffie_hellman(relay.public_bytes()).unwrap();
+    let from_relay = relay.diffie_hellman(host.public_bytes()).unwrap();
+    assert_eq!(from_host, from_relay, "X25519 is not symmetric?");
+
+    let proof = relay::challenge_proof(&host, relay.public_bytes(), &nonce).unwrap();
+    println!("host private:  {}", B64.encode([0x01u8; 32]));
+    println!("host public:   {}", B64.encode(host.public_bytes()));
+    println!("relay private: {}", B64.encode([0x02u8; 32]));
+    println!("relay public:  {}", B64.encode(relay.public_bytes()));
+    println!("nonce:         {}", B64.encode(nonce));
+    println!("shared:        {}", B64.encode(from_host));
+    println!("proof:         {}", B64.encode(proof));
+
+    assert_eq!(
+        B64.encode(host.public_bytes()),
+        "pOCSkrZRwni5dyxWn1-puxPZBrRqtoyd-dwrRAn4ogk"
+    );
+    assert_eq!(
+        B64.encode(relay.public_bytes()),
+        "zo060cy2M-x7cMF4FKXHbs0CloUFDTRHRboFhw5YfVk"
+    );
+    assert_eq!(
+        B64.encode(from_host),
+        "LtdqtUmx5zwDHrSclEjweYrqgbaYJ5oMPcPkn7_EuVM"
+    );
+    assert_eq!(
+        B64.encode(proof),
+        "BzDo2Jh0uedvZ-WrLiP4wkMcCFhvU9L9REMa8_die2U"
+    );
+}
+
+#[test]
+fn the_host_endpoint_is_the_documented_one() {
+    assert_eq!(
+        relay::host_endpoint("wss://relay.fletch.app", "abc"),
+        "wss://relay.fletch.app/v1/host/abc"
+    );
+    assert_eq!(
+        relay::host_endpoint("wss://relay.fletch.app/", "abc"),
+        "wss://relay.fletch.app/v1/host/abc"
+    );
+}
+
+/// The link is only up once the relay has verified the proof, and what it
+/// verified against is the host ID in the path.
+#[tokio::test]
+async fn the_link_authenticates_with_the_host_key_and_reports_connected() {
+    let mut relay = FakeRelay::start(Verdict::Accept).await;
+    let host = boot(&relay.url);
+    let link = relay.next_link().await;
+
+    assert_eq!(
+        link.path,
+        format!("/v1/host/{}", host.state.status().host_id)
+    );
+    until(&host.state, "the relay link connects", |s| {
+        s.relay.state == RelayState::Connected
+    })
+    .await;
+    let status = host.state.status();
+    assert_eq!(status.relay.url.as_deref(), Some(relay.url.as_str()));
+    assert_eq!(status.relay.error, None);
+}
+
+/// A relay that will not take the proof is a standing error the pane can show,
+/// and the host keeps trying: the operator may be fixing the relay.
+#[tokio::test]
+async fn a_rejected_proof_becomes_an_error_and_the_host_retries() {
+    let relay = FakeRelay::start(Verdict::Reject).await;
+    let host = boot(&relay.url);
+
+    until(&host.state, "the rejection surfaces", |s| {
+        s.relay.state == RelayState::Error
+            && s.relay
+                .error
+                .as_deref()
+                .is_some_and(|e| e.contains("rejected"))
+    })
+    .await;
+    // The URL stays on the status while the link is between attempts.
+    assert_eq!(
+        host.state.status().relay.url.as_deref(),
+        Some(relay.url.as_str())
+    );
+
+    for _ in 0..200 {
+        if relay.attempts.load(Ordering::SeqCst) >= 2 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    panic!("the host stopped after one rejected attempt");
+}
+
+/// The link dropping is not the end of it either.
+#[tokio::test]
+async fn a_dropped_link_reconnects() {
+    let mut relay = FakeRelay::start(Verdict::Accept).await;
+    let host = boot(&relay.url);
+    let mut first = relay.next_link().await;
+    until(&host.state, "the first link connects", |s| {
+        s.relay.state == RelayState::Connected
+    })
+    .await;
+
+    // The relay hangs up, as a Durable Object being evicted would.
+    let _ = first.ws.close(None).await;
+    drop(first);
+
+    let second = relay.next_link().await;
+    assert!(second.path.starts_with("/v1/host/"));
+    until(&host.state, "the link comes back", |s| {
+        s.relay.state == RelayState::Connected
+    })
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// Virtual connections
+// ---------------------------------------------------------------------------
+
+/// The whole point: a device that arrives over the relay is served by the same
+/// state machine a LAN socket is, Noise handshake and all.
+#[tokio::test]
+async fn a_relayed_device_handshakes_and_says_hello() {
+    let mut relay = FakeRelay::start(Verdict::Accept).await;
+    let host = boot(&relay.url);
+    let mut link = relay.next_link().await;
+
+    let phone = device();
+    host.state
+        .devices()
+        .register("phone", "ios", &phone.public)
+        .unwrap();
+
+    let mut conn = Phone::open(&mut link, 1, &phone).await;
+    conn.request(&mut link, "1", "hello", json!({})).await;
+    let hello = conn.next_json(&mut link).await;
+    assert_eq!(hello["id"], "1");
+    assert_eq!(hello["ok"], true);
+    assert!(hello["result"]["workspace"].is_object());
+
+    // And it is a session like any other: visible as connected, and on the
+    // event fan-out.
+    until(&host.state, "the relayed device counts as connected", |s| {
+        s.devices.first().is_some_and(|d| d.connected)
+    })
+    .await;
+    host.state
+        .forward_event("agent:status", r#"{"agentId":"arabia","status":"running"}"#);
+    let event = conn.next_json(&mut link).await;
+    assert_eq!(event["event"], "agent:status");
+
+    conn.request(&mut link, "2", "get_workspace", json!({}))
+        .await;
+    let reply = conn.next_json(&mut link).await;
+    assert_eq!(reply["id"], "2");
+    assert_eq!(reply["result"]["agents"], json!([]));
+}
+
+#[tokio::test]
+async fn two_relayed_devices_are_served_independently() {
+    let mut relay = FakeRelay::start(Verdict::Accept).await;
+    let host = boot(&relay.url);
+    let mut link = relay.next_link().await;
+
+    let (one, two) = (device(), device());
+    host.state
+        .devices()
+        .register("phone", "ios", &one.public)
+        .unwrap();
+    host.state
+        .devices()
+        .register("tablet", "android", &two.public)
+        .unwrap();
+
+    // Interleaved on purpose: the two handshakes share one link, and a mux that
+    // mixed the connections up would produce a Noise failure rather than a
+    // wrong answer.
+    let mut first = Phone::open(&mut link, 1, &one).await;
+    let mut second = Phone::open(&mut link, 2, &two).await;
+    first.request(&mut link, "a", "hello", json!({})).await;
+    second.request(&mut link, "b", "hello", json!({})).await;
+    assert_eq!(second.next_json(&mut link).await["id"], "b");
+    assert_eq!(first.next_json(&mut link).await["id"], "a");
+
+    first
+        .request(&mut link, "a2", "get_workspace", json!({}))
+        .await;
+    second
+        .request(&mut link, "b2", "get_workspace", json!({}))
+        .await;
+    assert_eq!(first.next_json(&mut link).await["id"], "a2");
+    assert_eq!(second.next_json(&mut link).await["id"], "b2");
+}
+
+/// Revoking reaches through the relay exactly as it reaches a socket, and it
+/// reaches only the revoked device's connection.
+#[tokio::test]
+async fn revoking_closes_only_that_virtual_connection() {
+    let mut relay = FakeRelay::start(Verdict::Accept).await;
+    let host = boot(&relay.url);
+    let mut link = relay.next_link().await;
+
+    let (one, two) = (device(), device());
+    let doomed = host
+        .state
+        .devices()
+        .register("phone", "ios", &one.public)
+        .unwrap();
+    host.state
+        .devices()
+        .register("tablet", "android", &two.public)
+        .unwrap();
+
+    let mut first = Phone::open(&mut link, 1, &one).await;
+    let mut second = Phone::open(&mut link, 2, &two).await;
+    first.request(&mut link, "a", "hello", json!({})).await;
+    assert_eq!(first.next_json(&mut link).await["ok"], true);
+    second.request(&mut link, "b", "hello", json!({})).await;
+    assert_eq!(second.next_json(&mut link).await["ok"], true);
+
+    host.state.revoke_device(&doomed.device_id).unwrap();
+    assert_eq!(
+        link.close_for(1).await,
+        (4003, "device revoked".to_string())
+    );
+
+    second
+        .request(&mut link, "b2", "get_workspace", json!({}))
+        .await;
+    assert_eq!(second.next_json(&mut link).await["id"], "b2");
+}
+
+/// Turning remote access off sends the host's own 4004 out over every virtual
+/// connection *before* the link goes, which is what lets the phone tell "the
+/// Mac said no" from "the relay lost the Mac".
+#[tokio::test]
+async fn stopping_closes_every_virtual_connection_with_4004_then_drops_the_link() {
+    let mut relay = FakeRelay::start(Verdict::Accept).await;
+    let host = boot(&relay.url);
+    let mut link = relay.next_link().await;
+
+    let (one, two) = (device(), device());
+    for (name, phone) in [("phone", &one), ("tablet", &two)] {
+        host.state
+            .devices()
+            .register(name, "ios", &phone.public)
+            .unwrap();
+    }
+    let mut first = Phone::open(&mut link, 1, &one).await;
+    let mut second = Phone::open(&mut link, 2, &two).await;
+    first.request(&mut link, "a", "hello", json!({})).await;
+    assert_eq!(first.next_json(&mut link).await["ok"], true);
+    second.request(&mut link, "b", "hello", json!({})).await;
+    assert_eq!(second.next_json(&mut link).await["ok"], true);
+
+    host.state.stop();
+
+    // Both closes land, then the link itself ends — `drain` returns when the
+    // relay's read side sees the close.
+    let frames = link.drain().await;
+    let closes: Vec<(u32, u16)> = frames
+        .iter()
+        .filter_map(|f| match f {
+            Frame::Close { conn, code, .. } => Some((*conn, *code)),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        closes.contains(&(1, 4004)) && closes.contains(&(2, 4004)),
+        "expected a 4004 for each virtual connection, got {frames:?}"
+    );
+    assert_eq!(
+        host.state.status().relay.state,
+        RelayState::Off,
+        "with remote access off there is no link to report on"
+    );
+}
+
+/// A device link that drops arrives as CLOSE 1006 from the relay. The session
+/// ends with it — nothing on the host waits for a socket that is gone.
+#[tokio::test]
+async fn a_relay_close_ends_the_session() {
+    let mut relay = FakeRelay::start(Verdict::Accept).await;
+    let host = boot(&relay.url);
+    let mut link = relay.next_link().await;
+
+    let phone = device();
+    host.state
+        .devices()
+        .register("phone", "ios", &phone.public)
+        .unwrap();
+    let mut conn = Phone::open(&mut link, 1, &phone).await;
+    conn.request(&mut link, "1", "hello", json!({})).await;
+    assert_eq!(conn.next_json(&mut link).await["ok"], true);
+    until(&host.state, "the device registers as connected", |s| {
+        s.devices.first().is_some_and(|d| d.connected)
+    })
+    .await;
+
+    link.send(Frame::Close {
+        conn: 1,
+        code: 1006,
+        reason: "device link dropped".to_string(),
+    })
+    .await;
+
+    until(&host.state, "the session ends", |s| {
+        s.devices.iter().all(|d| !d.connected)
+    })
+    .await;
+    // The relay closed it, so the host does not answer with a close of its own.
+    assert_eq!(
+        host.state.status().relay.state,
+        RelayState::Connected,
+        "one device going away is not the link going away"
+    );
+}
+
+/// DATA (or CLOSE) for a connection the host has finished with is ignored, not
+/// fatal: the relay may still be forwarding a device's last message.
+#[tokio::test]
+async fn frames_for_an_unknown_connection_are_ignored() {
+    let mut relay = FakeRelay::start(Verdict::Accept).await;
+    let host = boot(&relay.url);
+    let mut link = relay.next_link().await;
+
+    link.send(Frame::Data {
+        conn: 99,
+        payload: Bytes::from_static(b"who is this for"),
+    })
+    .await;
+    link.send(Frame::Close {
+        conn: 98,
+        code: 1006,
+        reason: "gone".to_string(),
+    })
+    .await;
+
+    // The link still works, which is the whole assertion.
+    let phone = device();
+    host.state
+        .devices()
+        .register("phone", "ios", &phone.public)
+        .unwrap();
+    let mut conn = Phone::open(&mut link, 1, &phone).await;
+    conn.request(&mut link, "1", "hello", json!({})).await;
+    assert_eq!(conn.next_json(&mut link).await["ok"], true);
+    assert_eq!(host.state.status().relay.state, RelayState::Connected);
+}
+
+// ---------------------------------------------------------------------------
+// The setting
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn the_relay_url_is_normalized_and_validated() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = RemoteState::new(dir.path(), Arc::new(StubDispatch));
+
+    // Absent, empty and whitespace all mean "no relay", and the status says so
+    // without a link ever starting.
+    for url in [None, Some(String::new()), Some("   ".to_string())] {
+        state.set_relay(url).unwrap();
+        let relay = state.status().relay;
+        assert_eq!(relay.url, None);
+        assert_eq!(relay.state, RelayState::Off);
+    }
+
+    // The scheme is the one thing worth refusing: a typo here is a link that
+    // could never connect, and the pane can say so at once.
+    for bad in ["relay.fletch.app", "https://relay.fletch.app", "wss:/x"] {
+        assert!(
+            state.set_relay(Some(bad.to_string())).is_err(),
+            "{bad} should be refused"
+        );
+    }
+
+    state
+        .set_relay(Some(format!("  {DEFAULT_RELAY_URL}/  ")))
+        .unwrap();
+    assert_eq!(
+        state.status().relay.url.as_deref(),
+        Some(DEFAULT_RELAY_URL),
+        "trimmed, with the trailing slash off"
+    );
+    assert_eq!(
+        state.status().relay.state,
+        RelayState::Off,
+        "a URL alone starts nothing: remote access is still off"
+    );
+
+    // And the pairing link carries it, url-encoded, only once it is set.
+    assert!(state.begin_pairing().url.contains(&format!(
+        "&relay={}",
+        DEFAULT_RELAY_URL.replace(':', "%3A").replace('/', "%2F")
+    )));
+    state.set_relay(None).unwrap();
+    assert!(!state.begin_pairing().url.contains("relay="));
+}

--- a/src-tauri/src/remote/secure.rs
+++ b/src-tauri/src/remote/secure.rs
@@ -95,6 +95,27 @@ impl HostKey {
         encode_key(&self.public)
     }
 
+    /// The raw public key — the host ID before it is base64url'd. The relay's
+    /// host-link challenge hashes these bytes, not the string.
+    pub(super) fn public_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.public
+    }
+
+    /// `X25519(host private, their_public)`: the shared secret the relay's host
+    /// link challenge is answered with (`docs/remote-protocol.md` → "Relay").
+    ///
+    /// Goes through the same DH implementation the handshake and
+    /// `public_from_private` use, so the relay proof needs no second crypto
+    /// dependency and cannot disagree with the identity it is proving.
+    pub(super) fn diffie_hellman(&self, their_public: &[u8; KEY_LEN]) -> Result<[u8; KEY_LEN]> {
+        let mut dh = curve25519()?;
+        dh.set(&self.private);
+        let mut shared = [0u8; KEY_LEN];
+        dh.dh(their_public, &mut shared)
+            .map_err(|e| noise_error("relay challenge dh", e))?;
+        Ok(shared)
+    }
+
     /// A responder handshake state carrying this identity.
     pub(super) fn responder(&self) -> Result<HandshakeState> {
         noise_builder()?
@@ -103,7 +124,9 @@ impl HostKey {
             .map_err(|e| noise_error("host handshake state", e))
     }
 
-    fn from_private(private: [u8; KEY_LEN]) -> Result<Self> {
+    /// An identity from raw private bytes, without touching the disk. The relay
+    /// tests build both ends' keys this way.
+    pub(super) fn from_private(private: [u8; KEY_LEN]) -> Result<Self> {
         let public = public_from_private(&private)?;
         Ok(Self { private, public })
     }
@@ -128,16 +151,23 @@ fn write_private(path: &Path, private: &[u8; KEY_LEN]) -> Result<()> {
 /// disk (the doc fixes the file at 32 bytes), so the public half is derived at
 /// load through the same DH implementation the handshake uses.
 fn public_from_private(private: &[u8; KEY_LEN]) -> Result<[u8; KEY_LEN]> {
-    use snow::params::DHChoice;
-    use snow::resolvers::{CryptoResolver, DefaultResolver};
-
-    let mut dh = DefaultResolver
-        .resolve_dh(&DHChoice::Curve25519)
-        .ok_or_else(|| Error::Other("remote: no X25519 implementation".to_string()))?;
+    let mut dh = curve25519()?;
     dh.set(private);
     dh.pubkey()
         .try_into()
         .map_err(|_| Error::Other("remote: X25519 public key is not 32 bytes".to_string()))
+}
+
+/// The X25519 primitive `snow` would use inside the handshake, on its own — for
+/// the two places that need a bare DH: deriving the public key from the stored
+/// private one, and answering the relay's challenge.
+fn curve25519() -> Result<Box<dyn snow::types::Dh>> {
+    use snow::params::DHChoice;
+    use snow::resolvers::{CryptoResolver, DefaultResolver};
+
+    DefaultResolver
+        .resolve_dh(&DHChoice::Curve25519)
+        .ok_or_else(|| Error::Other("remote: no X25519 implementation".to_string()))
 }
 
 /// A fresh static keypair. Used for the host key, and by the tests for a device.

--- a/src-tauri/src/remote/tests.rs
+++ b/src-tauri/src/remote/tests.rs
@@ -373,7 +373,7 @@ fn never_exposed_ops_are_not_dispatchable() {
 
 /// Answers only `get_workspace`, so the server can be exercised without a live
 /// `Supervisor`. Production runs `SupervisorDispatch`.
-struct StubDispatch;
+pub(super) struct StubDispatch;
 
 impl Dispatch for StubDispatch {
     fn dispatch<'a>(&'a self, op: &'a str, _args: Value) -> DispatchFuture<'a> {
@@ -420,12 +420,12 @@ fn boot_with(dispatch: Arc<dyn Dispatch>) -> Host {
 
 /// One phone's static identity: the keypair whose public half the host records
 /// and whose private half proves it in the handshake.
-struct Device {
-    private: Vec<u8>,
-    public: [u8; 32],
+pub(super) struct Device {
+    pub(super) private: Vec<u8>,
+    pub(super) public: [u8; 32],
 }
 
-fn device() -> Device {
+pub(super) fn device() -> Device {
     let keypair = secure::generate_keypair().unwrap();
     Device {
         public: keypair.public.clone().try_into().unwrap(),

--- a/src/api/domains/remote.ts
+++ b/src/api/domains/remote.ts
@@ -2,12 +2,16 @@ import { invoke } from "../invoke";
 import type { PairingInvite, RemoteStatus } from "../types/remote";
 
 /** Host-side control of the paired-device remote server. These are not remote
- *  ops — they are how the desktop turns the listener on, mints pairing codes
- *  and revokes devices. The mutating three answer with the resulting status so
- *  the pane never has to re-read (and never renders a state in between). */
+ *  ops — they are how the desktop turns the listener on, points it at a relay,
+ *  mints pairing codes and revokes devices. The mutating ones answer with the
+ *  resulting status so the pane never has to re-read (and never renders a state
+ *  in between). */
 export const remoteApi = {
   remoteStatus: () => invoke<RemoteStatus>("remote_status"),
   remoteSetEnabled: (enabled: boolean) => invoke<RemoteStatus>("remote_set_enabled", { enabled }),
+  /** Point this Mac at a relay so a phone can reach it off the local network,
+   *  or `null` to stop. Rejects a URL that is not `ws://` or `wss://`. */
+  remoteSetRelay: (url: string | null) => invoke<RemoteStatus>("remote_set_relay", { url }),
   /** Rejects while the listener is down: a code nothing can be typed into is
    *  worse than an error. */
   remoteBeginPairing: () => invoke<PairingInvite>("remote_begin_pairing"),

--- a/src/api/types/remote.ts
+++ b/src/api/types/remote.ts
@@ -16,6 +16,24 @@ export interface RemoteDevice {
   connected: boolean;
 }
 
+/** The relay the desktop offers when the switch goes on. Mirrors
+ *  `DEFAULT_RELAY_URL` in `src-tauri/src/remote/mod.rs`; only a suggestion —
+ *  the persisted setting is what decides, and anyone can run their own. */
+export const DEFAULT_RELAY_URL = "wss://relay.fletch.app";
+
+/** How the outbound host link is doing. `off` means no URL is set, or remote
+ *  access itself is off; `error` stands between reconnect attempts. */
+export type RelayState = "off" | "connecting" | "connected" | "error";
+
+/** `remote_status.relay`: the configured relay and the link to it. */
+export interface RelayStatus {
+  /** The configured base URL, reported whether or not the link is running. */
+  url: string | null;
+  state: RelayState;
+  /** The last failure, while the link is between reconnect attempts. */
+  error: string | null;
+}
+
 export interface RemoteStatus {
   /** The user's intent, independent of whether the bind currently holds. */
   enabled: boolean;
@@ -28,6 +46,8 @@ export interface RemoteStatus {
   /** Every IPv4 a phone could dial, best candidate (LAN) first. */
   addresses: string[];
   devices: RemoteDevice[];
+  /** The relay that carries devices off this network, and the host link to it. */
+  relay: RelayStatus;
   /** A standing problem with the remote surface itself, shown inline in the
    *  pane. Currently only one: paired devices cannot be stored, which also
    *  makes `remoteBeginPairing` refuse. */
@@ -37,8 +57,9 @@ export interface RemoteStatus {
 /** A minted pairing code: 8 characters from `A-Z2-9`, single use, five minutes. */
 export interface PairingInvite {
   token: string;
-  /** `fletch://pair?host=…&addr=…&token=…&name=…` — what the QR encodes.
-   *  `host` is the host ID (the public key), `addr` the `ip:port` to dial. */
+  /** `fletch://pair?host=…&addr=…&relay=…&token=…&name=…` — what the QR
+   *  encodes. `host` is the host ID (the public key), `addr` the `ip:port` to
+   *  dial, and `relay` is present only when one is configured. */
   url: string;
   /** RFC3339. */
   expiresAt: string;

--- a/src/components/SettingsScreen/MobileDevices/RelayRow.tsx
+++ b/src/components/SettingsScreen/MobileDevices/RelayRow.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { DEFAULT_RELAY_URL, type RelayState, type RelayStatus } from "@/api";
+import { SetRow, SetToggle } from "../primitives";
+
+/** What the pill says for each link state. `off` shows nothing: the switch is
+ *  already saying it. */
+const PILL: Record<RelayState, string> = {
+  off: "",
+  connecting: "connecting…",
+  connected: "connected",
+  error: "not connected",
+};
+
+/** Settings › Mobile devices › the relay switch.
+ *
+ *  The relay is a dumb pipe: it routes on this Mac's public key and sees only
+ *  the same ciphertext the LAN path carries, so turning it on adds reach and
+ *  not trust — hence one switch, the URL for anyone running their own, and the
+ *  link's state in plain words. */
+export function RelayRow({
+  relay,
+  disabled,
+  onSet,
+}: {
+  relay: RelayStatus;
+  /** Remote access is off, so there is nothing for a relay to carry. */
+  disabled?: boolean;
+  onSet: (url: string | null) => void;
+}) {
+  const on = relay.url !== null;
+  const [draft, setDraft] = useState(relay.url ?? DEFAULT_RELAY_URL);
+
+  // The host is the source of truth for the URL (it normalizes what it stores,
+  // and the setting outlives this pane), so the field follows it.
+  useEffect(() => {
+    if (relay.url) setDraft(relay.url);
+  }, [relay.url]);
+
+  const commit = () => {
+    const next = draft.trim();
+    if (!next || next === relay.url) return;
+    onSet(next);
+  };
+
+  return (
+    <>
+      <SetRow
+        title="Reach this Mac from anywhere"
+        sub="Keeps one outbound connection to a relay, so a paired phone can reach this Mac off your network. The relay only forwards bytes: every frame stays encrypted between the phone and this Mac."
+      >
+        <SetToggle
+          on={on}
+          disabled={disabled}
+          onClick={() => onSet(on ? null : DEFAULT_RELAY_URL)}
+        />
+      </SetRow>
+
+      {on && (
+        <SetRow title="Relay" sub="Point this at your own relay if you run one.">
+          <input
+            className="set-relay-url mono text-sm"
+            value={draft}
+            spellCheck={false}
+            autoCapitalize="off"
+            autoCorrect="off"
+            disabled={disabled}
+            aria-label="Relay URL"
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commit();
+              else if (e.key === "Escape") setDraft(relay.url ?? DEFAULT_RELAY_URL);
+            }}
+          />
+          <span className="set-relay-pill text-sm" data-state={relay.state}>
+            {relay.state === "error" ? (relay.error ?? PILL.error) : PILL[relay.state]}
+          </span>
+        </SetRow>
+      )}
+    </>
+  );
+}

--- a/src/components/SettingsScreen/MobileDevices/index.tsx
+++ b/src/components/SettingsScreen/MobileDevices/index.tsx
@@ -2,6 +2,7 @@ import { Button } from "@/components/ui/Button";
 import { SetGroup, SetRow, SetToggle } from "../primitives";
 import { DeviceRow } from "./DeviceRow";
 import { PairingCard } from "./PairingCard";
+import { RelayRow } from "./RelayRow";
 import { useRemote } from "./useRemote";
 
 /** Settings › General › Mobile devices: run the paired-device WebSocket server
@@ -12,7 +13,7 @@ import { useRemote } from "./useRemote";
  *  the switch opens, and pairing that is an explicit, expiring, single-use act
  *  rather than a standing invitation. */
 export function MobileDevices() {
-  const { status, invite, error, busy, setEnabled, beginPairing, revoke, clearInvite } =
+  const { status, invite, error, busy, setEnabled, setRelay, beginPairing, revoke, clearInvite } =
     useRemote();
 
   const enabled = !!status?.enabled;
@@ -40,6 +41,14 @@ export function MobileDevices() {
           onClick={() => void setEnabled(!enabled)}
         />
       </SetRow>
+
+      {status && (
+        <RelayRow
+          relay={status.relay}
+          disabled={busy || !enabled}
+          onSet={(url) => void setRelay(url)}
+        />
+      )}
 
       <SetRow title="Reachable at" sub={reach} align="start">
         {listening && <span className="set-remote-port mono text-sm">port {status?.port}</span>}

--- a/src/components/SettingsScreen/MobileDevices/useRemote.ts
+++ b/src/components/SettingsScreen/MobileDevices/useRemote.ts
@@ -12,6 +12,7 @@ export interface Remote {
   error: string | null;
   busy: boolean;
   setEnabled: (enabled: boolean) => Promise<void>;
+  setRelay: (url: string | null) => Promise<void>;
   beginPairing: () => Promise<void>;
   revoke: (deviceId: string) => Promise<void>;
   clearInvite: () => void;
@@ -40,7 +41,7 @@ export function useRemote(): Remote {
     return () => clearInterval(timer);
   }, [refresh]);
 
-  /** Run a mutating command; all three answer with the fresh status. */
+  /** Run a mutating command; they all answer with the fresh status. */
   const mutate = useCallback(async (call: () => Promise<RemoteStatus>) => {
     setBusy(true);
     setError(null);
@@ -62,6 +63,11 @@ export function useRemote(): Remote {
     [mutate],
   );
 
+  const setRelay = useCallback(
+    (url: string | null) => mutate(() => api.remoteSetRelay(url)),
+    [mutate],
+  );
+
   const beginPairing = useCallback(async () => {
     setError(null);
     try {
@@ -78,5 +84,5 @@ export function useRemote(): Remote {
 
   const clearInvite = useCallback(() => setInvite(null), []);
 
-  return { status, invite, error, busy, setEnabled, beginPairing, revoke, clearInvite };
+  return { status, invite, error, busy, setEnabled, setRelay, beginPairing, revoke, clearInvite };
 }

--- a/src/components/SettingsScreen/SettingsScreen.css
+++ b/src/components/SettingsScreen/SettingsScreen.css
@@ -843,6 +843,29 @@
   color: var(--fg-3);
   white-space: nowrap;
 }
+/* Relay URL, edited in place beside the link's state. */
+.set-relay-url {
+  width: 230px;
+  height: 26px;
+  padding: 0 8px;
+  color: var(--fg-0);
+  background: var(--bg-1);
+  border: 1px solid var(--bd);
+  border-radius: var(--r-sm);
+  outline: none;
+}
+.set-relay-url:focus {
+  border-color: var(--accent);
+}
+.set-relay-pill {
+  color: var(--fg-3);
+  white-space: nowrap;
+}
+.set-relay-pill[data-state="error"] {
+  color: var(--danger);
+  white-space: normal;
+  max-width: 28ch;
+}
 
 /* Live pairing code. Its own block rather than a `set-row`: the code is the
    content, not a control on the right of a label. */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,9 +24,10 @@ function copyFileIcons(): Plugin {
 
 export default defineConfig(async () => ({
   plugins: [tsconfigPaths(), react(), copyFileIcons()],
-  // The mobile companion under mobile/ is its own package with its own
-  // vitest run and node_modules; its tests do not resolve from here.
-  test: { exclude: [...configDefaults.exclude, "mobile/**"] },
+  // The mobile companion under mobile/ and the relay Worker under relay/ are
+  // their own packages with their own vitest runs and node_modules; their
+  // tests do not resolve from here.
+  test: { exclude: [...configDefaults.exclude, "mobile/**", "relay/**"] },
   clearScreen: false,
   server: {
     port: 1420,


### PR DESCRIPTION
## What

Off-network access. Both ends dial a relay outbound when the phone cannot reach the Mac on the LAN. The relay is a dumb pipe: it routes by host ID (the Mac's public key), verifies one DH proof that the Mac holds the private key, and multiplexes device links onto one host link. It sees only the ciphertext the secure channel from #654 already produces, so nothing above the transport changed.

The contract is the new **Relay** section of `docs/remote-protocol.md`; three implementations follow it.

### `relay/` — Cloudflare Worker + Durable Object
- One Durable Object per host ID, WebSocket Hibernation API: per-socket state in attachments, `getWebSockets(tag)` instead of in-memory maps, the 10 s proof deadline as a storage alarm. An idle host costs nothing.
- X25519 via WebCrypto (verified in workerd), SHA-256 proof, strict canonical host-ID decoding.
- Limits: 8 devices/host (`4429`), 4 MiB/message (`1009`), 100 msgs/10 s (`1008`), host offline (`4404`), replaced host link (`4409`).
- 54 tests in real workerd via `@cloudflare/vitest-pool-workers`; `wrangler deploy --dry-run` builds. README covers deploy and a custom domain.

### Desktop — `remote/relay.rs`
- Host link with backoff (1 s → 60 s) whenever remote access is on and `remote.relay_url` is set. Challenge answered with the host key through snow's X25519 resolver and `sha2` (no new crypto dependency).
- Each relay `OPEN` becomes a `VirtualConn` served by the same generic `serve()` as a LAN socket: backpressure `Sink`, locally answered liveness pings, per-connection `1008` on inbound overflow.
- `remote_set_relay` persists the URL, `RemoteStatus.relay` reports the link, the pairing link carries `relay=`, and Settings gains a "Reach this Mac from anywhere" row.
- Disable ordering: sessions get `4004` over the virtual connections first, then the link drops.
- Tests use a fake relay server: auth, bad proof → error + retry, reconnect on drop, two devices served independently, revoke closes one connId, stop closes all then drops, unknown connId ignored, URL normalization.

### Mobile
- Candidates in order within one attempt: LAN with a 3 s budget, then `wss://<relay>/v1/device/<hostKey>` (only when both relay and host key are known). A host-key mismatch on either path stops the list and is never retried, so an impostor cannot steer the phone onto the other path.
- The open timeout is enforced in Rust (`remote_connect` gains `timeout_ms`), so an abandoned dial is really gone.
- `relay` parsed from the link, persisted with the host, editable in the host sheet; the sheet shows which path is in use. Relay close codes surface as readable, retryable reasons.

### Cross-check
The relay's published DH vector (`relay/test-vector.json`, generated with Node's crypto and verified in workerd) is asserted byte-for-byte by the Rust host in `the_challenge_proof_matches_the_relays_published_vector`.

## Checks

| Suite | Result |
|---|---|
| Relay `vitest` (workerd), `tsc`, biome | 54 pass, clean |
| Desktop `cargo test --lib remote::` | 65 pass |
| Desktop `cargo fmt --check`, clippy with CI flags | clean |
| Desktop `bun run check`, biome on touched dirs | clean |
| Mobile `cargo test`, fmt, clippy | 13 pass, clean |
| Mobile `bun run check`, `bun run lint`, `bun run test` | 48 pass, clean |
| Root `bun run lint`, `bun run check` | clean (pre-existing warnings only) |

Not run: full Rust suite and root vitest (CI), a real deploy, and a live phone → relay → Mac session. The default relay URL `wss://relay.fletch.app` is a placeholder until the Worker is deployed behind a domain.

## Follow-ups
- Deploy the Worker and point the default URL at it.
- PR 5: push notifications via the relay (content-free wake hint → APNs).