### PR TITLE
feat: mirror user messages across desktop and mobile

### DIFF
--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -462,13 +462,17 @@ authenticated connection:
 agent:event            agent:status           agent:task
 agent:branch           agent:model            agent:effort
 agent:repo_added       agent:git-action       session:records-appended
-turn:started           workspace:changed      pr:state_changed
-verify:report          publish:approval-requested
+turn:sent              turn:started           workspace:changed
+pr:state_changed       verify:report          publish:approval-requested
 ```
 
 `agent:event` is forwarded unfiltered, including the provider's
 `control_request` records: that is the only way a held tool-use approval
 reaches the phone, and `answer_tool_use` needs the `request_id` it carries.
+`turn:sent` carries every accepted user message (`turn_id`, `text`,
+`attachments`, `follow_up`) whichever client sent it, so a chat reads the same
+on every device; a client skips the one whose `turn_id` matches its own
+optimistic bubble.
 On the `error` status transition, `agent:status` must carry the real
 `last_error`, since both clients keep the previous error when it is null.
 

--- a/mobile/src/remote/mock/index.ts
+++ b/mobile/src/remote/mock/index.ts
@@ -297,6 +297,15 @@ export class MockHost {
       }
       case "send_user_message": {
         const text = String(args.text ?? "");
+        // Echoed to every client before delivery, as the host does; the sender
+        // recognizes its own turn id and does not draw the bubble twice.
+        this.event("turn:sent", {
+          agent_id: id,
+          turn_id: String(args.turnId ?? ""),
+          text,
+          attachments: [],
+          follow_up: this.agent(id).status === "running",
+        });
         this.appendRecord(id, this.agent(id).provider, {
           type: "user",
           message: { role: "user", content: [{ type: "text", text }] },

--- a/mobile/src/store/events.ts
+++ b/mobile/src/store/events.ts
@@ -15,7 +15,12 @@ import type {
   Workspace,
 } from "@desktop/api/types/agent";
 import type { PrStateChangedEvent } from "@desktop/api/types/pr";
-import type { SessionRecordsAppendedEvent, TurnStartedEvent } from "@desktop/api/types/session";
+import type {
+  SessionRecordsAppendedEvent,
+  TurnSentEvent,
+  TurnStartedEvent,
+} from "@desktop/api/types/session";
+import { mirrorSentTurn } from "@desktop/helpers/mirrorTurn";
 import type { RawEvent } from "../adapters";
 import { ignore } from "../lib/ignore";
 import type { RemoteClient } from "../remote";
@@ -93,6 +98,22 @@ export function registerRemoteEvents(client: RemoteClient, set: Set, get: Get): 
             ? { ...s.busy, [e.agent_id]: true }
             : { ...s.busy, [e.agent_id]: false },
         turnStartedAt,
+      };
+    });
+  });
+
+  // A user message the host accepted, from whichever device sent it. Mirror it
+  // so a prompt typed on the Mac shows here while its turn is still running;
+  // our own send is already in the log under its turnId (see `send`) and is
+  // skipped. A turn-opening message asserts busy the way `send` does.
+  on<TurnSentEvent>("turn:sent", (e) => {
+    set((s) => {
+      const prev = s.logs[e.agent_id] ?? [];
+      const next = mirrorSentTurn(prev, e);
+      if (next === prev) return {};
+      return {
+        logs: { ...s.logs, [e.agent_id]: next },
+        busy: e.follow_up ? s.busy : { ...s.busy, [e.agent_id]: true },
       };
     });
   });

--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -479,17 +479,20 @@ export const useStore = create<MobileState>()((set, get) => ({
   async send(agentId, text) {
     const trimmed = text.trim();
     if (!trimmed) return;
-    // Optimistic bubble, reconciled away when the canonical records land.
+    // Optimistic bubble, reconciled away when the canonical records land. It
+    // carries the turn id so the host's `turn:sent` echo (which every device
+    // mirrors, see events.ts) is recognized as ours and not drawn twice.
+    const turnId = newId();
     set((s) => ({
       logs: {
         ...s.logs,
-        [agentId]: [...(s.logs[agentId] ?? []), { kind: "queued_message", text: trimmed }],
+        [agentId]: [...(s.logs[agentId] ?? []), { kind: "queued_message", text: trimmed, turnId }],
       },
       busy: { ...s.busy, [agentId]: true },
     }));
     return guard(set, async () => {
       try {
-        await api.sendUserMessage(agentId, newId(), trimmed);
+        await api.sendUserMessage(agentId, turnId, trimmed);
       } catch (e) {
         set((s) => ({ busy: { ...s.busy, [agentId]: false } }));
         throw e;
@@ -501,18 +504,19 @@ export const useStore = create<MobileState>()((set, get) => ({
     return guard(set, async () => {
       const name = await api.allocateDraftName([]);
       const record = await api.spawnAgent(repoPath, provider, name, effort, model, base);
+      const turnId = newId();
       set((s) => ({
         workspace: s.workspace
           ? { ...s.workspace, agents: [record, ...s.workspace.agents] }
           : s.workspace,
-        logs: { ...s.logs, [record.id]: [{ kind: "user_message", text: prompt }] },
+        logs: { ...s.logs, [record.id]: [{ kind: "user_message", text: prompt, turnId }] },
         busy: { ...s.busy, [record.id]: true },
       }));
       get().closeSheet();
       get().push("agent", { agentId: record.id });
       try {
         await waitForSpawn(get, record.id);
-        await api.sendUserMessage(record.id, newId(), prompt);
+        await api.sendUserMessage(record.id, turnId, prompt);
       } catch (e) {
         // The agent exists on the host but never got the prompt: drop the
         // optimistic turn and the busy flag, and let the refreshed workspace

--- a/mobile/tests/store.test.ts
+++ b/mobile/tests/store.test.ts
@@ -93,6 +93,22 @@ describe("event folding", () => {
       true,
     );
   });
+
+  it("does not draw our own send twice when the host echoes it as turn:sent", async () => {
+    await state().rebuildLog("kamakura");
+    const before = (state().logs.kamakura ?? []).length;
+    await state().send("kamakura", "one more thing from the phone");
+    // The echo arrived with the response; the optimistic bubble carries the
+    // same turn id, so the log grew by exactly one user-side item — whether we
+    // are looking at that bubble or at the canonical rebuild that replaced it.
+    const mine = (state().logs.kamakura ?? []).filter(
+      (i) =>
+        (i.kind === "queued_message" || i.kind === "user_message") &&
+        i.text === "one more thing from the phone",
+    );
+    expect(mine).toHaveLength(1);
+    expect((state().logs.kamakura ?? []).length).toBe(before + 1);
+  });
 });
 
 describe("transcripts through the desktop adapters", () => {

--- a/src-tauri/src/remote/events.rs
+++ b/src-tauri/src/remote/events.rs
@@ -24,6 +24,7 @@ pub const FORWARDED_EVENTS: &[&str] = &[
     "agent:repo_added",
     "agent:git-action",
     "session:records-appended",
+    "turn:sent",
     "turn:started",
     "workspace:changed",
     "pr:state_changed",

--- a/src-tauri/src/supervisor/events.rs
+++ b/src-tauri/src/supervisor/events.rs
@@ -137,6 +137,45 @@ pub(super) fn emit_turn_started(app: &AppHandle, agent_id: &str, started_at: i64
     );
 }
 
+/// A user message was accepted for an agent — from any client (desktop
+/// webview, a paired phone, a git-action trigger). Every connected client
+/// mirrors it into its chat log, so the conversation reads the same on every
+/// device rather than each one seeing only the prompts it typed itself. The
+/// sender dedupes against its own optimistic bubble by `turn_id`. `follow_up`
+/// says whether the agent was mid-turn when the message arrived — the same
+/// fact the sending client keyed its own render on — so a mirroring client
+/// draws a follow-up bubble vs. a turn-opening one without consulting its own
+/// (possibly lagging) busy flag.
+#[derive(Clone, serde::Serialize)]
+struct TurnSentPayload {
+    agent_id: String,
+    turn_id: String,
+    text: String,
+    attachments: Vec<String>,
+    follow_up: bool,
+}
+
+pub(super) fn emit_turn_sent(
+    app: &AppHandle,
+    agent_id: &str,
+    turn_id: &str,
+    text: &str,
+    attachments: &[String],
+    follow_up: bool,
+) {
+    emit(
+        app,
+        "turn:sent",
+        TurnSentPayload {
+            agent_id: agent_id.to_string(),
+            turn_id: turn_id.to_string(),
+            text: text.to_string(),
+            attachments: attachments.to_vec(),
+            follow_up,
+        },
+    );
+}
+
 #[derive(Clone, serde::Serialize)]
 struct AgentStatusPayload {
     agent_id: String,

--- a/src-tauri/src/supervisor/messaging.rs
+++ b/src-tauri/src/supervisor/messaging.rs
@@ -10,7 +10,7 @@ use crate::managed_session::ToolUseBehavior;
 use crate::message_queue::{decide_delivery, Delivery, PendingMsg};
 use crate::workspace::AgentStatus;
 
-use super::events::{emit_task, emit_turn_started};
+use super::events::{emit_task, emit_turn_sent, emit_turn_started};
 use super::{transition_active, Supervisor};
 
 impl Supervisor {
@@ -48,6 +48,16 @@ impl Supervisor {
             text: text.to_string(),
             attachments: attachments.to_vec(),
         };
+
+        // Announce the message to every client before delivering it. The one
+        // that sent it already shows an optimistic bubble and dedupes on
+        // `turn_id`; the others (a paired phone, or the desktop when the phone
+        // sent) would otherwise watch the agent's answer stream in with no
+        // prompt above it until the turn-end transcript rebuild. Before
+        // delivery, so it lands ahead of the `agent:status` Running flip that
+        // delivery raises — a mirroring client renders a turn-opening bubble
+        // for `!busy` and must not be told the turn is running first.
+        emit_turn_sent(app, agent_id, turn_id, text, attachments, busy);
 
         let delivery = decide_delivery(busy, mode, tool_gated, queue_nonempty);
         // Whether the message is genuinely held for a later boundary. A path

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -17,6 +17,10 @@ export type ChatItem =
        *  flight (the live turn); both absent for turns with no timing row. */
       startedAt?: number;
       endedAt?: number;
+      /** Client turn id on a store-inserted optimistic bubble (the message that
+       *  opened a turn, before the transcript echoes it). Lets the `turn:sent`
+       *  mirror skip this client's own send. Never set on adapter-reduced items. */
+      turnId?: string;
     }
   // A follow-up the user sent mid-turn that hasn't landed in the transcript
   // yet: delivered live into the running turn (claude) or queued for the next

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -34,6 +34,7 @@ import type { DockerBuildEvent, PublishApproval } from "./types/sandbox";
 import type {
   SessionRecordsAppendedEvent,
   SessionSyncHealthEvent,
+  TurnSentEvent,
   TurnStartedEvent,
 } from "./types/session";
 import type { VerificationReportEvent } from "./types/verify";
@@ -225,6 +226,12 @@ export function onSessionRecordsAppended(
  *  detected, or a prior drift cleared. Emitted on change only. */
 export function onSessionSyncHealth(cb: (e: SessionSyncHealthEvent) => void): Promise<UnlistenFn> {
   return listen<SessionSyncHealthEvent>("session:sync-health", (event) => cb(event.payload));
+}
+
+/** Fires when the host accepts a user message for an agent, from any client.
+ *  Mirror it into the log unless it is this client's own send (same turn id). */
+export function onTurnSent(cb: (e: TurnSentEvent) => void): Promise<UnlistenFn> {
+  return listen<TurnSentEvent>("turn:sent", (event) => cb(event.payload));
 }
 
 /** Fires when a turn flips to Running, carrying the backend's own start

--- a/src/api/types/session.ts
+++ b/src/api/types/session.ts
@@ -49,6 +49,21 @@ export interface SessionSyncHealthEvent {
   version: string | null;
 }
 
+/** A user message the host accepted for an agent, from whichever client sent
+ *  it. Every client mirrors it into the chat log (skipping its own, by
+ *  `turn_id`), so a prompt typed on the phone shows on the desktop and vice
+ *  versa while the turn is still running. */
+export interface TurnSentEvent {
+  agent_id: string;
+  /** The sender's client-generated turn id — matches the optimistic bubble. */
+  turn_id: string;
+  text: string;
+  attachments: string[];
+  /** The agent was mid-turn when this arrived: a follow-up (injected live or
+   *  queued), not the message that opened the turn. */
+  follow_up: boolean;
+}
+
 export interface TurnStartedEvent {
   agent_id: string;
   /** Backend epoch millis the turn began — the live-timer anchor. */

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -11,6 +11,7 @@
 
 export * from "./agentLookups";
 export * from "./commands";
+export * from "./mirrorTurn";
 export * from "./reasoning";
 export * from "./spawn";
 export * from "./transcript";

--- a/src/helpers/mirrorTurn.ts
+++ b/src/helpers/mirrorTurn.ts
@@ -1,0 +1,26 @@
+// Fold a `turn:sent` event into a chat log, so a message sent from one device
+// shows on every other one while the turn is still running. Pure and free of
+// store types so the phone imports it as-is.
+
+import type { ChatItem } from "@/adapters/types";
+import type { TurnSentEvent } from "@/api/types/session";
+
+/** The log already carries this turn — the sender's own optimistic bubble. */
+export function hasSentTurn(items: ChatItem[], turnId: string): boolean {
+  return items.some(
+    (it) => (it.kind === "user_message" || it.kind === "queued_message") && it.turnId === turnId,
+  );
+}
+
+/** Append the mirrored bubble for `e`, or return `items` untouched (same
+ *  reference) when it is already there. A follow-up renders as the same
+ *  `queued_message` the sender drew; a turn-opening message as a `user_message`.
+ *  Both are reconciled away by the turn-end rebuild exactly like the sender's. */
+export function mirrorSentTurn(items: ChatItem[], e: TurnSentEvent): ChatItem[] {
+  if (hasSentTurn(items, e.turn_id)) return items;
+  const attachments = e.attachments.length > 0 ? { attachments: e.attachments } : {};
+  const entry: ChatItem = e.follow_up
+    ? { kind: "queued_message", text: e.text, turnId: e.turn_id, ...attachments }
+    : { kind: "user_message", text: e.text, turnId: e.turn_id, ...attachments };
+  return [...items, entry];
+}

--- a/src/store/eventListeners.ts
+++ b/src/store/eventListeners.ts
@@ -26,6 +26,7 @@ import {
   onSessionRecordsAppended,
   onSessionSyncHealth,
   onShellOutput,
+  onTurnSent,
   onTurnStarted,
   onVerificationReport,
   onWorkspaceChanged,
@@ -36,6 +37,7 @@ import {
   applyEvent,
   applyUserTurns,
   carryForwardStoreOnly,
+  mirrorSentTurn,
   needsSessionIdRefresh,
   persistLiveReasoning,
   persistLiveUsage,
@@ -444,6 +446,23 @@ export const registerEventListeners = async (set: AppSet, get: AppGet) => {
               ? { ...state.managedBusy, [e.agent_id]: false }
               : state.managedBusy,
         turnStartedAt,
+      };
+    });
+  });
+
+  // A user message the host accepted, from whichever client sent it — this
+  // window, a paired phone, a git-action trigger. Mirror it so the chat reads
+  // the same on every device; our own send is already in the log under its
+  // turnId (see workspace.sendMessage) and is skipped. A turn-opening message
+  // asserts busy the way the sender did; the Running status lands right after.
+  await onTurnSent((e) => {
+    set((state) => {
+      const prev = state.managedLogs[e.agent_id] ?? [];
+      const next = mirrorSentTurn(prev, e);
+      if (next === prev) return {};
+      return {
+        managedLogs: { ...state.managedLogs, [e.agent_id]: next },
+        ...(e.follow_up ? {} : { managedBusy: { ...state.managedBusy, [e.agent_id]: true } }),
       };
     });
   });

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -520,6 +520,8 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
         // Optimistic mid-turn follow-up: default to no badge (the common case is
         // immediate live injection). If the backend reports it was enqueued, we
         // flip `queued` on below — carried by `turnId` so we can find it again.
+        // The turn-opening bubble carries `turnId` too, so the `turn:sent`
+        // mirror (see eventListeners) recognizes it as ours and skips it.
         const entry: ChatItem = wasBusy
           ? attachments.length > 0
             ? { kind: "queued_message", text, attachments, turnId }
@@ -527,8 +529,8 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
           : slashName
             ? { kind: "notice", subtype: "slash_command", text: `/${slashName}` }
             : attachments.length > 0
-              ? { kind: "user_message", text, attachments }
-              : { kind: "user_message", text };
+              ? { kind: "user_message", text, attachments, turnId }
+              : { kind: "user_message", text, turnId };
         return {
           managedLogs: {
             ...state.managedLogs,

--- a/tests/helpers/mirror-turn.test.ts
+++ b/tests/helpers/mirror-turn.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import type { ChatItem } from "@/adapters";
+import type { TurnSentEvent } from "@/api";
+import { hasSentTurn, mirrorSentTurn } from "@/helpers";
+
+const sent = (over: Partial<TurnSentEvent> = {}): TurnSentEvent => ({
+  agent_id: "arabia",
+  turn_id: "t-1",
+  text: "ship it",
+  attachments: [],
+  follow_up: false,
+  ...over,
+});
+
+describe("mirrorSentTurn", () => {
+  it("appends a turn-opening message as a user bubble carrying the turn id", () => {
+    const prev: ChatItem[] = [{ kind: "agent_message", text: "earlier answer" }];
+    expect(mirrorSentTurn(prev, sent())).toEqual([
+      ...prev,
+      { kind: "user_message", text: "ship it", turnId: "t-1" },
+    ]);
+  });
+
+  it("appends a follow-up as the same queued bubble the sender drew", () => {
+    expect(mirrorSentTurn([], sent({ follow_up: true }))).toEqual([
+      { kind: "queued_message", text: "ship it", turnId: "t-1" },
+    ]);
+  });
+
+  it("carries attachments only when there are any", () => {
+    const [withFiles] = mirrorSentTurn([], sent({ attachments: ["/tmp/a.png"] }));
+    expect(withFiles).toMatchObject({ attachments: ["/tmp/a.png"] });
+    const [bare] = mirrorSentTurn([], sent());
+    expect(bare).not.toHaveProperty("attachments");
+  });
+
+  it("skips the sender's own optimistic bubble, whichever kind it drew", () => {
+    const opening: ChatItem[] = [{ kind: "user_message", text: "ship it", turnId: "t-1" }];
+    expect(mirrorSentTurn(opening, sent())).toBe(opening);
+    const followUp: ChatItem[] = [{ kind: "queued_message", text: "ship it", turnId: "t-1" }];
+    expect(mirrorSentTurn(followUp, sent({ follow_up: true }))).toBe(followUp);
+  });
+
+  it("does not dedupe on text alone — a repeated prompt is a new turn", () => {
+    const prev: ChatItem[] = [{ kind: "user_message", text: "ship it" }];
+    expect(mirrorSentTurn(prev, sent({ turn_id: "t-2" }))).toHaveLength(2);
+    expect(hasSentTurn(prev, "t-2")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

With an agent open on desktop and mobile side by side, the agent's run (transcript, tool calls) streams to both, but a user message sent from one device does not appear on the other until the turn ends. Each client drew its own optimistic bubble locally, the host emitted nothing when it accepted a message, and the provider's live stream never echoes the typed prompt — so the other device watched the answer stream in with no prompt above it until the `session:records-appended` rebuild.

## Fix

- **Host:** the supervisor emits a new `turn:sent` event (`agent_id`, `turn_id`, `text`, `attachments`, `follow_up`) in `send_user_message`, before delivery so it lands ahead of the `agent:status` Running flip. Added to the relay's `FORWARDED_EVENTS` whitelist and to `docs/remote-protocol.md`.
- **Shared:** `src/helpers/mirrorTurn.ts` folds the event into a chat log — a follow-up as the same `queued_message` the sender drew, a turn-opening message as a `user_message` — and returns the log untouched when an item with that `turn_id` is already there.
- **Desktop:** listens for `turn:sent`; the optimistic turn-opening `user_message` now carries `turnId` (the `ChatItem` type gained an optional `turnId`) so the sender skips its own echo.
- **Mobile:** same listener; `send` and `spawn` generate the turn id up front and stamp it on the optimistic bubble. The mock host echoes `turn:sent` like the real one.

Mirrored bubbles are reconciled away by the existing turn-end rebuild exactly like the sender's own.

## Tests

- New `tests/helpers/mirror-turn.test.ts` (append, follow-up kind, attachments, dedupe by turn id, no dedupe on text).
- New mobile store test: the host's echo of our own send does not draw the bubble twice.
- Desktop: typecheck, biome, full vitest suite (1110 tests) pass. Mobile: typecheck, biome, store suite pass. Rust: `cargo fmt --check` passes; `cargo check` was still compiling from scratch when this PR was opened, so CI is the first full Rust compile of this change.