### PR TITLE
fix(mobile): sit the composer at the bottom of the screen

### DIFF
--- a/mobile/src/styles/agent.css
+++ b/mobile/src/styles/agent.css
@@ -267,7 +267,13 @@
 
 .composer {
   flex-shrink: 0;
-  padding: 8px 12px calc(var(--safe-bottom) + 4px);
+  /* Deliberately does not honour --safe-bottom. Reserving the full home
+     indicator inset (34px on a notched phone) left the prompt box floating on
+     a band of empty panel; the inset exists so content isn't *obscured*, and
+     there is nothing below a text box to obscure. A flat 10px keeps the send
+     row clear of the indicator while the box sits at the bottom of the
+     screen. */
+  padding: 8px 12px 10px;
   background: var(--bg-0);
   border-top: 1px solid var(--bd-soft);
 }


### PR DESCRIPTION
## Problem

The composer's prompt box didn't sit at the bottom of the screen — it sat on a panel with a wide empty band beneath it. Most noticeable while an agent is working, when the keyboard is down and the composer is the only thing at the foot of the screen.

The cause is the composer panel reserving the full bottom safe-area inset:

```css
.composer { padding: 8px 12px calc(var(--safe-bottom) + 4px); }
/* --safe-bottom: max(env(safe-area-inset-bottom, 0px), 10px) */
```

On a notched iPhone that's 34px + 4px of padding below the rounded input, rendered in the panel's own background — so the box floats and the panel's bottom edge is what reaches the screen.

Worth noting the composer has no busy-state styling at all, so its geometry is identical whether or not an agent is running; the gap was always there, it's just that watching a turn stream is when you sit and look at it.

## Change

`.composer` no longer honours `--safe-bottom` — flat `10px` instead. The safe-area inset exists so content isn't *obscured* by the home indicator, and there is nothing below a text box to obscure; 10px keeps the send row clear of the indicator while the box sits at the bottom of the screen. That was already the `--safe-bottom` floor, so nothing changes in a desktop browser or on a device without an inset.

Scoped to the composer. The other bottom-anchored surfaces — sheets, the FAB, the diff nav — still reserve the inset, since those do put controls in that strip.

## Verification

CSS-only; `biome check` clean, `tsc --noEmit` clean, mobile tests pass. **I could not verify this visually** — Chromium can't launch in my sandbox (SIGKILL), so I read the layout rather than looked at it. Please eyeball it on device: if 10px reads too tight against the home indicator, the value in `mobile/src/styles/agent.css` is the one knob — 14px would match what a no-inset device sees today.