### PR TITLE
feat(remote): expose the add-project commands as remote ops

### DIFF
--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -195,7 +195,12 @@ must pair again.
 Still in place from v1: pairing needs a single-use code, minted on the desktop
 and valid five minutes; turning remote access off closes every connection with
 `4004`; ops are an explicit allowlist with no shell, no file writes and no raw
-PTY, and events are a whitelist that excludes PTY output.
+PTY, and events are a whitelist that excludes PTY output. A paired phone can
+list directory names anywhere the desktop user can (`list_dir`), add any folder
+as a project and clone into any folder — the same reach the desktop's own New
+Project dialog has, and no more: it still cannot read files outside an agent's
+checkout, and the only writes outside one are the `git init` of a pinned folder
+and the clone itself, both into a folder the user chose.
 
 The relay adds a party that sees metadata but no content: which host IDs are
 online, when devices connect, and ciphertext sizes and timing. It cannot read
@@ -330,6 +335,11 @@ allowlist; any op not listed returns `{ ok: false, error: "unknown op" }`.
 | `list_repo_branches` | `{ repoPath }` | `string[]` |
 | `repo_default_branch` | `{ repoPath }` | `string` |
 | `discover_supported_models` | as command | `AgentModels[]` |
+| `list_dir` | `{ path }` (tilde-expanded on the host) | `DirListing` |
+| `add_workspace_repo` | `{ repoPath }` | `Workspace` |
+| `clone_repo` | `{ spec, destParent }` | `Workspace` |
+| `gh_status` | `{}` | `GhStatus` |
+| `gh_repo_list` | `{}` | `GhRepoSummary[]` |
 
 Never exposed, by design: the generic `db_*` table bridge, every file mutation
 (`write_checkout_file`, `rename_*`, `delete_*`, `create_*`, `copy_*`), shell
@@ -341,6 +351,21 @@ The spawn flow is the desktop's: `allocate_draft_name` → `spawn_agent` →
 wait for `agent:status` to leave `spawning` → `send_user_message` with the
 prompt as the first turn (`turnId` = client UUID). The phone does not send
 the prompt through `instructions`.
+
+Adding a project from the phone reuses the desktop's commands unchanged. Two
+flows: **open an existing folder** on the Mac (`list_dir` to browse, then
+`add_workspace_repo`) and **clone from GitHub** (`gh_status` to know whether
+`gh` is signed in, `gh_repo_list` to pick one of the user's repos or a typed
+`owner/repo` / URL, `list_dir` to pick the destination parent, then
+`clone_repo`). The result of either is the new `Workspace`, which the caller
+applies itself; neither command emits `workspace:changed` (the desktop frontend
+uses the returned value too), so other connected clients see the project on
+their next `get_workspace`. Note `DirListing.entries[].is_dir` is snake_case:
+`DirEntry` is serialized as-is, the one non-camelCase payload on the allowlist.
+Pinning a folder that is not yet a git repository runs `git init` plus an
+initial commit in it, exactly as the desktop dialog does. The phone remembers
+the last destination parent per host, as the desktop does. Creating a brand-new
+repo from the phone (`create_repo`) is a follow-up.
 
 ## Events (v1 whitelist)
 
@@ -420,5 +445,6 @@ launch once the disk recovers.
 Push notifications (the host sends the relay a content-free wake hint, the
 relay calls APNs, the phone connects and fetches), QR scanning on the phone
 (manual entry of address and code, plus `fletch://pair` deep-link parsing, for
-now), Add project / clone, voice, attachments, Run scripts, Keychain storage of
-the device key on the phone (it lives in the app data dir).
+now), creating a brand-new repo from the phone (`create_repo`), voice,
+attachments, Run scripts, Keychain storage of the device key on the phone (it
+lives in the app data dir).

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -358,9 +358,11 @@ flows: **open an existing folder** on the Mac (`list_dir` to browse, then
 `gh` is signed in, `gh_repo_list` to pick one of the user's repos or a typed
 `owner/repo` / URL, `list_dir` to pick the destination parent, then
 `clone_repo`). The result of either is the new `Workspace`, which the caller
-applies itself; neither command emits `workspace:changed` (the desktop frontend
-uses the returned value too), so other connected clients see the project on
-their next `get_workspace`. Note `DirListing.entries[].is_dir` is snake_case:
+applies itself; on success the host also emits `workspace:changed` (forwarded
+to every phone like any whitelisted event), so the desktop window and the other
+paired phones reload their project list at once. Applying the result and
+receiving the event both replace the workspace wholesale, so the order they
+land in does not matter. Note `DirListing.entries[].is_dir` is snake_case:
 `DirEntry` is serialized as-is, the one non-camelCase payload on the allowlist.
 Pinning a folder that is not yet a git repository runs `git init` plus an
 initial commit in it, exactly as the desktop dialog does. The phone remembers

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -3,7 +3,7 @@
 
 use std::path::Path;
 use std::sync::Arc;
-use tauri::State;
+use tauri::{AppHandle, State};
 
 use crate::error::{Error, Result};
 use crate::github::{self as gh, GhRepoSummary, GhStatus, PrState};
@@ -31,11 +31,15 @@ pub async fn gh_repo_list() -> Result<Vec<GhRepoSummary>> {
 /// workspace project.
 #[tauri::command]
 pub async fn clone_repo(
+    app: AppHandle,
     supervisor: State<'_, Arc<Supervisor>>,
     spec: String,
     dest_parent: String,
 ) -> Result<crate::workspace::Workspace> {
-    clone_repo_impl(&supervisor, &spec, &dest_parent).await
+    super::workspace::announce_workspace(
+        &app,
+        clone_repo_impl(&supervisor, &spec, &dest_parent).await,
+    )
 }
 
 /// Shared with the remote dispatcher, so a phone clones and pins through the

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -35,7 +35,17 @@ pub async fn clone_repo(
     spec: String,
     dest_parent: String,
 ) -> Result<crate::workspace::Workspace> {
-    let target = new_project::clone(&spec, Path::new(&dest_parent)).await?;
+    clone_repo_impl(&supervisor, &spec, &dest_parent).await
+}
+
+/// Shared with the remote dispatcher, so a phone clones and pins through the
+/// same path the desktop's New Project dialog uses.
+pub(crate) async fn clone_repo_impl(
+    supervisor: &Supervisor,
+    spec: &str,
+    dest_parent: &str,
+) -> Result<crate::workspace::Workspace> {
+    let target = new_project::clone(spec, Path::new(dest_parent)).await?;
     supervisor.add_workspace_repo(target)
 }
 

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -52,10 +52,18 @@ pub async fn add_workspace_repo(
     supervisor: State<'_, Arc<Supervisor>>,
     repo_path: String,
 ) -> Result<Workspace> {
-    let sup = supervisor.inner().clone();
+    add_workspace_repo_impl(&supervisor, repo_path).await
+}
+
+/// Shared with the remote dispatcher, so a folder pinned from a phone gets the
+/// same git initialization a folder picked on the desktop does.
+pub(crate) async fn add_workspace_repo_impl(
+    supervisor: &Supervisor,
+    repo_path: String,
+) -> Result<Workspace> {
     let path = PathBuf::from(repo_path);
     new_project::ensure_git_repo(&path).await?;
-    sup.add_workspace_repo(path)
+    supervisor.add_workspace_repo(path)
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use tauri::State;
+use tauri::{AppHandle, State};
 
 use crate::error::Result;
 use crate::names;
@@ -49,10 +49,11 @@ pub(crate) fn allocate_draft_name_impl(
 /// agents, checkouts, and history.
 #[tauri::command]
 pub async fn add_workspace_repo(
+    app: AppHandle,
     supervisor: State<'_, Arc<Supervisor>>,
     repo_path: String,
 ) -> Result<Workspace> {
-    add_workspace_repo_impl(&supervisor, repo_path).await
+    announce_workspace(&app, add_workspace_repo_impl(&supervisor, repo_path).await)
 }
 
 /// Shared with the remote dispatcher, so a folder pinned from a phone gets the
@@ -64,6 +65,21 @@ pub(crate) async fn add_workspace_repo_impl(
     let path = PathBuf::from(repo_path);
     new_project::ensure_git_repo(&path).await?;
     supervisor.add_workspace_repo(path)
+}
+
+/// Emit `workspace:changed` when a command has changed the project list, so
+/// every other view — the desktop window, each paired phone — reloads it rather
+/// than waiting for its next refresh. The caller still applies the returned
+/// `Workspace` itself; the event is for everyone else. Kept out of the `_impl`
+/// functions so the remote tests can drive those without a Tauri app.
+pub(crate) fn announce_workspace<T, E>(
+    app: &AppHandle,
+    result: std::result::Result<T, E>,
+) -> std::result::Result<T, E> {
+    if result.is_ok() {
+        crate::supervisor::emit_workspace_changed(app);
+    }
+    result
 }
 
 #[tauri::command]

--- a/src-tauri/src/remote/dispatch.rs
+++ b/src-tauri/src/remote/dispatch.rs
@@ -312,8 +312,12 @@ impl Dispatch for SupervisorDispatch {
                     ok(crate::model_catalog::discover_supported_models().await)
                 }
 
-                "list_dir" | "add_workspace_repo" | "clone_repo" | "gh_status" | "gh_repo_list" => {
-                    add_project_op(sup, op, args).await
+                "list_dir" | "gh_status" | "gh_repo_list" => add_project_op(sup, op, args).await,
+
+                // The two that change the project list also tell every other
+                // view about it, exactly as the Tauri commands do.
+                "add_workspace_repo" | "clone_repo" => {
+                    crate::commands::announce_workspace(app, add_project_op(sup, op, args).await)
                 }
 
                 // Unreachable while `OPS` and the arms above agree; kept so a
@@ -326,9 +330,11 @@ impl Dispatch for SupervisorDispatch {
 
 /// The "add a project" ops (protocol doc, "Adding a project from the phone"):
 /// browse the Mac's folders, pin one, or clone a GitHub repo into one. Split out
-/// of the match above because none of them needs the `AppHandle` — a bare
-/// `Supervisor` is the whole host state they touch, which is what lets the
-/// remote tests dispatch them for real without a Tauri app.
+/// of the match above because none of them needs the `AppHandle` to do its work
+/// — a bare `Supervisor` is the whole host state they touch, which is what lets
+/// the remote tests dispatch them for real without a Tauri app. The
+/// `workspace:changed` the two mutating ones owe everyone else is added by the
+/// caller, which has the handle.
 pub(super) async fn add_project_op(sup: &Supervisor, op: &str, args: Value) -> DispatchResult {
     match op {
         "list_dir" => {

--- a/src-tauri/src/remote/dispatch.rs
+++ b/src-tauri/src/remote/dispatch.rs
@@ -76,6 +76,11 @@ pub const OPS: &[&str] = &[
     "list_repo_branches",
     "repo_default_branch",
     "discover_supported_models",
+    "list_dir",
+    "add_workspace_repo",
+    "clone_repo",
+    "gh_status",
+    "gh_repo_list",
 ];
 
 pub fn is_allowed(op: &str) -> bool {
@@ -307,11 +312,46 @@ impl Dispatch for SupervisorDispatch {
                     ok(crate::model_catalog::discover_supported_models().await)
                 }
 
+                "list_dir" | "add_workspace_repo" | "clone_repo" | "gh_status" | "gh_repo_list" => {
+                    add_project_op(sup, op, args).await
+                }
+
                 // Unreachable while `OPS` and the arms above agree; kept so a
                 // name added to one and not the other fails closed.
                 _ => Err(UNKNOWN_OP.to_string()),
             }
         })
+    }
+}
+
+/// The "add a project" ops (protocol doc, "Adding a project from the phone"):
+/// browse the Mac's folders, pin one, or clone a GitHub repo into one. Split out
+/// of the match above because none of them needs the `AppHandle` — a bare
+/// `Supervisor` is the whole host state they touch, which is what lets the
+/// remote tests dispatch them for real without a Tauri app.
+pub(super) async fn add_project_op(sup: &Supervisor, op: &str, args: Value) -> DispatchResult {
+    match op {
+        "list_dir" => {
+            let a: PathArgs = parse(args)?;
+            res(crate::commands::list_dir(a.path).await)
+        }
+
+        "add_workspace_repo" => {
+            let a: RepoPathArgs = parse(args)?;
+            res(crate::commands::add_workspace_repo_impl(sup, a.repo_path).await)
+        }
+
+        "clone_repo" => {
+            let a: CloneArgs = parse(args)?;
+            res(crate::commands::clone_repo_impl(sup, &a.spec, &a.dest_parent).await)
+        }
+
+        // Both take no arguments; calling the commands themselves keeps the
+        // repo-list cap in one place.
+        "gh_status" => res(crate::commands::gh_status().await),
+        "gh_repo_list" => res(crate::commands::gh_repo_list().await),
+
+        _ => Err(UNKNOWN_OP.to_string()),
     }
 }
 
@@ -353,6 +393,18 @@ struct AgentSubdirArgs {
 #[serde(rename_all = "camelCase")]
 struct RepoPathArgs {
     repo_path: String,
+}
+
+#[derive(Deserialize)]
+struct PathArgs {
+    path: String,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CloneArgs {
+    spec: String,
+    dest_parent: String,
 }
 
 #[derive(Deserialize)]

--- a/src-tauri/src/remote/tests.rs
+++ b/src-tauri/src/remote/tests.rs
@@ -301,7 +301,7 @@ fn the_pairing_url_carries_the_host_id_and_an_address() {
 
 #[test]
 fn allowlist_matches_the_protocol_table() {
-    // The 26 rows of docs/remote-protocol.md's op table, spelled out here so a
+    // The 31 rows of docs/remote-protocol.md's op table, spelled out here so a
     // silent widening of the wire surface fails this test.
     let documented = [
         "get_workspace",
@@ -330,6 +330,11 @@ fn allowlist_matches_the_protocol_table() {
         "list_repo_branches",
         "repo_default_branch",
         "discover_supported_models",
+        "list_dir",
+        "add_workspace_repo",
+        "clone_repo",
+        "gh_status",
+        "gh_repo_list",
     ];
     assert_eq!(dispatch::OPS, documented.as_slice());
 }
@@ -359,12 +364,135 @@ fn never_exposed_ops_are_not_dispatchable() {
         "fork_agent",
         "merge_pr",
         "delete_project",
+        // Adding a project is exposed; creating a brand-new repo is the
+        // documented follow-up, so it stays off the wire.
+        "create_repo",
         "",
         "hello",
         "pair",
     ] {
         assert!(!dispatch::is_allowed(op), "{op} must not be dispatchable");
     }
+}
+
+// ---------------------------------------------------------------------------
+// Add-project ops
+//
+// Dispatched in process against a real `Supervisor` — the same code path the
+// socket runs, minus the `AppHandle` none of these five ops touches. Network
+// ops (`gh_status`, `gh_repo_list`, a real clone) are left to manual testing:
+// they need a signed-in `gh`.
+// ---------------------------------------------------------------------------
+
+/// A supervisor over a throwaway DB. The temp dir is returned so it outlives
+/// the connection.
+fn supervisor() -> (tempfile::TempDir, crate::supervisor::Supervisor) {
+    let dir = tempfile::tempdir().unwrap();
+    let db = crate::database::init(dir.path()).unwrap();
+    let workspace = Arc::new(crate::workspace::WorkspaceManager::new(db));
+    (dir, crate::supervisor::Supervisor::new(workspace))
+}
+
+/// `git init` a folder, as the phone's "open an existing folder" flow expects
+/// to find one.
+fn git_init(dir: &std::path::Path) {
+    std::fs::create_dir_all(dir).unwrap();
+    assert!(std::process::Command::new("git")
+        .current_dir(dir)
+        .args(["init", "-q"])
+        .status()
+        .unwrap()
+        .success());
+}
+
+#[tokio::test]
+async fn list_dir_answers_with_a_listing_and_expands_a_tilde() {
+    let (_db, sup) = supervisor();
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join("sub")).unwrap();
+    std::fs::write(dir.path().join("file.txt"), b"x").unwrap();
+
+    let listing = dispatch::add_project_op(&sup, "list_dir", json!({ "path": dir.path() }))
+        .await
+        .expect("list_dir");
+    assert_eq!(listing["base"], dir.path().to_string_lossy().as_ref());
+    let entries = listing["entries"].as_array().expect("entries");
+    let sub = entries
+        .iter()
+        .find(|e| e["name"] == "sub")
+        .expect("the subdirectory is listed");
+    assert_eq!(sub["is_dir"], true);
+    assert!(entries.iter().any(|e| e["name"] == "file.txt"));
+
+    // The phone sends the path the user typed; the host resolves `~`.
+    let home = dirs::home_dir().expect("a home directory");
+    let expanded = dispatch::add_project_op(&sup, "list_dir", json!({ "path": "~" }))
+        .await
+        .expect("list_dir ~");
+    // Compared as a `Path`: bare `~` expands with a trailing separator.
+    assert_eq!(
+        std::path::Path::new(expanded["base"].as_str().expect("base")),
+        home,
+    );
+}
+
+#[tokio::test]
+async fn add_workspace_repo_pins_the_folder_and_answers_with_the_workspace() {
+    let (_db, sup) = supervisor();
+    let parent = tempfile::tempdir().unwrap();
+    let repo = parent.path().join("notes");
+    git_init(&repo);
+
+    let workspace =
+        dispatch::add_project_op(&sup, "add_workspace_repo", json!({ "repoPath": repo }))
+            .await
+            .expect("add_workspace_repo");
+    assert_eq!(
+        workspace["repos"],
+        json!([repo.to_string_lossy().as_ref()]),
+        "the pinned repo comes back in the workspace"
+    );
+    assert_eq!(workspace["projects"][0]["name"], "notes");
+}
+
+/// An unparseable clone spec must come back as an op error, not a panic — and
+/// must not reach the network or leave a partial folder behind.
+#[tokio::test]
+async fn clone_repo_rejects_an_invalid_spec() {
+    let (_db, sup) = supervisor();
+    let dest = tempfile::tempdir().unwrap();
+
+    let err = dispatch::add_project_op(
+        &sup,
+        "clone_repo",
+        json!({ "spec": "not a repo", "destParent": dest.path() }),
+    )
+    .await
+    .expect_err("an invalid spec is an error");
+    assert!(err.starts_with("invalid path:"), "unexpected error: {err}");
+    assert_eq!(std::fs::read_dir(dest.path()).unwrap().count(), 0);
+}
+
+/// Missing or misspelled argument keys are a deserialization error, not a
+/// panic, and an op name that never reaches the match still fails closed.
+#[tokio::test]
+async fn add_project_ops_reject_bad_args_and_unknown_names() {
+    let (_db, sup) = supervisor();
+    assert!(dispatch::add_project_op(&sup, "list_dir", json!({}))
+        .await
+        .is_err());
+    assert!(
+        dispatch::add_project_op(&sup, "add_workspace_repo", json!({ "repo_path": "/tmp" }))
+            .await
+            .is_err(),
+        "the wire key is camelCase"
+    );
+    assert_eq!(
+        dispatch::add_project_op(&sup, "create_repo", json!({}))
+            .await
+            .unwrap_err(),
+        UNKNOWN_OP
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/supervisor/events.rs
+++ b/src-tauri/src/supervisor/events.rs
@@ -397,9 +397,10 @@ pub(super) fn emit_run_port(app: &AppHandle, agent_id: &str, port: u16) {
     );
 }
 
-/// Structural workspace change (archive/restore) — the frontend reloads the
-/// whole workspace on this signal rather than patching from finer events.
-pub(super) fn emit_workspace_changed(app: &AppHandle) {
+/// Structural workspace change (archive/restore, a project pinned or cloned) —
+/// the frontend reloads the whole workspace on this signal rather than patching
+/// from finer events.
+pub(crate) fn emit_workspace_changed(app: &AppHandle) {
     emit(app, "workspace:changed", ());
 }
 

--- a/src-tauri/src/supervisor/mod.rs
+++ b/src-tauri/src/supervisor/mod.rs
@@ -11,6 +11,7 @@ pub(crate) mod run;
 mod session_sync;
 mod shell;
 
+pub(crate) use events::emit_workspace_changed;
 pub use fork::{ForkCode, ForkContext};
 pub use lifecycle::SpawnRequest;
 pub(crate) use pr_set::sync_pr_set_links;


### PR DESCRIPTION
## What

Whitelists five existing desktop commands as remote ops so the phone can add a project: `list_dir` (browse the Mac's folders), `add_workspace_repo` (pin one), `clone_repo`, and `gh_status` / `gh_repo_list` for the clone picker. The phone UI lands in a follow-up PR on top of this one.

## How

- No new host logic. `add_workspace_repo` and `clone_repo` had their bodies inlined in the Tauri commands; both are extracted into shared functions that the command and the op call, so a folder pinned from a phone gets the same `git init` a desktop pick does.
- The five arms live in one `add_project_op(&Supervisor, …)` because none needs the `AppHandle`, which is what lets the remote tests dispatch them for real without a Tauri app.
- `docs/remote-protocol.md`: ops table rows, an "Adding a project from the phone" paragraph, and a threat-model sentence. The doc records what the commands actually do: neither emits `workspace:changed` (callers apply the returned `Workspace`), `DirEntry` is snake_case on the wire, and pinning a non-repo folder runs `git init` in it.

## Tests

`cargo test -p fletch --lib remote`: 84 passed. Four new: tilde-expanding `list_dir`, pinning a temp repo returns the `Workspace`, an invalid clone spec is an op error not a panic, bad args / unknown names are rejected. Clippy `-D warnings` clean.

## Not in scope

`create_repo` from the phone (listed as a follow-up in the doc).