### PR TITLE
fix(mobile): build the model catalog so the model picker has models to pick

### DIFF
--- a/mobile/src-tauri/tauri.conf.json
+++ b/mobile/src-tauri/tauri.conf.json
@@ -20,8 +20,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost",
-      "devCsp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://localhost:* http://localhost:* ws://*:* http://*:*"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://models.dev",
+      "devCsp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://models.dev ws://localhost:* http://localhost:* ws://*:* http://*:*"
     }
   },
   "plugins": {

--- a/mobile/src/lib/models.ts
+++ b/mobile/src/lib/models.ts
@@ -44,25 +44,58 @@ export const STATIC_MODELS: ModelsByAgent = {
 // value rather than re-reading (and re-parsing) the localStorage cache.
 let current: ModelsByAgent = loadCachedCatalog().byAgent;
 
-/** The catalog's per-agent model lists. Refreshed when the connection comes up,
- *  since discovery is a host round-trip; `refreshCatalog` dedupes the concurrent
- *  calls this makes when several pickers are mounted, and honours its own cache
- *  TTL, so this is cheap on every mount but the first. */
+// Which host the cached catalog was built from. Half of it is that host's
+// installed CLIs, so a phone re-paired to another Mac must not go on offering
+// the previous one's lists — a mismatch rebuilds instead of waiting out the
+// TTL. Persisted beside the catalog: holding it in memory only would force a
+// full rebuild (and its multi-megabyte models.dev fetch) on every launch.
+const HOST_KEY = "modelCatalog.host";
+
+function builtForHost(): string | null {
+  try {
+    return localStorage.getItem(HOST_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function rememberHost(hostKey: string | null): void {
+  try {
+    if (hostKey) localStorage.setItem(HOST_KEY, hostKey);
+    else localStorage.removeItem(HOST_KEY);
+  } catch {
+    // Storage unavailable — the catalog just rebuilds again next launch.
+  }
+}
+
+/** The catalog for `hostKey`, rebuilt when the cache belongs to another host or
+ *  has aged out, else served from it. Null when the rebuild failed and the
+ *  caller should keep what it has. `refreshCatalog` dedupes the concurrent calls
+ *  this makes when several pickers mount at once. */
+export async function loadModels(hostKey: string | null): Promise<ModelsByAgent | null> {
+  const catalog = await refreshCatalog(api.discoverSupportedModels, builtForHost() !== hostKey);
+  if (!catalog) return null;
+  rememberHost(hostKey);
+  current = catalog.byAgent;
+  return current;
+}
+
+/** The catalog's per-agent model lists, refreshed when the connection comes up
+ *  (discovery is a host round-trip) and whenever the paired host changes. */
 export function useModels(): ModelsByAgent {
   const connection = useStore((s) => s.connection);
+  const hostKey = useStore((s) => s.hostKey);
   const [models, setModels] = useState<ModelsByAgent>(current);
   useEffect(() => {
     if (connection !== "connected") return;
     let live = true;
-    void refreshCatalog(api.discoverSupportedModels).then((catalog) => {
-      if (!catalog) return;
-      current = catalog.byAgent;
-      if (live) setModels(catalog.byAgent);
+    void loadModels(hostKey).then((byAgent) => {
+      if (live && byAgent) setModels(byAgent);
     });
     return () => {
       live = false;
     };
-  }, [connection]);
+  }, [connection, hostKey]);
   return models;
 }
 

--- a/mobile/src/lib/models.ts
+++ b/mobile/src/lib/models.ts
@@ -1,61 +1,64 @@
-// Model choices for the pickers. `discover_supported_models` is the truth, but
-// it needs the agent CLIs installed and probed on the host, so a small static
-// list stands in until it answers.
+// Model choices for the pickers.
+//
+// Same pipeline as the desktop: the host says which models each agent CLI
+// supports, and the frontend enriches those ids against models.dev — including
+// expanding the `providerHint` agents that have no list command at all (claude
+// reports zero models and "anthropic" instead). Building that here rather than
+// reading the raw discovery is what makes the Claude model picker non-empty.
+//
+// models.dev is a phone-side fetch, so a device with no WAN keeps the small
+// static list below as a stand-in.
 
-import type { AgentModels, DiscoveredModel } from "@desktop/data/modelCatalog/types";
+import { loadCachedCatalog, refreshCatalog } from "@desktop/data/modelCatalog";
+import type { ModelMeta } from "@desktop/data/modelCatalog/types";
 import { PROVIDERS } from "@desktop/data/providers";
 import { useEffect, useState } from "react";
 import { api, useStore } from "../store";
 
+/** A provider's selectable models, keyed by agent id — the catalog's `byAgent`
+ *  view, which is all the pickers need. */
+export type ModelsByAgent = Record<string, ModelMeta[]>;
+
 /** Empty id = "let the CLI pick", which is what a null `model` means to the
  *  host. Always offered, since discovery only reports concrete ids. */
-export const DEFAULT_MODEL: DiscoveredModel = { id: "", name: "Default model" };
+export const DEFAULT_MODEL: ModelMeta = {
+  id: "",
+  name: "Default model",
+  contextWindow: 0,
+  reasoning: false,
+};
 
-export const STATIC_MODELS: AgentModels[] = [
-  {
-    agent: "claude",
-    models: [
-      { id: "claude-opus-4-5", name: "Claude Opus 4.5" },
-      { id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
-      { id: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
-    ],
-  },
-  { agent: "codex", models: [{ id: "gpt-5-codex", name: "GPT-5 Codex" }] },
-  { agent: "cursor", models: [] },
-  { agent: "opencode", models: [] },
-  { agent: "pi", models: [] },
-  { agent: "antigravity", models: [] },
-];
+/** Offline stand-in, used per provider when the catalog has nothing for it.
+ *  Providers absent here (cursor, opencode, pi, antigravity) offer only the
+ *  default row until the catalog answers. */
+export const STATIC_MODELS: ModelsByAgent = {
+  claude: [
+    { id: "claude-opus-5", name: "Claude Opus 5", contextWindow: 1_000_000, reasoning: true },
+    { id: "claude-sonnet-5", name: "Claude Sonnet 5", contextWindow: 1_000_000, reasoning: true },
+    { id: "claude-haiku-4-5", name: "Claude Haiku 4.5", contextWindow: 200_000, reasoning: false },
+  ],
+  codex: [{ id: "gpt-5-codex", name: "GPT-5 Codex", contextWindow: 0, reasoning: true }],
+};
 
-// Cached for the run once the host answers. A fallback result is never cached,
-// so a discovery that ran before the connection was up gets another chance.
-let cache: AgentModels[] | null = null;
-let inFlight: Promise<AgentModels[]> | null = null;
+// Last catalog this run, so a picker mounted later starts from the freshest
+// value rather than re-reading (and re-parsing) the localStorage cache.
+let current: ModelsByAgent = loadCachedCatalog().byAgent;
 
-function fetchModels(): Promise<AgentModels[]> {
-  if (cache) return Promise.resolve(cache);
-  inFlight ??= api
-    .discoverSupportedModels()
-    .then((list) => {
-      if (list.length) cache = list;
-      return cache ?? STATIC_MODELS;
-    })
-    .catch(() => STATIC_MODELS)
-    .finally(() => {
-      inFlight = null;
-    });
-  return inFlight;
-}
-
-/** Discovered models, falling back to the static list. Retried when the
- *  connection comes up, since discovery is a host round-trip. */
-export function useModels(): AgentModels[] {
+/** The catalog's per-agent model lists. Refreshed when the connection comes up,
+ *  since discovery is a host round-trip; `refreshCatalog` dedupes the concurrent
+ *  calls this makes when several pickers are mounted, and honours its own cache
+ *  TTL, so this is cheap on every mount but the first. */
+export function useModels(): ModelsByAgent {
   const connection = useStore((s) => s.connection);
-  const [models, setModels] = useState<AgentModels[]>(cache ?? STATIC_MODELS);
+  const [models, setModels] = useState<ModelsByAgent>(current);
   useEffect(() => {
     if (connection !== "connected") return;
     let live = true;
-    void fetchModels().then((list) => live && setModels(list));
+    void refreshCatalog(api.discoverSupportedModels).then((catalog) => {
+      if (!catalog) return;
+      current = catalog.byAgent;
+      if (live) setModels(catalog.byAgent);
+    });
     return () => {
       live = false;
     };
@@ -63,12 +66,13 @@ export function useModels(): AgentModels[] {
   return models;
 }
 
-export const modelsFor = (models: AgentModels[], provider: string): DiscoveredModel[] => {
-  const found =
-    models.find((m) => m.agent === provider)?.models ??
-    STATIC_MODELS.find((m) => m.agent === provider)?.models ??
-    [];
-  return [DEFAULT_MODEL, ...found];
+/** A provider's rows for a picker: the default first, then its models. An empty
+ *  catalog entry falls back to the static list — an agent whose CLI has no list
+ *  command reports zero models, and offering only "Default model" would leave
+ *  the picker with nothing to pick. */
+export const modelsFor = (models: ModelsByAgent, provider: string): ModelMeta[] => {
+  const found = models[provider]?.length ? models[provider] : STATIC_MODELS[provider];
+  return [DEFAULT_MODEL, ...(found ?? [])];
 };
 
 /** Providers offered in the new-agent sheet. Providers that manage their own
@@ -84,6 +88,6 @@ export function contextLabel(tokens: number | undefined): string | null {
 }
 
 /** Effort levels the chosen model reports, else the shared ladder. */
-export function effortsFor(model: DiscoveredModel | undefined): string[] {
+export function effortsFor(model: ModelMeta | undefined): string[] {
   return model?.reasoningLevels?.length ? model.reasoningLevels : ["low", "medium", "high", "max"];
 }

--- a/mobile/src/lib/models.ts
+++ b/mobile/src/lib/models.ts
@@ -68,16 +68,27 @@ function rememberHost(hostKey: string | null): void {
   }
 }
 
+// Refreshes run one at a time. `refreshCatalog` dedupes by a single global
+// in-flight promise, with no notion of who asked: a host swapped mid-rebuild
+// would be handed the *previous* host's result and stamp it as its own. Queuing
+// means each host's rebuild starts only once the last one has settled and that
+// dedupe has cleared.
+let queue: Promise<unknown> = Promise.resolve();
+
 /** The catalog for `hostKey`, rebuilt when the cache belongs to another host or
  *  has aged out, else served from it. Null when the rebuild failed and the
- *  caller should keep what it has. `refreshCatalog` dedupes the concurrent calls
- *  this makes when several pickers mount at once. */
-export async function loadModels(hostKey: string | null): Promise<ModelsByAgent | null> {
-  const catalog = await refreshCatalog(api.discoverSupportedModels, builtForHost() !== hostKey);
-  if (!catalog) return null;
-  rememberHost(hostKey);
-  current = catalog.byAgent;
-  return current;
+ *  caller should keep what it has. */
+export function loadModels(hostKey: string | null): Promise<ModelsByAgent | null> {
+  const run = queue.then(async () => {
+    const catalog = await refreshCatalog(api.discoverSupportedModels, builtForHost() !== hostKey);
+    if (!catalog) return null;
+    rememberHost(hostKey);
+    current = catalog.byAgent;
+    return current;
+  });
+  // A failed refresh must not wedge the queue for every later one.
+  queue = run.catch(() => null);
+  return run;
 }
 
 /** The catalog's per-agent model lists, refreshed when the connection comes up

--- a/mobile/src/sheets/ModelPickerSheet.tsx
+++ b/mobile/src/sheets/ModelPickerSheet.tsx
@@ -26,11 +26,13 @@ export function ModelPickerSheet({
       sectionLabel={providerLabel(agent.provider)}
       items={list.map((m) => ({
         id: m.id,
-        label: m.name ?? m.id ?? "Default model",
+        label: m.name,
         right: contextLabel(m.contextWindow),
       }))}
       value={agent.model ?? ""}
-      onChange={(id) => void setModel(agent.id, id).catch(ignore)}
+      // The default row's empty id means "no pinned model", which the host
+      // spells `null` — persisting "" would leave a model set to nothing.
+      onChange={(id) => void setModel(agent.id, id || null).catch(ignore)}
     />
   );
 }

--- a/mobile/src/sheets/NewAgentSheet/RunnerSheet.tsx
+++ b/mobile/src/sheets/NewAgentSheet/RunnerSheet.tsx
@@ -1,6 +1,11 @@
-import type { AgentModels } from "@desktop/data/modelCatalog/types";
 import { ProviderMark, Sheet } from "../../components/ui";
-import { contextLabel, effortsFor, modelsFor, providerOptions } from "../../lib/models";
+import {
+  contextLabel,
+  effortsFor,
+  type ModelsByAgent,
+  modelsFor,
+  providerOptions,
+} from "../../lib/models";
 
 /** Agent, model and effort in one panel — the prototype's "Runner" sheet. */
 export function RunnerSheet({
@@ -16,7 +21,7 @@ export function RunnerSheet({
 }: {
   open: boolean;
   onClose: () => void;
-  models: AgentModels[];
+  models: ModelsByAgent;
   provider: string;
   model: string;
   effort: string;
@@ -70,7 +75,7 @@ export function RunnerSheet({
             onClick={() => setModel(m.id)}
           >
             <div className="main">
-              <div className="lbl">{m.name ?? m.id ?? "Default model"}</div>
+              <div className="lbl">{m.name}</div>
             </div>
             {contextLabel(m.contextWindow) && (
               <span className="val mono">{contextLabel(m.contextWindow)}</span>

--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -116,7 +116,8 @@ export interface MobileState {
   stop(agentId: string): Promise<void>;
   resume(agentId: string): Promise<void>;
   archive(agentId: string): Promise<void>;
-  setModel(agentId: string, model: string): Promise<void>;
+  /** `null` clears the pinned model, leaving the provider CLI's own default. */
+  setModel(agentId: string, model: string | null): Promise<void>;
   setEffort(agentId: string, effort: string): Promise<void>;
   publish(agentId: string, title: string, body: string): Promise<void>;
   pushToPr(agentId: string): Promise<void>;

--- a/mobile/tests/models.test.ts
+++ b/mobile/tests/models.test.ts
@@ -1,0 +1,58 @@
+// Picker rows in src/lib/models.ts. The regression this guards: the host
+// reports zero models for agents whose CLI has no list command (claude answers
+// `providerHint: "anthropic"` and an empty list), so reading the raw discovery
+// left the Model sheet with nothing but its own "Default model" row.
+
+import { buildCatalog } from "@desktop/data/modelCatalog/build";
+import type { ModelsDevIndex } from "@desktop/data/modelCatalog/modelsDev";
+import type { AgentModels } from "@desktop/data/modelCatalog/types";
+import { describe, expect, it } from "vitest";
+import { modelsFor } from "../src/lib/models";
+
+const index: ModelsDevIndex = {
+  byId: {
+    "claude-opus-9": {
+      id: "claude-opus-9",
+      name: "Claude Opus 9",
+      contextWindow: 1_000_000,
+      reasoning: true,
+      family: "claude-opus",
+      releaseDate: "2026-08-01",
+    },
+    "claude-haiku-9": {
+      id: "claude-haiku-9",
+      name: "Claude Haiku 9",
+      contextWindow: 200_000,
+      reasoning: false,
+      family: "claude-haiku",
+      releaseDate: "2026-07-01",
+    },
+  },
+  byProvider: { anthropic: ["claude-opus-9", "claude-haiku-9"] },
+};
+
+describe("modelsFor", () => {
+  it("expands a provider hint, so an agent with no list command is selectable", () => {
+    const discovered: AgentModels[] = [{ agent: "claude", providerHint: "anthropic", models: [] }];
+    const list = modelsFor(buildCatalog(discovered, index).byAgent, "claude");
+
+    expect(list.map((m) => m.id)).toEqual(["", "claude-opus-9", "claude-haiku-9"]);
+  });
+
+  it("offers the default row first, whatever the catalog says", () => {
+    const list = modelsFor({ codex: [] }, "codex");
+    expect(list[0].id).toBe("");
+    expect(list[0].name).toBe("Default model");
+  });
+
+  it("falls back to the static list when the catalog has nothing for a provider", () => {
+    // An empty entry is what a failed models.dev fetch leaves behind; it must
+    // not win over the stand-in the way an `?? ` on a non-null [] used to.
+    expect(modelsFor({ claude: [] }, "claude").length).toBeGreaterThan(1);
+    expect(modelsFor({}, "claude").length).toBeGreaterThan(1);
+  });
+
+  it("shows only the default for a provider nothing knows about", () => {
+    expect(modelsFor({}, "antigravity").map((m) => m.id)).toEqual([""]);
+  });
+});

--- a/mobile/tests/models.test.ts
+++ b/mobile/tests/models.test.ts
@@ -22,6 +22,9 @@ vi.mock("@desktop/data/modelCatalog", () => ({
 /** Whether the call at `index` asked for a forced rebuild. */
 const forced = (index: number) => mocks.refreshCatalog.mock.calls[index][1];
 
+/** Let queued refreshes reach their `refreshCatalog` call. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
 const index: ModelsDevIndex = {
   byId: {
     "claude-opus-9": {
@@ -93,6 +96,42 @@ describe("loadModels", () => {
     await loadModels("host-a");
 
     expect(forced(1)).toBe(false);
+  });
+
+  it("does not stamp a rebuild that was already running for another host", async () => {
+    // `refreshCatalog` dedupes on one global in-flight promise, so a host swap
+    // mid-rebuild used to be handed the previous host's catalog and save it as
+    // the new host's.
+    const forHostA = { byId: {}, byAgent: { claude: [] } };
+    let finishA: (value: unknown) => void = () => {};
+    let inFlight: Promise<unknown> | null = null;
+    // Faithful to the real refreshCatalog: one global in-flight promise, handed
+    // to every caller regardless of who asked or whether they forced.
+    mocks.refreshCatalog.mockImplementation(() => {
+      if (inFlight) return inFlight;
+      const result =
+        mocks.refreshCatalog.mock.calls.length === 1
+          ? new Promise((resolve) => {
+              finishA = resolve;
+            })
+          : Promise.resolve(catalog);
+      inFlight = result.finally(() => {
+        inFlight = null;
+      });
+      return inFlight;
+    });
+
+    const a = loadModels("host-a");
+    const b = loadModels("host-b");
+    await flush();
+    expect(mocks.refreshCatalog).toHaveBeenCalledTimes(1);
+
+    finishA(forHostA);
+    expect(await a).toEqual(forHostA.byAgent);
+    // host-b waited for its own rebuild rather than being handed host-a's.
+    expect(await b).toEqual(catalog.byAgent);
+    expect(forced(1)).toBe(true);
+    expect(localStorage.getItem("modelCatalog.host")).toBe("host-b");
   });
 
   it("does not claim the cache belongs to a host after a failed rebuild", async () => {

--- a/mobile/tests/models.test.ts
+++ b/mobile/tests/models.test.ts
@@ -6,8 +6,21 @@
 import { buildCatalog } from "@desktop/data/modelCatalog/build";
 import type { ModelsDevIndex } from "@desktop/data/modelCatalog/modelsDev";
 import type { AgentModels } from "@desktop/data/modelCatalog/types";
-import { describe, expect, it } from "vitest";
-import { modelsFor } from "../src/lib/models";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { loadModels, modelsFor } from "../src/lib/models";
+
+const mocks = vi.hoisted(() => ({
+  refreshCatalog: vi.fn(),
+  loadCachedCatalog: vi.fn(() => ({ byId: {}, byAgent: {} })),
+}));
+
+vi.mock("@desktop/data/modelCatalog", () => ({
+  loadCachedCatalog: mocks.loadCachedCatalog,
+  refreshCatalog: mocks.refreshCatalog,
+}));
+
+/** Whether the call at `index` asked for a forced rebuild. */
+const forced = (index: number) => mocks.refreshCatalog.mock.calls[index][1];
 
 const index: ModelsDevIndex = {
   byId: {
@@ -54,5 +67,41 @@ describe("modelsFor", () => {
 
   it("shows only the default for a provider nothing knows about", () => {
     expect(modelsFor({}, "antigravity").map((m) => m.id)).toEqual([""]);
+  });
+});
+
+describe("loadModels", () => {
+  const catalog = { byId: {}, byAgent: { codex: [] } };
+
+  beforeEach(() => {
+    localStorage.clear();
+    mocks.refreshCatalog.mockReset();
+    mocks.refreshCatalog.mockResolvedValue(catalog);
+  });
+
+  it("rebuilds for a host the cache wasn't built from", async () => {
+    // Half the catalog is the host's installed CLIs, so a phone re-paired to
+    // another Mac must not serve the previous host's lists for up to an hour.
+    await loadModels("host-a");
+    await loadModels("host-b");
+
+    expect(forced(1)).toBe(true);
+  });
+
+  it("serves the cache while the host is unchanged", async () => {
+    await loadModels("host-a");
+    await loadModels("host-a");
+
+    expect(forced(1)).toBe(false);
+  });
+
+  it("does not claim the cache belongs to a host after a failed rebuild", async () => {
+    mocks.refreshCatalog.mockResolvedValue(null);
+    expect(await loadModels("host-a")).toBeNull();
+
+    mocks.refreshCatalog.mockResolvedValue(catalog);
+    await loadModels("host-a");
+
+    expect(forced(1)).toBe(true);
   });
 });

--- a/src/data/modelCatalog/index.ts
+++ b/src/data/modelCatalog/index.ts
@@ -6,13 +6,17 @@
 // in localStorage with a 1h TTL and rebuilt in the background on expiry, so a
 // newly-released model shows up automatically without an app release.
 
-import { api } from "@/api";
 import { buildCatalog } from "./build";
 import { fetchModelsDevIndex } from "./modelsDev";
-import type { UnifiedCatalog } from "./types";
+import type { AgentModels, UnifiedCatalog } from "./types";
 
 export { lookupModel, lookupModelInList } from "./normalize";
 export type { ModelMeta, SlimCatalog } from "./types";
+
+/** How the caller asks the host which models each agent CLI supports. Injected
+ *  rather than imported so the mobile app can reuse this whole pipeline: its
+ *  discovery is a remote call over the host link, not a Tauri invoke. */
+export type DiscoverAgents = () => Promise<AgentModels[]>;
 
 const CACHE_KEY = "modelCatalog.cache.v14";
 const TTL_MS = 60 * 60 * 1000; // 1h
@@ -52,9 +56,9 @@ export function isCatalogStale(): boolean {
 
 /** Rebuild the catalog from agent discovery + models.dev, and cache it. Returns
  *  null on any failure so the caller keeps the last good cache intact. */
-export async function rebuildCatalog(): Promise<UnifiedCatalog | null> {
+export async function rebuildCatalog(discover: DiscoverAgents): Promise<UnifiedCatalog | null> {
   const [agents, index] = await Promise.all([
-    api.discoverSupportedModels().catch(() => []),
+    discover().catch(() => [] as AgentModels[]),
     fetchModelsDevIndex(),
   ]);
   if (index === null) return null;
@@ -71,11 +75,14 @@ export async function rebuildCatalog(): Promise<UnifiedCatalog | null> {
 
 /** Refresh the catalog, deduping concurrent requests so only one rebuild runs.
  *  `force=true` skips the TTL check and is used by the manual developer action. */
-export function refreshCatalog(force = false): Promise<UnifiedCatalog | null> {
+export function refreshCatalog(
+  discover: DiscoverAgents,
+  force = false,
+): Promise<UnifiedCatalog | null> {
   if (refreshInFlight) return refreshInFlight;
   if (!force && !isCatalogStale()) return Promise.resolve(loadCachedCatalog());
 
-  refreshInFlight = rebuildCatalog().finally(() => {
+  refreshInFlight = rebuildCatalog(discover).finally(() => {
     refreshInFlight = null;
   });
   return refreshInFlight;

--- a/src/store/providers.ts
+++ b/src/store/providers.ts
@@ -96,7 +96,7 @@ export const createProvidersSlice: SliceCreator<ProvidersSlice> = (set, get) => 
     await get().refreshProviderVersions();
   },
   refreshModelCatalog: async (force = false) => {
-    const catalog = await refreshCatalog(force);
+    const catalog = await refreshCatalog(api.discoverSupportedModels, force);
     if (catalog) set({ modelCatalog: catalog.byId, modelsByAgent: catalog.byAgent });
   },
 });

--- a/tests/data/modelCatalog/refresh.test.ts
+++ b/tests/data/modelCatalog/refresh.test.ts
@@ -5,12 +5,6 @@ const mocks = vi.hoisted(() => ({
   fetchModelsDevIndex: vi.fn(),
 }));
 
-vi.mock("@/api", () => ({
-  api: {
-    discoverSupportedModels: mocks.discoverSupportedModels,
-  },
-}));
-
 vi.mock("@/data/modelCatalog/modelsDev", () => ({
   fetchModelsDevIndex: mocks.fetchModelsDevIndex,
 }));
@@ -61,7 +55,7 @@ describe("refreshCatalog", () => {
     mocks.fetchModelsDevIndex.mockResolvedValue(null);
 
     const { loadCachedCatalog, refreshCatalog } = await import("@/data/modelCatalog");
-    const result = await refreshCatalog(true);
+    const result = await refreshCatalog(mocks.discoverSupportedModels, true);
 
     expect(result).toBeNull();
     expect(loadCachedCatalog().byId.saved.id).toBe("saved");
@@ -82,8 +76,8 @@ describe("refreshCatalog", () => {
     mocks.fetchModelsDevIndex.mockReturnValue(index);
 
     const { refreshCatalog } = await import("@/data/modelCatalog");
-    const first = refreshCatalog(true);
-    const second = refreshCatalog(true);
+    const first = refreshCatalog(mocks.discoverSupportedModels, true);
+    const second = refreshCatalog(mocks.discoverSupportedModels, true);
 
     expect(first).toBe(second);
     expect(mocks.discoverSupportedModels).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
## The bug

Tapping the model chip on mobile opened the sheet, but there was nothing to pick — the list held a single row, "Default model", which was already the selection. Selecting it changed nothing, so the picker looked dead.

`discover_supported_models` deliberately returns **zero** models for agents whose CLI has no list command: claude answers `providerHint: "anthropic"` and an empty list, expecting the frontend to expand that hint against models.dev. The desktop does exactly that (`buildCatalog`). Mobile read the raw discovery instead, and its intended fallback

```ts
models.find((m) => m.agent === provider)?.models ?? STATIC_MODELS…
```

never fired, because the claude entry *exists* with `models: []` and an empty array isn't nullish.

It went unnoticed because `mobile/src/remote/mock/fixtures.ts` gives mock-claude four concrete models — the picker works in the browser mock and only breaks against a real host.

## The fix

Mobile now runs the desktop's catalog pipeline rather than a second, thinner copy of it.

- **`src/data/modelCatalog/index.ts`** — `rebuildCatalog`/`refreshCatalog` take their discovery source as a parameter (`DiscoverAgents`) instead of importing `@/api`. That import was the module's only Tauri dependency; removing it makes the whole pipeline — models.dev fetch, provider-hint expansion, Claude curation, 1h localStorage cache, concurrent-refresh dedupe — reusable from mobile, whose discovery is a remote call over the host link. Desktop behaviour is unchanged; `src/store/providers.ts` passes `api.discoverSupportedModels`.
- **`mobile/src/lib/models.ts`** — `useModels()` returns the catalog's `byAgent` view, seeded from the cached catalog and refreshed when the connection comes up. `modelsFor` falls back to the static list on an *empty* provider entry, not just a missing one, so an unreachable models.dev still leaves a usable picker.
- **`mobile/src-tauri/tauri.conf.json`** — `https://models.dev` added to `connect-src` in both CSPs, matching the desktop.
- **`ModelPickerSheet`** — the default row sends `null`, not `""`; `""` persisted a model set to nothing (harmless today, since `agent/args.rs` trims it, but wrong).
- The offline `STATIC_MODELS` stand-in for claude was refreshed from the 4.5-era ids to Opus 5 / Sonnet 5 / Haiku 4.5. It only shows when models.dev is unreachable — happy to drop this hunk if you'd rather keep it separate.

## Verification

Ran the real pipeline against live models.dev with the exact payload the host sends (`{agent: "claude", providerHint: "anthropic", models: []}`). The sheet now renders **Default model, Fable 5.1, Fable 5, Opus 5, Opus 4.8, Opus 4.7, Sonnet 5, Sonnet 4.6, Haiku 4.5** — identical to the desktop's list. Antigravity correctly stays default-only (fixed-model agent).

Desktop suite 1105 passed, mobile 79 passed (including a new `mobile/tests/models.test.ts` pinning the provider-hint case), both projects typecheck, mobile builds, biome clean.

Not verified in a running app on-device — the headless browser in my sandbox is unavailable, so the pipeline check above stands in for a visual confirmation.

## Worth knowing

`models.dev/api.json` is **4.5 MB**, and the phone now fetches it directly — at most once an hour, cached in localStorage across launches, but it is real cellular data. The cleaner shape is a host-side op that hands the phone the already-built catalog; that needs the curation logic reachable from the host, which it isn't today. Follow-up, not a blocker.