### PR TITLE
fix(mobile): sh.fletch.mobile bundle id, and ignore the generated iOS project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,9 +49,14 @@ mobile/node_modules/
 mobile/dist/
 mobile/.vite/
 mobile/src-tauri/target/
-# tauri-build regenerates these schemas on every build; the Xcode project that
-# `tauri ios init` puts beside them is committed once it exists.
-mobile/src-tauri/gen/schemas/
+# Everything under gen/ is generated: tauri-build rewrites the schemas on every
+# build, and `tauri ios init` regenerates the Xcode project from
+# tauri.conf.json plus the plugins' build scripts (which is where the
+# entitlements come from) — so it stays a local, per-machine artifact.
+mobile/src-tauri/gen/
+# Xcode/SPM writes this when it resolves a plugin's Swift package, and what it
+# pins comes from the Tauri package copied in at build time.
+mobile/src-tauri/plugins/*/ios/Package.resolved
 
 # Remote relay Worker (relay/). Same story as mobile/: the root-anchored
 # entries above do not reach into it.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -95,8 +95,9 @@ bun run test           # vitest
 
 ## iOS setup
 
-`src-tauri/gen/` (the generated Xcode project) is **not** in the repo; it is
-created on the first init, which needs Xcode and an Apple team ID.
+`src-tauri/gen/` (the generated Xcode project) is gitignored and never in the
+repo. Each machine creates its own on the first init, which needs Xcode and an
+Apple team ID.
 
 ```sh
 rustup target add aarch64-apple-ios aarch64-apple-ios-sim
@@ -105,5 +106,7 @@ bun run ios:init       # tauri ios init — writes src-tauri/gen/
 bun run tauri ios dev
 ```
 
-Commit `src-tauri/gen/` after that first init if the team wants a shared Xcode
-project; until then it is a local artifact.
+There is no shared Xcode project to commit: `tauri ios init` regenerates
+`gen/apple` from `tauri.conf.json`, its `project.pbxproj` hardcodes whichever
+`DEVELOPMENT_TEAM` ran the init, and the entitlements are written at build time
+by the plugins (see above). Re-run `ios:init` instead of sharing the output.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -74,11 +74,11 @@ Two things in it are worth knowing about:
 These cannot be committed and have to be done once, per team:
 
 1. In the Apple Developer portal, enable the **Push Notifications** capability
-   on the `com.fletch.mobile` App ID, then regenerate the provisioning profile
+   on the `sh.fletch.mobile` App ID, then regenerate the provisioning profile
    (Xcode's automatic signing does this for you once the App ID has it). Without
    it, signing fails with a missing-entitlement error.
 2. Create an APNs auth key (`.p8`) and give the relay `APNS_TEAM_ID`,
-   `APNS_KEY_ID`, `APNS_PRIVATE_KEY` and `APNS_BUNDLE_ID=com.fletch.mobile` —
+   `APNS_KEY_ID`, `APNS_PRIVATE_KEY` and `APNS_BUNDLE_ID=sh.fletch.mobile` —
    `apns-topic` is the bundle id, so the two have to match.
 3. Run on a real device. The simulator has no embedded profile and cannot
    receive a remote push; the plugin reports `sandbox` there.

--- a/mobile/src-tauri/tauri.conf.json
+++ b/mobile/src-tauri/tauri.conf.json
@@ -3,7 +3,7 @@
   "productName": "Fletch",
   "mainBinaryName": "Fletch",
   "version": "0.1.0",
-  "identifier": "com.fletch.mobile",
+  "identifier": "sh.fletch.mobile",
   "build": {
     "beforeDevCommand": "bun run dev",
     "devUrl": "http://localhost:1430",
@@ -33,7 +33,12 @@
   "bundle": {
     "active": true,
     "targets": ["app"],
-    "icon": ["icons/32x32.png", "icons/128x128.png", "icons/128x128@2x.png", "icons/icon.icns"],
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns"
+    ],
     "iOS": {
       "minimumSystemVersion": "15.0"
     }


### PR DESCRIPTION
Two things a `tauri ios dev` run surfaced locally.

## The bundle id

The App ID registered in the Apple Developer portal is `sh.fletch.mobile`, not `com.fletch.mobile`. `apns-topic` is the bundle id, so `tauri.conf.json`'s `identifier` and the relay's `APNS_BUNDLE_ID` have to agree with it — otherwise signing fails on the missing push entitlement and the relay's pushes are rejected. Renames the identifier and the two `mobile/README.md` lines that document the manual Apple steps. No `com.fletch.mobile` references remain.

The `"icon"` array reformat in `tauri.conf.json` is the Tauri CLI's own rewrite of the file, not a hand edit.

## The generated Xcode project

The root `.gitignore`'s `src-tauri/gen/` entry contains a slash, so git anchors it to the repo root and it never reached `mobile/` — only `mobile/src-tauri/gen/schemas/` was ignored there. A first `tauri ios init` therefore drops 34 `gen/apple` files plus the push plugin's SPM `Package.resolved` straight into `git status`.

Ignoring the whole `gen/` dir instead:

- Nothing in `gen/apple` is hand-edited. `tauri ios init` regenerates it from `tauri.conf.json`, and both entitlements it carries are written at build time — `aps-environment` by `mobile/src-tauri/plugins/push/build.rs`, associated domains by tauri-plugin-deep-link.
- `project.pbxproj` hardcodes a `DEVELOPMENT_TEAM` and is rewritten on every init, so committing it means a per-machine value in the repo and churn on every regeneration.
- No CI workflow builds iOS, so nothing outside a dev machine needs the project checked in.
- `mobile/README.md:58` already stated that `gen/apple` is gitignored, which until now it was not.

`Package.resolved` is Xcode/SPM output whose pins come from the Tauri package copied in at build time, so it goes with it (wildcarded across plugins).

The **iOS setup** section of `mobile/README.md` used to say to commit `src-tauri/gen/` for a shared Xcode project. With the dir ignored that would mean knowing to force-add 34 generated files, so the section now says each machine regenerates its own — and why sharing one would not work anyway.

## Follow-up, deliberately not here

`relay/wrangler.toml` has an uncommitted `relay.fletch.sh` custom-domain route that contradicts `DEFAULT_RELAY_URL = "wss://relay.fletch.app"` in `src-tauri/src/remote/mod.rs:64`, the `mobile/src/sheets/HostSheet.tsx` placeholder, and `docs/remote-protocol.md:100`. Needs a decision on which host is real before it lands.

## Testing

No app source changed — this is config, ignore rules and docs. Verified `git status` goes from 38 entries to a clean tree (bar the wrangler change above), and that the on-disk Xcode project is untouched, so the local emulator run still works.