### PR TITLE
fix(mobile): show provider brand icons instead of monograms

### DIFF
--- a/mobile/src-tauri/tauri.conf.json
+++ b/mobile/src-tauri/tauri.conf.json
@@ -20,8 +20,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost",
-      "devCsp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost ws://localhost:* http://localhost:* ws://*:* http://*:*"
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://fletch.sh",
+      "devCsp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; font-src 'self' data:; img-src 'self' data:; connect-src 'self' ipc: http://ipc.localhost https://fletch.sh ws://localhost:* http://localhost:* ws://*:* http://*:*"
     }
   },
   "plugins": {

--- a/mobile/src/components/ui/index.tsx
+++ b/mobile/src/components/ui/index.tsx
@@ -6,6 +6,7 @@ import type { AgentStatus, ProjectRef } from "@desktop/api/types/agent";
 import type { PrState } from "@desktop/api/types/pr";
 import { type ReactNode, useEffect, useState } from "react";
 import { hueColor, projectHue, providerHue, providerShort } from "../../lib/agents";
+import { useProviderIcon } from "../../lib/useProviderIcon";
 import { Icon, type IconName } from "../Icon";
 
 export function Nav({
@@ -261,8 +262,14 @@ export function Swatch({ project, size }: { project: ProjectRef; size?: number }
   );
 }
 
+/** A provider's brand icon in a hue-tinted square. The SVG comes from the same
+ *  website CDN the desktop chip uses (see `useProviderIcon`) and is inlined, so
+ *  marks authored with `currentColor` pick up the provider hue. A missing or
+ *  unreachable icon falls back to the abbreviation monogram; while the fetch is
+ *  in flight the square stays empty rather than flashing a monogram. */
 export function ProviderMark({ id, lg }: { id: string; lg?: boolean }) {
   const hue = providerHue(id);
+  const { svg, failed } = useProviderIcon(id);
   return (
     <span
       className={`pm${lg ? " lg" : ""}`}
@@ -271,15 +278,19 @@ export function ProviderMark({ id, lg }: { id: string; lg?: boolean }) {
         color: `oklch(0.78 0.13 ${hue})`,
       }}
     >
-      <span
-        style={{
-          fontFamily: "var(--font-mono)",
-          fontSize: lg ? 11 : 8,
-          fontWeight: 600,
-        }}
-      >
-        {providerShort(id)}
-      </span>
+      {svg && !failed ? (
+        <span className="pm-svg" dangerouslySetInnerHTML={{ __html: svg }} />
+      ) : failed ? (
+        <span
+          style={{
+            fontFamily: "var(--font-mono)",
+            fontSize: lg ? 11 : 8,
+            fontWeight: 600,
+          }}
+        >
+          {providerShort(id)}
+        </span>
+      ) : null}
     </span>
   );
 }

--- a/mobile/src/lib/useProviderIcon.ts
+++ b/mobile/src/lib/useProviderIcon.ts
@@ -36,15 +36,25 @@ export function useProviderIcon(slug: string): { svg: string | null; failed: boo
   const current = loaded.slug === slug ? loaded : initial(slug);
   if (current !== loaded) setLoaded(current);
 
+  // Always go through the loader, even when the render above found the icon
+  // cached: effects flush after paint, so a sibling mark's shared request can
+  // land in between, and a cache write is not a render. Skipping the loader on
+  // a hit would strand this mark empty until it remounted. The loader answers a
+  // hit from cache, and returning `prev` unchanged keeps that free of a render.
   useEffect(() => {
-    if (cachedProviderIcon(slug)) return;
     let active = true;
     loadProviderIcon(slug)
       .then((svg) => {
-        if (active) setLoaded({ slug, svg, failed: false });
+        if (!active) return;
+        setLoaded((prev) =>
+          prev.slug === slug && prev.svg === svg ? prev : { slug, svg, failed: false },
+        );
       })
       .catch(() => {
-        if (active) setLoaded({ slug, svg: null, failed: true });
+        if (!active) return;
+        setLoaded((prev) =>
+          prev.slug === slug && prev.failed ? prev : { slug, svg: null, failed: true },
+        );
       });
     return () => {
       active = false;

--- a/mobile/src/lib/useProviderIcon.ts
+++ b/mobile/src/lib/useProviderIcon.ts
@@ -1,0 +1,41 @@
+import { cachedProviderIcon, loadProviderIcon } from "@desktop/data/providerIcon";
+import { useEffect, useState } from "react";
+
+/**
+ * A provider's brand SVG for `slug`, sanitized and cached by the shared loader
+ * in `@desktop/data/providerIcon` — the same icons and cache semantics the
+ * desktop chip uses. Three states: markup to inline, `failed` (missing or
+ * unreachable, so render the monogram fallback), and neither, meaning the fetch
+ * is still in flight and the mark should stay empty rather than flash a
+ * monogram it is about to replace.
+ *
+ * A copy of the desktop's `components/useProviderIcon` on purpose: the two apps
+ * have separate React installs, so a hook shared through `@desktop/*` would run
+ * against the wrong copy. Everything with logic in it lives in the loader.
+ */
+export function useProviderIcon(slug: string): { svg: string | null; failed: boolean } {
+  const [svg, setSvg] = useState<string | null>(() => cachedProviderIcon(slug));
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    const cached = cachedProviderIcon(slug);
+    setSvg(cached);
+    setFailed(false);
+    if (cached) return;
+    const ctrl = new AbortController();
+    let active = true;
+    loadProviderIcon(slug, ctrl.signal)
+      .then((markup) => {
+        if (active) setSvg(markup);
+      })
+      .catch((e: Error) => {
+        if (active && e.name !== "AbortError") setFailed(true);
+      });
+    return () => {
+      active = false;
+      ctrl.abort();
+    };
+  }, [slug]);
+
+  return { svg, failed };
+}

--- a/mobile/src/lib/useProviderIcon.ts
+++ b/mobile/src/lib/useProviderIcon.ts
@@ -1,6 +1,18 @@
 import { cachedProviderIcon, loadProviderIcon } from "@desktop/data/providerIcon";
 import { useEffect, useState } from "react";
 
+interface IconState {
+  slug: string;
+  svg: string | null;
+  failed: boolean;
+}
+
+const initial = (slug: string): IconState => ({
+  slug,
+  svg: cachedProviderIcon(slug),
+  failed: false,
+});
+
 /**
  * A provider's brand SVG for `slug`, sanitized and cached by the shared loader
  * in `@desktop/data/providerIcon` — the same icons and cache semantics the
@@ -14,28 +26,30 @@ import { useEffect, useState } from "react";
  * against the wrong copy. Everything with logic in it lives in the loader.
  */
 export function useProviderIcon(slug: string): { svg: string | null; failed: boolean } {
-  const [svg, setSvg] = useState<string | null>(() => cachedProviderIcon(slug));
-  const [failed, setFailed] = useState(false);
+  const [loaded, setLoaded] = useState<IconState>(() => initial(slug));
+
+  // State carries the slug it belongs to and is reset *during* the render that
+  // changes slug (React's "adjusting state when a prop changes"), not in the
+  // effect that follows it. Resetting in the effect would commit one frame of
+  // the previous provider's mark under the new provider's colour — the runner
+  // sheet switches one mark in place like that.
+  const current = loaded.slug === slug ? loaded : initial(slug);
+  if (current !== loaded) setLoaded(current);
 
   useEffect(() => {
-    const cached = cachedProviderIcon(slug);
-    setSvg(cached);
-    setFailed(false);
-    if (cached) return;
-    const ctrl = new AbortController();
+    if (cachedProviderIcon(slug)) return;
     let active = true;
-    loadProviderIcon(slug, ctrl.signal)
-      .then((markup) => {
-        if (active) setSvg(markup);
+    loadProviderIcon(slug)
+      .then((svg) => {
+        if (active) setLoaded({ slug, svg, failed: false });
       })
-      .catch((e: Error) => {
-        if (active && e.name !== "AbortError") setFailed(true);
+      .catch(() => {
+        if (active) setLoaded({ slug, svg: null, failed: true });
       });
     return () => {
       active = false;
-      ctrl.abort();
     };
   }, [slug]);
 
-  return { svg, failed };
+  return { svg: current.svg, failed: current.failed };
 }

--- a/mobile/src/styles/base.css
+++ b/mobile/src/styles/base.css
@@ -725,9 +725,18 @@ a {
   justify-content: center;
   flex-shrink: 0;
 }
+.pm-svg {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Brand marks authored with currentColor inherit the square's hue; full-colour
+     logos keep their own fills. */
+  color: currentColor;
+}
 .pm svg {
   width: 11px;
   height: 11px;
+  display: block;
 }
 .theme-light .pm {
   filter: saturate(1.1) brightness(0.72);

--- a/mobile/tests/providerMark.test.ts
+++ b/mobile/tests/providerMark.test.ts
@@ -94,3 +94,31 @@ test("switching provider never renders the previous brand", async () => {
   expect(seen.length).toBeGreaterThan(0);
   expect(seen).not.toContain(mark("opencode"));
 });
+
+test("adopts a cache entry that landed after its render", async () => {
+  // Effects flush after paint, so a sibling mark's shared request can fill the
+  // cache in the window between this mark's render and its effect. The stub
+  // reproduces that window exactly: empty at render time, warm afterwards.
+  const AGY_SVG = mark("antigravity");
+  let reads = 0;
+  vi.resetModules();
+  vi.doMock("@desktop/data/providerIcon", () => ({
+    cachedProviderIcon: () => (reads++ === 0 ? null : AGY_SVG),
+    loadProviderIcon: async () => AGY_SVG,
+  }));
+  const { useProviderIcon: hook } = await import("../src/lib/useProviderIcon");
+
+  let svg: string | null = null;
+  function Probe() {
+    svg = hook("antigravity").svg;
+    return null;
+  }
+  const { root } = mount();
+  await act(async () => {
+    root.render(createElement(Probe));
+  });
+  expect(svg).toBe(AGY_SVG);
+
+  vi.doUnmock("@desktop/data/providerIcon");
+  vi.resetModules();
+});

--- a/mobile/tests/providerMark.test.ts
+++ b/mobile/tests/providerMark.test.ts
@@ -2,8 +2,19 @@ import { act, createElement } from "react";
 import { createRoot } from "react-dom/client";
 import { expect, test, vi } from "vitest";
 import { ProviderMark } from "../src/components/ui";
+import { useProviderIcon } from "../src/lib/useProviderIcon";
 
+const mark = (slug: string) => `<svg viewBox="0 0 24 24"><title>${slug}</title></svg>`;
 const CLAUDE_SVG = `<svg viewBox="0 0 24 24"><script>bad()</script><path fill="currentColor" d="M1 1h2v2z"/></svg>`;
+
+// The loader's cache lives for the lifetime of the module, so each test claims
+// its own provider rather than fighting over one.
+const mount = () => {
+  const host = document.createElement("div");
+  document.body.append(host);
+  const root = createRoot(host);
+  return { host, root };
+};
 
 test("inlines the brand svg and strips scripts", async () => {
   vi.stubGlobal(
@@ -13,10 +24,9 @@ test("inlines the brand svg and strips scripts", async () => {
       return { ok: true, text: async () => CLAUDE_SVG } as Response;
     }),
   );
-  const host = document.createElement("div");
-  document.body.append(host);
+  const { host, root } = mount();
   await act(async () => {
-    createRoot(host).render(createElement(ProviderMark, { id: "claude" }));
+    root.render(createElement(ProviderMark, { id: "claude" }));
   });
   expect(host.querySelector(".pm .pm-svg svg")).not.toBeNull();
   expect(host.innerHTML).not.toContain("<script>");
@@ -28,11 +38,59 @@ test("falls back to the monogram when the icon is missing", async () => {
     "fetch",
     vi.fn(async () => ({ ok: false, status: 404 }) as Response),
   );
-  const host = document.createElement("div");
-  document.body.append(host);
+  const { host, root } = mount();
   await act(async () => {
-    createRoot(host).render(createElement(ProviderMark, { id: "codex" }));
+    root.render(createElement(ProviderMark, { id: "codex" }));
   });
   expect(host.querySelector("svg")).toBeNull();
   expect(host.textContent).toBe("CX");
+});
+
+test("marks for one provider share a single request", async () => {
+  const fetchMock = vi.fn(async () => ({ ok: true, text: async () => mark("cursor") }) as Response);
+  vi.stubGlobal("fetch", fetchMock);
+  // What the agent screen does: the same mark in the header and the composer.
+  const { host, root } = mount();
+  await act(async () => {
+    root.render(
+      createElement("div", null, [
+        createElement(ProviderMark, { id: "cursor", key: "head" }),
+        createElement(ProviderMark, { id: "cursor", key: "composer", lg: true }),
+      ]),
+    );
+  });
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  expect(host.querySelectorAll(".pm-svg svg")).toHaveLength(2);
+});
+
+test("switching provider never renders the previous brand", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) =>
+      url.includes("opencode")
+        ? ({ ok: true, text: async () => mark("opencode") } as Response)
+        : // The incoming provider's icon stays in flight, so anything rendered
+          // under it could only have come from the outgoing one.
+          new Promise<Response>(() => {}),
+    ),
+  );
+
+  const seen: (string | null)[] = [];
+  function Probe({ slug }: { slug: string }) {
+    seen.push(useProviderIcon(slug).svg);
+    return null;
+  }
+
+  const { root } = mount();
+  await act(async () => {
+    root.render(createElement(Probe, { slug: "opencode" }));
+  });
+  expect(seen).toContain(mark("opencode"));
+
+  seen.length = 0;
+  await act(async () => {
+    root.render(createElement(Probe, { slug: "pi" }));
+  });
+  expect(seen.length).toBeGreaterThan(0);
+  expect(seen).not.toContain(mark("opencode"));
 });

--- a/mobile/tests/providerMark.test.ts
+++ b/mobile/tests/providerMark.test.ts
@@ -1,0 +1,38 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { expect, test, vi } from "vitest";
+import { ProviderMark } from "../src/components/ui";
+
+const CLAUDE_SVG = `<svg viewBox="0 0 24 24"><script>bad()</script><path fill="currentColor" d="M1 1h2v2z"/></svg>`;
+
+test("inlines the brand svg and strips scripts", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      expect(url).toBe("https://fletch.sh/agents/claude.svg");
+      return { ok: true, text: async () => CLAUDE_SVG } as Response;
+    }),
+  );
+  const host = document.createElement("div");
+  document.body.append(host);
+  await act(async () => {
+    createRoot(host).render(createElement(ProviderMark, { id: "claude" }));
+  });
+  expect(host.querySelector(".pm .pm-svg svg")).not.toBeNull();
+  expect(host.innerHTML).not.toContain("<script>");
+  expect(host.textContent).toBe("");
+});
+
+test("falls back to the monogram when the icon is missing", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: false, status: 404 }) as Response),
+  );
+  const host = document.createElement("div");
+  document.body.append(host);
+  await act(async () => {
+    createRoot(host).render(createElement(ProviderMark, { id: "codex" }));
+  });
+  expect(host.querySelector("svg")).toBeNull();
+  expect(host.textContent).toBe("CX");
+});

--- a/src/components/ProviderIcon.tsx
+++ b/src/components/ProviderIcon.tsx
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { agentIconUrl } from "@/data/providers";
+import { useProviderIcon } from "@/components/useProviderIcon";
 
 interface ProviderIconProps {
   /** Provider/agent slug; builds the icon URL and identifies the agent. */
@@ -9,21 +8,6 @@ interface ProviderIconProps {
   /** Hue (oklch) tinting the chip border, background, and fallback text. */
   hue: number;
   size?: number;
-}
-
-/** Parsed-and-sanitized SVG markup, keyed by slug, so re-opening the pane
- *  doesn't re-fetch or flash. The webview's HTTP cache backs the network side;
- *  this just skips the empty frame on remount. */
-const svgCache = new Map<string, string>();
-
-/** Strip executable content from a trusted-origin SVG before inlining it:
- *  <script> elements, inline on* handlers, and <foreignObject> (which can host
- *  arbitrary HTML). Defense-in-depth — the markup comes from our own CDN. */
-function sanitizeSvg(svg: string): string {
-  return svg
-    .replace(/<script[\s\S]*?<\/script>/gi, "")
-    .replace(/<foreignObject[\s\S]*?<\/foreignObject>/gi, "")
-    .replace(/\son\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, "");
 }
 
 /**
@@ -37,38 +21,7 @@ function sanitizeSvg(svg: string): string {
  * updates the icon for everyone without an app release.
  */
 export function ProviderIcon({ slug, short, hue, size = 30 }: ProviderIconProps) {
-  const [svg, setSvg] = useState<string | null>(() => svgCache.get(slug) ?? null);
-  const [failed, setFailed] = useState(false);
-
-  useEffect(() => {
-    const cached = svgCache.get(slug);
-    if (cached) {
-      setSvg(cached);
-      setFailed(false);
-      return;
-    }
-    setSvg(null);
-    setFailed(false);
-    const ctrl = new AbortController();
-    let active = true;
-    fetch(agentIconUrl(slug), { signal: ctrl.signal })
-      .then((r) => {
-        if (!r.ok) throw new Error(String(r.status));
-        return r.text();
-      })
-      .then((text) => {
-        const clean = sanitizeSvg(text);
-        svgCache.set(slug, clean);
-        if (active) setSvg(clean);
-      })
-      .catch((e) => {
-        if (active && e.name !== "AbortError") setFailed(true);
-      });
-    return () => {
-      active = false;
-      ctrl.abort();
-    };
-  }, [slug]);
+  const { svg, failed } = useProviderIcon(slug);
 
   const cls = ["chip-mono", "iflex-center", svg && !failed ? "has-brand-icon" : ""]
     .filter(Boolean)

--- a/src/components/useProviderIcon.ts
+++ b/src/components/useProviderIcon.ts
@@ -34,15 +34,25 @@ export function useProviderIcon(slug: string): { svg: string | null; failed: boo
   const current = loaded.slug === slug ? loaded : initial(slug);
   if (current !== loaded) setLoaded(current);
 
+  // Always go through the loader, even when the render above found the icon
+  // cached: effects flush after paint, so a sibling mark's shared request can
+  // land in between, and a cache write is not a render. Skipping the loader on
+  // a hit would strand this chip empty until it remounted. The loader answers a
+  // hit from cache, and returning `prev` unchanged keeps that free of a render.
   useEffect(() => {
-    if (cachedProviderIcon(slug)) return;
     let active = true;
     loadProviderIcon(slug)
       .then((svg) => {
-        if (active) setLoaded({ slug, svg, failed: false });
+        if (!active) return;
+        setLoaded((prev) =>
+          prev.slug === slug && prev.svg === svg ? prev : { slug, svg, failed: false },
+        );
       })
       .catch(() => {
-        if (active) setLoaded({ slug, svg: null, failed: true });
+        if (!active) return;
+        setLoaded((prev) =>
+          prev.slug === slug && prev.failed ? prev : { slug, svg: null, failed: true },
+        );
       });
     return () => {
       active = false;

--- a/src/components/useProviderIcon.ts
+++ b/src/components/useProviderIcon.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import { cachedProviderIcon, loadProviderIcon } from "@/data/providerIcon";
+
+/**
+ * A provider's brand SVG for `slug`, sanitized and cached (see
+ * `data/providerIcon.ts`). Three states worth distinguishing: markup to inline,
+ * `failed` — the icon is missing or unreachable, so render the monogram
+ * fallback — and neither, meaning the fetch is still in flight and the chip
+ * should stay empty rather than flash a monogram it is about to replace.
+ *
+ * The mobile app has the same hook over the same loader (`lib/useProviderIcon`);
+ * only the React instance differs.
+ */
+export function useProviderIcon(slug: string): { svg: string | null; failed: boolean } {
+  const [svg, setSvg] = useState<string | null>(() => cachedProviderIcon(slug));
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    const cached = cachedProviderIcon(slug);
+    setSvg(cached);
+    setFailed(false);
+    if (cached) return;
+    const ctrl = new AbortController();
+    let active = true;
+    loadProviderIcon(slug, ctrl.signal)
+      .then((markup) => {
+        if (active) setSvg(markup);
+      })
+      .catch((e: Error) => {
+        if (active && e.name !== "AbortError") setFailed(true);
+      });
+    return () => {
+      active = false;
+      ctrl.abort();
+    };
+  }, [slug]);
+
+  return { svg, failed };
+}

--- a/src/components/useProviderIcon.ts
+++ b/src/components/useProviderIcon.ts
@@ -1,6 +1,18 @@
 import { useEffect, useState } from "react";
 import { cachedProviderIcon, loadProviderIcon } from "@/data/providerIcon";
 
+interface IconState {
+  slug: string;
+  svg: string | null;
+  failed: boolean;
+}
+
+const initial = (slug: string): IconState => ({
+  slug,
+  svg: cachedProviderIcon(slug),
+  failed: false,
+});
+
 /**
  * A provider's brand SVG for `slug`, sanitized and cached (see
  * `data/providerIcon.ts`). Three states worth distinguishing: markup to inline,
@@ -12,28 +24,30 @@ import { cachedProviderIcon, loadProviderIcon } from "@/data/providerIcon";
  * only the React instance differs.
  */
 export function useProviderIcon(slug: string): { svg: string | null; failed: boolean } {
-  const [svg, setSvg] = useState<string | null>(() => cachedProviderIcon(slug));
-  const [failed, setFailed] = useState(false);
+  const [loaded, setLoaded] = useState<IconState>(() => initial(slug));
+
+  // State carries the slug it belongs to and is reset *during* the render that
+  // changes slug (React's "adjusting state when a prop changes"), not in the
+  // effect that follows it. Resetting in the effect would commit one frame of
+  // the previous provider's mark under the new provider's colour — visible
+  // wherever one chip switches provider in place, e.g. the model picker.
+  const current = loaded.slug === slug ? loaded : initial(slug);
+  if (current !== loaded) setLoaded(current);
 
   useEffect(() => {
-    const cached = cachedProviderIcon(slug);
-    setSvg(cached);
-    setFailed(false);
-    if (cached) return;
-    const ctrl = new AbortController();
+    if (cachedProviderIcon(slug)) return;
     let active = true;
-    loadProviderIcon(slug, ctrl.signal)
-      .then((markup) => {
-        if (active) setSvg(markup);
+    loadProviderIcon(slug)
+      .then((svg) => {
+        if (active) setLoaded({ slug, svg, failed: false });
       })
-      .catch((e: Error) => {
-        if (active && e.name !== "AbortError") setFailed(true);
+      .catch(() => {
+        if (active) setLoaded({ slug, svg: null, failed: true });
       });
     return () => {
       active = false;
-      ctrl.abort();
     };
   }, [slug]);
 
-  return { svg, failed };
+  return { svg: current.svg, failed: current.failed };
 }

--- a/src/data/providerIcon.ts
+++ b/src/data/providerIcon.ts
@@ -1,0 +1,44 @@
+// Fetching a provider's brand SVG off the website CDN, shared by the desktop
+// chip (`components/ProviderIcon`) and the mobile mark (`ProviderMark`) so both
+// surfaces resolve the same icon the same way — and a rebrand still only needs
+// the SVG re-uploaded, no app release.
+//
+// Deliberately React-free: the two apps have their own React installs, so a
+// hook living here would run against the wrong copy in one of them. Each side
+// wraps these in its own tiny hook.
+
+import { agentIconUrl } from "./providers";
+
+/** Parsed-and-sanitized SVG markup, keyed by slug, so re-opening a pane
+ *  doesn't re-fetch or flash. The webview's HTTP cache backs the network side;
+ *  this just skips the empty frame on remount. */
+const svgCache = new Map<string, string>();
+
+/** Strip executable content from a trusted-origin SVG before inlining it:
+ *  <script> elements, inline on* handlers, and <foreignObject> (which can host
+ *  arbitrary HTML). Defense-in-depth — the markup comes from our own CDN. */
+function sanitizeSvg(svg: string): string {
+  return svg
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<foreignObject[\s\S]*?<\/foreignObject>/gi, "")
+    .replace(/\son\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, "");
+}
+
+/** Already-fetched markup for `slug`, if any — lets a remount paint the icon on
+ *  its first frame instead of flashing the monogram fallback. */
+export function cachedProviderIcon(slug: string): string | null {
+  return svgCache.get(slug) ?? null;
+}
+
+/** Fetch and sanitize a provider's brand icon, memoized by slug. Rejects when
+ *  the icon is missing or unreachable (404, offline, network/CORS error), which
+ *  callers render as the abbreviation monogram. */
+export async function loadProviderIcon(slug: string, signal?: AbortSignal): Promise<string> {
+  const cached = svgCache.get(slug);
+  if (cached) return cached;
+  const res = await fetch(agentIconUrl(slug), { signal });
+  if (!res.ok) throw new Error(String(res.status));
+  const clean = sanitizeSvg(await res.text());
+  svgCache.set(slug, clean);
+  return clean;
+}

--- a/src/data/providerIcon.ts
+++ b/src/data/providerIcon.ts
@@ -14,6 +14,14 @@ import { agentIconUrl } from "./providers";
  *  this just skips the empty frame on remount. */
 const svgCache = new Map<string, string>();
 
+/** Requests that haven't settled yet, so simultaneous marks for one provider
+ *  share a single fetch — the agent screen alone renders the same mark in its
+ *  header and its composer. Dropped once settled: a success is served from
+ *  `svgCache` afterwards, and a failure stays retryable on the next mount
+ *  rather than being cached for the session (an offline first run would
+ *  otherwise never recover). */
+const inFlight = new Map<string, Promise<string>>();
+
 /** Strip executable content from a trusted-origin SVG before inlining it:
  *  <script> elements, inline on* handlers, and <foreignObject> (which can host
  *  arbitrary HTML). Defense-in-depth — the markup comes from our own CDN. */
@@ -30,15 +38,29 @@ export function cachedProviderIcon(slug: string): string | null {
   return svgCache.get(slug) ?? null;
 }
 
-/** Fetch and sanitize a provider's brand icon, memoized by slug. Rejects when
- *  the icon is missing or unreachable (404, offline, network/CORS error), which
- *  callers render as the abbreviation monogram. */
-export async function loadProviderIcon(slug: string, signal?: AbortSignal): Promise<string> {
-  const cached = svgCache.get(slug);
-  if (cached) return cached;
-  const res = await fetch(agentIconUrl(slug), { signal });
+async function fetchProviderIcon(slug: string): Promise<string> {
+  const res = await fetch(agentIconUrl(slug));
   if (!res.ok) throw new Error(String(res.status));
   const clean = sanitizeSvg(await res.text());
   svgCache.set(slug, clean);
   return clean;
+}
+
+/** Fetch and sanitize a provider's brand icon, memoized by slug and shared
+ *  while in flight. Rejects when the icon is missing or unreachable (404,
+ *  offline, network/CORS error), which callers render as the abbreviation
+ *  monogram.
+ *
+ *  There is no per-caller cancellation on purpose: one caller walking away
+ *  must not abort a request its siblings are still waiting on, and a request
+ *  that outlives its component still lands in the cache, which is where the
+ *  next mount wants it. Callers that no longer care just ignore the result. */
+export function loadProviderIcon(slug: string): Promise<string> {
+  const cached = svgCache.get(slug);
+  if (cached) return Promise.resolve(cached);
+  const pending = inFlight.get(slug);
+  if (pending) return pending;
+  const req = fetchProviderIcon(slug).finally(() => inFlight.delete(slug));
+  inFlight.set(slug, req);
+  return req;
 }


### PR DESCRIPTION
Mobile showed the generic two-letter monogram (`CC`, `CX`, …) everywhere the desktop app shows a provider's brand logo. `ProviderMark` never fetched the SVG, and mobile's Tauri CSP had no `connect-src` entry for the icon CDN, so a fetch would have been blocked in the real app anyway.

## Changes

- **`src/data/providerIcon.ts`** (new) — the fetch/sanitize/memoize logic lifted out of the desktop `ProviderIcon`, so both apps resolve icons from the same CDN URL with the same `<script>`/`on*`/`<foreignObject>` stripping and the same per-slug cache. Deliberately React-free: the two apps have separate React installs, so a hook shared through `@desktop/*` would resolve against the root copy and break at runtime.
- **`src/components/useProviderIcon.ts`** and **`mobile/src/lib/useProviderIcon.ts`** — a thin hook per app over that loader. Three states worth distinguishing: markup to inline, `failed` (404/offline → monogram), and in-flight → empty, so the mark doesn't flash a monogram it's about to replace.
- **`mobile/src/components/ui/index.tsx`** — `ProviderMark` inlines the SVG, monogram as fallback. It's the only provider-mark surface on mobile, so agent rows, the agent screen header, the composer, and both new-agent sheets all pick this up.
- **`mobile/src/styles/base.css`** — added `.pm-svg`. The existing `.pm svg` sizing (11px, 17px for `lg`) already fit, and inheriting the square's hue via `currentColor` keeps the light-theme `filter` working.
- **`mobile/src-tauri/tauri.conf.json`** — added `https://fletch.sh` to `connect-src` in `csp` and `devCsp`, matching what desktop already allows.

## Testing

`mobile/tests/providerMark.test.ts` covers both paths: the SVG inlined with the script stripped, and `CX` rendered on a 404. `check`, `lint` and the test suites pass on both apps (77 mobile, 1105 desktop).

Not verified in a real webview — headless Chromium is unavailable in this environment, so the verification is jsdom-level rather than a screenshot on device. The CSP change in particular only takes effect in an actual iOS build.