### PR TITLE
fix(relay): serve and dial the relay at relay.fletch.sh

### DIFF
--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -97,7 +97,7 @@ Cloudflare Worker fronting one Durable Object per host ID (`relay/` in this
 repo); anyone can run their own and point both apps at it.
 
 - **Base URL.** Host setting `remote.relay_url`; absent or empty means no
-  relay. The desktop's suggested default is `wss://relay.fletch.app`. The
+  relay. The desktop's suggested default is `wss://relay.fletch.sh`. The
   pairing link carries the URL as `relay=<url-encoded>` when set, and the phone
   persists it with the host.
 - **Endpoints.** `wss://<relay>/v1/host/<hostId>` for the Mac,

--- a/mobile/src-tauri/src/remote/mod.rs
+++ b/mobile/src-tauri/src/remote/mod.rs
@@ -481,7 +481,7 @@ mod tests {
         assert!(with_budget.contains("timed out"), "{with_budget}");
         assert!(with_budget.contains("3000 ms"), "{with_budget}");
         assert!(with_budget.contains("ws://192.168.1.24:47285/ws"));
-        assert!(timed_out("wss://relay.fletch.app/v1/device/k", None).contains("timed out"));
+        assert!(timed_out("wss://relay.fletch.sh/v1/device/k", None).contains("timed out"));
     }
 
     /// `within` is what makes the budget real: a future that has not finished

--- a/mobile/src/remote/types.ts
+++ b/mobile/src/remote/types.ts
@@ -60,7 +60,7 @@ export interface HostTarget {
    *  pairing link, absent for hand-typed entry until the first connection
    *  pins the key it meets. */
   hostKey?: string;
-  /** Relay base URL, e.g. `wss://relay.fletch.app` — the fallback path when the
+  /** Relay base URL, e.g. `wss://relay.fletch.sh` — the fallback path when the
    *  LAN address cannot be reached. Comes from `relay=` in the pairing link, or
    *  is entered later in the Host sheet; absent means LAN only. */
   relay?: string;

--- a/mobile/src/sheets/HostSheet.tsx
+++ b/mobile/src/sheets/HostSheet.tsx
@@ -135,7 +135,7 @@ export function HostSheet({ open, onClose }: { open: boolean; onClose: () => voi
         <input
           id="host-relay"
           value={draft}
-          placeholder="wss://relay.fletch.app"
+          placeholder="wss://relay.fletch.sh"
           autoCapitalize="off"
           autoCorrect="off"
           spellCheck={false}

--- a/mobile/tests/protocol.test.ts
+++ b/mobile/tests/protocol.test.ts
@@ -141,13 +141,13 @@ describe("pairing URL", () => {
   it("parses relay= url-decoded, and leaves it out when the host has none", () => {
     expect(
       parsePairUrl(
-        "fletch://pair?host=Zm9vYmFy&addr=192.168.1.24:47285&relay=wss%3A%2F%2Frelay.fletch.app&token=K7PQ2M9X",
+        "fletch://pair?host=Zm9vYmFy&addr=192.168.1.24:47285&relay=wss%3A%2F%2Frelay.fletch.sh&token=K7PQ2M9X",
       ),
     ).toEqual({
       host: "192.168.1.24",
       port: 47285,
       hostKey: "Zm9vYmFy",
-      relay: "wss://relay.fletch.app",
+      relay: "wss://relay.fletch.sh",
       pairingToken: "K7PQ2M9X",
     });
     expect(
@@ -156,14 +156,14 @@ describe("pairing URL", () => {
   });
 
   it("builds the device endpoint and tolerates a trailing slash on the base", () => {
-    expect(relayDeviceUrl("wss://relay.fletch.app", "Zm9vYmFy")).toBe(
-      "wss://relay.fletch.app/v1/device/Zm9vYmFy",
+    expect(relayDeviceUrl("wss://relay.fletch.sh", "Zm9vYmFy")).toBe(
+      "wss://relay.fletch.sh/v1/device/Zm9vYmFy",
     );
-    expect(relayDeviceUrl("wss://relay.fletch.app/", "Zm9vYmFy")).toBe(
-      "wss://relay.fletch.app/v1/device/Zm9vYmFy",
+    expect(relayDeviceUrl("wss://relay.fletch.sh/", "Zm9vYmFy")).toBe(
+      "wss://relay.fletch.sh/v1/device/Zm9vYmFy",
     );
-    expect(relayDeviceUrl(" wss://relay.fletch.app// ", "Zm9vYmFy")).toBe(
-      "wss://relay.fletch.app/v1/device/Zm9vYmFy",
+    expect(relayDeviceUrl(" wss://relay.fletch.sh// ", "Zm9vYmFy")).toBe(
+      "wss://relay.fletch.sh/v1/device/Zm9vYmFy",
     );
   });
 });

--- a/relay/wrangler.toml
+++ b/relay/wrangler.toml
@@ -26,3 +26,7 @@ new_sqlite_classes = ["HostRelay"]
 
 [observability]
 enabled = true
+
+[[routes]]
+pattern = "relay.fletch.sh"
+custom_domain = true

--- a/src-tauri/src/remote/mod.rs
+++ b/src-tauri/src/remote/mod.rs
@@ -61,7 +61,7 @@ pub const RELAY_URL_SETTING: &str = "remote.relay_url";
 /// (`src/api/types/remote.ts`), so nothing in Rust reads it outside the tests
 /// that check it is a URL `set_relay` accepts.
 #[cfg_attr(not(test), allow(dead_code))]
-pub const DEFAULT_RELAY_URL: &str = "wss://relay.fletch.app";
+pub const DEFAULT_RELAY_URL: &str = "wss://relay.fletch.sh";
 /// Default listen port (protocol doc).
 pub const DEFAULT_PORT: u16 = 47285;
 /// The only path the listener serves.

--- a/src-tauri/src/remote/relay_tests.rs
+++ b/src-tauri/src/remote/relay_tests.rs
@@ -461,12 +461,12 @@ fn the_challenge_proof_matches_a_known_answer_vector() {
 #[test]
 fn the_host_endpoint_is_the_documented_one() {
     assert_eq!(
-        relay::host_endpoint("wss://relay.fletch.app", "abc"),
-        "wss://relay.fletch.app/v1/host/abc"
+        relay::host_endpoint("wss://relay.fletch.sh", "abc"),
+        "wss://relay.fletch.sh/v1/host/abc"
     );
     assert_eq!(
-        relay::host_endpoint("wss://relay.fletch.app/", "abc"),
-        "wss://relay.fletch.app/v1/host/abc"
+        relay::host_endpoint("wss://relay.fletch.sh/", "abc"),
+        "wss://relay.fletch.sh/v1/host/abc"
     );
 }
 
@@ -929,7 +929,7 @@ async fn the_relay_url_is_normalized_and_validated() {
 
     // The scheme is the one thing worth refusing: a typo here is a link that
     // could never connect, and the pane can say so at once.
-    for bad in ["relay.fletch.app", "https://relay.fletch.app", "wss:/x"] {
+    for bad in ["relay.fletch.sh", "https://relay.fletch.sh", "wss:/x"] {
         assert!(
             state.set_relay(Some(bad.to_string())).is_err(),
             "{bad} should be refused"

--- a/src/api/types/remote.ts
+++ b/src/api/types/remote.ts
@@ -22,7 +22,7 @@ export interface RemoteDevice {
 /** The relay the desktop offers when the switch goes on. Mirrors
  *  `DEFAULT_RELAY_URL` in `src-tauri/src/remote/mod.rs`; only a suggestion —
  *  the persisted setting is what decides, and anyone can run their own. */
-export const DEFAULT_RELAY_URL = "wss://relay.fletch.app";
+export const DEFAULT_RELAY_URL = "wss://relay.fletch.sh";
 
 /** How the outbound host link is doing. `off` means no URL is set, or remote
  *  access itself is off; `error` stands between reconnect attempts. */


### PR DESCRIPTION
The relay Worker had no route, so it only answered on `fletch-relay.<subdomain>.workers.dev`, while every client default named `relay.fletch.app` — a host that does not answer. This puts both ends on `relay.fletch.sh`, the domain the rest of the product already uses (`fletch.sh/releases/latest.json`, `fletch.sh/terms`, `feedback@fletch.sh`).

## The route

```toml
[[routes]]
pattern = "relay.fletch.sh"
custom_domain = true
```

Per the Workers custom-domain docs and `relay/README.md:169`. Also adds the trailing newline the file was missing.

## The clients

Renames all 19 `relay.fletch.app` references, in 8 files:

- `src-tauri/src/remote/mod.rs:64` — `DEFAULT_RELAY_URL`, what the desktop dials when `remote.relay_url` is unset
- `src/api/types/remote.ts:25` — the frontend's copy of the same default
- `mobile/src/sheets/HostSheet.tsx:138` — the host input's placeholder
- `mobile/src/remote/types.ts:63`, `docs/remote-protocol.md:100` — docs
- `src-tauri/src/remote/relay_tests.rs`, `mobile/src-tauri/src/remote/mod.rs:484`, `mobile/tests/protocol.test.ts` — fixtures

`git grep relay.fletch.app` now returns nothing.

Existing installs are unaffected: `remote.relay_url` is persisted per user (`remote_set_relay`), so only a fresh install takes the default.

## Testing

- `bun run test` — desktop 1105 passed, mobile 75 passed, relay 80 passed
- `cargo test --lib remote::` — desktop 91 passed, mobile 13 passed
- Not deployed yet; `wrangler deploy` needs `relay.fletch.sh` on the account's zone first.

## Not in scope

`relay/test/apns.test.ts` and `relay/test/relay.test.ts` use `ai.fletch.app` as the `APNS_BUNDLE_ID` fixture. That is a bundle id, not the relay host, so it is untouched — though it no longer matches the real `sh.fletch.mobile` either, if someone wants to tidy it.