### PR TITLE
feat(mobile): add a project from the phone

### DIFF
--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -6,6 +6,7 @@ import { FileScreen } from "./screens/File";
 import { HomeScreen } from "./screens/Home";
 import { PairScreen } from "./screens/Pair";
 import { ProjectScreen } from "./screens/Project";
+import { AddProjectSheet } from "./sheets/AddProjectSheet";
 import { AgentMoreSheet } from "./sheets/AgentMoreSheet";
 import { HostSheet } from "./sheets/HostSheet";
 import { ModelPickerSheet } from "./sheets/ModelPickerSheet";
@@ -17,7 +18,7 @@ import "./styles/screens.css";
 import "./styles/agent.css";
 
 /** Sheets that push the whole stack back rather than sitting over it. */
-const FULL_SHEETS = new Set(["newAgent", "pr"]);
+const FULL_SHEETS = new Set(["newAgent", "addProject", "pr"]);
 
 function Screen({ item }: { item: NavItem }) {
   switch (item.screen) {
@@ -84,6 +85,7 @@ export function App() {
           </div>
           <HostSheet open={isOpen("host")} onClose={closeSheet} />
           <NewAgentSheet open={isOpen("newAgent")} onClose={closeSheet} {...props("newAgent")} />
+          <AddProjectSheet open={isOpen("addProject")} onClose={closeSheet} />
           <AgentMoreSheet open={isOpen("agentMore")} onClose={closeSheet} {...props("agentMore")} />
           <ModelPickerSheet
             open={isOpen("modelPicker")}

--- a/mobile/src/api/index.ts
+++ b/mobile/src/api/index.ts
@@ -4,9 +4,15 @@
 // renamed or reshaped anywhere in mobile.
 
 import type { AgentRecord, Workspace } from "@desktop/api/types/agent";
-import type { CheckoutFile, CheckoutFileContents, DiffBaseMode } from "@desktop/api/types/checkout";
+import type {
+  CheckoutFile,
+  CheckoutFileContents,
+  DiffBaseMode,
+  DirListing,
+} from "@desktop/api/types/checkout";
 import type { DiffStats, GitState } from "@desktop/api/types/git";
 import type { PrChecks, PrLive, PrState } from "@desktop/api/types/pr";
+import type { GhRepoSummary, GhStatus } from "@desktop/api/types/providers";
 import type { SessionRecord, UserTurn } from "@desktop/api/types/session";
 import type { AgentModels } from "@desktop/data/modelCatalog/types";
 import type { RemoteClient } from "../remote";
@@ -90,6 +96,14 @@ export function createApi(client: RemoteClient) {
     listRepoBranches: (repoPath: string) => call<string[]>("list_repo_branches", { repoPath }),
     repoDefaultBranch: (repoPath: string) => call<string>("repo_default_branch", { repoPath }),
     discoverSupportedModels: () => call<AgentModels[]>("discover_supported_models"),
+    /** `path` may be `~`-relative; the host expands it and reports the
+     *  absolute `base` it read, which is what the picker navigates from. */
+    listDir: (path: string) => call<DirListing>("list_dir", { path }),
+    addWorkspaceRepo: (repoPath: string) => call<Workspace>("add_workspace_repo", { repoPath }),
+    cloneRepo: (spec: string, destParent: string) =>
+      call<Workspace>("clone_repo", { spec, destParent }),
+    ghStatus: () => call<GhStatus>("gh_status"),
+    ghRepoList: () => call<GhRepoSummary[]>("gh_repo_list"),
   };
 }
 

--- a/mobile/src/lib/paths.ts
+++ b/mobile/src/lib/paths.ts
@@ -1,0 +1,25 @@
+// Absolute-path arithmetic for the folder picker and the mock host's fake
+// filesystem. The host answers `list_dir` with the absolute, tilde-expanded
+// `base` it actually read, so every path built here is anchored on that rather
+// than on whatever the user typed.
+
+/** Join a listing's `base` with an entry name. `base` ends in a separator at
+ *  the root and nowhere else, and a doubled one is a different path to some
+ *  hosts — so trim before joining. */
+export function childPath(base: string, name: string): string {
+  return `${base.replace(/\/+$/, "")}/${name}`;
+}
+
+/** The containing directory, or null when `path` is already the root. */
+export function parentPath(path: string): string | null {
+  const trimmed = path.replace(/\/+$/, "");
+  const cut = trimmed.lastIndexOf("/");
+  if (cut < 0) return null;
+  return cut === 0 ? "/" : trimmed.slice(0, cut);
+}
+
+/** The last segment of a path — the folder's own name. */
+export function baseName(path: string): string {
+  const trimmed = path.replace(/\/+$/, "");
+  return trimmed.slice(trimmed.lastIndexOf("/") + 1) || "/";
+}

--- a/mobile/src/remote/mock/fixtures.ts
+++ b/mobile/src/remote/mock/fixtures.ts
@@ -3,9 +3,10 @@
 // desktop adapters render them exactly as they render a live host's.
 
 import type { AgentRecord, TrackedRepo, Workspace } from "@desktop/api/types/agent";
-import type { CheckoutFile, CheckoutFileContents } from "@desktop/api/types/checkout";
+import type { CheckoutFile, CheckoutFileContents, DirEntry } from "@desktop/api/types/checkout";
 import type { GitState } from "@desktop/api/types/git";
 import type { PrChecks, PrState } from "@desktop/api/types/pr";
+import type { GhRepoSummary, GhStatus } from "@desktop/api/types/providers";
 import type { SessionRecord, UserTurn } from "@desktop/api/types/session";
 import type { AgentModels } from "@desktop/data/modelCatalog/types";
 
@@ -491,3 +492,72 @@ export const supportedModels: AgentModels[] = [
 ];
 
 export const hostInfo = { name: "Alex's MacBook Pro", appVersion: "0.7.23", os: "macos" };
+
+/** What `~` expands to on the fake host. */
+export const HOME = "/Users/alex";
+
+const dir = (name: string): DirEntry => ({ name, is_dir: true });
+const file = (name: string): DirEntry => ({ name, is_dir: false });
+
+/** A small fake filesystem for `list_dir`, so the folder picker has somewhere
+ *  real-looking to walk in the browser dev loop. Only the interesting nodes are
+ *  listed: a directory its parent names but that has no row of its own reads as
+ *  empty (see `MockHost.listDir`), which keeps this table short. Files are in
+ *  here too, because filtering them out is part of the picker's job. */
+export const filesystem: Record<string, DirEntry[]> = {
+  "/": [dir("Applications"), dir("Users"), dir("tmp")],
+  "/Users": [dir("alex"), dir("Shared")],
+  [HOME]: [
+    dir(".config"),
+    dir(".fletch"),
+    dir(".ssh"),
+    dir("Code"),
+    dir("Documents"),
+    dir("Downloads"),
+    file(".zshrc"),
+  ],
+  [`${HOME}/.config`]: [dir("gh")],
+  [`${HOME}/.config/gh`]: [file("hosts.yml")],
+  [`${HOME}/.fletch`]: [dir("workspaces")],
+  [`${HOME}/.fletch/workspaces`]: [dir("atlas"), dir("fletch"), dir("uluru")],
+  [FLETCH_REPO]: [dir("docs"), dir("mobile"), dir("src"), file("package.json")],
+  [ATLAS_REPO]: [dir("src"), file("Cargo.toml")],
+  [`${HOME}/Code`]: [dir("playground"), dir("scratch"), file("README.md")],
+  [`${HOME}/Code/playground`]: [dir("src"), file("README.md")],
+  [`${HOME}/Downloads`]: [file("fletch-0.7.23.dmg")],
+};
+
+export const ghStatus: GhStatus = { installed: true, authenticated: true, login: "alexchaplinsky" };
+
+export const ghRepos: GhRepoSummary[] = [
+  {
+    name_with_owner: "fwdai/fletch",
+    description: "Agent workspaces for the Mac",
+    is_private: true,
+    updated_at: "2026-09-08T08:41:00Z",
+  },
+  {
+    name_with_owner: "fwdai/atlas",
+    description: "Rust core for the model catalog",
+    is_private: true,
+    updated_at: "2026-09-06T17:02:00Z",
+  },
+  {
+    name_with_owner: "fwdai/relay",
+    description: "Cloudflare Worker relay for off-network access",
+    is_private: false,
+    updated_at: "2026-09-05T11:20:00Z",
+  },
+  {
+    name_with_owner: "alexchaplinsky/dotfiles",
+    description: null,
+    is_private: false,
+    updated_at: "2026-08-22T09:15:00Z",
+  },
+  {
+    name_with_owner: "alexchaplinsky/geist-playground",
+    description: "Type experiments",
+    is_private: false,
+    updated_at: "2026-07-30T14:48:00Z",
+  },
+];

--- a/mobile/src/remote/mock/index.ts
+++ b/mobile/src/remote/mock/index.ts
@@ -4,7 +4,10 @@
 // real in mock mode and in tests.
 
 import type { AgentRecord, Workspace } from "@desktop/api/types/agent";
+import type { DirEntry, DirListing } from "@desktop/api/types/checkout";
 import type { SessionRecord } from "@desktop/api/types/session";
+import { parseRepoSpec } from "@desktop/util/repoSpec";
+import { baseName, childPath, parentPath } from "../../lib/paths";
 import type { Socket, SocketFactory } from "../socket";
 import {
   CLOSE_BAD_FIRST_FRAME,
@@ -32,7 +35,22 @@ interface MockState {
   records: Record<string, SessionRecord[]>;
   pendingToolUse: Record<string, string>;
   nextPrNumber: number;
+  /** Mutable, because cloning creates a directory the next clone must trip
+   *  over ("a folder already exists at …"). */
+  filesystem: Record<string, DirEntry[]>;
 }
+
+/** Tilde expansion, as the host does it — including the trailing slash a bare
+ *  `~` comes back with, which is exactly the shape `childPath` has to collapse. */
+function expandTilde(path: string): string {
+  if (path === "~") return `${fx.HOME}/`;
+  if (path.startsWith("~/")) return `${fx.HOME}${path.slice(1)}`;
+  return path;
+}
+
+/** Trailing separators off (but never the root's), so one directory has one key
+ *  in the fake filesystem however it was reached. */
+const normalize = (path: string) => path.replace(/(.)\/+$/, "$1");
 
 /** A live mock host session. Exposed so tests can await the scripted stream. */
 export class MockHost {
@@ -51,6 +69,7 @@ export class MockHost {
       records: structuredClone(fx.records),
       pendingToolUse: { pamukkale: fx.PENDING_REQUEST_ID },
       nextPrNumber: 649,
+      filesystem: structuredClone(fx.filesystem),
     };
   }
 
@@ -137,6 +156,50 @@ export class MockHost {
         body,
       },
     ];
+  }
+
+  /** A directory exists if it has a row of its own or its parent names it as
+   *  one — so the fixture table only has to list the interesting nodes. */
+  private isDir(abs: string): boolean {
+    const path = normalize(abs);
+    if (path === "/") return true;
+    if (this.state.filesystem[path]) return true;
+    const parent = parentPath(path);
+    if (!parent) return false;
+    return !!this.state.filesystem[parent]?.some((e) => e.name === baseName(path) && e.is_dir);
+  }
+
+  private listDir(path: string): DirListing {
+    const base = expandTilde(path);
+    if (!this.isDir(base)) throw new Error(`no such directory: ${base}`);
+    return { base, entries: this.state.filesystem[normalize(base)] ?? [] };
+  }
+
+  /** Track a folder as a project, the way both add-project ops end. Mirrors
+   *  the host: a folder that is already a project comes back unchanged (the
+   *  desktop pin is idempotent), and a folder inside an existing repository is
+   *  refused with the host's own wording. */
+  private addProject(path: string): Workspace {
+    const repoPath = normalize(path);
+    if (this.state.workspace.projects.some((p) => p.path === repoPath)) {
+      return this.state.workspace;
+    }
+    const enclosing = this.state.workspace.projects.find((p) => repoPath.startsWith(`${p.path}/`));
+    if (enclosing) {
+      throw new Error(
+        `${repoPath} is inside the git repository at ${enclosing.path} — add that folder instead`,
+      );
+    }
+    const name = baseName(repoPath);
+    this.state.workspace = {
+      ...this.state.workspace,
+      repos: [...this.state.workspace.repos, repoPath],
+      projects: [
+        ...this.state.workspace.projects,
+        { path: repoPath, name, project_id: `prj-${name}`, label: null },
+      ],
+    };
+    return this.state.workspace;
   }
 
   /** Play a scripted turn: live `agent:event` frames, then the canonical
@@ -351,6 +414,34 @@ export class MockHost {
         return "main";
       case "discover_supported_models":
         return fx.supportedModels;
+      case "list_dir":
+        return this.listDir(String(args.path ?? "~"));
+      case "add_workspace_repo": {
+        const repoPath = expandTilde(String(args.repoPath ?? ""));
+        if (!this.isDir(repoPath)) throw new Error(`no such directory: ${repoPath}`);
+        // A folder that is not a repo yet gets `git init` on the real host, so
+        // there is nothing to refuse here.
+        return this.addProject(repoPath);
+      }
+      case "clone_repo": {
+        const spec = String(args.spec ?? "");
+        const destParent = expandTilde(String(args.destParent ?? ""));
+        const { valid, name } = parseRepoSpec(spec);
+        if (!valid || !name) throw new Error(`not a repository: ${spec}`);
+        if (!this.isDir(destParent)) throw new Error(`no such directory: ${destParent}`);
+        const dest = childPath(destParent, name);
+        if (this.isDir(dest)) throw new Error(`a folder already exists at ${dest}`);
+        const parent = normalize(destParent);
+        this.state.filesystem[parent] = [
+          ...(this.state.filesystem[parent] ?? []),
+          { name, is_dir: true },
+        ];
+        return this.addProject(dest);
+      }
+      case "gh_status":
+        return fx.ghStatus;
+      case "gh_repo_list":
+        return fx.ghRepos;
       default:
         throw new Error("unknown op");
     }

--- a/mobile/src/screens/Home/index.tsx
+++ b/mobile/src/screens/Home/index.tsx
@@ -111,6 +111,10 @@ export function HomeScreen() {
       <div className="scroll home-body">
         <div className="sect">
           Projects <span className="n">{projects.length}</span>
+          <button type="button" className="sect-add" onClick={() => openSheet("addProject")}>
+            <Icon name="plus" size={12} sw={2.2} />
+            Add
+          </button>
           <span className="grow" />
           {attention > 0 && (
             <span
@@ -143,7 +147,15 @@ export function HomeScreen() {
         {projects.length === 0 && (
           <div className="empty">
             <b>No projects on the host</b>
-            Pin a repo in Fletch on your Mac and it shows up here.
+            Open a folder on your Mac, or clone one from GitHub.
+            <button
+              type="button"
+              className="btn ghost ap-empty"
+              onClick={() => openSheet("addProject")}
+            >
+              <Icon name="plus" size={16} sw={2.2} />
+              Add project
+            </button>
           </div>
         )}
       </div>

--- a/mobile/src/sheets/AddProjectSheet/CloneForm.tsx
+++ b/mobile/src/sheets/AddProjectSheet/CloneForm.tsx
@@ -1,0 +1,167 @@
+import type { GhRepoSummary, GhStatus } from "@desktop/api/types/providers";
+import { parseRepoSpec } from "@desktop/util/repoSpec";
+import { useEffect, useState } from "react";
+import { Icon } from "../../components/Icon";
+import { childPath } from "../../lib/paths";
+import { useStore } from "../../store";
+import { FolderPickerSheet } from "./FolderPicker";
+import type { RunAddProject } from "./useAddProject";
+
+/** Clone from GitHub: one of the user's repos when `gh` is signed in, or a
+ *  typed `owner/repo` / URL either way. */
+export function CloneForm({
+  busy,
+  error,
+  setError,
+  run,
+}: {
+  busy: boolean;
+  error: string | null;
+  setError: (text: string) => void;
+  run: RunAddProject;
+}) {
+  const ghStatus = useStore((s) => s.ghStatus);
+  const ghRepoList = useStore((s) => s.ghRepoList);
+  const cloneRepo = useStore((s) => s.cloneRepo);
+  const lastDestParent = useStore((s) => s.lastDestParent);
+
+  const [gh, setGh] = useState<GhStatus | null>(null);
+  const [probing, setProbing] = useState(true);
+  const [repos, setRepos] = useState<GhRepoSummary[]>([]);
+  const [filter, setFilter] = useState("");
+  const [selected, setSelected] = useState<string | null>(null);
+  const [typed, setTyped] = useState("");
+  // Defaults to the folder the last clone on this host went into.
+  const [parent, setParent] = useState(lastDestParent ?? "");
+  const [picking, setPicking] = useState(false);
+
+  useEffect(() => {
+    let live = true;
+    const probe = async () => {
+      const status = await ghStatus();
+      if (!live) return;
+      setGh(status);
+      if (!status.authenticated) return;
+      const list = await ghRepoList();
+      if (live) setRepos(list);
+    };
+    probe()
+      .catch((e: unknown) => {
+        if (live) setError(e instanceof Error ? e.message : String(e));
+      })
+      .finally(() => {
+        if (live) setProbing(false);
+      });
+    return () => {
+      live = false;
+    };
+  }, [ghStatus, ghRepoList, setError]);
+
+  // A typed spec wins while it has anything in it; picking a repo clears it.
+  const spec = typed.trim() || (selected ?? "");
+  const parsed = parseRepoSpec(spec);
+  const query = filter.trim().toLowerCase();
+  const shown = query
+    ? repos.filter((r) => r.name_with_owner.toLowerCase().includes(query))
+    : repos;
+  const canClone = parsed.valid && !!parent && !busy;
+
+  return (
+    <>
+      {probing && <div className="empty">Checking GitHub…</div>}
+      {!probing && gh?.authenticated && (
+        <>
+          <div className="search">
+            <Icon name="search" size={15} />
+            <input
+              placeholder={`Filter ${gh.login ?? "your"} repositories`}
+              value={filter}
+              autoCapitalize="off"
+              autoCorrect="off"
+              spellCheck={false}
+              onChange={(e) => setFilter(e.target.value)}
+            />
+          </div>
+          <div className="card">
+            {shown.map((repo) => (
+              <button
+                type="button"
+                key={repo.name_with_owner}
+                className="row"
+                onClick={() => {
+                  setSelected(repo.name_with_owner);
+                  setTyped("");
+                }}
+              >
+                <Icon name="github" size={15} />
+                <div className="main">
+                  <div className="lbl">{repo.name_with_owner}</div>
+                  {repo.description && <div className="sub">{repo.description}</div>}
+                </div>
+                {repo.is_private && <span className="val mono">private</span>}
+                {selected === repo.name_with_owner && !typed.trim() ? (
+                  <Icon name="check" size={18} sw={2} className="check-ic" />
+                ) : (
+                  <span style={{ width: 18 }} />
+                )}
+              </button>
+            ))}
+            {shown.length === 0 && <div className="empty">No matches</div>}
+          </div>
+        </>
+      )}
+      {!probing && !gh?.authenticated && (
+        <div className="empty">
+          <b>GitHub isn't connected</b>
+          {gh?.installed
+            ? "Run gh auth login on your Mac to pick from your repositories."
+            : "Install the GitHub CLI on your Mac to pick from your repositories."}
+        </div>
+      )}
+      <div className="ap-field">
+        <label htmlFor="ap-spec">
+          {gh?.authenticated ? "Or paste owner/repo or a URL" : "owner/repo or a URL"}
+        </label>
+        <input
+          id="ap-spec"
+          placeholder="fwdai/fletch"
+          value={typed}
+          autoCapitalize="off"
+          autoCorrect="off"
+          spellCheck={false}
+          onChange={(e) => setTyped(e.target.value)}
+        />
+      </div>
+      <div className="sect ap-sect">Destination</div>
+      <div className="card">
+        <button type="button" className="row" onClick={() => setPicking(true)}>
+          <Icon name="folder" size={16} />
+          <div className="main">
+            <div className="lbl mono">
+              {parent ? childPath(parent, parsed.name ?? "…") : "Choose a folder"}
+            </div>
+            <div className="sub">
+              {parent ? "Where the clone lands" : "Browse your Mac for a parent folder"}
+            </div>
+          </div>
+          <Icon name="chevR" size={16} className="chev" />
+        </button>
+      </div>
+      {error && <div className="err ap-err">{error}</div>}
+      <button
+        type="button"
+        className="btn primary block ap-use"
+        disabled={!canClone}
+        onClick={() => void run(() => cloneRepo(spec, parent))}
+      >
+        {busy ? "Cloning…" : "Clone repository"}
+      </button>
+      <FolderPickerSheet
+        open={picking}
+        onClose={() => setPicking(false)}
+        start={parent || "~"}
+        onPick={setParent}
+      />
+    </>
+  );
+}

--- a/mobile/src/sheets/AddProjectSheet/FolderPicker.tsx
+++ b/mobile/src/sheets/AddProjectSheet/FolderPicker.tsx
@@ -1,0 +1,163 @@
+import type { DirEntry, DirListing } from "@desktop/api/types/checkout";
+import { type ReactNode, useEffect, useState } from "react";
+import { Icon } from "../../components/Icon";
+import { Sheet } from "../../components/ui";
+import { childPath, parentPath } from "../../lib/paths";
+import { useStore } from "../../store";
+
+const isHidden = (entry: DirEntry) => entry.name.startsWith(".");
+
+/** Browse the Mac over `list_dir`. Directories only — everything this sheet
+ *  can do takes a folder — and the walk is anchored on the `base` the host
+ *  reports, never on the string it was asked for: `~` and symlinks resolve
+ *  there, not here. */
+export function FolderPicker({
+  start = "~",
+  actionLabel,
+  hint,
+  onUse,
+  busy,
+  error,
+}: {
+  start?: string;
+  actionLabel: string;
+  hint?: ReactNode;
+  onUse: (path: string) => void;
+  busy?: boolean;
+  /** An error from whatever the caller did with the picked folder; shown in
+   *  the same place as a failed listing. */
+  error?: string | null;
+}) {
+  const listDir = useStore((s) => s.listDir);
+  const [path, setPath] = useState(start);
+  const [listing, setListing] = useState<DirListing | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [showHidden, setShowHidden] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let live = true;
+    setLoading(true);
+    setListError(null);
+    listDir(path).then(
+      (next) => {
+        if (!live) return;
+        setListing(next);
+        setLoading(false);
+      },
+      (e: unknown) => {
+        if (!live) return;
+        // Drop the old listing with it, so the crumb and the action point at
+        // the folder that failed rather than at the last one that worked.
+        setListing(null);
+        setListError(e instanceof Error ? e.message : String(e));
+        setLoading(false);
+      },
+    );
+    return () => {
+      live = false;
+    };
+  }, [path, listDir]);
+
+  const base = listing?.base ?? path;
+  const dirs = (listing?.entries ?? []).filter((e) => e.is_dir);
+  const hiddenCount = dirs.filter(isHidden).length;
+  const shown = showHidden ? dirs : dirs.filter((e) => !isHidden(e));
+  const up = parentPath(base);
+  const shownError = error ?? listError;
+
+  return (
+    <>
+      <div className="ap-path">
+        {up && (
+          <button
+            type="button"
+            className="ibtn sm"
+            onClick={() => setPath(up)}
+            aria-label="Up one folder"
+          >
+            <Icon name="chevL" size={18} sw={1.8} />
+          </button>
+        )}
+        <span className="p mono">{base}</span>
+      </div>
+      <div className="card">
+        {shown.map((entry) => (
+          <button
+            type="button"
+            key={entry.name}
+            className="row"
+            onClick={() => setPath(childPath(base, entry.name))}
+          >
+            <Icon name="folder" size={16} />
+            <div className="main">
+              <div className="lbl">{entry.name}</div>
+            </div>
+            <Icon name="chevR" size={16} className="chev" />
+          </button>
+        ))}
+        {shown.length === 0 && (
+          <div className="empty">
+            {loading ? "Reading…" : listError ? "Couldn't read this folder" : "No folders here"}
+          </div>
+        )}
+      </div>
+      {hiddenCount > 0 && (
+        <div className="ap-hid">
+          <button type="button" className="chip" onClick={() => setShowHidden(!showHidden)}>
+            <Icon name={showHidden ? "minus" : "plus"} size={11} sw={2.2} />
+            {showHidden ? "Hide" : "Show"} {hiddenCount} hidden
+          </button>
+        </div>
+      )}
+      {shownError && <div className="err ap-err">{shownError}</div>}
+      <button
+        type="button"
+        className="btn primary block ap-use"
+        disabled={busy || !listing}
+        onClick={() => onUse(base)}
+      >
+        {busy ? "Working…" : actionLabel}
+      </button>
+      {hint && <div className="ap-hint">{hint}</div>}
+    </>
+  );
+}
+
+/** The same picker one sheet up, for choosing a folder without losing the form
+ *  underneath. It unmounts a beat after closing, so the next open starts from
+ *  `start` again. */
+export function FolderPickerSheet({
+  open,
+  onClose,
+  start,
+  onPick,
+}: {
+  open: boolean;
+  onClose: () => void;
+  start?: string;
+  onPick: (path: string) => void;
+}) {
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      stacked
+      title="Destination folder"
+      right={
+        <button type="button" className="tbtn" onClick={onClose}>
+          Cancel
+        </button>
+      }
+    >
+      <FolderPicker
+        start={start}
+        actionLabel="Use this folder"
+        onUse={(picked) => {
+          onPick(picked);
+          onClose();
+        }}
+      />
+    </Sheet>
+  );
+}

--- a/mobile/src/sheets/AddProjectSheet/OpenFolderForm.tsx
+++ b/mobile/src/sheets/AddProjectSheet/OpenFolderForm.tsx
@@ -1,0 +1,25 @@
+import { useStore } from "../../store";
+import { FolderPicker } from "./FolderPicker";
+import type { RunAddProject } from "./useAddProject";
+
+/** Pin a folder that is already on the Mac. */
+export function OpenFolderForm({
+  busy,
+  error,
+  run,
+}: {
+  busy: boolean;
+  error: string | null;
+  run: RunAddProject;
+}) {
+  const addWorkspaceRepo = useStore((s) => s.addWorkspaceRepo);
+  return (
+    <FolderPicker
+      actionLabel="Use this folder"
+      hint="Not a git repo yet? Fletch will run git init here."
+      busy={busy}
+      error={error}
+      onUse={(path) => void run(() => addWorkspaceRepo(path))}
+    />
+  );
+}

--- a/mobile/src/sheets/AddProjectSheet/index.tsx
+++ b/mobile/src/sheets/AddProjectSheet/index.tsx
@@ -1,0 +1,39 @@
+import { Segmented, Sheet } from "../../components/ui";
+import { CloneForm } from "./CloneForm";
+import { OpenFolderForm } from "./OpenFolderForm";
+import { useAddProject } from "./useAddProject";
+
+const TABS = [
+  { id: "folder", label: "Open folder" },
+  { id: "clone", label: "Clone" },
+];
+
+/** The two ways a project reaches the host from the phone (docs/remote-protocol.md,
+ *  "Adding a project from the phone"). Creating a brand-new repo is not one of
+ *  them yet. */
+export function AddProjectSheet({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const { tab, switchTab, busy, error, setError, run } = useAddProject(open);
+
+  return (
+    <Sheet
+      open={open}
+      onClose={onClose}
+      full
+      title="Add project"
+      left={
+        <button type="button" className="tbtn q" onClick={onClose}>
+          Cancel
+        </button>
+      }
+    >
+      <div className="ap-seg">
+        <Segmented items={TABS} value={tab} onChange={switchTab} />
+      </div>
+      {tab === "folder" ? (
+        <OpenFolderForm busy={busy} error={error} run={run} />
+      ) : (
+        <CloneForm busy={busy} error={error} setError={setError} run={run} />
+      )}
+    </Sheet>
+  );
+}

--- a/mobile/src/sheets/AddProjectSheet/useAddProject.ts
+++ b/mobile/src/sheets/AddProjectSheet/useAddProject.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useState } from "react";
+import { useStore } from "../../store";
+
+export type AddProjectTab = "folder" | "clone";
+
+/** Runs one add-project op. The store closes the sheet on success, so nothing
+ *  here has to know which op it was. */
+export type RunAddProject = (op: () => Promise<unknown>) => Promise<void>;
+
+/** State the two forms share: which one is showing, whether an op is in
+ *  flight, and the error text the last one failed with. */
+export function useAddProject(open: boolean) {
+  const [tab, setTab] = useState<AddProjectTab>("folder");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const clearError = useStore((s) => s.clearError);
+
+  // A fresh sheet every time it opens: a failed attempt must not greet the
+  // next one. The store's own `lastError` is cleared with it, since `guard`
+  // recorded this error there as well.
+  useEffect(() => {
+    if (!open) return;
+    setTab("folder");
+    setBusy(false);
+    setError(null);
+    clearError();
+  }, [open, clearError]);
+
+  const switchTab = useCallback((next: string) => {
+    setTab(next as AddProjectTab);
+    setError(null);
+  }, []);
+
+  const run = useCallback<RunAddProject>(async (op) => {
+    setBusy(true);
+    setError(null);
+    try {
+      await op();
+    } catch (e) {
+      // The sheet stays open on the text the host sent, so the user can fix
+      // the destination or the spec and try again.
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }, []);
+
+  return { tab, switchTab, busy, error, setError, run };
+}

--- a/mobile/src/sheets/NewAgentSheet/index.tsx
+++ b/mobile/src/sheets/NewAgentSheet/index.tsx
@@ -80,7 +80,7 @@ export function NewAgentSheet({
       <Sheet open={open} onClose={onClose} full title="New agent">
         <div className="empty">
           <b>No projects on the host</b>
-          Pin a repo in Fletch on your Mac first.
+          Add one from Home first, or pin a repo in Fletch on your Mac.
         </div>
       </Sheet>
     );

--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -88,7 +88,10 @@ export interface MobileState {
   push(screen: ScreenName, props?: Record<string, string>): void;
   pop(): void;
   openSheet(name: SheetName, props?: Record<string, string>): void;
-  closeSheet(): void;
+  /** Close the open sheet. With `name`, only if that is the sheet showing: an
+   *  async action finishing late must not dismiss whatever the user opened
+   *  since. */
+  closeSheet(name?: SheetName): void;
 
   refreshWorkspace(): Promise<void>;
   openAgent(agentId: string): void;
@@ -362,8 +365,10 @@ export const useStore = create<MobileState>()((set, get) => ({
   openSheet(name, props = {}) {
     set({ sheet: { name, props, open: true } });
   },
-  closeSheet() {
-    set((s) => (s.sheet ? { sheet: { ...s.sheet, open: false } } : s));
+  closeSheet(name) {
+    set((s) =>
+      s.sheet && (!name || s.sheet.name === name) ? { sheet: { ...s.sheet, open: false } } : s,
+    );
   },
 
   async refreshWorkspace() {
@@ -552,15 +557,16 @@ export const useStore = create<MobileState>()((set, get) => ({
     return guard(set, () => api.listDir(path));
   },
 
-  /** Both add-project ops answer with the whole new `Workspace`, and neither
-   *  raises `workspace:changed` — so applying the result is the only way the
-   *  new project appears. It replaces the workspace wholesale, which is what
-   *  `refreshWorkspace` does too: a `workspace:changed` from anything else
-   *  landing either side of this leaves the same state. */
+  /** Both add-project ops answer with the whole new `Workspace`, which is
+   *  applied here rather than waited for as a `workspace:changed`: it replaces
+   *  the workspace wholesale, exactly as `refreshWorkspace` does, so an event
+   *  landing either side of this leaves the same state. Only the Add Project
+   *  sheet is closed on success — a slow clone must not dismiss a sheet the user
+   *  opened in the meantime. */
   async addWorkspaceRepo(repoPath) {
     return guard(set, async () => {
       set({ workspace: await api.addWorkspaceRepo(repoPath) });
-      get().closeSheet();
+      get().closeSheet("addProject");
     });
   },
 
@@ -569,7 +575,7 @@ export const useStore = create<MobileState>()((set, get) => ({
       const workspace = await api.cloneRepo(spec, destParent);
       set({ workspace, lastDestParent: destParent });
       await saveDestParent(get().hostKey, destParent);
-      get().closeSheet();
+      get().closeSheet("addProject");
     });
   },
 

--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -88,10 +88,12 @@ export interface MobileState {
   push(screen: ScreenName, props?: Record<string, string>): void;
   pop(): void;
   openSheet(name: SheetName, props?: Record<string, string>): void;
-  /** Close the open sheet. With `name`, only if that is the sheet showing: an
-   *  async action finishing late must not dismiss whatever the user opened
-   *  since. */
-  closeSheet(name?: SheetName): void;
+  /** Close whatever sheet is open. Safe to hand straight to an `onClose` or
+   *  `onClick`: it ignores its arguments. */
+  closeSheet(): void;
+  /** Close the sheet only if `name` is the one showing: for an async action
+   *  finishing late, which must not dismiss whatever the user opened since. */
+  closeSheetIf(name: SheetName): void;
 
   refreshWorkspace(): Promise<void>;
   openAgent(agentId: string): void;
@@ -365,10 +367,11 @@ export const useStore = create<MobileState>()((set, get) => ({
   openSheet(name, props = {}) {
     set({ sheet: { name, props, open: true } });
   },
-  closeSheet(name) {
-    set((s) =>
-      s.sheet && (!name || s.sheet.name === name) ? { sheet: { ...s.sheet, open: false } } : s,
-    );
+  closeSheet() {
+    set((s) => (s.sheet ? { sheet: { ...s.sheet, open: false } } : s));
+  },
+  closeSheetIf(name) {
+    if (get().sheet?.name === name) get().closeSheet();
   },
 
   async refreshWorkspace() {
@@ -566,7 +569,7 @@ export const useStore = create<MobileState>()((set, get) => ({
   async addWorkspaceRepo(repoPath) {
     return guard(set, async () => {
       set({ workspace: await api.addWorkspaceRepo(repoPath) });
-      get().closeSheet("addProject");
+      get().closeSheetIf("addProject");
     });
   },
 
@@ -575,7 +578,7 @@ export const useStore = create<MobileState>()((set, get) => ({
       const workspace = await api.cloneRepo(spec, destParent);
       set({ workspace, lastDestParent: destParent });
       await saveDestParent(get().hostKey, destParent);
-      get().closeSheet("addProject");
+      get().closeSheetIf("addProject");
     });
   },
 

--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -1,7 +1,8 @@
 import type { AgentRecord, Workspace } from "@desktop/api/types/agent";
-import type { CheckoutFile } from "@desktop/api/types/checkout";
+import type { CheckoutFile, DirListing } from "@desktop/api/types/checkout";
 import type { DiffStats, GitState } from "@desktop/api/types/git";
 import type { PrChecks, PrState } from "@desktop/api/types/pr";
+import type { GhRepoSummary, GhStatus } from "@desktop/api/types/providers";
 import { create } from "zustand";
 import type { ChatItem, RawEvent } from "../adapters";
 import { createApi } from "../api";
@@ -16,7 +17,7 @@ import {
   type Via,
 } from "../remote";
 import { registerRemoteEvents } from "./events";
-import { clearHost, loadSettings, saveSettings } from "./persist";
+import { clearHost, loadDestParent, loadSettings, saveDestParent, saveSettings } from "./persist";
 import { applyUserTurns, reduceRecords } from "./transcript";
 
 export const client = createClient();
@@ -24,7 +25,7 @@ export const api = createApi(client);
 
 export type ThemeMode = "system" | "light" | "dark";
 export type ScreenName = "home" | "project" | "agent" | "file" | "diff";
-export type SheetName = "host" | "newAgent" | "agentMore" | "modelPicker" | "pr";
+export type SheetName = "host" | "newAgent" | "addProject" | "agentMore" | "modelPicker" | "pr";
 
 export interface NavItem {
   key: number;
@@ -52,6 +53,9 @@ export interface MobileState {
   /** Which path the live connection took — mirrored from the client for the
    *  Host sheet, and null when there is no connection. */
   via: Via | null;
+  /** Where the last clone landed on this host, so the next one is offered the
+   *  same folder. Hydrated from the persist layer when the host is known. */
+  lastDestParent: string | null;
 
   workspace: Workspace | null;
   logs: Record<string, ChatItem[]>;
@@ -108,6 +112,12 @@ export interface MobileState {
   setEffort(agentId: string, effort: string): Promise<void>;
   publish(agentId: string, title: string, body: string): Promise<void>;
   pushToPr(agentId: string): Promise<void>;
+
+  listDir(path: string): Promise<DirListing>;
+  addWorkspaceRepo(repoPath: string): Promise<void>;
+  cloneRepo(spec: string, destParent: string): Promise<void>;
+  ghStatus(): Promise<GhStatus>;
+  ghRepoList(): Promise<GhRepoSummary[]>;
 }
 
 export interface SpawnInput {
@@ -171,6 +181,7 @@ export const useStore = create<MobileState>()((set, get) => ({
   hostKey: null,
   relay: null,
   via: null,
+  lastDestParent: null,
 
   workspace: null,
   logs: {},
@@ -224,7 +235,10 @@ export const useStore = create<MobileState>()((set, get) => ({
     // A saved host key is the whole credential: `hello` authenticates with the
     // device key the Rust layer holds.
     if (saved.host && saved.hostKey) {
-      set({ hostKey: saved.hostKey });
+      set({
+        hostKey: saved.hostKey,
+        lastDestParent: saved.destParents?.[saved.hostKey] ?? null,
+      });
       await get()
         .connect({
           host: saved.host,
@@ -253,6 +267,9 @@ export const useStore = create<MobileState>()((set, get) => ({
         hostKey,
         relay,
         via: client.via,
+        // The remembered clone destination is per host, so it can only be
+        // resolved once the handshake says which host this is.
+        lastDestParent: await loadDestParent(hostKey),
         nav: [{ key: Date.now(), screen: "home", props: {}, phase: "idle" }],
       });
       // Mock mode must not leave a "mock" host behind for the next real run.
@@ -289,6 +306,7 @@ export const useStore = create<MobileState>()((set, get) => ({
       hostKey: null,
       relay: null,
       via: null,
+      lastDestParent: null,
       workspace: null,
       hostInfo: null,
       logs: {},
@@ -528,6 +546,39 @@ export const useStore = create<MobileState>()((set, get) => ({
     if (git?.files.length) await api.commitAgent(agentId, title);
     await api.pushAgent(agentId);
     await get().loadGit(agentId);
+  },
+
+  async listDir(path) {
+    return guard(set, () => api.listDir(path));
+  },
+
+  /** Both add-project ops answer with the whole new `Workspace`, and neither
+   *  raises `workspace:changed` — so applying the result is the only way the
+   *  new project appears. It replaces the workspace wholesale, which is what
+   *  `refreshWorkspace` does too: a `workspace:changed` from anything else
+   *  landing either side of this leaves the same state. */
+  async addWorkspaceRepo(repoPath) {
+    return guard(set, async () => {
+      set({ workspace: await api.addWorkspaceRepo(repoPath) });
+      get().closeSheet();
+    });
+  },
+
+  async cloneRepo(spec, destParent) {
+    return guard(set, async () => {
+      const workspace = await api.cloneRepo(spec, destParent);
+      set({ workspace, lastDestParent: destParent });
+      await saveDestParent(get().hostKey, destParent);
+      get().closeSheet();
+    });
+  },
+
+  async ghStatus() {
+    return guard(set, () => api.ghStatus());
+  },
+
+  async ghRepoList() {
+    return guard(set, () => api.ghRepoList());
   },
 }));
 

--- a/mobile/src/store/persist.ts
+++ b/mobile/src/store/persist.ts
@@ -18,6 +18,10 @@ export interface Persisted {
   hostKey?: string;
   /** Relay base URL for this host, from the pairing link or the Host sheet. */
   relay?: string;
+  /** Where the last clone landed, keyed by host public key — the desktop
+   *  remembers the same thing, and the folder only means something on the Mac
+   *  that owns it. */
+  destParents?: Record<string, string>;
   theme?: "system" | "light" | "dark";
 }
 
@@ -67,9 +71,23 @@ export async function saveSettings(patch: Persisted): Promise<Persisted> {
   return next;
 }
 
+/** The clone destination this host was last given, or null when it has none.
+ *  Keyed by host key so re-pairing the same Mac gets its folder back. */
+export async function loadDestParent(hostKey: string | null): Promise<string | null> {
+  if (!hostKey) return null;
+  return (await readAll()).destParents?.[hostKey] ?? null;
+}
+
+export async function saveDestParent(hostKey: string | null, parent: string): Promise<void> {
+  if (!hostKey) return;
+  const { destParents } = await readAll();
+  await saveSettings({ destParents: { ...destParents, [hostKey]: parent } });
+}
+
 /** Forget the paired host — address, name, pinned key and relay — and keep the
- *  rest. */
+ *  rest. The destination folders stay: they are keyed by host key, so they are
+ *  meaningless to anyone else and useful again if this Mac is re-paired. */
 export async function clearHost(): Promise<void> {
-  const { theme } = await readAll();
-  await writeAll(theme ? { theme } : {});
+  const { theme, destParents } = await readAll();
+  await writeAll({ ...(theme ? { theme } : {}), ...(destParents ? { destParents } : {}) });
 }

--- a/mobile/src/styles/screens.css
+++ b/mobile/src/styles/screens.css
@@ -1,6 +1,6 @@
-/* Home, Project, Pair, Host sheet, New agent. Ported from the prototype;
-   Add-project and voice capture are out of scope for v1 and their rules are
-   dropped rather than left dead. */
+/* Home, Project, Pair, Host sheet, New agent, Add project. Ported from the
+   prototype; voice capture is out of scope for v1 and its rules are dropped
+   rather than left dead. */
 
 /* Home */
 .home-head {
@@ -622,6 +622,7 @@
   line-height: 1.5;
 }
 .pair label,
+.ap-field label,
 .relay-field label {
   display: block;
   font-size: 11px;
@@ -635,6 +636,7 @@
   margin-top: 2px;
 }
 .pair input,
+.ap-field input,
 .relay-field input {
   width: 100%;
   background: var(--bg-2);
@@ -647,6 +649,7 @@
   transition: border-color 0.2s;
 }
 .pair input:focus,
+.ap-field input:focus,
 .relay-field input:focus {
   border-color: var(--accent-line);
 }
@@ -707,4 +710,73 @@
   color: inherit;
   font-weight: 600;
   text-decoration: underline;
+}
+
+/* Add project: the section-header affordance on Home, and the sheet's own
+   rows. Everything else in the sheet is .card/.row/.search/.chip/.err. */
+.sect-add {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  height: 22px;
+  padding: 0 7px 0 5px;
+  border-radius: 7px;
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  background: var(--accent-soft);
+}
+.sect-add:active {
+  background: var(--bg-3);
+}
+.empty .ap-empty {
+  margin-top: 16px;
+}
+.ap-seg {
+  margin: 4px 0 14px;
+}
+/* The current folder, with the walk-up button. Scrolls sideways rather than
+   wrapping: a deep path must not push the list down the screen. */
+.ap-path {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 0 8px;
+}
+/* Pulled left so the glyph, not the tap target, lines up with the card below. */
+.ap-path .ibtn {
+  margin-left: -8px;
+}
+.ap-path .p {
+  flex: 1;
+  min-width: 0;
+  font-size: 11.5px;
+  color: var(--fg-2);
+  white-space: nowrap;
+  overflow-x: auto;
+}
+.ap-hid {
+  display: flex;
+  justify-content: center;
+  margin-top: 10px;
+}
+.ap-field {
+  margin-top: 18px;
+}
+.ap-sect {
+  margin-top: 20px;
+}
+.ap-err {
+  padding: 14px 2px 0;
+}
+.ap-use {
+  margin-top: 16px;
+}
+.ap-hint {
+  font-size: 12px;
+  color: var(--fg-3);
+  line-height: 1.45;
+  margin-top: 8px;
+  text-align: center;
 }

--- a/mobile/tests/addProject.test.ts
+++ b/mobile/tests/addProject.test.ts
@@ -132,6 +132,14 @@ describe("clone from GitHub", () => {
     expect(state().sheet).toMatchObject({ name: "host", open: true });
     spy.mockRestore();
   });
+
+  it("closeSheet still closes when wired straight to a click handler", () => {
+    state().openSheet("host");
+    // React hands an onClick/onClose callback its event; the unconditional
+    // closer must ignore it rather than read it as a sheet name.
+    (state().closeSheet as (e: unknown) => void)({ type: "click" });
+    expect(state().sheet).toMatchObject({ name: "host", open: false });
+  });
 });
 
 // First-render markup only — enough to catch a form that cannot render and to

--- a/mobile/tests/addProject.test.ts
+++ b/mobile/tests/addProject.test.ts
@@ -114,6 +114,24 @@ describe("clone from GitHub", () => {
     expect(state().lastError).toContain("a folder already exists at");
     spy.mockRestore();
   });
+
+  it("closes only the Add Project sheet when a slow clone finishes", async () => {
+    let finish: (w: NonNullable<ReturnType<typeof state>["workspace"]>) => void = () => {};
+    const spy = vi
+      .spyOn(api, "cloneRepo")
+      .mockReturnValue(new Promise((resolve) => (finish = resolve)));
+    state().openSheet("addProject");
+    const cloning = state().cloneRepo("fwdai/other", await codeDir());
+
+    // The user gave up waiting and opened something else.
+    state().closeSheet();
+    state().openSheet("host");
+    finish(state().workspace as NonNullable<ReturnType<typeof state>["workspace"]>);
+    await cloning;
+
+    expect(state().sheet).toMatchObject({ name: "host", open: true });
+    spy.mockRestore();
+  });
 });
 
 // First-render markup only — enough to catch a form that cannot render and to

--- a/mobile/tests/addProject.test.ts
+++ b/mobile/tests/addProject.test.ts
@@ -1,0 +1,154 @@
+// The add-project flows end to end over the mock host: the real protocol
+// client, the real store actions, the real persist layer. The jsdom URL in
+// vite.config.ts puts this file in mock mode (see `mockEnabled`).
+
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import { childPath, parentPath } from "../src/lib/paths";
+import { MOCK_HOST_KEY } from "../src/remote/mock";
+import { HOME } from "../src/remote/mock/fixtures";
+import { AddProjectSheet } from "../src/sheets/AddProjectSheet";
+import { CloneForm } from "../src/sheets/AddProjectSheet/CloneForm";
+import { OpenFolderForm } from "../src/sheets/AddProjectSheet/OpenFolderForm";
+import { api, useStore } from "../src/store";
+import { loadDestParent } from "../src/store/persist";
+
+const state = () => useStore.getState();
+
+/** Where the picker would land after browsing to `~/Code` — the absolute base
+ *  the host reports, not the string it was asked for. */
+const codeDir = async () => (await state().listDir("~/Code")).base;
+
+beforeAll(async () => {
+  await state().init();
+  await vi.waitFor(() => expect(state().connection).toBe("connected"), { timeout: 5000 });
+});
+
+describe("path arithmetic", () => {
+  it("joins a listing base with an entry name without doubling the separator", () => {
+    // A bare `~` comes back expanded *with* a trailing slash, so this is the
+    // real shape, not a defensive edge case.
+    expect(childPath(`${HOME}/`, "Code")).toBe("/Users/alex/Code");
+    expect(childPath(HOME, "Code")).toBe("/Users/alex/Code");
+    expect(childPath("/", "Users")).toBe("/Users");
+  });
+
+  it("walks back up, and stops at the root", () => {
+    expect(parentPath("/Users/alex/Code")).toBe("/Users/alex");
+    expect(parentPath("/Users/alex/")).toBe("/Users");
+    expect(parentPath("/Users")).toBe("/");
+    expect(parentPath("/")).toBeNull();
+  });
+});
+
+describe("browsing the host", () => {
+  it("reports the absolute base for a tilde path, and directories to walk", async () => {
+    const listing = await state().listDir("~");
+    expect(listing.base).toBe(`${HOME}/`);
+    expect(listing.entries).toContainEqual({ name: "Code", is_dir: true });
+    // Files come back too; the picker is what filters them out.
+    expect(listing.entries.some((e) => !e.is_dir)).toBe(true);
+  });
+
+  it("records a failed listing in lastError and rethrows it", async () => {
+    await expect(state().listDir("/nope")).rejects.toThrow("no such directory");
+    expect(state().lastError).toContain("no such directory");
+  });
+});
+
+describe("open an existing folder", () => {
+  it("sends the picked absolute path and takes the workspace the host returns", async () => {
+    const spy = vi.spyOn(api, "addWorkspaceRepo");
+    const picked = childPath(await codeDir(), "playground");
+    await state().addWorkspaceRepo(picked);
+    expect(spy).toHaveBeenCalledWith("/Users/alex/Code/playground");
+    // No `workspace:changed` follows these ops, so the returned workspace is
+    // the only thing that puts the project on the home screen.
+    expect(state().workspace?.projects.map((p) => p.path)).toContain(picked);
+    spy.mockRestore();
+  });
+
+  it("pinning a folder that is already a project changes nothing", async () => {
+    const picked = childPath(await codeDir(), "playground");
+    const before = state().workspace;
+    await state().addWorkspaceRepo(picked);
+    expect(state().workspace?.projects).toEqual(before?.projects);
+  });
+
+  it("records the host's refusal in lastError and rethrows it", async () => {
+    // The host refuses a folder nested inside an existing repository rather
+    // than running `git init` in it.
+    const nested = childPath(childPath(await codeDir(), "playground"), "src");
+    await expect(state().addWorkspaceRepo(nested)).rejects.toThrow("inside the git repository");
+    expect(state().lastError).toContain("inside the git repository");
+  });
+});
+
+describe("clone from GitHub", () => {
+  it("knows whether gh is signed in, and lists the user's repos", async () => {
+    expect(await state().ghStatus()).toMatchObject({
+      authenticated: true,
+      login: "alexchaplinsky",
+    });
+    expect((await state().ghRepoList()).map((r) => r.name_with_owner)).toContain("fwdai/fletch");
+  });
+
+  it("clones into the chosen parent and remembers it for this host", async () => {
+    expect(state().lastDestParent).toBeNull();
+    const parent = await codeDir();
+    await state().cloneRepo("https://github.com/fwdai/relay.git", parent);
+    expect(state().workspace?.projects.map((p) => p.path)).toContain(`${parent}/relay`);
+    expect(state().lastDestParent).toBe(parent);
+    // What the next session would hydrate as the clone form's default.
+    expect(await loadDestParent(MOCK_HOST_KEY)).toBe(parent);
+  });
+
+  it("reuses the remembered parent, and surfaces the collision it causes", async () => {
+    const spy = vi.spyOn(api, "cloneRepo");
+    const remembered = state().lastDestParent ?? "";
+    await expect(state().cloneRepo("fwdai/relay", remembered)).rejects.toThrow(
+      `a folder already exists at ${remembered}/relay`,
+    );
+    expect(spy).toHaveBeenCalledWith("fwdai/relay", remembered);
+    expect(state().lastError).toContain("a folder already exists at");
+    spy.mockRestore();
+  });
+});
+
+// First-render markup only — enough to catch a form that cannot render and to
+// pin the two things the layout has to say before anything is picked.
+describe("the sheet", () => {
+  const noop = async () => {};
+
+  it("offers both flows, and tells the user about git init", () => {
+    const html = renderToStaticMarkup(
+      createElement(AddProjectSheet, { open: true, onClose: () => {} }),
+    );
+    expect(html).toContain("Open folder");
+    expect(html).toContain("Clone");
+    expect(html).toContain("Use this folder");
+    expect(html).toContain("git init");
+  });
+
+  it("asks for a destination, and will not clone without one", () => {
+    // A render-only harness reads zustand's *initial* state, so this is the
+    // nothing-remembered case; the remembered one is asserted on the store.
+    const html = renderToStaticMarkup(
+      createElement(CloneForm, { busy: false, error: null, setError: () => {}, run: noop }),
+    );
+    expect(html).toContain("Choose a folder");
+    expect(html).toContain('class="btn primary block ap-use" disabled=""');
+  });
+
+  it("shows a failed op's own text, in place", () => {
+    const html = renderToStaticMarkup(
+      createElement(OpenFolderForm, {
+        busy: false,
+        error: "a folder already exists at /Users/alex/Code/relay",
+        run: noop,
+      }),
+    );
+    expect(html).toContain("a folder already exists at /Users/alex/Code/relay");
+  });
+});


### PR DESCRIPTION
## What

The phone half of "Add project", stacked on #657 (which exposes the ops). An Add Project sheet reachable from Home's "Projects" header and its empty state, with two flows:

- **Open folder**: browse the Mac with `list_dir` from `~` (directories only, hidden entries behind a toggle, walk-up), then `add_workspace_repo`. A hint under the action says a non-repo folder gets `git init`.
- **Clone**: `gh_status`, then the user's repos from `gh_repo_list` with a filter box, or a typed `owner/repo` / URL validated with the desktop's own `parseRepoSpec`; destination parent picked with the same folder picker and remembered per host key; then `clone_repo`.

## How

- `mobile/src/sheets/AddProjectSheet/` split into `index`, `FolderPicker`, `OpenFolderForm`, `CloneForm`, `useAddProject`; reuses the existing `Sheet`/`Segmented` chrome. Path arithmetic in `mobile/src/lib/paths.ts` is shared by the picker, the clone form and the mock host.
- Store actions go through the existing `guard` (record `lastError`, rethrow) and apply the returned `Workspace` themselves, since neither op emits `workspace:changed`. `lastDestParent` persists per host key and survives un-pairing.
- The mock host implements the five ops over a small fake filesystem and mirrors the real host's quirks: trailing slash on a bare `~`, snake_case `is_dir`, idempotent re-pin, refusal of a folder nested inside an existing repo.
- `NewAgentSheet`'s empty state now points at this sheet instead of only "pin a repo on your Mac".

## Tests

`bun run test` in `mobile/`: 61 passed. New file `tests/addProject.test.ts` drives the real client, store and persist layer against the mock host: path joins never double the separator, `~` reports the absolute base, the picked absolute path reaches `add_workspace_repo`, re-pin is a no-op, a nested folder's refusal lands in `lastError` and rethrows, the clone form defaults to the remembered parent, and the forms render. `tsc --noEmit`, mobile Biome and root Biome clean.

Not exercised in a browser: the sandbox kills Chromium, so the forms are render-tested with `react-dom/server` instead.