### PR TITLE
fix(mobile): list a project's agents newest first

### DIFF
--- a/mobile/src/lib/agents.ts
+++ b/mobile/src/lib/agents.ts
@@ -29,11 +29,14 @@ export const baseOf = (a: AgentRecord) => primaryRepo(a)?.parent_branch ?? "main
 
 /** A project's live agents, newest first. The host hands the snapshot back in
  *  `created_at` order, so the list has to be reversed here or the most recent
- *  agent lands at the bottom — same ordering the desktop sidebar applies. */
+ *  agent lands at the bottom — same ordering the desktop sidebar applies.
+ *  Agents spawned in the same millisecond (a workflow's fan-out) break the tie
+ *  on id, so the order is total rather than left to the sort's discretion —
+ *  the tie-break `deriveStepChildren` already uses. */
 export const agentsOfProject = (ws: Workspace | null, projectId: string) =>
   (ws?.agents ?? [])
     .filter((a) => a.project_id === projectId && !a.archive)
-    .sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
+    .sort((a, b) => b.created_at.localeCompare(a.created_at) || a.id.localeCompare(b.id));
 
 export const providerLabel = (id: string) => PROVIDERS.find((p) => p.id === id)?.label ?? id;
 

--- a/mobile/src/lib/agents.ts
+++ b/mobile/src/lib/agents.ts
@@ -27,8 +27,13 @@ export const branchOf = (a: AgentRecord) => primaryRepo(a)?.branch ?? "—";
 
 export const baseOf = (a: AgentRecord) => primaryRepo(a)?.parent_branch ?? "main";
 
+/** A project's live agents, newest first. The host hands the snapshot back in
+ *  `created_at` order, so the list has to be reversed here or the most recent
+ *  agent lands at the bottom — same ordering the desktop sidebar applies. */
 export const agentsOfProject = (ws: Workspace | null, projectId: string) =>
-  (ws?.agents ?? []).filter((a) => a.project_id === projectId && !a.archive);
+  (ws?.agents ?? [])
+    .filter((a) => a.project_id === projectId && !a.archive)
+    .sort((a, b) => (a.created_at < b.created_at ? 1 : -1));
 
 export const providerLabel = (id: string) => PROVIDERS.find((p) => p.id === id)?.label ?? id;
 

--- a/mobile/tests/agents.test.ts
+++ b/mobile/tests/agents.test.ts
@@ -29,6 +29,15 @@ describe("agentsOfProject", () => {
     expect(list.map((a) => a.id)).toEqual(["new", "mid", "old"]);
   });
 
+  it("breaks a same-millisecond tie on id, so the order is total", () => {
+    const tied = ["c", "a", "b"].map((id) => agent({ id, created_at: "2026-01-01T00:00:01.000Z" }));
+    const list = agentsOfProject(
+      ws([...tied, agent({ id: "newer", created_at: "2026-01-01T00:00:02.000Z" })]),
+      "p1",
+    );
+    expect(list.map((a) => a.id)).toEqual(["newer", "a", "b", "c"]);
+  });
+
   it("keeps out other projects' agents and archived ones", () => {
     const list = agentsOfProject(
       ws([

--- a/mobile/tests/agents.test.ts
+++ b/mobile/tests/agents.test.ts
@@ -1,0 +1,54 @@
+// Derivations over the workspace snapshot in src/lib/agents.ts.
+
+import type { AgentRecord, Workspace } from "@desktop/api/types/agent";
+import { describe, expect, it } from "vitest";
+import { agentsOfProject } from "../src/lib/agents";
+
+const agent = (over: Partial<AgentRecord>) =>
+  ({
+    id: "a",
+    project_id: "p1",
+    created_at: "2026-01-01T00:00:00.000Z",
+    repos: [],
+    ...over,
+  }) as AgentRecord;
+
+const ws = (agents: AgentRecord[]) => ({ agents, projects: [] }) as unknown as Workspace;
+
+describe("agentsOfProject", () => {
+  it("returns the project's agents newest first, whatever order the host sent", () => {
+    // The host selects `ORDER BY w.created_at` — oldest first.
+    const list = agentsOfProject(
+      ws([
+        agent({ id: "old", created_at: "2026-01-01T00:00:01.000Z" }),
+        agent({ id: "mid", created_at: "2026-01-01T00:00:02.000Z" }),
+        agent({ id: "new", created_at: "2026-01-01T00:00:03.000Z" }),
+      ]),
+      "p1",
+    );
+    expect(list.map((a) => a.id)).toEqual(["new", "mid", "old"]);
+  });
+
+  it("keeps out other projects' agents and archived ones", () => {
+    const list = agentsOfProject(
+      ws([
+        agent({ id: "mine" }),
+        agent({ id: "theirs", project_id: "p2" }),
+        agent({
+          id: "archived",
+          archive: {
+            archived_at: "2026-01-02T00:00:00.000Z",
+            repos: [],
+            diff_stats: { additions: 0, deletions: 0 },
+          },
+        }),
+      ]),
+      "p1",
+    );
+    expect(list.map((a) => a.id)).toEqual(["mine"]);
+  });
+
+  it("is empty with no snapshot", () => {
+    expect(agentsOfProject(null, "p1")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Problem

On mobile, the agent list inside a project was reversed — the most recent agent appeared at the bottom instead of the top.

The host returns the workspace snapshot with `ORDER BY w.created_at` (oldest first, `src-tauri/src/workspace/query.rs:180`). The desktop sidebar re-sorts it descending (`src/components/Sidebar/index.tsx:167`), but mobile's `agentsOfProject` only filtered, so the list rendered oldest → newest.

## Change

- `mobile/src/lib/agents.ts` — `agentsOfProject` now sorts newest first, using the same comparator as the desktop sidebar. This also covers the Home screen's per-project agent previews, and keeps a locally created agent (optimistically prepended in `mobile/src/store/index.ts`) at the top after the next snapshot refresh instead of dropping it to the bottom.
- `mobile/tests/agents.test.ts` — regression test for the ordering, plus the existing project/archive filtering.

## Side effect

The Project screen's base-branch pill reads `baseOf(agents[0])`, so it now reflects the newest agent's parent branch rather than the oldest one's. Arguably the more sensible reading, but it is a behaviour change worth noting.

## Verification

`tsc --noEmit` clean, `biome check` clean, 74 mobile tests pass.