### PR TITLE
fix(mobile): let the iOS webview own the whole screen

### DIFF
--- a/mobile/src-tauri/Cargo.lock
+++ b/mobile/src-tauri/Cargo.lock
@@ -1174,6 +1174,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
  "futures-util",
+ "objc2",
  "serde",
  "serde_json",
  "snow",

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -37,6 +37,11 @@ serde = { version = "1", features = ["derive"] }
 # `generate_context!` expands to serde_json for the capability scopes.
 serde_json = "1"
 
+[target.'cfg(target_os = "ios")'.dependencies]
+# `with_webview` hands out the raw WKWebView; objc2 is how we say anything to
+# it. Already in the tree via tauri, so this pins nothing new.
+objc2 = "0.6"
+
 [dev-dependencies]
 # The connect budget is async, so the test that drives it needs a runtime.
 tokio = { version = "1", features = ["rt", "time"] }

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -4,6 +4,34 @@
 
 mod remote;
 
+/// Hand the safe-area insets back to CSS, so the web content owns the whole
+/// screen.
+///
+/// wry builds the `WKWebView` at the full size of the window, but never touches
+/// its scroll view's `contentInsetAdjustmentBehavior` — which defaults to
+/// `.automatic`. UIKit then insets that scroll view by the safe area, and WebKit
+/// measures the layout viewport against the *un-inset* region, so a
+/// `position: fixed; inset: 0` shell (`.m-app`) comes out short by the status bar
+/// plus the home-indicator strip. The bottom-anchored composer ends up floating
+/// well above the bottom of the screen with window background beneath it.
+///
+/// `.never` leaves the viewport at full screen size, which is what
+/// `index.html`'s `viewport-fit=cover` and the `--safe-top` / `--safe-bottom`
+/// custom properties are already written against.
+#[cfg(target_os = "ios")]
+fn own_the_whole_screen(webview: tauri::webview::PlatformWebview) {
+    /// `UIScrollViewContentInsetAdjustmentNever`.
+    const NEVER: isize = 2;
+
+    let wk = webview.inner() as *mut objc2::runtime::AnyObject;
+    // SAFETY: `inner()` is the window's live WKWebView, and Tauri runs this
+    // closure on the main thread — where UIKit requires both calls to happen.
+    unsafe {
+        let scroll: *mut objc2::runtime::AnyObject = objc2::msg_send![wk, scrollView];
+        let _: () = objc2::msg_send![scroll, setContentInsetAdjustmentBehavior: NEVER];
+    }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -11,6 +39,16 @@ pub fn run() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_push::init())
+        .setup(|_app| {
+            #[cfg(target_os = "ios")]
+            {
+                use tauri::Manager;
+                for webview in _app.webview_windows().values() {
+                    webview.with_webview(own_the_whole_screen)?;
+                }
+            }
+            Ok(())
+        })
         .manage(remote::Remote::default())
         .invoke_handler(tauri::generate_handler![
             remote::remote_connect,


### PR DESCRIPTION
## Symptom

The composer sits well above the bottom of the screen, on a wide band of empty background. Alex confirmed it's there on a fresh launch, before the composer is ever focused — so it isn't the keyboard, and it isn't the composer's own safe-area padding (that was #665, closed as a misdiagnosis).

## Measurement

From the screenshots (~2.0 screenshot px per CSS px, screen interior 1746px ≈ 874 CSS px, which checks out for an iPhone 17):

- the composer's rounded box ends **~135 CSS px** above the bottom of the screen; its own padding accounts for at most 38 of that
- back-solving the nav's `calc(var(--safe-top) + 4px)` against the rendered position of the back chevron puts the page origin at the *top* of the screen with a real ~59px top inset — so `viewport-fit=cover` works and `env(safe-area-inset-*)` is live
- so the layout viewport is roughly 100–130 CSS px shorter than the screen while still being anchored at the top

The app's CSS can't cause that. `AgentScreen` renders `Nav / .ag-tabs / .ag-body(flex:1) / Composer` as direct flex children of `.scr` (`position:absolute; inset:0`, inside `.m-app` at `position:fixed; inset:0`), so the composer is already pinned to the bottom of whatever viewport it's handed.

## Cause

wry creates the `WKWebView` with `initWithFrame: ns_view.frame()` and sets only `scrollView.setBounces(false)` — it never touches `contentInsetAdjustmentBehavior`, so it stays at UIKit's default `.automatic` (checked in `wry-0.55.1/src/wkwebview/mod.rs:447-530`; there's no knob for it anywhere in `tauri`, `tauri-runtime-wry` or `wry`). UIKit then insets that scroll view by the safe area and WebKit measures the layout viewport against the un-inset region. Same remedy Capacitor applies in its iOS bridge.

## Change

`mobile/src-tauri/src/lib.rs` sets the behaviour to `.never` at startup via Tauri's `with_webview`, handing the insets back to CSS where `viewport-fit=cover` and `--safe-top` / `--safe-bottom` already account for them. `objc2` (already in the tree via tauri, so no new version is pinned) is added as an iOS-only dependency.

This lives in the app's own Rust deliberately: `mobile/src-tauri/gen/apple` is gitignored and rewritten by `tauri ios init`, so a Swift-side patch wouldn't survive.

No CSS change — `main`'s `calc(var(--safe-bottom) + 4px)` on `.composer` is correct once the viewport is the right size, and it keeps the send button out of the home-indicator gesture region.

## Verification — please read

**I could not run this.** `cargo check --target aarch64-apple-ios-sim` dies in tauri's build script, because SwiftPM shells out to `sandbox-exec` and macOS refuses that inside my already-sandboxed session (`sandbox_apply: Operation not permitted`). What I did instead: temporarily widened the two `#[cfg(target_os = "ios")]` gates to include macOS and ran a host `cargo check` — clean, so the `objc2` call, `PlatformWebview::inner()`, the `with_webview` signature and the `setup` wiring all type-check. Then reverted the widening. The frontend build is also clean.

So: the code compiles and the mechanism is well-established, but **the fix itself is unverified on device**. Worth checking two things when you run it:

1. the gap is gone and the composer sits 38px above the screen bottom, clear of the home indicator
2. **the keyboard case** — with `.never`, WebKit no longer insets for the keyboard either. The app has no `visualViewport` handling at all today, so if the keyboard now covers the composer, that's a known follow-up rather than a surprise.

If the gap only partly closes, the next thing to try is `setObscuredInsets:`/pinning the webview frame explicitly, but I'd want your observation first rather than stacking another guess.