### PR TITLE
Dictate messages from the phone, transcribed on the Mac

### DIFF
--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -330,3 +330,33 @@ The silence gate needs no model, so its test always runs; set
 `FLETCH_WHISPER_TEST_SILENT_WAV` to try a real recording instead of synthetic
 zeroes. The resampler is likewise covered without a microphone — `capture.rs`
 puts a 440 Hz tone through it and checks the length and loudness that come out.
+
+## Dictating from the phone
+
+The mobile app has a mic button in its composer, but no speech model on the
+phone: it captures the microphone in the webview and streams PCM to the Mac
+over the remote protocol, and the Mac runs the local engine on it. The wire
+contract is in [remote-protocol.md](remote-protocol.md), "Dictation"; the host
+side is `src-tauri/src/dictation/remote.rs`.
+
+What it reuses, and what it doesn't:
+
+- The transcription is `whisper::engine::transcribe` — the same call the desktop
+  stop makes, with the same silence gate, the same model cache and the same
+  one-decode-at-a-time lock. The resampler is `capture::resample`, so the phone
+  can send audio at whatever rate its audio session runs at.
+- It requires the local engine: `dictation_engine` set to `whisper` and the
+  selected model downloaded — the same two conditions [Dispatch](#dispatch)
+  requires. Unlike the desktop there is **no fallback** to Apple's recognizer,
+  which needs a microphone the Mac doesn't have; `dictation_status` tells the
+  phone why, and it shows the reason instead of a mic.
+- The microphone is the phone's, so `apple.rs` is not involved, and neither are
+  the desktop's `dictation:*` events: whisper has no partials, so the transcript
+  is simply the reply to `dictation_end`.
+- Hands-free auto-stop is not there yet. The detector in `capture.rs` runs in
+  the mic tap, and the phone's tap is JavaScript; porting the three constants
+  and the RMS-over-noise-floor rule is a follow-up.
+
+Audio is held in memory only, for the length of a session plus a 60 s idle
+sweep, and never written to disk. The phone's `NSMicrophoneUsageDescription`
+lives in `mobile/src-tauri/Info.ios.plist`.

--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -353,9 +353,13 @@ What it reuses, and what it doesn't:
 - The microphone is the phone's, so `apple.rs` is not involved, and neither are
   the desktop's `dictation:*` events: whisper has no partials, so the transcript
   is simply the reply to `dictation_end`.
-- Hands-free auto-stop is not there yet. The detector in `capture.rs` runs in
-  the mic tap, and the phone's tap is JavaScript; porting the three constants
-  and the RMS-over-noise-floor rule is a follow-up.
+- Hands-free auto-stop is the same policy, ported to TypeScript in
+  `mobile/src/dictation/silence.ts`: the same `SILENCE_STOP` (2 s),
+  `NO_SPEECH_TIMEOUT` (10 s) and `SILENCE_POLL` (100 ms), and the same
+  RMS-over-noise-floor rule, computed on the main thread from the Float32
+  frames the worklet posts (the worklet stays a plain copy) and polled by
+  `capture.ts`, which hands the pause to the session — so the stop takes the
+  same path a tap on the button takes.
 
 Audio is held in memory only, for the length of a session plus a 60 s idle
 sweep, and never written to disk. The phone's `NSMicrophoneUsageDescription`

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -292,6 +292,15 @@ could send paired phones misleading alerts, which stays within the
 deny-or-annoy ceiling: tapping one only opens the app, which then talks to the
 real host over the secure channel.
 
+Dictation puts the user's voice on the wire, which nothing did before. It
+travels inside the same Noise channel as every other frame, so the relay sees
+ciphertext sizes and timing (someone is talking, roughly how long) and nothing
+else; the Mac holds the audio in memory only until `dictation_end` or the idle
+sweep and never writes it out; and the transcript comes back over the same
+channel. Apple is not a party: the local engine never calls a speech service.
+A paired phone can make the Mac spend CPU on transcription, bounded by the
+session cap and the capture cap.
+
 ## Envelope
 
 Client → host request:
@@ -421,6 +430,11 @@ allowlist; any op not listed returns `{ ok: false, error: "unknown op" }`.
 | `clone_repo` | `{ spec, destParent }` | `Workspace` |
 | `gh_status` | `{}` | `GhStatus` |
 | `gh_repo_list` | `{}` | `GhRepoSummary[]` |
+| `dictation_status` | `{}` (remote-only, see "Dictation") | `{ available: boolean, reason: string \| null }` |
+| `dictation_begin` | `{}` (remote-only) | `{ session: string }` |
+| `dictation_audio` | `{ session, rate: number, pcm: string }` — base64 of 16-bit little-endian mono PCM at `rate` Hz (remote-only) | `null` |
+| `dictation_end` | `{ session }` (remote-only) | `{ text: string }` |
+| `dictation_cancel` | `{ session }` (remote-only) | `null` |
 | `register_push` | `{ token: string \| null, environment?: "sandbox" \| "production" }` — `environment` required with a token, ignored on clear (remote-only, see "Push notifications") | `null` |
 
 Never exposed, by design: the generic `db_*` table bridge, every file mutation
@@ -450,6 +464,45 @@ Pinning a folder that is not yet a git repository runs `git init` plus an
 initial commit in it, exactly as the desktop dialog does. The phone remembers
 the last destination parent per host, as the desktop does. Creating a brand-new
 repo from the phone (`create_repo`) is a follow-up.
+
+## Dictation
+
+The phone has a mic button too, but no speech model: it captures, and the Mac
+transcribes with the local whisper.cpp engine the desktop composer can opt into
+(docs/dictation.md, "Local Whisper engine"). The five `dictation_*` ops are
+remote-only — the desktop has its own microphone and its own commands — and
+answer through the generic dispatcher, since none of them needs to know which
+device is asking.
+
+- **Preconditions.** The Mac's `dictation_engine` setting must be `whisper` and
+  the selected model's weights must be on disk. `dictation_status` reports
+  exactly that as `available`, with a `reason` the phone shows as-is when it is
+  false ("Local dictation is off on your Mac. Turn on the Whisper engine in
+  Settings › Dictation."). There is no fallback to Apple's recognizer on this
+  path: it needs a microphone the Mac does not have.
+- **Flow.** `dictation_begin` re-checks the preconditions (so the phone learns
+  before its mic opens) and answers with a host-minted `session` id. While the
+  user talks, the phone sends `dictation_audio` about once a second with the
+  PCM captured since the last chunk. On stop it sends `dictation_end` and shows
+  "transcribing" until the reply, whose `text` is the whole transcript (empty
+  when the clip had no speech in it — the engine's silence gate, identical to
+  the desktop). `dictation_cancel` throws the audio away; it is idempotent.
+- **Audio.** `pcm` is base64 of 16-bit little-endian mono samples at `rate` Hz,
+  whatever rate the phone's audio session runs at (typically 48 000). The rate
+  is fixed by the first chunk of a session; a chunk that names another is
+  refused. The host resamples to the model's 16 kHz itself with the same
+  converter the desktop path uses. A decoded chunk over 2 MiB is refused.
+- **Bounds.** Everything a session holds is bounded and lives in memory only.
+  Audio past the desktop's capture cap (five minutes) is dropped, not refused,
+  so the transcript is truncated rather than the session failing. At most 4
+  sessions are open at once across every phone; a session that has received no
+  chunk for 60 s is swept (a phone that lost its connection mid-sentence never
+  sends `dictation_end`), after which its id is unknown. Nothing is written to
+  disk, and no `dictation:*` event is forwarded — the transcript is the reply.
+- **Wire cost.** Chunks are about 100 KB a second at 48 kHz mono before base64,
+  well under the 4 MiB frame cap and the relay's 100-messages-per-10-s limit at
+  one chunk a second. Two decodes never run at once (the engine serialises
+  them), so a phone's transcription may wait behind a desktop session's.
 
 ## Events (v1 whitelist)
 
@@ -532,7 +585,7 @@ launch once the disk recovers.
 
 QR scanning on the phone (manual entry of address and code, plus
 `fletch://pair` deep-link parsing, for now), creating a brand-new repo from the
-phone (`create_repo`), voice, attachments, Run scripts, Keychain storage of the
+phone (`create_repo`), attachments, Run scripts, Keychain storage of the
 device key on the phone (it lives in the app data dir). Push follow-ups:
 feeding APNs `410 Unregistered` back to the host so stale tokens are dropped,
 noticing a permission revoked in iOS Settings (the phone has no way to observe

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -91,7 +91,11 @@ phone"). There is no speech model on the phone: `src/dictation/capture.ts` opens
 `getUserMedia` into an `AudioWorklet` tap and batches a second of 16-bit PCM at
 a time, `src/dictation/session.ts` streams those chunks to the host in order and
 asks for the transcript on stop, and `useDictation` turns that into the button's
-phases. The Mac has to have its local Whisper engine on with a model downloaded;
+phases. One tap is enough: `src/dictation/silence.ts` is a port of the desktop's
+detector — same constants, same RMS-over-noise-floor rule, run on the main
+thread over the frames the worklet posts — and the session ends itself two
+seconds after you stop talking. The Mac has to have its local Whisper engine on
+with a model downloaded;
 `dictation_status` says so, and a slashed mic that explains itself on tap is
 what the phone shows otherwise.
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -83,6 +83,31 @@ These cannot be committed and have to be done once, per team:
 3. Run on a real device. The simulator has no embedded profile and cannot
    receive a remote push; the plugin reports `sandbox` there.
 
+## Dictation
+
+The composer's mic button records in the webview and has the Mac transcribe
+(docs/remote-protocol.md, "Dictation"; docs/dictation.md, "Dictating from the
+phone"). There is no speech model on the phone: `src/dictation/capture.ts` opens
+`getUserMedia` into an `AudioWorklet` tap and batches a second of 16-bit PCM at
+a time, `src/dictation/session.ts` streams those chunks to the host in order and
+asks for the transcript on stop, and `useDictation` turns that into the button's
+phases. The Mac has to have its local Whisper engine on with a model downloaded;
+`dictation_status` says so, and a slashed mic that explains itself on tap is
+what the phone shows otherwise.
+
+Two things are worth knowing:
+
+- **The mic prompt string is `src-tauri/Info.ios.plist`.** The Tauri CLI merges
+  it into the generated project's `Info.plist` during `ios dev` / `ios build`
+  (it is not applied by `ios init`). Without `NSMicrophoneUsageDescription` iOS
+  kills the app on the first `getUserMedia`.
+- **The webview's permission prompt is answered by wry.** Its `WKUIDelegate`
+  grants `requestMediaCapturePermission` outright, so the only prompt the user
+  sees is the system one for the microphone.
+
+`mobile/spike/` holds a standalone capture diagnostic for when something about
+the webview's audio needs checking on a device.
+
 ## Web dev loop
 
 ```sh

--- a/mobile/spike/README.md
+++ b/mobile/spike/README.md
@@ -1,0 +1,29 @@
+# Mic capture spike
+
+A single page that reports whether microphone capture works inside the Tauri
+iOS webview: secure context, `getUserMedia`, `AudioContext` rates, an
+`AudioWorklet` tap (frames, RMS, non-zero count) and `MediaRecorder` mime
+types. Everything is printed into the page, so a screenshot is the whole log.
+
+Not shipped. It lives here rather than in `public/` so it never lands in a
+build.
+
+## Run it on a device or simulator
+
+```sh
+cd mobile
+mkdir -p public && cp spike/spike.html spike/spike.js spike/spike-worklet.js public/
+# Point the dev webview at the page instead of the app:
+#   tauri.conf.json → "build.devUrl": "http://localhost:1430/spike.html"
+bun run tauri ios dev
+```
+
+`NSMicrophoneUsageDescription` comes from `src-tauri/Info.ios.plist`, which
+the Tauri CLI merges into the generated project during `ios dev` / `ios build`.
+Revert `devUrl` and delete `public/` afterwards.
+
+Expected on a working device: `secure true`, `gUM ok`, a worklet line with a
+non-zero `rms` while you talk, and `recorder mime=audio/mp4`. A worklet line
+with `rms=0.00000 nonzero=0` means the mic opened but WebKit delivered silence,
+which is the failure mode that would send the feature to a native capture
+plugin instead.

--- a/mobile/spike/spike-worklet.js
+++ b/mobile/spike/spike-worklet.js
@@ -1,0 +1,8 @@
+class Tap extends AudioWorkletProcessor {
+  process(inputs) {
+    const ch = inputs[0]?.[0];
+    if (ch) this.port.postMessage(Float32Array.from(ch));
+    return true;
+  }
+}
+registerProcessor("tap", Tap);

--- a/mobile/spike/spike.html
+++ b/mobile/spike/spike.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>mic spike</title>
+    <style>
+      body { margin: 0; padding: 60px 12px 12px; background: #111; color: #eee; font: 15px/1.5 -apple-system, Menlo, monospace; }
+      pre { white-space: pre-wrap; word-break: break-all; margin: 0; }
+      button { font-size: 20px; padding: 12px 20px; margin-bottom: 12px; }
+    </style>
+  </head>
+  <body>
+    <button id="go" type="button">start</button>
+    <pre id="out">booting…</pre>
+    <script src="/spike.js"></script>
+  </body>
+</html>

--- a/mobile/spike/spike.js
+++ b/mobile/spike/spike.js
@@ -1,0 +1,134 @@
+// Mic capture spike for the Tauri iOS webview. Reports into the page so a
+// simulator screenshot is the whole log. Not shipped.
+const out = document.getElementById("out");
+const lines = [];
+const log = (s) => {
+  lines.push(s);
+  out.textContent = lines.join("\n");
+};
+
+function stats(chunks) {
+  let n = 0;
+  let sq = 0;
+  let max = 0;
+  let nonzero = 0;
+  for (const c of chunks) {
+    for (let i = 0; i < c.length; i++) {
+      const v = c[i];
+      n++;
+      sq += v * v;
+      const a = Math.abs(v);
+      if (a > max) max = a;
+      if (v !== 0) nonzero++;
+    }
+  }
+  return { n, rms: n ? Math.sqrt(sq / n) : 0, max, nonzero };
+}
+
+async function captureWorklet(ctx, stream, seconds) {
+  await ctx.audioWorklet.addModule("/spike-worklet.js");
+  const src = ctx.createMediaStreamSource(stream);
+  const node = new AudioWorkletNode(ctx, "tap", { numberOfInputs: 1, numberOfOutputs: 0 });
+  const chunks = [];
+  node.port.onmessage = (e) => chunks.push(e.data);
+  src.connect(node);
+  await new Promise((r) => setTimeout(r, seconds * 1000));
+  src.disconnect();
+  node.port.onmessage = null;
+  return chunks;
+}
+
+async function captureScriptProcessor(ctx, stream, seconds) {
+  const src = ctx.createMediaStreamSource(stream);
+  const node = ctx.createScriptProcessor(4096, 1, 1);
+  const chunks = [];
+  node.onaudioprocess = (e) => chunks.push(Float32Array.from(e.inputBuffer.getChannelData(0)));
+  src.connect(node);
+  node.connect(ctx.destination);
+  await new Promise((r) => setTimeout(r, seconds * 1000));
+  src.disconnect();
+  node.disconnect();
+  return chunks;
+}
+
+async function run() {
+  lines.length = 0;
+  log(`url ${location.href}`);
+  log(`secure ${window.isSecureContext}`);
+  log(`mediaDevices ${!!navigator.mediaDevices} gUM ${!!navigator.mediaDevices?.getUserMedia}`);
+  log(`MediaRecorder ${typeof MediaRecorder}`);
+  if (typeof MediaRecorder !== "undefined") {
+    for (const t of ["audio/mp4", "audio/mp4;codecs=pcm", "audio/webm;codecs=opus", "audio/wav"]) {
+      log(`  ${t}: ${MediaRecorder.isTypeSupported(t)}`);
+    }
+  }
+  log(`AudioWorklet ${typeof AudioWorkletNode}`);
+  let stream;
+  try {
+    const t0 = performance.now();
+    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    const track = stream.getAudioTracks()[0];
+    log(
+      `gUM ok in ${Math.round(performance.now() - t0)}ms track=${track?.label} state=${track?.readyState} muted=${track?.muted}`,
+    );
+    log(`settings ${JSON.stringify(track?.getSettings?.() ?? {})}`);
+  } catch (e) {
+    log(`gUM FAILED ${e?.name}: ${e?.message}`);
+    return;
+  }
+  for (const rate of [undefined, 16000]) {
+    let ctx;
+    try {
+      ctx = rate ? new AudioContext({ sampleRate: rate }) : new AudioContext();
+      await ctx.resume();
+      log(`ctx(${rate ?? "default"}) rate=${ctx.sampleRate} state=${ctx.state}`);
+    } catch (e) {
+      log(`ctx(${rate ?? "default"}) FAILED ${e?.name}: ${e?.message}`);
+      continue;
+    }
+    try {
+      const chunks = await captureWorklet(ctx, stream, 3);
+      const s = stats(chunks);
+      log(
+        `  worklet: chunks=${chunks.length} frames=${s.n} (${(s.n / ctx.sampleRate).toFixed(2)}s) rms=${s.rms.toFixed(5)} max=${s.max.toFixed(4)} nonzero=${s.nonzero}`,
+      );
+    } catch (e) {
+      log(`  worklet FAILED ${e?.name}: ${e?.message}`);
+      try {
+        const chunks = await captureScriptProcessor(ctx, stream, 3);
+        const s = stats(chunks);
+        log(
+          `  scriptproc: frames=${s.n} rms=${s.rms.toFixed(5)} max=${s.max.toFixed(4)} nonzero=${s.nonzero}`,
+        );
+      } catch (e2) {
+        log(`  scriptproc FAILED ${e2?.name}: ${e2?.message}`);
+      }
+    }
+    await ctx.close();
+  }
+  if (typeof MediaRecorder !== "undefined") {
+    try {
+      const rec = new MediaRecorder(stream);
+      const blobs = [];
+      rec.ondataavailable = (e) => blobs.push(e.data);
+      rec.start();
+      await new Promise((r) => setTimeout(r, 2000));
+      await new Promise((r) => {
+        rec.onstop = r;
+        rec.stop();
+      });
+      const size = blobs.reduce((a, b) => a + b.size, 0);
+      log(`recorder mime=${rec.mimeType} blobs=${blobs.length} bytes=${size}`);
+    } catch (e) {
+      log(`recorder FAILED ${e?.name}: ${e?.message}`);
+    }
+  }
+  for (const t of stream.getTracks()) t.stop();
+  log("done");
+}
+
+document
+  .getElementById("go")
+  .addEventListener("click", () => run().catch((e) => log(`run FAILED ${e}`)));
+// Auto-start: the simulator has no tap command.
+setTimeout(() => run().catch((e) => log(`run FAILED ${e}`)), 1500);

--- a/mobile/src-tauri/Info.ios.plist
+++ b/mobile/src-tauri/Info.ios.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Fletch uses the microphone to dictate messages to your agents. Audio is sent to your paired Mac for transcription.</string>
+</dict>
+</plist>

--- a/mobile/src/api/index.ts
+++ b/mobile/src/api/index.ts
@@ -111,7 +111,25 @@ export function createApi(client: RemoteClient) {
      *  `token: null` on its own. */
     registerPush: (token: string | null, environment?: "sandbox" | "production") =>
       call<null>("register_push", token === null ? { token: null } : { token, environment }),
+
+    /** Remote-only (docs/remote-protocol.md, "Dictation"): the phone captures,
+     *  the Mac transcribes with its local whisper engine. `pcm` is base64 of
+     *  16-bit little-endian mono samples at `rate` Hz; the transcript is the
+     *  reply to `dictationEnd`. */
+    dictationStatus: () => call<DictationStatus>("dictation_status"),
+    dictationBegin: () => call<{ session: string }>("dictation_begin"),
+    dictationAudio: (session: string, rate: number, pcm: string) =>
+      call<null>("dictation_audio", { session, rate, pcm }),
+    dictationEnd: (session: string) => call<{ text: string }>("dictation_end", { session }),
+    dictationCancel: (session: string) => call<null>("dictation_cancel", { session }),
   };
+}
+
+/** Whether the Mac can transcribe for this phone right now. `reason` is shown
+ *  as-is when it can't (the local engine is off, or its model isn't downloaded). */
+export interface DictationStatus {
+  available: boolean;
+  reason: string | null;
 }
 
 export type Api = ReturnType<typeof createApi>;

--- a/mobile/src/components/Icon/paths.tsx
+++ b/mobile/src/components/Icon/paths.tsx
@@ -264,6 +264,22 @@ export const ICON_PATHS = {
       <circle cx="11.5" cy="8" r="1" fill="currentColor" stroke="none" />
     </>
   ),
+  mic: (
+    <>
+      <rect x="6" y="1.5" width="4" height="8" rx="2" />
+      <path d="M3.5 7.5a4.5 4.5 0 0 0 9 0" />
+      <path d="M8 12v2.5M5.5 14.5h5" />
+    </>
+  ),
+  micOff: (
+    <>
+      <path d="M6 6v1.5a2 2 0 0 0 3.4 1.4" />
+      <path d="M10 7.5V3.5a2 2 0 0 0-4 0v.5" />
+      <path d="M3.5 7.5a4.5 4.5 0 0 0 7.2 3.6M12.5 7.5a4.5 4.5 0 0 1-.4 1.8" />
+      <path d="M8 12v2.5M5.5 14.5h5" />
+      <path d="M2.5 2.5l11 11" />
+    </>
+  ),
 } satisfies Record<string, ReactElement>;
 
 export type IconName = keyof typeof ICON_PATHS;

--- a/mobile/src/dictation/DictationButton.tsx
+++ b/mobile/src/dictation/DictationButton.tsx
@@ -1,0 +1,40 @@
+import { Icon } from "../components/Icon";
+import type { DictationPhase } from "./useDictation";
+
+/** The composer's mic. Lives in the bar next to send, because dictation puts
+ *  text into *this* message. Tap to start, tap again to stop; the spinner is
+ *  the wait for the Mac to run the model on what was said. */
+export function DictationButton({
+  phase,
+  blocked,
+  onToggle,
+}: {
+  phase: DictationPhase;
+  /** The Mac can't transcribe right now. Still tappable: the tap surfaces why. */
+  blocked: boolean;
+  onToggle: () => void;
+}) {
+  const listening = phase === "listening";
+  const busy = phase === "starting" || phase === "transcribing";
+  const label = listening
+    ? "Stop dictation"
+    : phase === "transcribing"
+      ? "Transcribing"
+      : "Dictate";
+  return (
+    <button
+      type="button"
+      className={`micbtn${listening ? " listening" : ""}${blocked ? " off" : ""}`}
+      onClick={onToggle}
+      disabled={busy}
+      aria-label={label}
+      aria-pressed={listening}
+    >
+      {phase === "transcribing" ? (
+        <Icon name="refresh" size={16} className="spin" />
+      ) : (
+        <Icon name={blocked ? "micOff" : "mic"} size={16} />
+      )}
+    </button>
+  );
+}

--- a/mobile/src/dictation/capture.ts
+++ b/mobile/src/dictation/capture.ts
@@ -1,0 +1,148 @@
+// Microphone capture in the webview: `getUserMedia` into an `AudioWorklet`
+// tap, batched into ~1 s chunks of 16-bit PCM. Nothing here knows about the
+// host; `session.ts` decides where the chunks go.
+
+import { concatPcm16, floatToPcm16 } from "./encode";
+
+/** How much audio one chunk holds. A second keeps the wire under the relay's
+ *  message-rate limit with room to spare and the host's per-chunk cap far off. */
+const CHUNK_MS = 1000;
+
+export type ChunkSink = (pcm: Int16Array, rate: number) => void;
+
+export interface Capture {
+  /** The audio session's rate — typically 48 000 on an iPhone. The host
+   *  resamples, so nothing here does. */
+  rate: number;
+  /** Release the mic. Flushes what was buffered into the sink first. */
+  stop(): Promise<void>;
+}
+
+/** Whether this webview has the APIs at all. False in the vitest jsdom and in
+ *  a WKWebView with no mic entitlement, where the button is best not shown. */
+export function canCapture(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    !!navigator.mediaDevices?.getUserMedia &&
+    typeof AudioContext !== "undefined"
+  );
+}
+
+/** Open the mic and start delivering chunks. Rejects with a message the user
+ *  can act on when the OS says no.
+ *
+ *  Call this from the tap handler: WebKit only lets an `AudioContext` start
+ *  inside a user gesture, and the context is created before the first `await`
+ *  so the gesture still covers it. */
+export async function startCapture(onChunk: ChunkSink): Promise<Capture> {
+  const ctx = new AudioContext();
+  let stream: MediaStream;
+  try {
+    await ctx.resume();
+    stream = await navigator.mediaDevices.getUserMedia({
+      audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
+    });
+  } catch (e) {
+    await ctx.close().catch(() => {});
+    throw new Error(describe(e));
+  }
+
+  const rate = ctx.sampleRate;
+  const framesPerChunk = Math.round((rate * CHUNK_MS) / 1000);
+  let pending: Float32Array[] = [];
+  let pendingFrames = 0;
+
+  const flush = () => {
+    if (pendingFrames === 0) return;
+    const chunk = concatPcm16(pending.map(floatToPcm16));
+    pending = [];
+    pendingFrames = 0;
+    onChunk(chunk, rate);
+  };
+  const push = (frames: Float32Array) => {
+    pending.push(frames);
+    pendingFrames += frames.length;
+    if (pendingFrames >= framesPerChunk) flush();
+  };
+
+  const source = ctx.createMediaStreamSource(stream);
+  let teardown: () => void;
+  try {
+    // The worklet is the right tool: it runs off the main thread and costs a
+    // copy per render quantum. `ScriptProcessorNode` is the deprecated
+    // fallback — for a WebKit build without worklets, or a module the page's
+    // CSP refused to load.
+    teardown = await tapWithWorklet(ctx, source, push).catch(() =>
+      tapWithScriptProcessor(ctx, source, push),
+    );
+  } catch (e) {
+    for (const t of stream.getTracks()) t.stop();
+    await ctx.close().catch(() => {});
+    throw new Error(`Couldn't start the microphone: ${describe(e)}`);
+  }
+
+  return {
+    rate,
+    async stop() {
+      teardown();
+      for (const t of stream.getTracks()) t.stop();
+      await ctx.close().catch(() => {});
+      flush();
+    },
+  };
+}
+
+type Push = (frames: Float32Array) => void;
+
+/** Resolves to the teardown once the worklet is wired. The module is emitted
+ *  as its own asset (see `assetsInlineLimit` in vite.config.ts): inlined as a
+ *  `data:` URL it would be a script the CSP does not allow. */
+async function tapWithWorklet(
+  ctx: AudioContext,
+  source: MediaStreamAudioSourceNode,
+  push: Push,
+): Promise<() => void> {
+  if (typeof AudioWorkletNode === "undefined" || !ctx.audioWorklet) {
+    throw new Error("no AudioWorklet");
+  }
+  await ctx.audioWorklet.addModule(new URL("./worklet.js", import.meta.url));
+  const tap = new AudioWorkletNode(ctx, "fletch-pcm-tap", {
+    numberOfInputs: 1,
+    numberOfOutputs: 0,
+  });
+  tap.port.onmessage = (e: MessageEvent<Float32Array>) => push(e.data);
+  source.connect(tap);
+  return () => {
+    tap.port.onmessage = null;
+    source.disconnect();
+  };
+}
+
+function tapWithScriptProcessor(
+  ctx: AudioContext,
+  source: MediaStreamAudioSourceNode,
+  push: Push,
+): () => void {
+  const tap = ctx.createScriptProcessor(4096, 1, 1);
+  tap.onaudioprocess = (e) => push(Float32Array.from(e.inputBuffer.getChannelData(0)));
+  source.connect(tap);
+  // A ScriptProcessorNode only runs while connected to the destination.
+  tap.connect(ctx.destination);
+  return () => {
+    tap.onaudioprocess = null;
+    source.disconnect();
+    tap.disconnect();
+  };
+}
+
+/** `getUserMedia`'s DOMExceptions, in words. A denied grant can only be undone
+ *  in iOS Settings, so say so rather than fail silently. */
+function describe(e: unknown): string {
+  const name = (e as { name?: string })?.name;
+  if (name === "NotAllowedError" || name === "SecurityError") {
+    return "Microphone access was denied. Allow it for Fletch in iOS Settings › Privacy & Security.";
+  }
+  if (name === "NotFoundError") return "No microphone was found on this device.";
+  if (name === "NotReadableError") return "The microphone is in use by another app.";
+  return e instanceof Error ? e.message : String(e);
+}

--- a/mobile/src/dictation/capture.ts
+++ b/mobile/src/dictation/capture.ts
@@ -1,14 +1,24 @@
 // Microphone capture in the webview: `getUserMedia` into an `AudioWorklet`
-// tap, batched into ~1 s chunks of 16-bit PCM. Nothing here knows about the
-// host; `session.ts` decides where the chunks go.
+// tap, batched into ~1 s chunks of 16-bit PCM, with each quantum's loudness
+// fed to the silence detector so the owner can be told when the talking
+// stopped. Nothing here knows about the host; `session.ts` decides where the
+// chunks go and what a pause means.
 
 import { concatPcm16, floatToPcm16 } from "./encode";
+import { SILENCE_POLL_MS, SilenceMonitor } from "./silence";
 
 /** How much audio one chunk holds. A second keeps the wire under the relay's
  *  message-rate limit with room to spare and the host's per-chunk cap far off. */
 const CHUNK_MS = 1000;
 
 export type ChunkSink = (pcm: Int16Array, rate: number) => void;
+
+export interface CaptureOptions {
+  /** Called at most once, when the user has spoken and then gone quiet (or
+   *  never spoke at all) — see `silence.ts`. What that means is the caller's
+   *  business: this module knows nothing about sessions. */
+  onDoneTalking?: () => void;
+}
 
 export interface Capture {
   /** The audio session's rate — typically 48 000 on an iPhone. The host
@@ -34,7 +44,10 @@ export function canCapture(): boolean {
  *  Call this from the tap handler: WebKit only lets an `AudioContext` start
  *  inside a user gesture, and the context is created before the first `await`
  *  so the gesture still covers it. */
-export async function startCapture(onChunk: ChunkSink): Promise<Capture> {
+export async function startCapture(
+  onChunk: ChunkSink,
+  opts: CaptureOptions = {},
+): Promise<Capture> {
   const ctx = new AudioContext();
   let stream: MediaStream;
   try {
@@ -59,7 +72,13 @@ export async function startCapture(onChunk: ChunkSink): Promise<Capture> {
     pendingFrames = 0;
     onChunk(chunk, rate);
   };
+  // Loudness is measured here rather than in the worklet: the worklet stays a
+  // plain copy (it is loaded by URL, not bundled, so the less logic that lives
+  // there the better), and one pass over a render quantum is nothing next to
+  // the conversion `flush` already does on this thread.
+  const silence = new SilenceMonitor();
   const push = (frames: Float32Array) => {
+    silence.hear(frames);
     pending.push(frames);
     pendingFrames += frames.length;
     if (pendingFrames >= framesPerChunk) flush();
@@ -81,15 +100,30 @@ export async function startCapture(onChunk: ChunkSink): Promise<Capture> {
     throw new Error(`Couldn't start the microphone: ${describe(e)}`);
   }
 
+  const unwatch = watchForSilence(silence, opts.onDoneTalking);
   return {
     rate,
     async stop() {
+      unwatch();
       teardown();
       for (const t of stream.getTracks()) t.stop();
       await ctx.close().catch(() => {});
       flush();
     },
   };
+}
+
+/** Poll the detector on a timer, like the desktop's monitor task, and report
+ *  the pause once. A timer rather than a check inside `push`, so a mic that
+ *  stopped delivering frames still ends its session. Returns the teardown. */
+function watchForSilence(silence: SilenceMonitor, onDoneTalking?: () => void): () => void {
+  if (!onDoneTalking) return () => {};
+  const timer = setInterval(() => {
+    if (!silence.doneTalking()) return;
+    clearInterval(timer);
+    onDoneTalking();
+  }, SILENCE_POLL_MS);
+  return () => clearInterval(timer);
 }
 
 type Push = (frames: Float32Array) => void;

--- a/mobile/src/dictation/encode.ts
+++ b/mobile/src/dictation/encode.ts
@@ -1,0 +1,48 @@
+// The wire encoding of a dictation chunk (docs/remote-protocol.md,
+// "Dictation"): 16-bit little-endian mono PCM, base64. Pure, so it is tested
+// without an AudioContext.
+
+/** Web Audio hands out float samples in [-1, 1]; the host wants 16-bit
+ *  integers. Clamped, because a hot input can overshoot the range. */
+export function floatToPcm16(samples: Float32Array): Int16Array {
+  const out = new Int16Array(samples.length);
+  for (let i = 0; i < samples.length; i++) {
+    const v = Math.max(-1, Math.min(1, samples[i]));
+    out[i] = Math.round(v < 0 ? v * 32768 : v * 32767);
+  }
+  return out;
+}
+
+export function concatPcm16(chunks: Int16Array[]): Int16Array {
+  let n = 0;
+  for (const c of chunks) n += c.length;
+  const out = new Int16Array(n);
+  let at = 0;
+  for (const c of chunks) {
+    out.set(c, at);
+    at += c.length;
+  }
+  return out;
+}
+
+/** Little-endian regardless of the platform, so the byte layout is the wire
+ *  contract and not whatever `Int16Array` happens to be backed by. */
+export function pcm16ToBytes(pcm: Int16Array): Uint8Array {
+  const bytes = new Uint8Array(pcm.length * 2);
+  const view = new DataView(bytes.buffer);
+  for (let i = 0; i < pcm.length; i++) view.setInt16(i * 2, pcm[i], true);
+  return bytes;
+}
+
+/** `btoa` over a chunked binary string: a second of audio is ~100 KB, and
+ *  `String.fromCharCode(...bytes)` on that many arguments overflows the stack. */
+export function bytesToBase64(bytes: Uint8Array): string {
+  const STEP = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += STEP) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + STEP));
+  }
+  return btoa(binary);
+}
+
+export const pcm16ToBase64 = (pcm: Int16Array) => bytesToBase64(pcm16ToBytes(pcm));

--- a/mobile/src/dictation/index.ts
+++ b/mobile/src/dictation/index.ts
@@ -1,0 +1,2 @@
+export { DictationButton } from "./DictationButton";
+export { type DictationPhase, useDictation } from "./useDictation";

--- a/mobile/src/dictation/session.ts
+++ b/mobile/src/dictation/session.ts
@@ -1,0 +1,95 @@
+// One dictation, from the tap that opens the mic to the transcript: opens a
+// host session, streams every chunk in order while the user talks, and on stop
+// waits for the backlog before asking the host to transcribe. No React and no
+// browser APIs — the capture is injected — so the sequencing is unit-tested.
+
+import type { Api } from "../api";
+import type { Capture, ChunkSink } from "./capture";
+import { pcm16ToBase64 } from "./encode";
+
+export type DictationApi = Pick<
+  Api,
+  "dictationBegin" | "dictationAudio" | "dictationEnd" | "dictationCancel"
+>;
+
+export type CaptureStarter = (onChunk: ChunkSink) => Promise<Capture>;
+
+export class DictationSession {
+  private session: string | null = null;
+  private capture: Capture | null = null;
+  /** Chunks go out one at a time, in order: the host fixes the sample rate on
+   *  the first and appends the rest, and one request in flight keeps a slow
+   *  link from piling up against the connection's in-flight cap. */
+  private queue: Promise<void> = Promise.resolve();
+  /** The first chunk that failed to send. Later chunks are dropped — the
+   *  transcript would have a hole in it either way — and `stop` reports it
+   *  instead of asking the host to transcribe half a sentence. */
+  private failed: Error | null = null;
+  private done = false;
+
+  constructor(
+    private readonly api: DictationApi,
+    private readonly startCapture: CaptureStarter,
+  ) {}
+
+  /** Open the host session, then the mic. The host is asked first so a Mac
+   *  that can't transcribe (engine off, model missing) answers before the
+   *  user has said anything. */
+  async start(): Promise<void> {
+    const { session } = await this.api.dictationBegin();
+    this.session = session;
+    try {
+      this.capture = await this.startCapture((pcm, rate) => this.send(pcm, rate));
+    } catch (e) {
+      await this.cancel();
+      throw e;
+    }
+  }
+
+  /** Close the mic, drain the backlog, transcribe. Resolves with the
+   *  transcript — empty when the host heard no speech. */
+  async stop(): Promise<string> {
+    const session = this.session;
+    if (!session || this.done) return "";
+    this.done = true;
+    // `stop` flushes the tail into `send` synchronously before resolving, so
+    // awaiting the queue afterwards covers the last chunk too.
+    await this.capture?.stop();
+    this.capture = null;
+    await this.queue;
+    if (this.failed) {
+      void this.api.dictationCancel(session).catch(() => {});
+      this.session = null;
+      throw this.failed;
+    }
+    this.session = null;
+    const { text } = await this.api.dictationEnd(session);
+    return text;
+  }
+
+  /** Throw the audio away, on both ends. Safe to call at any point, including
+   *  after `stop`, when there is nothing left to cancel. */
+  async cancel(): Promise<void> {
+    const session = this.session;
+    this.session = null;
+    this.done = true;
+    const capture = this.capture;
+    this.capture = null;
+    await capture?.stop().catch(() => {});
+    if (session) await this.api.dictationCancel(session).catch(() => {});
+  }
+
+  private send(pcm: Int16Array, rate: number) {
+    const session = this.session;
+    if (!session || this.failed) return;
+    const encoded = pcm16ToBase64(pcm);
+    this.queue = this.queue.then(async () => {
+      if (this.failed) return;
+      try {
+        await this.api.dictationAudio(session, rate, encoded);
+      } catch (e) {
+        this.failed = e instanceof Error ? e : new Error(String(e));
+      }
+    });
+  }
+}

--- a/mobile/src/dictation/session.ts
+++ b/mobile/src/dictation/session.ts
@@ -4,7 +4,7 @@
 // browser APIs — the capture is injected — so the sequencing is unit-tested.
 
 import type { Api } from "../api";
-import type { Capture, ChunkSink } from "./capture";
+import type { Capture, CaptureOptions, ChunkSink } from "./capture";
 import { pcm16ToBase64 } from "./encode";
 
 export type DictationApi = Pick<
@@ -12,7 +12,7 @@ export type DictationApi = Pick<
   "dictationBegin" | "dictationAudio" | "dictationEnd" | "dictationCancel"
 >;
 
-export type CaptureStarter = (onChunk: ChunkSink) => Promise<Capture>;
+export type CaptureStarter = (onChunk: ChunkSink, opts: CaptureOptions) => Promise<Capture>;
 
 export class DictationSession {
   private session: string | null = null;
@@ -34,12 +34,25 @@ export class DictationSession {
 
   /** Open the host session, then the mic. The host is asked first so a Mac
    *  that can't transcribe (engine off, model missing) answers before the
-   *  user has said anything. */
-  async start(): Promise<void> {
+   *  user has said anything.
+   *
+   *  `onAutoStop` fires when the mic hears the pause that ends a session. It is
+   *  the caller's job to run the same `stop` a tap on the button runs, so that
+   *  hands-free and by-hand take one code path. */
+  async start(onAutoStop?: () => void): Promise<void> {
     const { session } = await this.api.dictationBegin();
     this.session = session;
+    // A pause that lands while the session is already ending — the user tapped
+    // stop at the same moment — is nobody's to act on: `done` says so.
+    const onDoneTalking = onAutoStop
+      ? () => {
+          if (!this.done) onAutoStop();
+        }
+      : undefined;
     try {
-      this.capture = await this.startCapture((pcm, rate) => this.send(pcm, rate));
+      this.capture = await this.startCapture((pcm, rate) => this.send(pcm, rate), {
+        onDoneTalking,
+      });
     } catch (e) {
       await this.cancel();
       throw e;

--- a/mobile/src/dictation/silence.ts
+++ b/mobile/src/dictation/silence.ts
@@ -1,0 +1,102 @@
+// Hands-free dictation on the phone: has the user spoken and then gone quiet?
+//
+// A port of the detector in `src-tauri/src/dictation/capture.rs` — the same
+// rules and the same constants, because the Mac transcribes both paths and a
+// session that ended at a different moment on the phone would read as a bug.
+// The host's monitor can't do this job for us: it never sees the frames, only
+// the chunks the phone chose to send.
+//
+// Numbers and an injectable clock, nothing else: no audio, no timers, no
+// React. `capture.ts` feeds it and polls it.
+
+/** How long a pause has to last, once something has been said, for the session
+ *  to end itself — long enough to think mid-sentence, short enough that the
+ *  text lands while the user is still looking at the composer. */
+export const SILENCE_STOP_MS = 2_000;
+
+/** How long a session in which nothing was ever said stays open: the user
+ *  tapped the mic and put the phone down. The clip has no speech in it, so the
+ *  host's silence gate answers empty and the session just ends. */
+export const NO_SPEECH_TIMEOUT_MS = 10_000;
+
+/** How often the owner looks. Well under `SILENCE_STOP_MS`, and cheap. */
+export const SILENCE_POLL_MS = 100;
+
+/** How far above the room's own noise a buffer has to be to count as speech.
+ *
+ *  Deliberately the only loudness rule: an absolute "this loud is always
+ *  speech" level was tried on the desktop and dropped, because steady noise
+ *  above it (music, a train) would refresh the speech clock on every buffer and
+ *  the session could never observe a pause. Relative to the floor, steady noise
+ *  *is* the floor and never counts. */
+const SPEECH_OVER_FLOOR = 3;
+
+/** Floor under the noise floor. Digital silence would otherwise put the speech
+ *  threshold at zero and make the first faint buffer an utterance. */
+const NOISE_FLOOR_MIN = 0.000_5;
+
+/** The host's clip gate (`whisper::engine::MIN_RMS`): audio too quiet for the
+ *  Mac to transcribe can't be worth waiting for silence after. */
+export const MIN_RMS = 0.002;
+
+/** One render quantum's loudness. */
+export function rms(frames: Float32Array): number {
+  if (frames.length === 0) return 0;
+  let squares = 0;
+  for (const sample of frames) squares += sample * sample;
+  return Math.sqrt(squares / frames.length);
+}
+
+/** Is a buffer this loud speech, in a room whose noise floor is `floor`? Pure,
+ *  and the whole of the detector. */
+export function isSpeech(level: number, floor: number): boolean {
+  return level >= Math.max(floor * SPEECH_OVER_FLOOR, MIN_RMS);
+}
+
+/** Fold a buffer's loudness into the noise floor: the running minimum, never
+ *  below `NOISE_FLOOR_MIN`. */
+export function settleFloor(floor: number, level: number): number {
+  return Math.min(floor, Math.max(level, NOISE_FLOOR_MIN));
+}
+
+/** Classify one buffer against the floor as it stood *before* this buffer, then
+ *  fold the buffer in. Judging a buffer against a floor it has just lowered
+ *  would make the first loud buffer of a session its own noise floor. */
+export function track(floor: number, level: number): [speech: boolean, floor: number] {
+  return [isSpeech(level, floor), settleFloor(floor, level)];
+}
+
+/** Should the session end itself now? `lastSpeech` is how far into the session
+ *  speech was last heard, in ms, or null if it never was. Pure, so the
+ *  thresholds are testable without a microphone. */
+export function shouldAutoStop(lastSpeech: number | null, elapsed: number): boolean {
+  if (lastSpeech === null) return elapsed >= NO_SPEECH_TIMEOUT_MS;
+  return elapsed - lastSpeech >= SILENCE_STOP_MS;
+}
+
+/** The detector with the state a session accumulates: the room's noise floor
+ *  and when speech was last heard. `now` is injected so tests need no timers. */
+export class SilenceMonitor {
+  /** A running minimum has to start above anything it will see; the first
+   *  buffer sets it, and can't be speech against itself. */
+  private floor = 1;
+  /** Milliseconds into the session, or null for never. */
+  private lastSpeech: number | null = null;
+  private readonly start: number;
+
+  constructor(private readonly now: () => number = Date.now) {
+    this.start = now();
+  }
+
+  /** Fold one render quantum's frames into the tracker. */
+  hear(frames: Float32Array): void {
+    const [speech, floor] = track(this.floor, rms(frames));
+    this.floor = floor;
+    if (speech) this.lastSpeech = this.now() - this.start;
+  }
+
+  /** Has the user spoken and then gone quiet (or never spoken at all)? */
+  doneTalking(): boolean {
+    return shouldAutoStop(this.lastSpeech, this.now() - this.start);
+  }
+}

--- a/mobile/src/dictation/useDictation.ts
+++ b/mobile/src/dictation/useDictation.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { DictationStatus } from "../api";
+import { api, useStore } from "../store";
+import { canCapture, startCapture } from "./capture";
+import { DictationSession } from "./session";
+
+export type DictationPhase = "idle" | "starting" | "listening" | "transcribing";
+
+/** Failures land where every other action's do (`lastError`), so the composer
+ *  needs no error UI of its own. */
+const fail = (e: unknown) => {
+  useStore.setState({ lastError: e instanceof Error ? e.message : String(e) });
+};
+
+/** Voice dictation for one composer. Owns the session and reports its phase;
+ *  the transcript is handed to `onText` once, when the host answers.
+ *
+ *  Unlike the desktop hook there are no partials to splice as they arrive —
+ *  whisper answers once, at the end — so the composer only has to append. */
+export function useDictation(onText: (text: string) => void) {
+  const connection = useStore((s) => s.connection);
+  // null while the probe is in flight; `available: false` with no reason is a
+  // host too old to know the op, where the button is best not shown at all.
+  const [status, setStatus] = useState<DictationStatus | null>(null);
+  const [phase, setPhase] = useState<DictationPhase>("idle");
+  const sessionRef = useRef<DictationSession | null>(null);
+  const onTextRef = useRef(onText);
+  onTextRef.current = onText;
+
+  // Probe on mount and on every reconnect: the answer depends on the Mac's
+  // settings, which can change between one connection and the next.
+  useEffect(() => {
+    if (connection !== "connected") return;
+    let cancelled = false;
+    api
+      .dictationStatus()
+      .then((s) => {
+        if (!cancelled) setStatus(s);
+      })
+      .catch(() => {
+        if (!cancelled) setStatus({ available: false, reason: null });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [connection]);
+
+  // Unmounting mid-session (leaving the agent) must not leave the mic open.
+  useEffect(
+    () => () => {
+      void sessionRef.current?.cancel();
+      sessionRef.current = null;
+    },
+    [],
+  );
+
+  const toggle = useCallback(async () => {
+    if (phase === "listening") {
+      const session = sessionRef.current;
+      if (!session) return;
+      setPhase("transcribing");
+      try {
+        const text = await session.stop();
+        if (text) onTextRef.current(text);
+      } catch (e) {
+        fail(e);
+      } finally {
+        sessionRef.current = null;
+        setPhase("idle");
+      }
+      return;
+    }
+    if (phase !== "idle") return;
+    if (status && !status.available) {
+      // The mic is shown slashed; tapping it says why.
+      if (status.reason) fail(new Error(status.reason));
+      return;
+    }
+    setPhase("starting");
+    const session = new DictationSession(api, startCapture);
+    sessionRef.current = session;
+    try {
+      await session.start();
+      setPhase("listening");
+    } catch (e) {
+      sessionRef.current = null;
+      setPhase("idle");
+      fail(e);
+    }
+  }, [phase, status]);
+
+  return {
+    /** False until the host says it can transcribe, or when this webview has
+     *  no microphone API; the composer hides the button then. */
+    supported: canCapture() && status !== null && (status.available || status.reason !== null),
+    blocked: status !== null && !status.available,
+    phase,
+    toggle,
+  };
+}

--- a/mobile/src/dictation/useDictation.ts
+++ b/mobile/src/dictation/useDictation.ts
@@ -16,7 +16,11 @@ const fail = (e: unknown) => {
  *  the transcript is handed to `onText` once, when the host answers.
  *
  *  Unlike the desktop hook there are no partials to splice as they arrive —
- *  whisper answers once, at the end — so the composer only has to append. */
+ *  whisper answers once, at the end — so the composer only has to append.
+ *
+ *  A session usually ends itself: the mic reports the pause after the user
+ *  stops talking (`silence.ts`), and that runs the same stop a second tap
+ *  would, so dictating is one tap. */
 export function useDictation(onText: (text: string) => void) {
   const connection = useStore((s) => s.connection);
   // null while the probe is in flight; `available: false` with no reason is a
@@ -54,20 +58,27 @@ export function useDictation(onText: (text: string) => void) {
     [],
   );
 
+  /** Close the session and splice what the Mac heard. The one stop path: a tap
+   *  on the button and the mic's own "done talking" both land here, and taking
+   *  the session out of the ref claims it, so the two can't end it twice. */
+  const finish = useCallback(async () => {
+    const session = sessionRef.current;
+    if (!session) return;
+    sessionRef.current = null;
+    setPhase("transcribing");
+    try {
+      const text = await session.stop();
+      if (text) onTextRef.current(text);
+    } catch (e) {
+      fail(e);
+    } finally {
+      setPhase("idle");
+    }
+  }, []);
+
   const toggle = useCallback(async () => {
     if (phase === "listening") {
-      const session = sessionRef.current;
-      if (!session) return;
-      setPhase("transcribing");
-      try {
-        const text = await session.stop();
-        if (text) onTextRef.current(text);
-      } catch (e) {
-        fail(e);
-      } finally {
-        sessionRef.current = null;
-        setPhase("idle");
-      }
+      await finish();
       return;
     }
     if (phase !== "idle") return;
@@ -80,14 +91,14 @@ export function useDictation(onText: (text: string) => void) {
     const session = new DictationSession(api, startCapture);
     sessionRef.current = session;
     try {
-      await session.start();
+      await session.start(() => void finish());
       setPhase("listening");
     } catch (e) {
       sessionRef.current = null;
       setPhase("idle");
       fail(e);
     }
-  }, [phase, status]);
+  }, [phase, status, finish]);
 
   return {
     /** False until the host says it can transcribe, or when this webview has

--- a/mobile/src/dictation/worklet.js
+++ b/mobile/src/dictation/worklet.js
@@ -1,0 +1,16 @@
+// The mic tap, on the audio rendering thread. Plain JS because an
+// AudioWorklet module is loaded by URL, not bundled with the app; it is
+// referenced from capture.ts as `new URL("./worklet.js", import.meta.url)`.
+//
+// Nothing happens here but a copy: the render quantum's first channel is
+// posted to the main thread, which batches, converts and sends. Averaging
+// channels down would belong here too, but `getUserMedia` audio is mono.
+class PcmTap extends AudioWorkletProcessor {
+  process(inputs) {
+    const channel = inputs[0]?.[0];
+    if (channel) this.port.postMessage(Float32Array.from(channel));
+    return true;
+  }
+}
+
+registerProcessor("fletch-pcm-tap", PcmTap);

--- a/mobile/src/remote/mock/index.ts
+++ b/mobile/src/remote/mock/index.ts
@@ -59,6 +59,8 @@ export class MockHost {
   private timers = new Set<ReturnType<typeof setTimeout>>();
   private state: MockState;
   private seq = 1000;
+  /** Open dictation sessions → chunks received. */
+  private dictation = new Map<string, number>();
 
   constructor(
     private readonly emit: (frame: ResponseFrame | EventFrame) => void,
@@ -426,6 +428,34 @@ export class MockHost {
       // There is no APNs behind a browser, so the mock host only has to accept
       // the op — a registration that errored would surface as a real failure.
       case "register_push":
+        return null;
+      // Dictation: the browser has a mic but no Mac to transcribe on, so the
+      // mock counts chunks and answers a fixed sentence for any session that
+      // sent audio — enough to exercise the composer's listening → transcribing
+      // → text path.
+      case "dictation_status":
+        return { available: true, reason: null };
+      case "dictation_begin": {
+        const session = `dict-${this.dictation.size + 1}`;
+        this.dictation.set(session, 0);
+        return { session };
+      }
+      case "dictation_audio": {
+        const session = String(args.session ?? "");
+        const chunks = this.dictation.get(session);
+        if (chunks === undefined) throw new Error("dictation: unknown session");
+        this.dictation.set(session, chunks + 1);
+        return null;
+      }
+      case "dictation_end": {
+        const session = String(args.session ?? "");
+        const chunks = this.dictation.get(session);
+        if (chunks === undefined) throw new Error("dictation: unknown session");
+        this.dictation.delete(session);
+        return { text: chunks > 0 ? "Add retries to the upload path and log each attempt" : "" };
+      }
+      case "dictation_cancel":
+        this.dictation.delete(String(args.session ?? ""));
         return null;
       case "list_dir":
         return this.listDir(String(args.path ?? "~"));

--- a/mobile/src/screens/Agent/Composer.tsx
+++ b/mobile/src/screens/Agent/Composer.tsx
@@ -9,6 +9,12 @@ import { autosize } from "../../lib/autosize";
 import { ignore } from "../../lib/ignore";
 import { useStore } from "../../store";
 
+/** The session ends itself once the user stops talking, so the placeholder has
+ *  to say so — a mic that stops on its own otherwise reads as a bug, and the
+ *  pause is the only thing left for the user to do. Same words as the desktop's
+ *  mic tooltip. */
+const LISTENING_HINT = "Listening… stops when you pause";
+
 export function Composer({
   agent,
   onSend,
@@ -41,7 +47,7 @@ export function Composer({
 
   const placeholder =
     dictation.phase === "listening"
-      ? "Listening…"
+      ? LISTENING_HINT
       : dictation.phase === "transcribing"
         ? "Transcribing…"
         : busy

--- a/mobile/src/screens/Agent/Composer.tsx
+++ b/mobile/src/screens/Agent/Composer.tsx
@@ -1,7 +1,9 @@
 import type { AgentRecord } from "@desktop/api/types/agent";
+import { spliceTranscript } from "@desktop/components/Composer/dictation/spliceTranscript";
 import { useRef, useState } from "react";
 import { Icon } from "../../components/Icon";
 import { ProviderMark } from "../../components/ui";
+import { DictationButton, useDictation } from "../../dictation";
 import { isBusy, modelLabel } from "../../lib/agents";
 import { autosize } from "../../lib/autosize";
 import { ignore } from "../../lib/ignore";
@@ -21,6 +23,12 @@ export function Composer({
   const [text, setText] = useState("");
   const ta = useRef<HTMLTextAreaElement>(null);
   const busy = isBusy(agent);
+  // The transcript lands once, appended to whatever was typed — the same join
+  // rule as the desktop, so a dictated list item keeps its newline.
+  const dictation = useDictation((spoken) => {
+    setText((current) => spliceTranscript(current, spoken).text);
+    requestAnimationFrame(() => autosize(ta.current));
+  });
 
   const submit = () => {
     const value = text.trim();
@@ -31,13 +39,22 @@ export function Composer({
     void send(agent.id, value).catch(ignore);
   };
 
+  const placeholder =
+    dictation.phase === "listening"
+      ? "Listening…"
+      : dictation.phase === "transcribing"
+        ? "Transcribing…"
+        : busy
+          ? "Message agent · queued until it pauses"
+          : "Message agent";
+
   return (
     <div className="composer">
       <div className="cmp">
         <textarea
           ref={ta}
           rows={1}
-          placeholder={busy ? "Message agent · queued until it pauses" : "Message agent"}
+          placeholder={placeholder}
           value={text}
           onChange={(e) => {
             setText(e.target.value);
@@ -63,6 +80,13 @@ export function Composer({
             <Icon name="chevD" size={12} style={{ color: "var(--fg-3)" }} />
           </button>
           <span className="grow" />
+          {dictation.supported && (
+            <DictationButton
+              phase={dictation.phase}
+              blocked={dictation.blocked}
+              onToggle={() => void dictation.toggle()}
+            />
+          )}
           {busy && !text.trim() ? (
             <button
               type="button"

--- a/mobile/src/styles/agent.css
+++ b/mobile/src/styles/agent.css
@@ -455,6 +455,37 @@
   background: var(--bg-3);
   color: var(--fg-3);
 }
+/* Dictation: same footprint as send, quiet until it is listening. */
+.micbtn {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: var(--bg-3);
+  color: var(--fg-1);
+  display: grid;
+  place-items: center;
+  transition: all 0.22s var(--ease-out);
+}
+.micbtn:active {
+  transform: scale(0.92);
+}
+.micbtn.off,
+.micbtn[disabled] {
+  color: var(--fg-3);
+}
+.micbtn.listening {
+  background: var(--danger);
+  color: var(--knob);
+  animation: mic-pulse 1.4s ease-out infinite;
+}
+@keyframes mic-pulse {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--danger) 50%, transparent);
+  }
+  100% {
+    box-shadow: 0 0 0 8px transparent;
+  }
+}
 
 /* Code tab */
 .tree {

--- a/mobile/tests/dictation.test.ts
+++ b/mobile/tests/dictation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { Capture, ChunkSink } from "../src/dictation/capture";
+import type { Capture, CaptureOptions, ChunkSink } from "../src/dictation/capture";
 import {
   bytesToBase64,
   concatPcm16,
@@ -63,19 +63,25 @@ function harness(opts: { failAudioAt?: number; beginFails?: boolean } = {}) {
   };
   let sink: ChunkSink | null = null;
   let stopped = 0;
+  let doneTalking: (() => void) | undefined;
   const mic = {
     started: 0,
     /** Feed a chunk as the worklet would. */
     speak(samples: number[]) {
       sink?.(Int16Array.from(samples), 48_000);
     },
+    /** Report the pause, as the capture's silence monitor would. */
+    pause() {
+      doneTalking?.();
+    },
     get stopped() {
       return stopped;
     },
   };
-  const startCapture = async (onChunk: ChunkSink): Promise<Capture> => {
+  const startCapture = async (onChunk: ChunkSink, opts: CaptureOptions): Promise<Capture> => {
     mic.started += 1;
     sink = onChunk;
+    doneTalking = opts.onDoneTalking;
     return {
       rate: 48_000,
       async stop() {
@@ -146,12 +152,50 @@ describe("DictationSession", () => {
     expect(h.mic.stopped).toBe(1);
   });
 
+  it("a mic that reports the pause ends the session through the normal stop", async () => {
+    const h = harness();
+    const s = new DictationSession(h.api, h.startCapture);
+    // What `useDictation` does with the signal: run the very stop a tap runs.
+    const stops: Promise<string>[] = [];
+    await s.start(() => stops.push(s.stop()));
+
+    h.mic.speak([1, 2]);
+    h.mic.pause();
+
+    expect(await Promise.all(stops)).toEqual(["hello world"]);
+    expect(h.ops.map((o) => o.op)).toEqual(["begin", "audio", "audio", "end"]);
+    expect(h.mic.stopped).toBe(1);
+  });
+
+  it("a pause that lands while the user is stopping cannot end the session twice", async () => {
+    const h = harness();
+    const s = new DictationSession(h.api, h.startCapture);
+    const stops: Promise<string>[] = [];
+    await s.start(() => stops.push(s.stop()));
+    h.mic.speak([1]);
+
+    // The tap wins, and the pause arriving inside it is dropped rather than
+    // stopping a mic that is already closing or transcribing twice.
+    const tapped = s.stop();
+    h.mic.pause();
+
+    expect(await tapped).toBe("hello world");
+    expect(stops).toEqual([]);
+    expect(h.ops.filter((o) => o.op === "end")).toHaveLength(1);
+    expect(h.mic.stopped).toBe(1);
+  });
+
   it("cancel releases the mic and the host session, and is idempotent", async () => {
     const h = harness();
     const s = new DictationSession(h.api, h.startCapture);
-    await s.start();
+    const stops: Promise<string>[] = [];
+    await s.start(() => stops.push(s.stop()));
     await s.cancel();
     await s.cancel();
+    // A pause reported after the teardown — the screen was left mid-session —
+    // has nothing left to end.
+    h.mic.pause();
+    expect(stops).toEqual([]);
     expect(h.mic.stopped).toBe(1);
     expect(h.ops.map((o) => o.op)).toEqual(["begin", "cancel"]);
     expect(await s.stop()).toBe("");

--- a/mobile/tests/dictation.test.ts
+++ b/mobile/tests/dictation.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import type { Capture, ChunkSink } from "../src/dictation/capture";
+import {
+  bytesToBase64,
+  concatPcm16,
+  floatToPcm16,
+  pcm16ToBase64,
+  pcm16ToBytes,
+} from "../src/dictation/encode";
+import { type DictationApi, DictationSession } from "../src/dictation/session";
+
+describe("chunk encoding", () => {
+  it("scales and clamps float samples to 16-bit", () => {
+    const pcm = floatToPcm16(Float32Array.from([0, 1, -1, 0.5, 2, -2]));
+    expect(Array.from(pcm)).toEqual([0, 32767, -32768, 16384, 32767, -32768]);
+  });
+
+  it("writes little-endian bytes whatever the platform", () => {
+    expect(Array.from(pcm16ToBytes(Int16Array.from([256, -1])))).toEqual([0, 1, 255, 255]);
+  });
+
+  it("round-trips through base64, including chunks past one btoa call", () => {
+    const pcm = new Int16Array(70_000);
+    for (let i = 0; i < pcm.length; i++) pcm[i] = ((i * 7919) % 65536) - 32768;
+    const decoded = Uint8Array.from(atob(pcm16ToBase64(pcm)), (c) => c.charCodeAt(0));
+    expect(decoded).toEqual(pcm16ToBytes(pcm));
+    expect(bytesToBase64(new Uint8Array([0, 1, 0, 255]))).toBe("AAEA/w==");
+  });
+
+  it("concatenates in order", () => {
+    expect(
+      Array.from(concatPcm16([Int16Array.from([1, 2]), new Int16Array(0), Int16Array.from([3])])),
+    ).toEqual([1, 2, 3]);
+  });
+});
+
+/** A host that records every op, and a mic the test drives by hand. */
+function harness(opts: { failAudioAt?: number; beginFails?: boolean } = {}) {
+  const ops: { op: string; args: unknown[] }[] = [];
+  let audioCalls = 0;
+  const api: DictationApi = {
+    async dictationBegin() {
+      ops.push({ op: "begin", args: [] });
+      if (opts.beginFails) throw new Error("Local dictation is off on your Mac.");
+      return { session: "s1" };
+    },
+    async dictationAudio(session, rate, pcm) {
+      audioCalls += 1;
+      ops.push({ op: "audio", args: [session, rate, pcm] });
+      if (opts.failAudioAt === audioCalls) throw new Error("frame too large");
+      // Out-of-order delivery would show up as a reordered `ops` list.
+      await new Promise((r) => setTimeout(r, audioCalls % 2 ? 5 : 0));
+      return null;
+    },
+    async dictationEnd(session) {
+      ops.push({ op: "end", args: [session] });
+      return { text: "hello world" };
+    },
+    async dictationCancel(session) {
+      ops.push({ op: "cancel", args: [session] });
+      return null;
+    },
+  };
+  let sink: ChunkSink | null = null;
+  let stopped = 0;
+  const mic = {
+    started: 0,
+    /** Feed a chunk as the worklet would. */
+    speak(samples: number[]) {
+      sink?.(Int16Array.from(samples), 48_000);
+    },
+    get stopped() {
+      return stopped;
+    },
+  };
+  const startCapture = async (onChunk: ChunkSink): Promise<Capture> => {
+    mic.started += 1;
+    sink = onChunk;
+    return {
+      rate: 48_000,
+      async stop() {
+        stopped += 1;
+        // The real capture flushes its tail into the sink before resolving.
+        sink?.(Int16Array.from([9]), 48_000);
+        sink = null;
+      },
+    };
+  };
+  return { ops, api, mic, startCapture };
+}
+
+describe("DictationSession", () => {
+  it("opens the host session before the mic, streams chunks in order, and ends with the text", async () => {
+    const h = harness();
+    const s = new DictationSession(h.api, h.startCapture);
+    await s.start();
+    expect(h.ops.map((o) => o.op)).toEqual(["begin"]);
+    expect(h.mic.started).toBe(1);
+
+    h.mic.speak([1, 2]);
+    h.mic.speak([3]);
+    const text = await s.stop();
+
+    expect(text).toBe("hello world");
+    expect(h.mic.stopped).toBe(1);
+    expect(h.ops.map((o) => o.op)).toEqual(["begin", "audio", "audio", "audio", "end"]);
+    // Every chunk names the session and the capture rate, and the tail the
+    // mic flushed at stop went out before `end`.
+    const audio = h.ops.filter((o) => o.op === "audio");
+    expect(audio.map((o) => o.args[0])).toEqual(["s1", "s1", "s1"]);
+    expect(audio.map((o) => o.args[1])).toEqual([48_000, 48_000, 48_000]);
+    expect(audio.map((o) => o.args[2])).toEqual([
+      pcm16ToBase64(Int16Array.from([1, 2])),
+      pcm16ToBase64(Int16Array.from([3])),
+      pcm16ToBase64(Int16Array.from([9])),
+    ]);
+  });
+
+  it("a mic that will not open cancels the host session", async () => {
+    const h = harness();
+    const s = new DictationSession(h.api, async () => {
+      throw new Error("Microphone access was denied.");
+    });
+    await expect(s.start()).rejects.toThrow("denied");
+    expect(h.ops.map((o) => o.op)).toEqual(["begin", "cancel"]);
+  });
+
+  it("a host that cannot transcribe fails before the mic opens", async () => {
+    const h = harness({ beginFails: true });
+    const s = new DictationSession(h.api, h.startCapture);
+    await expect(s.start()).rejects.toThrow("off on your Mac");
+    expect(h.mic.started).toBe(0);
+  });
+
+  it("a chunk that fails to send fails the stop instead of transcribing a hole", async () => {
+    const h = harness({ failAudioAt: 1 });
+    const s = new DictationSession(h.api, h.startCapture);
+    await s.start();
+    h.mic.speak([1]);
+    h.mic.speak([2]);
+    await expect(s.stop()).rejects.toThrow("frame too large");
+    // Later chunks were dropped rather than sent past the failure, the host
+    // was told to drop the session, and no transcription was asked for.
+    expect(h.ops.filter((o) => o.op === "audio")).toHaveLength(1);
+    expect(h.ops.map((o) => o.op)).toEqual(["begin", "audio", "cancel"]);
+    expect(h.mic.stopped).toBe(1);
+  });
+
+  it("cancel releases the mic and the host session, and is idempotent", async () => {
+    const h = harness();
+    const s = new DictationSession(h.api, h.startCapture);
+    await s.start();
+    await s.cancel();
+    await s.cancel();
+    expect(h.mic.stopped).toBe(1);
+    expect(h.ops.map((o) => o.op)).toEqual(["begin", "cancel"]);
+    expect(await s.stop()).toBe("");
+  });
+});

--- a/mobile/tests/silence.test.ts
+++ b/mobile/tests/silence.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+  isSpeech,
+  MIN_RMS,
+  NO_SPEECH_TIMEOUT_MS,
+  rms,
+  SILENCE_STOP_MS,
+  SilenceMonitor,
+  shouldAutoStop,
+  track,
+} from "../src/dictation/silence";
+
+const repeat = <T>(times: number, value: T): T[] => Array.from({ length: times }, () => value);
+
+/** Walk a sequence of buffer RMS values through the detector the way the
+ *  capture path would, and report which of them counted as speech. Mirrors the
+ *  `detect` helper in `src-tauri/src/dictation/capture.rs`, whose cases these
+ *  are: the two detectors have to agree buffer for buffer. */
+function detect(sequence: number[]): boolean[] {
+  let floor = 1;
+  return sequence.map((level) => {
+    const [speech, next] = track(floor, level);
+    floor = next;
+    return speech;
+  });
+}
+
+describe("silence detector", () => {
+  /** The shape every session has: a quiet room, an utterance, then quiet
+   *  again. Only the utterance may count, and the trailing silence must not —
+   *  that is what ends the session. */
+  it("detects speech between silences", () => {
+    const sequence = [...repeat(5, 0.001), ...repeat(10, 0.05), ...repeat(5, 0.001)];
+
+    const speech = detect(sequence);
+
+    expect(speech.slice(0, 5)).toEqual(repeat(5, false));
+    expect(speech.slice(5, 15)).toEqual(repeat(10, true));
+    expect(speech.slice(15)).toEqual(repeat(5, false));
+  });
+
+  /** Talking from the very first buffer — tapping mid-sentence — sets the floor
+   *  to the voice itself, so nothing counts until the first gap between words
+   *  lowers it; from then on the speech does. */
+  it("counts speech from the first buffer after the first gap", () => {
+    expect(detect([0.05, 0.05, 0.002, 0.05, 0.05, 0.002])).toEqual([
+      false,
+      false,
+      false,
+      true,
+      true,
+      false,
+    ]);
+  });
+
+  /** Steady noise of any level is the room, not a voice: it must never keep the
+   *  session open, however loud. */
+  it("never reads steady noise as speech", () => {
+    expect(detect(repeat(6, 0.02))).toEqual(repeat(6, false));
+    expect(detect(repeat(6, 0.2))).toEqual(repeat(6, false));
+  });
+
+  /** A hot input's noise is louder than a quiet one's speech, so below the
+   *  absolute level the threshold follows the room rather than a fixed
+   *  number. */
+  it("adapts the floor to the room", () => {
+    expect(detect([0.01, 0.01, 0.015])).toEqual([false, false, false]);
+    expect(detect([0.0005, 0.0005, 0.005])).toEqual([false, false, true]);
+  });
+
+  /** A muted mic is all zeroes: the adaptive threshold collapses to nothing
+   *  there, and the lower bound has to hold. */
+  it("never reads digital silence as speech", () => {
+    expect(detect(repeat(4, 0))).toEqual(repeat(4, false));
+    expect(isSpeech(MIN_RMS / 2, 0)).toBe(false);
+  });
+
+  it("auto-stops on a pause but not before speech", () => {
+    const long = NO_SPEECH_TIMEOUT_MS + 1_000;
+    const spokeAt = 1_000;
+    expect(shouldAutoStop(spokeAt, spokeAt + SILENCE_STOP_MS / 2)).toBe(false);
+    expect(shouldAutoStop(spokeAt, spokeAt + SILENCE_STOP_MS)).toBe(true);
+    // Speech that started after a long wait counts from when it was heard, not
+    // from the start of the session.
+    expect(shouldAutoStop(long, long + SILENCE_STOP_MS / 2)).toBe(false);
+    // Never spoke: the pause is the whole session, and only the longer deadline
+    // ends it.
+    expect(shouldAutoStop(null, SILENCE_STOP_MS * 2)).toBe(false);
+    expect(shouldAutoStop(null, long)).toBe(true);
+  });
+
+  it("measures a buffer's loudness", () => {
+    expect(rms(new Float32Array(0))).toBe(0);
+    expect(rms(Float32Array.from([0.5, -0.5]))).toBeCloseTo(0.5);
+    expect(rms(Float32Array.from([1, -1, 0, 0]))).toBeCloseTo(Math.SQRT1_2);
+  });
+});
+
+describe("SilenceMonitor", () => {
+  /** A monitor on a clock the test winds by hand, so the deadlines are checked
+   *  without waiting for them. */
+  function monitor() {
+    let now = 1_000;
+    const m = new SilenceMonitor(() => now);
+    const quantum = (level: number) => m.hear(new Float32Array(128).fill(level));
+    return {
+      /** Feed one buffer at `level`, `ms` after the previous one. */
+      hear(level: number, ms: number) {
+        now += ms;
+        quantum(level);
+      },
+      wait(ms: number) {
+        now += ms;
+      },
+      done: () => m.doneTalking(),
+    };
+  }
+
+  it("ends a session two seconds after the talking stops", () => {
+    const m = monitor();
+    // A quiet room first, so the floor is the room and not the voice.
+    m.hear(0.001, 20);
+    m.hear(0.05, 20);
+    expect(m.done()).toBe(false);
+
+    m.wait(SILENCE_STOP_MS - 1);
+    expect(m.done()).toBe(false);
+    m.wait(1);
+    expect(m.done()).toBe(true);
+  });
+
+  it("holds a session open while the speech keeps coming", () => {
+    const m = monitor();
+    m.hear(0.001, 20);
+    for (let i = 0; i < 20; i++) m.hear(0.05, SILENCE_STOP_MS - 100);
+    expect(m.done()).toBe(false);
+  });
+
+  it("ends a session nobody ever spoke in on the longer deadline", () => {
+    const m = monitor();
+    m.hear(0, 20);
+    m.wait(NO_SPEECH_TIMEOUT_MS - 20 - 1);
+    expect(m.done()).toBe(false);
+    m.wait(1);
+    expect(m.done()).toBe(true);
+  });
+});

--- a/mobile/vite.config.ts
+++ b/mobile/vite.config.ts
@@ -7,6 +7,11 @@ const host = process.env.TAURI_DEV_HOST;
 
 export default defineConfig({
   plugins: [tsconfigPaths(), react()],
+  build: {
+    // The dictation AudioWorklet module is loaded by URL. Small assets are
+    // otherwise inlined as `data:` URLs, which `script-src 'self'` refuses.
+    assetsInlineLimit: (file) => (file.endsWith("worklet.js") ? false : undefined),
+  },
   resolve: {
     // vite-tsconfig-paths only rewrites imports inside this project, and the
     // reused desktop files (../src/**) are written against the desktop's own

--- a/src-tauri/src/dictation/capture.rs
+++ b/src-tauri/src/dictation/capture.rs
@@ -34,11 +34,7 @@ use super::apple::Tap;
 use super::whisper::engine;
 use crate::error::{Error, Result};
 
-/// How much audio one session may capture. A dictation is a sentence or two;
-/// this is the bound that keeps a mic left open by a forgotten window from
-/// growing the buffer — and the transcription that follows — without limit.
-/// Audio past it is dropped, which truncates the transcript rather than failing.
-const MAX_CAPTURE_SECS: f64 = 300.0;
+use super::MAX_CAPTURE_SECS;
 
 /// How long a pause has to last, once something has been said, for the session
 /// to end itself — long enough to think mid-sentence, short enough that the
@@ -261,8 +257,9 @@ const RESAMPLE_SLACK_FRAMES: u32 = 4096;
 ///
 /// Every ObjC handle here is created, used and dropped inside this call, so
 /// nothing is shared across threads and nothing is live across an `.await` —
-/// the same rule the recognizer path follows.
-fn resample(rate: f64, samples: Vec<f32>) -> Result<Vec<f32>> {
+/// the same rule the recognizer path follows. Shared with `super::remote`,
+/// whose audio arrives at whatever rate the phone captured.
+pub(super) fn resample(rate: f64, samples: Vec<f32>) -> Result<Vec<f32>> {
     let target = f64::from(engine::SAMPLE_RATE);
     if rate == target || samples.is_empty() {
         return Ok(samples);

--- a/src-tauri/src/dictation/mod.rs
+++ b/src-tauri/src/dictation/mod.rs
@@ -38,6 +38,17 @@ mod capture;
 // Compiles everywhere (the catalog and download are plain Rust); the engine
 // itself is gated inside. `pub` so `lib.rs` can seed the models root.
 pub mod whisper;
+// A paired phone's dictation: it captures, this Mac transcribes. Compiles
+// everywhere so the remote dispatcher can name the ops; the transcription
+// itself is macOS-only inside, like the engine.
+pub mod remote;
+
+/// How much audio one session may capture, whichever microphone it comes from.
+/// A dictation is a sentence or two; this is the bound that keeps a mic left
+/// open by a forgotten window (or a phone that stopped talking to us) from
+/// growing the buffer — and the transcription that follows — without limit.
+/// Audio past it is dropped, which truncates the transcript rather than failing.
+pub(super) const MAX_CAPTURE_SECS: f64 = 300.0;
 
 /// A TCC (privacy) permission state, for either the microphone or speech
 /// recognition. Mirrors both `SFSpeechRecognizerAuthorizationStatus` and

--- a/src-tauri/src/dictation/remote.rs
+++ b/src-tauri/src/dictation/remote.rs
@@ -82,6 +82,8 @@ pub(super) struct Store {
 }
 
 /// What `end` hands to the transcriber: the audio and the rate it was captured at.
+// Only the macOS transcriber reads it; the stub elsewhere refuses before looking.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub(super) struct Clip {
     pub rate: f64,
     pub samples: Vec<i16>,

--- a/src-tauri/src/dictation/remote.rs
+++ b/src-tauri/src/dictation/remote.rs
@@ -1,0 +1,406 @@
+//! Dictation for a paired phone: the phone captures its microphone, streams
+//! PCM over the remote protocol, and this Mac runs the local whisper.cpp engine
+//! on it — the same `engine::transcribe` the desktop composer's stop calls.
+//!
+//! The wire shape is four ops (`docs/remote-protocol.md`, "Dictation"):
+//! `dictation_begin` opens a session, `dictation_audio` appends a chunk while
+//! the user talks, `dictation_end` transcribes and answers with the text, and
+//! `dictation_cancel` throws the audio away. `dictation_status` beside them
+//! says whether any of that would work, so the phone can hide its mic button
+//! the way the desktop composer hides its own.
+//!
+//! No events, no partials: whisper.cpp has nothing to say until the whole clip
+//! is in, so the transcript is simply the reply to `dictation_end`, and the
+//! phone shows "transcribing" for as long as that request is outstanding.
+//!
+//! Audio arrives as 16-bit little-endian mono PCM at the phone's own rate and
+//! is resampled here with the same converter the desktop path uses, so the
+//! phone never has to know what the model wants. Everything a session holds is
+//! bounded: a capture cap in seconds (the desktop's), a cap on concurrent
+//! sessions, and an idle sweep for a phone that vanished mid-sentence. Nothing
+//! is written to disk.
+
+use std::collections::HashMap;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use parking_lot::Mutex;
+use serde::Serialize;
+use tauri::AppHandle;
+
+use crate::error::{Error, Result};
+
+/// Sessions that may be open at once, across every paired phone. A dictation is
+/// one utterance from one person; this is a bound on abuse, not on use.
+pub const MAX_SESSIONS: usize = 4;
+
+/// How long a session may go without a chunk before it is swept. A phone that
+/// loses its connection mid-sentence never sends `dictation_end`, and the
+/// buffer it left behind is minutes of audio.
+pub const SESSION_IDLE: Duration = Duration::from_secs(60);
+
+/// Largest decoded chunk accepted. A second of 48 kHz mono is under 100 KB; a
+/// phone that sends this much in one frame is not streaming.
+pub const MAX_CHUNK_BYTES: usize = 2 * 1024 * 1024;
+
+/// Sample rates a phone could plausibly report. Outside this the numbers are a
+/// bug, and resampling from them would only produce garbage for the model.
+const RATE_RANGE: std::ops::RangeInclusive<f64> = 8_000.0..=192_000.0;
+
+#[derive(Clone, Serialize)]
+pub struct Status {
+    /// `dictation_begin` would succeed right now.
+    pub available: bool,
+    /// Why not, in words the phone shows as-is. `None` when available.
+    pub reason: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct Begun {
+    pub session: String,
+}
+
+#[derive(Serialize)]
+pub struct Ended {
+    /// The transcript, or empty for a clip with no speech in it (see the
+    /// engine's silence gate).
+    pub text: String,
+}
+
+struct Session {
+    /// Fixed by the first chunk; every later chunk must agree.
+    rate: Option<f64>,
+    samples: Vec<i16>,
+    touched: Instant,
+}
+
+/// The open sessions. Separate from the global so the tests can drive one of
+/// their own, with a clock they control.
+pub(super) struct Store {
+    sessions: Mutex<HashMap<String, Session>>,
+}
+
+/// What `end` hands to the transcriber: the audio and the rate it was captured at.
+pub(super) struct Clip {
+    pub rate: f64,
+    pub samples: Vec<i16>,
+}
+
+/// The process-wide store the ops act on. `OnceLock` rather than `LazyLock`:
+/// the crate's MSRV predates the latter.
+static STORE: OnceLock<Store> = OnceLock::new();
+
+fn store() -> &'static Store {
+    STORE.get_or_init(Store::new)
+}
+
+impl Store {
+    pub(super) fn new() -> Self {
+        Self {
+            sessions: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Open a session. Sweeps idle ones first, so a phone that dropped out
+    /// never blocks the next one from starting.
+    pub(super) fn begin(&self, now: Instant) -> Result<String> {
+        let mut sessions = self.sessions.lock();
+        sessions.retain(|_, s| now.duration_since(s.touched) < SESSION_IDLE);
+        if sessions.len() >= MAX_SESSIONS {
+            return Err(Error::Other(
+                "Too many dictation sessions are open on your Mac. Try again in a minute.".into(),
+            ));
+        }
+        let id = uuid::Uuid::new_v4().to_string();
+        sessions.insert(
+            id.clone(),
+            Session {
+                rate: None,
+                samples: Vec::new(),
+                touched: now,
+            },
+        );
+        Ok(id)
+    }
+
+    /// Append one chunk of 16-bit little-endian mono PCM. Audio past the
+    /// capture cap is dropped rather than refused, exactly as the desktop's mic
+    /// tap does: the transcript is truncated instead of the session failing.
+    pub(super) fn append(&self, id: &str, rate: f64, pcm: &[u8], now: Instant) -> Result<()> {
+        if !RATE_RANGE.contains(&rate) {
+            return Err(Error::Other(format!(
+                "dictation: {rate} Hz is not a usable sample rate"
+            )));
+        }
+        if pcm.len() % 2 != 0 {
+            return Err(Error::Other(
+                "dictation: audio chunk is not whole 16-bit samples".into(),
+            ));
+        }
+        let mut sessions = self.sessions.lock();
+        let session = sessions.get_mut(id).ok_or_else(unknown_session)?;
+        match session.rate {
+            None => session.rate = Some(rate),
+            Some(fixed) if fixed != rate => {
+                return Err(Error::Other(format!(
+                    "dictation: sample rate changed mid-session ({fixed} Hz to {rate} Hz)"
+                )));
+            }
+            Some(_) => {}
+        }
+        session.touched = now;
+        let limit = (rate * super::MAX_CAPTURE_SECS) as usize;
+        let room = limit.saturating_sub(session.samples.len());
+        let samples = pcm
+            .chunks_exact(2)
+            .take(room)
+            .map(|b| i16::from_le_bytes([b[0], b[1]]));
+        session.samples.extend(samples);
+        Ok(())
+    }
+
+    /// Close the session and take its audio. `None` rate means no chunk ever
+    /// arrived, which the caller treats as an empty clip.
+    pub(super) fn take(&self, id: &str) -> Result<Clip> {
+        let session = self
+            .sessions
+            .lock()
+            .remove(id)
+            .ok_or_else(unknown_session)?;
+        Ok(Clip {
+            rate: session.rate.unwrap_or(16_000.0),
+            samples: session.samples,
+        })
+    }
+
+    /// Drop a session's audio. Idempotent: a cancel for a session that was
+    /// already swept or ended has nothing left to do.
+    pub(super) fn cancel(&self, id: &str) {
+        self.sessions.lock().remove(id);
+    }
+
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.sessions.lock().len()
+    }
+}
+
+fn unknown_session() -> Error {
+    Error::Other("dictation: unknown session — it may have timed out; start again".into())
+}
+
+fn decode(pcm_base64: &str) -> Result<Vec<u8>> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(pcm_base64)
+        .map_err(|e| Error::Other(format!("dictation: audio chunk is not base64: {e}")))?;
+    if bytes.len() > MAX_CHUNK_BYTES {
+        return Err(Error::Other(format!(
+            "dictation: audio chunk of {} bytes is over the {} byte limit",
+            bytes.len(),
+            MAX_CHUNK_BYTES
+        )));
+    }
+    Ok(bytes)
+}
+
+// ---------------------------------------------------------------------------
+// The ops, as the dispatcher calls them.
+
+/// Whether a phone can dictate through this Mac right now, and if not, what the
+/// user has to do about it. Cheap — two settings reads and a metadata stat.
+pub fn status(app: &AppHandle) -> Status {
+    match readiness(app) {
+        Ok(()) => Status {
+            available: true,
+            reason: None,
+        },
+        Err(e) => Status {
+            available: false,
+            reason: Some(e.to_string()),
+        },
+    }
+}
+
+pub fn begin(app: &AppHandle) -> Result<Begun> {
+    // Checked up front so the phone learns before it opens its mic, not after
+    // the user has spoken a paragraph.
+    readiness(app)?;
+    Ok(Begun {
+        session: store().begin(Instant::now())?,
+    })
+}
+
+pub fn append(session: &str, rate: f64, pcm_base64: &str) -> Result<()> {
+    let pcm = decode(pcm_base64)?;
+    store().append(session, rate, &pcm, Instant::now())
+}
+
+pub fn cancel(session: &str) {
+    store().cancel(session);
+}
+
+/// Close the session and transcribe what it holds. The buffer is consumed
+/// whatever happens next, so a failed transcription doesn't leave audio behind.
+pub async fn end(app: &AppHandle, session: &str) -> Result<Ended> {
+    let clip = store().take(session)?;
+    transcribe(app, clip).await.map(|text| Ended { text })
+}
+
+/// The local engine has to be chosen *and* have its weights on disk — the
+/// same two conditions `dictation::engine` requires before a desktop session
+/// uses it. There is no fallback to the platform recognizer here: it needs a
+/// microphone this Mac doesn't have.
+#[cfg(target_os = "macos")]
+fn readiness(app: &AppHandle) -> Result<()> {
+    use tauri::Manager;
+    let (enabled, model) = super::engine_settings(&app.state::<crate::DbState>());
+    if !enabled {
+        return Err(Error::Other(
+            "Local dictation is off on your Mac. Turn on the Whisper engine in Settings › Dictation."
+                .into(),
+        ));
+    }
+    if super::whisper::models::installed_path(model).is_none() {
+        return Err(Error::Other(
+            "The dictation model isn't downloaded on your Mac yet. Finish the download in \
+             Settings › Dictation."
+                .into(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+async fn transcribe(app: &AppHandle, clip: Clip) -> Result<String> {
+    use tauri::Manager;
+    // Read at the end, like the desktop's stop: the model a session transcribes
+    // with is the one Settings showed when it ended.
+    let (_, model) = super::engine_settings(&app.state::<crate::DbState>());
+    let Clip { rate, samples } = clip;
+    let samples = tokio::task::spawn_blocking(move || {
+        let samples: Vec<f32> = samples.iter().map(|s| f32::from(*s) / 32768.0).collect();
+        super::capture::resample(rate, samples)
+    })
+    .await
+    .map_err(|e| Error::Other(format!("dictation: resampling task failed: {e}")))??;
+    super::whisper::engine::transcribe(model, samples).await
+}
+
+#[cfg(not(target_os = "macos"))]
+fn readiness(_app: &AppHandle) -> Result<()> {
+    Err(Error::Other(
+        "Dictation from a phone needs a Mac host: whisper.cpp is only built there.".into(),
+    ))
+}
+
+#[cfg(not(target_os = "macos"))]
+async fn transcribe(_app: &AppHandle, _clip: Clip) -> Result<String> {
+    Err(Error::Other(
+        "Dictation from a phone needs a Mac host: whisper.cpp is only built there.".into(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pcm(samples: &[i16]) -> Vec<u8> {
+        samples.iter().flat_map(|s| s.to_le_bytes()).collect()
+    }
+
+    #[test]
+    fn chunks_accumulate_in_order_and_end_takes_them() {
+        let store = Store::new();
+        let now = Instant::now();
+        let id = store.begin(now).unwrap();
+        store.append(&id, 48_000.0, &pcm(&[1, 2, 3]), now).unwrap();
+        store.append(&id, 48_000.0, &pcm(&[4]), now).unwrap();
+
+        let clip = store.take(&id).unwrap();
+        assert_eq!(clip.rate, 48_000.0);
+        assert_eq!(clip.samples, [1, 2, 3, 4]);
+        assert!(store.take(&id).is_err(), "a session ends once");
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn a_session_that_never_got_audio_ends_as_an_empty_clip() {
+        let store = Store::new();
+        let id = store.begin(Instant::now()).unwrap();
+        let clip = store.take(&id).unwrap();
+        assert!(clip.samples.is_empty());
+    }
+
+    #[test]
+    fn bad_chunks_are_refused() {
+        let store = Store::new();
+        let now = Instant::now();
+        let id = store.begin(now).unwrap();
+        assert!(store.append("nope", 48_000.0, &pcm(&[1]), now).is_err());
+        assert!(
+            store.append(&id, 48_000.0, &[1, 2, 3], now).is_err(),
+            "odd byte count"
+        );
+        assert!(
+            store.append(&id, 1.0, &pcm(&[1]), now).is_err(),
+            "absurd rate"
+        );
+        store.append(&id, 48_000.0, &pcm(&[1]), now).unwrap();
+        assert!(
+            store.append(&id, 44_100.0, &pcm(&[1]), now).is_err(),
+            "the rate is fixed by the first chunk"
+        );
+        // None of the refusals touched the buffer.
+        assert_eq!(store.take(&id).unwrap().samples, [1]);
+    }
+
+    #[test]
+    fn audio_past_the_capture_cap_is_dropped_not_refused() {
+        let store = Store::new();
+        let now = Instant::now();
+        let id = store.begin(now).unwrap();
+        let rate = 8_000.0;
+        let limit = (rate * crate::dictation::MAX_CAPTURE_SECS) as usize;
+        let big = vec![7i16; limit + 100];
+        store.append(&id, rate, &pcm(&big), now).unwrap();
+        store.append(&id, rate, &pcm(&[9]), now).unwrap();
+        assert_eq!(store.take(&id).unwrap().samples.len(), limit);
+    }
+
+    #[test]
+    fn idle_sessions_are_swept_and_live_ones_capped() {
+        let store = Store::new();
+        let t0 = Instant::now();
+        let stale = store.begin(t0).unwrap();
+        for _ in 1..MAX_SESSIONS {
+            store.begin(t0).unwrap();
+        }
+        assert!(store.begin(t0).is_err(), "the cap holds while all are live");
+
+        let later = t0 + SESSION_IDLE;
+        let fresh = store.begin(later).unwrap();
+        assert!(
+            store.append(&stale, 16_000.0, &pcm(&[1]), later).is_err(),
+            "the idle session was swept to make room"
+        );
+        store.append(&fresh, 16_000.0, &pcm(&[1]), later).unwrap();
+    }
+
+    #[test]
+    fn cancel_is_idempotent() {
+        let store = Store::new();
+        let id = store.begin(Instant::now()).unwrap();
+        store.cancel(&id);
+        store.cancel(&id);
+        assert!(store.take(&id).is_err());
+    }
+
+    #[test]
+    fn chunks_are_base64_and_bounded() {
+        assert_eq!(decode("AAEA/w==").unwrap(), [0, 1, 0, 255]);
+        assert!(decode("not base64!").is_err());
+        let over = base64::engine::general_purpose::STANDARD.encode(vec![0u8; MAX_CHUNK_BYTES + 2]);
+        assert!(decode(&over).is_err());
+    }
+}

--- a/src-tauri/src/remote/dispatch.rs
+++ b/src-tauri/src/remote/dispatch.rs
@@ -83,6 +83,11 @@ pub const OPS: &[&str] = &[
     "clone_repo",
     "gh_status",
     "gh_repo_list",
+    "dictation_status",
+    "dictation_begin",
+    "dictation_audio",
+    "dictation_end",
+    "dictation_cancel",
 ];
 
 pub const REGISTER_PUSH: &str = "register_push";
@@ -342,6 +347,25 @@ impl Dispatch for SupervisorDispatch {
                     crate::commands::announce_workspace(app, add_project_op(sup, op, args).await)
                 }
 
+                // Remote-only: the phone captures, this Mac transcribes with the
+                // local whisper engine (`dictation::remote`). The transcript is
+                // the reply to `dictation_end`; no event is involved.
+                "dictation_status" => ok(crate::dictation::remote::status(app)),
+                "dictation_begin" => res(crate::dictation::remote::begin(app)),
+                "dictation_audio" => {
+                    let a: DictationAudioArgs = parse(args)?;
+                    res(crate::dictation::remote::append(&a.session, a.rate, &a.pcm))
+                }
+                "dictation_end" => {
+                    let a: DictationSessionArgs = parse(args)?;
+                    res(crate::dictation::remote::end(app, &a.session).await)
+                }
+                "dictation_cancel" => {
+                    let a: DictationSessionArgs = parse(args)?;
+                    crate::dictation::remote::cancel(&a.session);
+                    Ok(Value::Null)
+                }
+
                 // Unreachable while `OPS` and the arms above agree; kept so a
                 // name added to one and not the other fails closed.
                 _ => Err(UNKNOWN_OP.to_string()),
@@ -524,6 +548,20 @@ struct CreatePrArgs {
     body: String,
     #[serde(default)]
     subdir: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct DictationSessionArgs {
+    session: String,
+}
+
+/// One chunk of a phone's dictation: 16-bit little-endian mono PCM, base64,
+/// at the rate the phone captured it. See `dictation::remote`.
+#[derive(Deserialize)]
+struct DictationAudioArgs {
+    session: String,
+    rate: f64,
+    pcm: String,
 }
 
 #[cfg(test)]

--- a/src-tauri/src/remote/tests.rs
+++ b/src-tauri/src/remote/tests.rs
@@ -352,7 +352,7 @@ fn the_pairing_url_carries_the_host_id_and_an_address() {
 
 #[test]
 fn allowlist_matches_the_protocol_table() {
-    // The 32 rows of docs/remote-protocol.md's op table, spelled out here so a
+    // The 37 rows of docs/remote-protocol.md's op table, spelled out here so a
     // silent widening of the wire surface fails this test. `register_push` is
     // the one the session layer answers itself (it needs the connection's
     // device identity), so it lives in `SESSION_OPS`; the two together are what
@@ -389,6 +389,11 @@ fn allowlist_matches_the_protocol_table() {
         "clone_repo",
         "gh_status",
         "gh_repo_list",
+        "dictation_status",
+        "dictation_begin",
+        "dictation_audio",
+        "dictation_end",
+        "dictation_cancel",
         "register_push",
     ];
     assert_eq!(


### PR DESCRIPTION
## Summary

The mobile app gets the desktop's dictation feature without a speech model on the phone: the phone captures the microphone and streams PCM to the Mac, which transcribes with the local whisper.cpp engine the desktop composer can already opt into. Latency after tapping stop is the last chunk plus one whisper decode, since audio streams while you talk.

### Host (`src-tauri`)

- Five remote-only ops on the allowlist: `dictation_status`, `dictation_begin`, `dictation_audio`, `dictation_end`, `dictation_cancel`. Audio is 16-bit little-endian mono PCM, base64, at the phone's own sample rate; the Mac resamples with the existing `capture::resample` and runs the existing `whisper::engine::transcribe`. The transcript is the reply to `dictation_end`, so no new events cross the wire.
- Requires the local engine to be on with its model downloaded. There is no fallback to Apple's recognizer here (it needs a microphone the Mac does not have); `dictation_status` reports the reason and the phone shows it.
- Bounded and memory-only: the desktop's five-minute capture cap, 4 concurrent sessions, 60 s idle sweep for a phone that dropped mid-sentence, 2 MiB per chunk. Nothing is written to disk.
- `docs/remote-protocol.md` gets the op rows, a Dictation section and a threat-model note (voice now crosses the wire, inside the same Noise channel). `docs/dictation.md` gets a "Dictating from the phone" section.

### Phone (`mobile`)

- Mic button in the composer. `getUserMedia` into an `AudioWorklet` tap (ScriptProcessorNode fallback), ~1 s chunks sent in order, one request in flight; hands-free auto-stop with the desktop detector ported to TypeScript (same RMS-over-noise-floor rule, same 2 s / 10 s constants), so dictating is one tap; the transcript is spliced into the draft with the desktop's `spliceTranscript`. A slashed mic that explains itself on tap when the Mac cannot transcribe. Errors land in `lastError` like every other action.
- `src-tauri/Info.ios.plist` carries `NSMicrophoneUsageDescription`; the Tauri CLI merges it at `ios dev` / `ios build`.
- The worklet module is excluded from Vite's asset inlining so it is not a `data:` script the CSP would refuse.
- `mobile/spike/` holds a standalone capture diagnostic page for on-device checks.

## Verification

- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`: clean.
- `cargo test` for the `dictation::` and `remote::` modules: 79 passed (7 new).
- Mobile `bun run check`, `bun run lint`, `bun run test`: clean, 116 passed (21 new). Production build emits the worklet as a real asset.
- Not verified here: the end-to-end path on a real iPhone. The sandbox cannot build the iOS target (SwiftPM's manifest compiler uses `sandbox-exec`). First on-device test: enable Whisper in desktop Settings, run `bun run tauri ios dev`, tap the mic.

## Follow-ups

- Downsample on the phone if cellular upload turns out to be the bottleneck.