### PR TITLE
fix(mobile): follow streaming chat output to the bottom

### DIFF
--- a/mobile/src/lib/useStickyScroll.ts
+++ b/mobile/src/lib/useStickyScroll.ts
@@ -1,0 +1,42 @@
+import { type MutableRefObject, useCallback, useLayoutEffect, useRef } from "react";
+
+/** How many pixels short of the bottom still count as "at the bottom".
+ *  Sub-pixel rounding makes exact equality flaky; the desktop transcript
+ *  allows the same slop. */
+const BOTTOM_SLOP = 40;
+
+/** Keep a scroll container pinned to its bottom as content arrives, and stop
+ *  following the moment the user scrolls up — the desktop transcript's
+ *  behaviour (`TranscriptList`).
+ *
+ *  `deps` are change signals, not values the effect reads: pass whatever
+ *  identifies "new content" (a log array, a status). They have to change on
+ *  *every* update that grows the container, including a streaming message
+ *  extended in place — which is why this can't key off a rendered item count.
+ *
+ *  Pass `pinRef` to own the pin flag in a parent, so a composer that sends a
+ *  message can re-pin the log the way the desktop's `ChatView` does. */
+export function useStickyScroll<T extends HTMLElement>(
+  deps: unknown[],
+  pinRef?: MutableRefObject<boolean>,
+) {
+  const ref = useRef<T>(null);
+  const ownPin = useRef(true);
+  const pinned = pinRef ?? ownPin;
+
+  const onScroll = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    pinned.current = el.scrollHeight - el.scrollTop - el.clientHeight <= BOTTOM_SLOP;
+  }, [pinned]);
+
+  // A layout effect, so the jump happens before the browser paints the content
+  // that grew — a plain effect shows one frame at the old offset.
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el || !pinned.current) return;
+    el.scrollTop = el.scrollHeight;
+  }, [...deps, pinned]);
+
+  return { ref, onScroll };
+}

--- a/mobile/src/lib/useStickyScroll.ts
+++ b/mobile/src/lib/useStickyScroll.ts
@@ -30,6 +30,16 @@ export function useStickyScroll<T extends HTMLElement>(
     pinned.current = el.scrollHeight - el.scrollTop - el.clientHeight <= BOTTOM_SLOP;
   }, [pinned]);
 
+  // A freshly mounted scroller opens at its latest, so a lifted `pinRef` can't
+  // carry a stale `false` into it — scroll up in the chat, switch to Code and
+  // back, and the new scroller would otherwise sit at the top and never
+  // follow. The desktop re-pins on the same reasoning when you switch agents.
+  // Declared before the follow effect so it has already run when that one
+  // does its initial scroll.
+  useLayoutEffect(() => {
+    pinned.current = true;
+  }, [pinned]);
+
   // A layout effect, so the jump happens before the browser paints the content
   // that grew — a plain effect shows one frame at the old offset.
   useLayoutEffect(() => {

--- a/mobile/src/screens/Agent/ChatTab.tsx
+++ b/mobile/src/screens/Agent/ChatTab.tsx
@@ -1,10 +1,11 @@
 import type { AgentRecord } from "@desktop/api/types/agent";
-import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
+import { type MutableRefObject, useMemo } from "react";
 import { applyPolicy, type ChatItem, getAdapter } from "../../adapters";
 import { Icon } from "../../components/Icon";
 import { Md } from "../../components/ui";
 import { isBusy, providerLabel } from "../../lib/agents";
 import { fmtElapsed, useElapsed } from "../../lib/hooks";
+import { useStickyScroll } from "../../lib/useStickyScroll";
 import { useStore } from "../../store";
 import { ApprovalCard, ErrorCard } from "./ApprovalCard";
 import { ToolRow } from "./ToolRow";
@@ -70,13 +71,19 @@ function Item({ item }: { item: ChatItem }) {
   }
 }
 
-export function ChatTab({ agent }: { agent: AgentRecord }) {
+export function ChatTab({
+  agent,
+  pinRef,
+}: {
+  agent: AgentRecord;
+  /** Owned by the screen so the composer can re-pin on send. */
+  pinRef?: MutableRefObject<boolean>;
+}) {
   // No `?? []` inside a selector: a fresh empty value on every call is a new
   // reference and re-renders forever under zustand v5.
   const log = useStore((s) => s.logs[agent.id]);
   const pending = useStore((s) => s.pendingToolUse[agent.id]);
   const startedAt = useStore((s) => s.turnStartedAt[agent.id]);
-  const scroller = useRef<HTMLDivElement>(null);
   const busy = isBusy(agent);
   const elapsed = useElapsed(startedAt, busy);
 
@@ -92,24 +99,17 @@ export function ChatTab({ agent }: { agent: AgentRecord }) {
     return map;
   }, [log]);
 
-  useLayoutEffect(() => {
-    const el = scroller.current;
-    if (el) el.scrollTop = el.scrollHeight;
-  }, []);
-  const blockCount = blocks.length;
-  useEffect(() => {
-    const el = scroller.current;
-    if (!el || blockCount === 0) return;
-    // Animate while a turn is streaming; jump when the log is rebuilt from
-    // records, where a long smooth scroll would look like a glitch.
-    el.scrollTo({
-      top: el.scrollHeight,
-      behavior: agent.status === "running" ? "smooth" : "auto",
-    });
-  }, [blockCount, agent.status]);
+  // `log` is the signal that matters: a streaming message is extended in
+  // place, so the item count stays put while the rendered height grows. The
+  // rest are the cards this pane draws as siblings of the log — the approval
+  // prompt, the error card, the working indicator.
+  const { ref: scroller, onScroll } = useStickyScroll<HTMLDivElement>(
+    [log, pending, agent.status, busy],
+    pinRef,
+  );
 
   return (
-    <div className="scroll chat" ref={scroller}>
+    <div className="scroll chat" ref={scroller} onScroll={onScroll}>
       {blocks.map((b) =>
         b.kind === "tools" ? (
           <div key={b.key} className="tools rise">

--- a/mobile/src/screens/Agent/Composer.tsx
+++ b/mobile/src/screens/Agent/Composer.tsx
@@ -7,7 +7,14 @@ import { autosize } from "../../lib/autosize";
 import { ignore } from "../../lib/ignore";
 import { useStore } from "../../store";
 
-export function Composer({ agent }: { agent: AgentRecord }) {
+export function Composer({
+  agent,
+  onSend,
+}: {
+  agent: AgentRecord;
+  /** Fires as the message goes out, so the screen can re-pin the log. */
+  onSend?: () => void;
+}) {
   const send = useStore((s) => s.send);
   const stop = useStore((s) => s.stop);
   const openSheet = useStore((s) => s.openSheet);
@@ -20,6 +27,7 @@ export function Composer({ agent }: { agent: AgentRecord }) {
     if (!value) return;
     setText("");
     requestAnimationFrame(() => autosize(ta.current));
+    onSend?.();
     void send(agent.id, value).catch(ignore);
   };
 

--- a/mobile/src/screens/Agent/index.tsx
+++ b/mobile/src/screens/Agent/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Icon } from "../../components/Icon";
 import { Nav, ProviderMark, Segmented } from "../../components/ui";
 import { baseOf, branchOf, isBusy, STATUS_LABEL } from "../../lib/agents";
@@ -89,6 +89,8 @@ export function AgentScreen({ agentId }: { agentId: string }) {
   const git = useStore((s) => s.gitStates[agentId]);
   const [tab, setTab] = useState<Tab>("chat");
   const [dir, setDir] = useState(1);
+  // Owned here so sending a message can re-pin the log to the bottom.
+  const pinnedToBottom = useRef(true);
   if (!agent) return null;
 
   const go = (next: string) => {
@@ -147,13 +149,20 @@ export function AgentScreen({ agentId }: { agentId: string }) {
               } as React.CSSProperties
             }
           >
-            {tab === "chat" && <ChatTab agent={agent} />}
+            {tab === "chat" && <ChatTab agent={agent} pinRef={pinnedToBottom} />}
             {tab === "code" && <CodeTab agent={agent} />}
             {tab === "changes" && <ChangesTab agent={agent} />}
           </div>
         )}
       </div>
-      {tab === "chat" && agent.status !== "spawning" && <Composer agent={agent} />}
+      {tab === "chat" && agent.status !== "spawning" && (
+        <Composer
+          agent={agent}
+          onSend={() => {
+            pinnedToBottom.current = true;
+          }}
+        />
+      )}
     </>
   );
 }


### PR DESCRIPTION
## Problem

On mobile, the chat pane stopped following the agent's output mid-turn: streamed text ran below the fold and the newest lines were only visible after scrolling by hand. It snapped back to the bottom at turn end.

The autoscroll effect was keyed on the number of rendered blocks:

```ts
const blockCount = blocks.length;
useEffect(() => { ...scrollTo({ top: el.scrollHeight }) }, [blockCount, agent.status]);
```

But streaming extends the **last item in place** — `extendLastAssistant` (`src/adapters/claude/reduce.ts:104`) and `appendToolInputDelta` (`:111`) both return a same-length log. So the log's identity changed on every token while `blockCount` did not, the effect never re-ran, and the container never followed. The snap at turn end was `agent.status` flipping to `idle` and firing the effect once. The same blind spot covered a tool result attaching to an existing card, the approval card, the error card, and the working indicator — all of which change height without adding a block.

## Change

Follow the log itself, the way the desktop transcript does (`src/components/Workspace/messages/TranscriptList.tsx:66-72`), and bring over the bottom-pinning the desktop pairs it with — which mobile had no equivalent of at all:

- **`mobile/src/lib/useStickyScroll.ts`** (new) — pins a scroll container to its bottom as content arrives and lets go once the user scrolls up past a 40px slop, the desktop's own tolerance. Takes change signals rather than a rendered count, and accepts an optional lifted pin ref. Extracted rather than inlined in `ChatTab` because nothing about it is chat-specific.
- **`ChatTab`** — uses the hook with `[log, pending, agent.status, busy]` and wires `onScroll`. Also drops `behavior: "smooth"`: the desktop does a plain `scrollTop = scrollHeight` jump, and per-token smooth scrolling visibly lags a live stream.
- **`AgentScreen` / `Composer`** — the pin ref is owned by the screen and re-pinned from the composer's `onSend`, since `Composer` is `ChatTab`'s sibling. Mirrors `ChatView.tsx:19,105`.

Net behaviour, matching desktop: the log follows the stream; scrolling up to read history stops it; scrolling back to the bottom or sending a message resumes it.

## Notes

No test for this one — jsdom reports `scrollHeight`/`clientHeight` as 0, so a test would be asserting against faked metrics rather than the behaviour that was broken. `tsc --noEmit` clean, `biome check` clean, the existing 71 mobile tests pass. Worth a hands-on check on device against a live turn.

Independent of #663 (that one touches `lib/agents.ts` only), so this is based on `main` and the two can merge in either order.