### PR TITLE
feat(dictation): make Apple's SpeechAnalyzer the default engine

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,22 @@
+# Repo-wide cargo settings. Discovered from the repo root and from src-tauri/
+# alike (cargo walks up from the working directory), so CI's
+# `--manifest-path src-tauri/Cargo.toml` invocations and `tauri build` both see
+# it.
+
+[env]
+# whisper.cpp (built from source by whisper-rs-sys, macOS only) lets ggml's
+# CMake detect ARM CPU features by compiling tiny probe programs with
+# `-mcpu=native+<feature>` and *running* them. The probes for features the CPU
+# lacks are meant to die with SIGILL, and cmake records "failed to run". Under
+# a sandbox that stalls macOS crash handling, a probe that faults can instead
+# sit suspended at the faulting instruction forever — and the whole cargo build
+# hangs behind it with no output.
+#
+# whisper-rs-sys forwards every `GGML_*` env var to cmake as a define, and
+# `check_cxx_source_runs` skips a probe whose result variable is already
+# defined. So answer the two probes that fault on Apple Silicon up front:
+# no Mac has SVE (Apple never implemented it), and SME (M4 onwards) buys ggml
+# nothing here — its SME kernels live behind KleidiAI, which is off. dotprod
+# and i8mm keep being probed; those succeed, and never crash.
+GGML_MACHINE_SUPPORTS_sve = "0"
+GGML_MACHINE_SUPPORTS_sme = "0"

--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -7,15 +7,19 @@ and where your audio goes.
 
 ## Platform support
 
-**Apple only.** The default implementation is Apple's Speech framework
-(`SFSpeechRecognizer` fed by an `AVAudioEngine` mic tap), reached through the
-`objc2` bindings — the same code compiles for macOS and iOS, with no Swift
-toolchain step. Linux and Windows get a stub that reports `supported: false`,
-and the composer hides the button entirely rather than offer one that can only
-fail.
+**macOS 26 or newer.** The default engine is Apple's on-device `SpeechAnalyzer`
+(the model behind the system's own dictation since macOS 26), fed by an
+`AVAudioEngine` mic tap. The analyzer is a Swift-only API, so it is reached
+through a small Swift bridge compiled into the binary — see
+[Building the Swift bridge](#building-the-swift-bridge). Linux and Windows get
+a stub that reports `supported: false`, and the composer hides the button
+entirely rather than offer one that can only fail. A Mac below 26 gets the same
+answer from the real implementation, as does a Mac whose language Apple has no
+model for.
 
 macOS additionally has a local whisper.cpp engine the user can opt into; see
-[The local engine](#the-local-engine) below.
+[Local Whisper engine](#local-whisper-engine-opt-in) below. It has no macOS 26
+requirement, so on an older Mac it is the only way to get the button back.
 
 The flow, end to end:
 
@@ -27,35 +31,32 @@ The flow, end to end:
 | Events | `src/api/events.ts` — `dictation:transcript`, `dictation:state` |
 | Commands + contract | `src-tauri/src/dictation/mod.rs` |
 | Microphone (both engines) | `src-tauri/src/dictation/apple.rs` |
+| Default engine | `src-tauri/src/dictation/speech.rs` (Rust side), `src-tauri/swift/SpeechBridge.swift` (Swift side) |
 | Local engine | `src-tauri/src/dictation/capture.rs`, `src-tauri/src/dictation/whisper/` |
 
 ## Permissions
 
-Apple's recognizer needs **two** separate TCC grants, prompted on the first
-`dictation_start` (speech first, then the microphone, one dialog at a time):
+Dictation needs **one** TCC grant, the microphone, prompted on the first
+`dictation_start`. The usage string, `NSMicrophoneUsageDescription`, lives in
+`src-tauri/Info.plist`, which the Tauri CLI picks up by filename and
+`tauri-codegen` also embeds into the dev binary — so the prompt works under
+`tauri dev`, not just in a bundle.
 
-- `NSSpeechRecognitionUsageDescription`
-- `NSMicrophoneUsageDescription`
+Apple's analyzer does **not** need the Speech Recognition grant. This was
+checked rather than assumed: a throwaway app bundle with a fresh bundle id and
+no `NSSpeechRecognitionUsageDescription` transcribed a file with
+`SFSpeechRecognizer.authorizationStatus()` reading "not determined" before and
+after, and no prompt. So nothing calls `requestAuthorization:` any more, the
+plist key is gone, and `dictation_availability`'s `speech` field is vestigial —
+always `not_determined`, kept only so the wire shape didn't change. The button
+ignores it.
 
-Both strings live in `src-tauri/Info.plist`, which the Tauri CLI picks up by
-filename and `tauri-codegen` also embeds into the dev binary — so the prompts
-work under `tauri dev`, not just in a bundle. The speech string is load-bearing
-rather than cosmetic: `requestAuthorization:` crashes the process outright if
-it is missing.
-
-The local engine asks for the microphone only. Opting out of Apple's speech
-service and then being made to authorize it would be a contradiction, so that
-path never calls `requestAuthorization:` — and `dictation_availability`'s
-`speech` field is meaningless when `engine` is `whisper`, which is why the
-button ignores it there.
-
-A denied grant can only be undone in System Settings › Privacy & Security, so
-the button shows a slashed mic and says so. To get the first-run prompts back
-while testing:
+A denied microphone grant can only be undone in System Settings › Privacy &
+Security, so the button shows a slashed mic and says so. To get the first-run
+prompt back while testing:
 
 ```sh
 tccutil reset Microphone com.fletch.desktop
-tccutil reset SpeechRecognition com.fletch.desktop
 ```
 
 ## The audio-input entitlement
@@ -71,24 +72,106 @@ The failure mode when this doesn't reach `codesign` is quiet: dev builds work,
 the notarized app lights the mic and transcribes silence. If dictation returns
 an empty transcript only in a released build, check the entitlement first.
 
-## On-device vs Apple's servers
+## The default engine
 
-The request sets `requiresOnDeviceRecognition` to whatever the recognizer
-reports as `supportsOnDeviceRecognition()`. Where that is true (a supported
-locale on Apple Silicon, with the assets downloaded) **no audio leaves the
-machine**. Where it is false, recognition is server-backed and Apple caps a
-session at roughly a minute, after which the recognizer ends it itself — the
-composer sees the ordinary final transcript and `stopped`, so a long dictation
-simply stops rather than breaking. `dictation_availability` reports which mode
-this machine is in as `on_device`.
+`SpeechAnalyzer` runs entirely on this machine: **no audio leaves it**, there
+is no server path and so no server-side session cap. `dictation_availability`
+reports `on_device: true` for both engines, and the field exists only because
+the wire shape predates this.
+
+### Locale and the model
+
+`SpeechTranscriber` takes its locale explicitly. The bridge uses
+`Locale.current` and matches it against `SpeechTranscriber.supportedLocales` —
+exactly first, then any variant of the same language, so a Mac set to
+English/Poland still dictates in English. No match means
+`dictation_availability.supported` is false and a start would say "Dictation
+doesn't support this Mac's language." There is no setting for it.
+
+The per-locale model is downloaded by the OS on demand, not bundled. The first
+`dictation_start` (not launch) asks `AssetInventory` whether anything is
+missing; if so it kicks off the download in the background and **rejects** the
+start with "Downloading the speech model for English (12%). Try again in a
+moment." — a readable failure rather than a mic button that hangs for a
+multi-hundred-megabyte fetch. Once the model has landed the next start goes
+through. `AssetInventory.reserve(locale:)` is called each time so the OS keeps
+the model resident for us.
+
+All of that is the bridge's `prepare` step, which `apple::start` awaits after
+the permission check and before opening the mic. It also caches the audio
+format the analyzer wants (`bestAvailableAudioFormat`, 16 kHz mono `Int16` in
+practice), so the actual session start is synchronous.
+
+### Volatile and final results
+
+The transcriber is configured for `.volatileResults`: while the user speaks it
+emits guesses that each replace the previous guess, and periodically a
+`isFinal` result that commits a stretch of text. The bridge keeps the
+concatenation of finalized results and sends `finalized + latest volatile` on
+every result, so each `dictation:transcript` event is the whole running text —
+the contract `useDictation` already relied on with the legacy recognizer.
+
+A stop finishes the input stream and calls
+`finalizeAndFinishThroughEndOfInput()`; the results sequence then ends, and
+that end is reported as the one `is_final` transcript, which is what drives
+`stopped` (the same shape `endAudio` had). A teardown calls
+`cancelAndFinishNow()` instead. Should the analyzer never finish, the
+two-second flush deadline in `apple.rs` forces the stop.
+
+### Threading
+
+The bridge's callbacks arrive on Swift's cooperative executors, never on the
+main thread, so each one hops onto it with `run_on_main_thread` before touching
+session state, stamped with the generation it belongs to. The tap's job is
+unchanged: hand the buffer over and return. The conversion from the mic's
+format to the analyzer's (an `AVAudioConverter`, which also serves as the copy
+the tap's reused buffer needs) happens inside the bridge's `feed`, on the render
+thread — the same thing Apple's own `SpeechAnalyzer` sample does.
+
+## Building the Swift bridge
+
+`SpeechAnalyzer`, `SpeechTranscriber`, `AnalyzerInput` and `AssetInventory`
+have no Objective-C surface, so `objc2` can't reach them. `src-tauri/build.rs`
+(`build_speech_bridge`) compiles `src-tauri/swift/SpeechBridge.swift` into a
+static library and links it into the Rust binary; the Swift side exposes six
+`@_cdecl` C functions (`availability`, `prepare`, `start`, `feed`, `finish`,
+`cancel`) and takes C function pointers for its callbacks. All session state
+stays in Rust; the Swift object holds only what has to be Swift.
+
+The invocation, per target architecture:
+
+```sh
+xcrun --sdk macosx --find swiftc   # the compiler of the selected Xcode / CLT
+swiftc -emit-library -static -parse-as-library -module-name FletchSpeech \
+  -swift-version 5 -O \
+  -target arm64-apple-macos13.0 \       # or x86_64-apple-macos13.0
+  -sdk "$(xcrun --sdk macosx --show-sdk-path)" \
+  swift/SpeechBridge.swift -o "$OUT_DIR/libfletch_speech.a"
+```
+
+The deployment target is `13.0`, matching `minimumSystemVersion`; the Swift
+code guards every entry point with `#available(macOS 26, *)`, so the binary
+still launches on older macOS and dictation reports unsupported there. Nothing
+is bundled: the Swift objects carry autolink entries for `swiftCore`,
+`Foundation`, `Speech` and friends, and the only thing the Rust link adds is a
+search path to the SDK's `usr/lib/swift` stubs, which resolve to the runtime
+that has shipped with macOS since 10.14.4. Both release slices (`arm64`,
+`x86_64`) build from the same file.
+
+The build needs the macOS 26 SDK — Xcode 26 or the matching Command Line Tools
+— and stops early with a message saying so if `xcrun` is missing or the
+selected SDK is older, rather than failing at the linker. The Linux CI build
+compiles none of this (`CARGO_CFG_TARGET_OS` gate). A change to the Swift file
+reruns the build script; so does a change of `SDKROOT` or
+`MACOSX_DEPLOYMENT_TARGET`.
 
 ## Local Whisper engine (opt-in)
 
 Settings › General › Dictation offers a second engine: whisper.cpp running
-locally, for people who want transcription that never depends on Apple's
-locale support or its servers. Apple's recognizer stays the default — the
-local engine costs a one-time model download, so it can only be a choice the
-user makes.
+locally, for people who want transcription that doesn't depend on Apple's
+locale support or on macOS 26. Apple's engine stays the default — the local
+engine costs a one-time model download, so it can only be a choice the user
+makes.
 
 The opt-in is the `dictation_engine` settings row (`whisper` or `apple`),
 written by the backend `set_dictation_engine` command. Enabling it starts the
@@ -197,10 +280,20 @@ whisper.cpp is compiled from source by `whisper-rs-sys`, which needs **cmake**
 on the build host. The dependency lives under
 `[target.'cfg(target_os = "macos")'.dependencies]` for two reasons: `metal`
 puts inference on the GPU, and the Linux CI build has no business compiling a
-C++ tree it will never run. iOS therefore keeps Apple's recognizer whatever the
-setting says — `dictation/capture.rs` and `dictation/whisper/engine.rs` don't
-exist there. No link flags of our own are needed; `whisper-rs-sys` emits the
-`c++`/Accelerate/Foundation/Metal/MetalKit lines itself.
+C++ tree it will never run. No link flags of our own are needed;
+`whisper-rs-sys` emits the `c++`/Accelerate/Foundation/Metal/MetalKit lines
+itself.
+
+ggml's CMake detects ARM CPU features by compiling probe programs with
+`-mcpu=native+<feature>` and running them; the probes for features the CPU
+lacks (SVE and SME on Apple Silicon) are meant to die with SIGILL. Under a
+sandbox that stalls crash handling they can instead hang forever, and the whole
+cargo build with them — silently, at the cmake configure step. The repo-root
+`.cargo/config.toml` therefore pre-answers those two probes through the
+`GGML_MACHINE_SUPPORTS_sve` / `GGML_MACHINE_SUPPORTS_sme` env vars, which
+`whisper-rs-sys` forwards to cmake as defines. If a build ever sits in
+`whisper-rs-sys` with no output, look for a `cmTC_*` process and check
+`CMakeConfigureLog.yaml` under its `out/build` for which probe is running.
 
 ### Capture, and why resampling isn't decimation
 
@@ -236,9 +329,9 @@ so a mistimed press leaves the composer exactly as it was.
 ### Hands-free: auto-stop
 
 On the local engine a session ends itself once the user has spoken and then
-gone quiet, so dictating is one click rather than two. Apple's recognizer is
-untouched — it streams results and manages its own end-of-utterance, and there
-is no PCM buffer on that path to measure.
+gone quiet, so dictating is one click rather than two. Apple's engine is
+untouched — it streams results while the mic is open, and there is no PCM
+buffer on that path to measure.
 
 The detector is two atomics on the capture buffer, updated by the tap on the
 render thread. Each buffer's RMS is computed in the same pass that averages the
@@ -292,7 +385,7 @@ an opt-out would gate the monitor rather than change them.
 
 ### `transcribing`, and the model's lifetime
 
-Apple's recognizer streams revisions while the user speaks; whisper.cpp has
+Apple's engine streams revisions while the user speaks; whisper.cpp has
 nothing to say until the whole clip is in. A stop on the local engine therefore
 closes the mic, emits a new `dictation:state` of **`transcribing`**, runs the
 model, and only then emits the one final transcript and `stopped` (or `error`

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1365,7 +1365,6 @@ dependencies = [
  "objc2-av-foundation",
  "objc2-avf-audio",
  "objc2-foundation",
- "objc2-speech",
  "parking_lot",
  "portable-pty",
  "rand",
@@ -3133,18 +3132,6 @@ dependencies = [
  "bitflags 2.11.1",
  "objc2",
  "objc2-core-foundation",
- "objc2-foundation",
-]
-
-[[package]]
-name = "objc2-speech"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9eb609f9d2a25e0f8b76954f3acaa58348ce2a91285fe867643b2224ac4d263"
-dependencies = [
- "block2",
- "objc2",
- "objc2-avf-audio",
  "objc2-foundation",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -115,26 +115,17 @@ security-framework = "3"
 # GGML's own logging in our log file instead of on stderr.
 whisper-rs = { version = "0.16", features = ["metal", "tracing_backend"] }
 
-# Voice dictation (dictation/apple.rs): Apple's Speech framework driven by an
-# AVAudioEngine mic tap. objc2 + objc2-foundation + block2 are already in the
+# Voice dictation (dictation/apple.rs): an AVAudioEngine mic tap feeding either
+# Apple's `SpeechAnalyzer` (Swift-only, reached through the static library
+# `build.rs` compiles from swift/SpeechBridge.swift — no crate involved) or the
+# local whisper engine. objc2 + objc2-foundation + block2 are already in the
 # tree (tauri's own macOS backend); the framework crates are added here.
 # `default-features = false` throughout because these crates' defaults compile
 # *every* class in the framework — we name only the handful of classes and the
-# `block2` bridge (completion/result handlers) that the recognizer path needs.
-[target.'cfg(any(target_os = "macos", target_os = "ios"))'.dependencies]
+# `block2` bridge (completion handlers, the tap block) that the mic path needs.
 objc2 = "0.6"
 objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSError", "NSString"] }
 block2 = "0.6"
-objc2-speech = { version = "0.3", default-features = false, features = [
-    "std",
-    "block2",
-    "objc2-avf-audio",
-    "SFSpeechRecognizer",
-    "SFSpeechRecognitionRequest",
-    "SFSpeechRecognitionResult",
-    "SFSpeechRecognitionTask",
-    "SFTranscription",
-] }
 objc2-avf-audio = { version = "0.3", default-features = false, features = [
     "std",
     "block2",

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -4,17 +4,15 @@
   Merged into the bundle's generated Info.plist by the Tauri CLI, which picks
   this file up by name from the config directory (no tauri.conf.json entry).
   tauri-codegen additionally embeds it into the dev binary via embed_plist, so
-  the dictation permission prompts also appear under `tauri dev`.
+  the dictation permission prompt also appears under `tauri dev`.
 
-  These two usage strings are load-bearing, not cosmetic: SFSpeechRecognizer's
-  requestAuthorization: crashes the process outright if
-  NSSpeechRecognitionUsageDescription is missing.
+  Dictation asks for the microphone only: Apple's SpeechAnalyzer runs on-device
+  and needs no Speech Recognition grant (see docs/dictation.md), so there is no
+  NSSpeechRecognitionUsageDescription here.
 -->
 <plist version="1.0">
   <dict>
     <key>NSMicrophoneUsageDescription</key>
     <string>Fletch uses the microphone to dictate prompts.</string>
-    <key>NSSpeechRecognitionUsageDescription</key>
-    <string>Fletch uses speech recognition to turn your dictated prompts into text.</string>
   </dict>
 </plist>

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -43,9 +43,124 @@ fn main() {
     }
 
     link_clang_runtime();
+    build_speech_bridge();
 
     tauri_build::build()
 }
+
+/// The Swift half of dictation's default engine (see `swift/SpeechBridge.swift`
+/// and `docs/dictation.md`). `SpeechAnalyzer` is Swift-only, so this compiles
+/// the one Swift file into a static library with `swiftc` and links it in.
+///
+/// The Swift objects carry autolink entries (`LC_LINKER_OPTION`) for
+/// `swiftCore`, `Foundation`, `Speech` and friends, so the only thing the Rust
+/// link needs beyond the archive itself is a search path to the OS runtime's
+/// stubs in the SDK — nothing is bundled; the Swift runtime has shipped with
+/// macOS since 10.14.4.
+fn build_speech_bridge() {
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("macos") {
+        return;
+    }
+    println!("cargo::rerun-if-changed={SPEECH_BRIDGE}");
+    // `xcrun` honours both; a switch of SDK or deployment target must rebuild.
+    println!("cargo::rerun-if-env-changed=SDKROOT");
+    println!("cargo::rerun-if-env-changed=MACOSX_DEPLOYMENT_TARGET");
+
+    let arch = match std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() {
+        Ok("aarch64") => "arm64",
+        Ok("x86_64") => "x86_64",
+        other => panic!("dictation: no Swift target for architecture {other:?}"),
+    };
+    let deployment = std::env::var("MACOSX_DEPLOYMENT_TARGET")
+        .unwrap_or_else(|_| MACOS_DEPLOYMENT_TARGET.to_string());
+
+    let sdk = xcrun(&["--sdk", "macosx", "--show-sdk-path"]);
+    let sdk_version = xcrun(&["--sdk", "macosx", "--show-sdk-version"]);
+    let sdk_major: u32 = sdk_version
+        .split('.')
+        .next()
+        .and_then(|major| major.parse().ok())
+        .unwrap_or(0);
+    assert!(
+        sdk_major >= 26,
+        "dictation: the Swift bridge needs the macOS 26 SDK (Xcode 26 or newer); \
+         `xcrun --show-sdk-path` found SDK {sdk_version} at {sdk}. Select a newer Xcode \
+         with `sudo xcode-select -s /Applications/Xcode.app`."
+    );
+    let swiftc = xcrun(&["--sdk", "macosx", "--find", "swiftc"]);
+
+    let out_dir = std::env::var("OUT_DIR").expect("cargo sets OUT_DIR");
+    let archive = format!("{out_dir}/libfletch_speech.a");
+    let status = std::process::Command::new(&swiftc)
+        .args([
+            "-emit-library",
+            "-static",
+            "-parse-as-library",
+            "-module-name",
+            "FletchSpeech",
+            "-swift-version",
+            "5",
+            "-O",
+            "-target",
+            &format!("{arch}-apple-macos{deployment}"),
+            "-sdk",
+            &sdk,
+            SPEECH_BRIDGE,
+            "-o",
+            &archive,
+        ])
+        .status();
+    match status {
+        Ok(status) if status.success() => {}
+        Ok(status) => {
+            panic!("dictation: `{swiftc}` failed with {status} compiling {SPEECH_BRIDGE}")
+        }
+        Err(e) => panic!("dictation: couldn't run `{swiftc}`: {e}"),
+    }
+
+    println!("cargo::rustc-link-search=native={out_dir}");
+    println!("cargo::rustc-link-lib=static=fletch_speech");
+    println!("cargo::rustc-link-search=native={sdk}/usr/lib/swift");
+    // `libswift_Concurrency` is the one runtime library the objects reference
+    // as `@rpath/…` rather than by absolute path (it is the back-deployable
+    // one), so without an rpath the binary aborts at load with "Library not
+    // loaded". `swiftc` adds this same rpath to everything it links on macOS.
+    println!("cargo::rustc-link-arg=-Wl,-rpath,/usr/lib/swift");
+}
+
+/// Run `xcrun` and return its trimmed stdout, or stop the build with a message
+/// that says what to install. `xcrun` is the one tool that knows which Xcode
+/// (or Command Line Tools) is selected, so it locates both the SDK and
+/// `swiftc` rather than us guessing at versioned paths.
+fn xcrun(args: &[&str]) -> String {
+    match std::process::Command::new("xcrun").args(args).output() {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        Ok(out) => panic!(
+            "dictation: `xcrun {}` failed: {}\nBuilding Fletch for macOS needs Xcode 26 or \
+             newer (its Swift compiler builds the dictation bridge, {SPEECH_BRIDGE}). \
+             Install Xcode and select it with `sudo xcode-select -s /Applications/Xcode.app`, \
+             or install the Command Line Tools with `xcode-select --install`.",
+            args.join(" "),
+            String::from_utf8_lossy(&out.stderr).trim()
+        ),
+        Err(e) => panic!(
+            "dictation: couldn't run `xcrun`: {e}\nBuilding Fletch for macOS needs Xcode 26 or \
+             newer (its Swift compiler builds the dictation bridge, {SPEECH_BRIDGE}). \
+             Install Xcode and select it with `sudo xcode-select -s /Applications/Xcode.app`, \
+             or install the Command Line Tools with `xcode-select --install`."
+        ),
+    }
+}
+
+/// The dictation bridge, relative to this package (build scripts run with the
+/// package directory as CWD).
+const SPEECH_BRIDGE: &str = "swift/SpeechBridge.swift";
+
+/// Deployment target for the bridge when the build doesn't set one — the same
+/// `13.0` as `bundle.macOS.minimumSystemVersion` in `tauri.conf.json`. It only
+/// decides which Swift runtime the objects expect at link time; the code itself
+/// is gated at runtime on macOS 26 with `#available`.
+const MACOS_DEPLOYMENT_TARGET: &str = "13.0";
 
 /// whisper.cpp's Metal backend guards its residency-set path on
 /// `@available(macOS 15.0, ...)` (`ggml/src/ggml-metal/ggml-metal-device.m`),

--- a/src-tauri/src/dictation/apple.rs
+++ b/src-tauri/src/dictation/apple.rs
@@ -3,27 +3,28 @@
 //!
 //! Both engines share everything about opening the mic and owning the one live
 //! session; they differ only in the [`Sink`] the tap feeds. Apple's
-//! `SFSpeechAudioBufferRecognitionRequest` streams results back on its own,
-//! which is why a stop there hands off to the recognizer's flush. The local
-//! engine's sink is a plain PCM buffer (`super::capture`) that is transcribed in
-//! one pass once the mic is closed.
+//! `SpeechAnalyzer` (behind [`super::speech`] and its Swift bridge) streams
+//! results back on its own, which is why a stop there hands off to the
+//! analyzer's flush. The local engine's sink is a plain PCM buffer
+//! (`super::capture`) that is transcribed in one pass once the mic is closed.
 //!
 //! # Threading
 //!
-//! Speech and AVFoundation objects are not `Send`, and Apple calls our blocks
-//! back on queues of its own choosing. Rather than wrap the handles in a
-//! `Send` lie, everything that touches session state runs on the main thread
-//! (`on_main`), and the session itself lives in a `thread_local` — so there is
-//! no lock to hold, nothing to declare `unsafe impl Send`, and no way for a
-//! callback to observe a half-built session.
+//! AVFoundation objects are not `Send`, and both Apple and the Swift bridge
+//! call us back on threads of their own choosing. Rather than wrap the handles
+//! in a `Send` lie, everything that touches session state runs on the main
+//! thread ([`on_main`], [`spawn_main`]), and the session itself lives in a
+//! `thread_local` — so there is no lock to hold, nothing to declare
+//! `unsafe impl Send`, and no way for a callback to observe a half-built
+//! session.
 //!
-//! That works because `SFSpeechRecognizer`'s `queue` defaults to the main
-//! queue: the result handler is *dispatched* to the same thread we mutate
-//! state on rather than re-entering us, so it cannot run until the
-//! `on_main` block that created the task has returned. The one exception is
-//! the audio tap, which Apple invokes on a real-time render thread — it
-//! deliberately touches no session state, only its own retained sink, which is
-//! the pattern Apple documents for it.
+//! The bridge's callbacks arrive on Swift's executors, never on the main
+//! thread, so each one hops onto it with `run_on_main_thread`. The hop is a
+//! dispatch, not a re-entry: a callback cannot run before the `on_main` block
+//! that created its session has returned. The one exception is the audio tap,
+//! which Apple invokes on a real-time render thread — it deliberately touches
+//! no session state, only its own sink handle, which is the pattern Apple
+//! documents for it.
 //!
 //! Note that `#[tauri::command]` futures must be `Send`, which is the second
 //! reason for this shape: no ObjC handle is ever live across an `.await`.
@@ -35,19 +36,13 @@ use std::time::Duration;
 
 use block2::RcBlock;
 use objc2::rc::Retained;
-use objc2::AllocAnyThread;
 use objc2_av_foundation::{AVAuthorizationStatus, AVCaptureDevice, AVMediaTypeAudio};
 use objc2_avf_audio::{
     AVAudioEngine, AVAudioFormat, AVAudioInputNode, AVAudioPCMBuffer, AVAudioTime,
 };
-use objc2_foundation::NSError;
-use objc2_speech::{
-    SFSpeechAudioBufferRecognitionRequest, SFSpeechRecognitionResult, SFSpeechRecognitionTask,
-    SFSpeechRecognizer, SFSpeechRecognizerAuthorizationStatus,
-};
 use tauri::AppHandle;
 
-use super::{emit_state, emit_transcript, Auth, Availability, Engine, State};
+use super::{emit_state, emit_transcript, speech, Auth, Availability, Engine, State};
 use crate::error::{Error, Result};
 
 /// The engine's only input bus.
@@ -57,9 +52,9 @@ const BUS: usize = 0;
 /// sample. The engine clamps this to a size it can service.
 const TAP_BUFFER_FRAMES: u32 = 1024;
 
-/// How long to wait after `endAudio` for the recognizer's final result before
-/// forcing the teardown. Apple normally flushes in well under a second; the
-/// deadline exists so a wedged recognizer can't leave the UI stuck in
+/// How long to wait after the input ends for the analyzer's final result
+/// before forcing the teardown. It normally finalizes in well under a second;
+/// the deadline exists so a wedged analyzer can't leave the UI stuck in
 /// `listening` with no way back.
 const FLUSH_TIMEOUT: Duration = Duration::from_secs(2);
 
@@ -73,12 +68,12 @@ thread_local! {
 
     /// A `dictation_stop` that arrived while a start was in flight — `ACTIVE`
     /// claimed but `SESSION` still empty, which is exactly the span of the
-    /// permission prompts. Without this the stop would be swallowed and the
-    /// mic would open anyway once the user granted access. Set only in that
-    /// window (an idle stop leaves nothing behind), consumed by `begin`, and
-    /// cleared on the one path that abandons a claim without reaching `begin`.
-    /// Both ends run on the main thread, which is what orders a stop against a
-    /// concurrent start.
+    /// permission prompt and the model check. Without this the stop would be
+    /// swallowed and the mic would open anyway once the user granted access.
+    /// Set only in that window (an idle stop leaves nothing behind), consumed
+    /// by `begin`, and cleared on the one path that abandons a claim without
+    /// reaching `begin`. Both ends run on the main thread, which is what orders
+    /// a stop against a concurrent start.
     static STOP_PENDING: Cell<bool> = const { Cell::new(false) };
 }
 
@@ -91,18 +86,14 @@ static ACTIVE: AtomicBool = AtomicBool::new(false);
 
 static NEXT_GENERATION: AtomicU64 = AtomicU64::new(0);
 
-/// Where a session's audio goes. `Retained` and `Arc` both clone cheaply, so
-/// `stop` can lift the sink out of `SESSION` before calling into ObjC.
+/// Where a session's audio goes. Both variants clone cheaply, so `stop` can
+/// lift the sink out of `SESSION` before calling into the frameworks.
 #[derive(Clone)]
 enum Sink {
-    /// Apple's recognizer, which delivers its own results through
-    /// `result_handler` and needs `endAudio` to flush the last of them.
-    Speech {
-        request: Retained<SFSpeechAudioBufferRecognitionRequest>,
-        task: Retained<SFSpeechRecognitionTask>,
-    },
+    /// Apple's analyzer, which delivers its own results through the bridge's
+    /// callbacks and needs `finish` to flush the last of them.
+    Speech(speech::Session),
     /// The local engine's capture buffer, transcribed in one pass at stop.
-    #[cfg(target_os = "macos")]
     Pcm(std::sync::Arc<super::capture::Pcm>),
 }
 
@@ -112,16 +103,15 @@ impl Sink {
     /// simply dropped; marking it closed is what retires its silence monitor.
     fn cancel(&self) {
         match self {
-            Sink::Speech { task, .. } => unsafe { task.cancel() },
-            #[cfg(target_os = "macos")]
+            Sink::Speech(session) => session.cancel(),
             Sink::Pcm(pcm) => pcm.close(),
         }
     }
 }
 
 struct Session {
-    /// Distinguishes this session from its successors. Every block Apple may
-    /// invoke late (a post-cancel result, the flush deadline) carries the
+    /// Distinguishes this session from its successors. Every callback that may
+    /// arrive late (a post-cancel result, the flush deadline) carries the
     /// generation it was created for and does nothing if it no longer matches
     /// — otherwise a straggler could tear down a session the user has since
     /// started.
@@ -133,21 +123,19 @@ struct Session {
     /// take ownership, but holding our own reference costs nothing and takes
     /// a use-after-free off the table.
     _tap: Tap,
-    /// True once the user asked to stop. After that point Apple's recognizer
-    /// reports the end of the stream *as an error* (a cancellation or
-    /// no-speech code from a private domain), which is the expected tail of a
-    /// normal session and must surface as `stopped`, not `error`.
+    /// True once the user asked to stop. An analyzer error after that point
+    /// (a cancellation racing the finalization) is the tail of a normal
+    /// session and must surface as `stopped`, not `error`.
     stopping: bool,
 }
 
 /// What a stop left for the caller to finish once it is off the main thread.
 enum Stopping {
-    /// Apple's recognizer owns the rest: `endAudio` makes it flush a final
+    /// Apple's analyzer owns the rest: ending the input makes it flush a final
     /// result, and that result drives the teardown and the terminal state.
     Flushing(u64),
     /// The local engine: the mic is already closed and the session claimed, and
     /// the audio is the caller's to transcribe.
-    #[cfg(target_os = "macos")]
     Captured(u64, std::sync::Arc<super::capture::Pcm>),
 }
 
@@ -169,6 +157,15 @@ async fn on_main<T: Send + 'static>(
         .map_err(|_| Error::Other("dictation: main thread task was dropped".into()))
 }
 
+/// Fire-and-forget [`on_main`], for callbacks that have no one to answer to.
+/// The only failure is an app that is shutting down, which is logged, not
+/// propagated — there is no session left to matter.
+fn spawn_main(app: &AppHandle, f: impl FnOnce() + Send + 'static) {
+    if let Err(e) = app.run_on_main_thread(f) {
+        tracing::warn!(error = %e, "dictation: main thread unavailable");
+    }
+}
+
 /// Is the session that `generation` belongs to still the live one?
 fn is_live(generation: u64) -> bool {
     SESSION.with_borrow(|s| s.as_ref().is_some_and(|s| s.generation == generation))
@@ -177,13 +174,12 @@ fn is_live(generation: u64) -> bool {
 /// The live session's capture buffer, if `generation` is still it and it is a
 /// local-engine session. Main thread, like every read of `SESSION`; the buffer
 /// itself is then readable from anywhere.
-#[cfg(target_os = "macos")]
 fn captured(generation: u64) -> Option<std::sync::Arc<super::capture::Pcm>> {
     SESSION.with_borrow(|slot| {
         let session = slot.as_ref().filter(|s| s.generation == generation)?;
         match &session.sink {
             Sink::Pcm(pcm) => Some(pcm.clone()),
-            Sink::Speech { .. } => None,
+            Sink::Speech(_) => None,
         }
     })
 }
@@ -214,24 +210,13 @@ fn teardown(session: Session) {
 // ---------------------------------------------------------------------------
 // Permissions
 
-impl From<SFSpeechRecognizerAuthorizationStatus> for Auth {
-    fn from(status: SFSpeechRecognizerAuthorizationStatus) -> Self {
-        match status {
-            SFSpeechRecognizerAuthorizationStatus::Authorized => Auth::Authorized,
-            SFSpeechRecognizerAuthorizationStatus::Denied => Auth::Denied,
-            SFSpeechRecognizerAuthorizationStatus::Restricted => Auth::Restricted,
-            // NotDetermined, and anything a future OS adds: treat as "ask".
-            _ => Auth::NotDetermined,
-        }
-    }
-}
-
 impl From<AVAuthorizationStatus> for Auth {
     fn from(status: AVAuthorizationStatus) -> Self {
         match status {
             AVAuthorizationStatus::Authorized => Auth::Authorized,
             AVAuthorizationStatus::Denied => Auth::Denied,
             AVAuthorizationStatus::Restricted => Auth::Restricted,
+            // NotDetermined, and anything a future OS adds: treat as "ask".
             _ => Auth::NotDetermined,
         }
     }
@@ -245,10 +230,6 @@ fn microphone_auth() -> Auth {
         return Auth::NotDetermined;
     };
     unsafe { AVCaptureDevice::authorizationStatusForMediaType(audio) }.into()
-}
-
-fn speech_auth() -> Auth {
-    unsafe { SFSpeechRecognizer::authorizationStatus() }.into()
 }
 
 /// Turn a settled permission state into a message the user can act on. The
@@ -267,23 +248,11 @@ fn authorized_or_error(what: &str, auth: Auth) -> Result<()> {
     }
 }
 
-/// The two `requestAuthorization`-style APIs hand their answer to a block on
-/// an arbitrary queue. These helpers are deliberately non-`async`: the block
-/// is created, handed off, and dropped entirely within them, so no ObjC handle
-/// is ever live across the caller's `.await`. Apple copies the block, so
-/// releasing our reference here is safe.
-fn request_speech_auth() -> tokio::sync::oneshot::Receiver<Auth> {
-    let (tx, rx) = tokio::sync::oneshot::channel();
-    let tx = parking_lot::Mutex::new(Some(tx));
-    let handler = RcBlock::new(move |status: SFSpeechRecognizerAuthorizationStatus| {
-        if let Some(tx) = tx.lock().take() {
-            let _ = tx.send(status.into());
-        }
-    });
-    unsafe { SFSpeechRecognizer::requestAuthorization(&handler) };
-    rx
-}
-
+/// `requestAccessForMediaType:` hands its answer to a block on an arbitrary
+/// queue. Deliberately non-`async`: the block is created, handed off, and
+/// dropped entirely within the call, so no ObjC handle is ever live across the
+/// caller's `.await`. Apple copies the block, so releasing our reference here
+/// is safe.
 fn request_microphone_auth() -> tokio::sync::oneshot::Receiver<Auth> {
     let (tx, rx) = tokio::sync::oneshot::channel();
     let Some(audio) = (unsafe { AVMediaTypeAudio }) else {
@@ -303,24 +272,11 @@ fn request_microphone_auth() -> tokio::sync::oneshot::Receiver<Auth> {
     rx
 }
 
-/// Ensure the permissions this engine needs, prompting for whichever hasn't
-/// been asked yet. Sequential rather than concurrent so the user sees one
-/// dialog at a time.
-///
-/// The local engine touches Apple's recognizer for nothing, so it must not
-/// raise its TCC prompt either: opting out of Apple's speech service and then
-/// being asked to authorize it would be a straight contradiction.
-async fn ensure_authorized(engine: Engine) -> Result<()> {
-    if engine == Engine::Apple {
-        let mut speech = speech_auth();
-        if speech == Auth::NotDetermined {
-            speech = request_speech_auth().await.map_err(|_| {
-                Error::Other("dictation: speech permission prompt was dismissed".into())
-            })?;
-        }
-        authorized_or_error("speech recognition", speech)?;
-    }
-
+/// Ensure the microphone permission, prompting if it hasn't been asked yet.
+/// The only grant either engine needs: Apple's analyzer runs on-device and
+/// asks for no Speech Recognition authorization (verified against a fresh
+/// bundle id — no prompt, no usage string, status stays "not determined").
+async fn ensure_authorized() -> Result<()> {
     let mut mic = microphone_auth();
     if mic == Auth::NotDetermined {
         mic = request_microphone_auth().await.map_err(|_| {
@@ -330,22 +286,31 @@ async fn ensure_authorized(engine: Engine) -> Result<()> {
     authorized_or_error("microphone", mic)
 }
 
+/// Everything a session needs settled before the mic opens: the permission,
+/// and for Apple's engine the locale, model assets and audio format. Both can
+/// take a while (a TCC prompt; a model download) and both reject with a message
+/// the user can act on.
+async fn ready(engine: Engine) -> Result<()> {
+    ensure_authorized().await?;
+    if engine == Engine::Apple {
+        speech::prepare().await?;
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Commands
 
-pub fn availability(engine: Engine) -> Availability {
-    // The local engine is on-device by construction and needs no recognizer, so
-    // don't probe for one. Otherwise: a recognizer only exists for a supported
-    // locale, and without one there is nothing to ask about on-device support —
-    // report the conservative answer and let `start` produce the readable error.
-    let on_device = engine == Engine::Whisper
-        || unsafe { SFSpeechRecognizer::init(SFSpeechRecognizer::alloc()) }
-            .is_some_and(|r| unsafe { r.supportsOnDeviceRecognition() });
+pub async fn availability(engine: Engine) -> Availability {
+    // The local engine runs wherever whisper.cpp is built; Apple's needs
+    // macOS 26 and a model for this Mac's language. Neither sends audio off
+    // the machine, and neither asks for the speech-recognition grant.
+    let supported = engine == Engine::Whisper || speech::supported().await;
     Availability {
-        supported: true,
-        speech: speech_auth(),
+        supported,
+        speech: Auth::NotDetermined,
         microphone: microphone_auth(),
-        on_device,
+        on_device: true,
         engine,
     }
 }
@@ -355,7 +320,7 @@ pub fn availability(engine: Engine) -> Availability {
 /// started, so no terminal event will follow.
 pub async fn start(app: AppHandle, engine: Engine) -> Result<Option<u64>> {
     // Claiming ACTIVE up front is what makes a second start a no-op, and it
-    // has to happen before the permission prompts, which can sit on screen
+    // has to happen before the permission prompt, which can sit on screen
     // for a long time.
     if ACTIVE.swap(true, Ordering::SeqCst) {
         return Ok(None);
@@ -364,11 +329,11 @@ pub async fn start(app: AppHandle, engine: Engine) -> Result<Option<u64>> {
     // hasn't run, then `begin` itself on failure, then `teardown` once the
     // session is up. Handing it over rather than clearing it from here means
     // a caller who drops this future after the session came up can't leave a
-    // live recognizer behind a cleared flag.
-    if let Err(e) = ensure_authorized(engine).await {
+    // live analyzer behind a cleared flag.
+    if let Err(e) = ready(engine).await {
         ACTIVE.store(false, Ordering::SeqCst);
         // The only path that drops the claim without `begin` consuming a stop
-        // that landed during the prompts — clear it, or it would cancel an
+        // that landed during the wait — clear it, or it would cancel an
         // unrelated later start.
         let _ = on_main(&app, || STOP_PENDING.set(false)).await;
         return Err(e);
@@ -382,9 +347,8 @@ pub async fn start(app: AppHandle, engine: Engine) -> Result<Option<u64>> {
             return Err(e);
         }
     };
-    // Hands-free stop is the local engine's alone: Apple's recognizer decides
+    // Hands-free stop is the local engine's alone: Apple's analyzer decides
     // for itself when an utterance has ended, and we have no PCM to measure.
-    #[cfg(target_os = "macos")]
     if let (Some(generation), Engine::Whisper) = (started, engine) {
         watch_for_silence(app, generation);
     }
@@ -400,7 +364,6 @@ pub async fn start(app: AppHandle, engine: Engine) -> Result<Option<u64>> {
 /// buffer it was given is closed (any teardown does that), and the stop it
 /// finally issues names its own session, so a monitor that outlives its
 /// session cannot cut a later one short.
-#[cfg(target_os = "macos")]
 fn watch_for_silence(app: AppHandle, generation: u64) {
     tokio::spawn(async move {
         let Ok(Some(pcm)) = on_main(&app, move || captured(generation)).await else {
@@ -422,7 +385,7 @@ fn watch_for_silence(app: AppHandle, generation: u64) {
 }
 
 fn begin(app: AppHandle, engine: Engine) -> Result<Option<u64>> {
-    // The user asked to stop while the permission prompts were up. Honour it
+    // The user asked to stop while the permission prompt was up. Honour it
     // instead of opening the mic behind their back. No state event: the
     // session never came up, so there is nothing to close out — the `None`
     // is what tells the caller not to wait for one.
@@ -451,19 +414,10 @@ fn build_session(app: AppHandle, engine: Engine) -> Result<u64> {
     let generation = NEXT_GENERATION.fetch_add(1, Ordering::SeqCst);
 
     let (sink, tap) = match engine {
-        Engine::Apple => speech_sink(&app, generation)?,
-        #[cfg(target_os = "macos")]
+        Engine::Apple => speech_sink(&app, generation, &format)?,
         Engine::Whisper => {
             let (pcm, tap) = super::capture::sink(&format)?;
             (Sink::Pcm(pcm), tap)
-        }
-        // iOS: `super::engine` never answers `Whisper` where whisper.cpp isn't
-        // built, so this is unreachable rather than a fallback.
-        #[cfg(not(target_os = "macos"))]
-        Engine::Whisper => {
-            return Err(Error::Other(
-                "Local dictation isn't available on this platform.".into(),
-            ))
         }
     };
 
@@ -521,85 +475,68 @@ fn open_microphone() -> Result<(
     Ok((audio, input, format))
 }
 
-/// Apple's recognizer, plus the tap that streams the mic straight into it.
-fn speech_sink(app: &AppHandle, generation: u64) -> Result<(Sink, Tap)> {
-    let recognizer = unsafe { SFSpeechRecognizer::init(SFSpeechRecognizer::alloc()) }
-        .ok_or_else(|| Error::Other("Dictation doesn't support this Mac's language.".into()))?;
-    if !unsafe { recognizer.isAvailable() } {
-        return Err(Error::Other(
-            "Speech recognition is unavailable right now. If it needs the network, check your \
-             connection and try again."
-                .into(),
-        ));
-    }
-
-    let request = unsafe { SFSpeechAudioBufferRecognitionRequest::new() };
-    unsafe {
-        request.setShouldReportPartialResults(true);
-        // Keep the audio on this machine whenever the recognizer can manage
-        // it, and fall back to Apple's servers (with their ~1 minute cap)
-        // only when it can't.
-        request.setRequiresOnDeviceRecognition(recognizer.supportsOnDeviceRecognition());
-    }
-
-    let tap_request = request.clone();
+/// Apple's analyzer, plus the tap that streams the mic straight into it. The
+/// format conversion the analyzer needs happens in the bridge, not here.
+fn speech_sink(app: &AppHandle, generation: u64, format: &AVAudioFormat) -> Result<(Sink, Tap)> {
+    let session = speech::Session::start(
+        format,
+        speech::Events {
+            on_result: Box::new(on_result(app.clone(), generation)),
+            on_error: Box::new(on_error(app.clone(), generation)),
+        },
+    )?;
     let tap = RcBlock::new(
         move |buffer: NonNull<AVAudioPCMBuffer>, _when: NonNull<AVAudioTime>| {
-            // Real-time audio thread. Appending is the only thing that may
-            // happen here — no session state, no allocation, no emit.
-            unsafe { tap_request.appendAudioPCMBuffer(buffer.as_ref()) };
+            // Real-time audio thread. Handing the buffer over is the only
+            // thing that may happen here — no session state, no emit.
+            session.feed(unsafe { buffer.as_ref() });
         },
     );
-
-    let results = result_handler(app.clone(), generation);
-    let task = unsafe { recognizer.recognitionTaskWithRequest_resultHandler(&request, &results) };
-    Ok((Sink::Speech { request, task }, tap))
+    Ok((Sink::Speech(session), tap))
 }
 
-/// The recognizer's result handler. Runs on the recognizer's queue — the main
-/// queue by default, i.e. the thread `SESSION` lives on.
-fn result_handler(
-    app: AppHandle,
-    generation: u64,
-) -> RcBlock<dyn Fn(*mut SFSpeechRecognitionResult, *mut NSError)> {
-    RcBlock::new(
-        move |result: *mut SFSpeechRecognitionResult, error: *mut NSError| {
-            // Apple passes one or the other, and both may be null.
-            if let Some(result) = unsafe { result.as_ref() } {
-                let text = unsafe { result.bestTranscription().formattedString() }.to_string();
-                let is_final = unsafe { result.isFinal() };
-                // A result for an already-replaced session must stay silent,
-                // or it would overwrite the new session's transcript.
-                if !is_live(generation) {
-                    return;
-                }
-                emit_transcript(&app, generation, text, is_final);
-                if is_final {
-                    if let Some(session) = claim(generation) {
-                        teardown(session);
-                        emit_state(&app, generation, State::Stopped, None);
-                    }
-                }
+/// The analyzer's transcript callback: every revision of the running text, and
+/// once, last, the final one that ends the session.
+fn on_result(app: AppHandle, generation: u64) -> impl Fn(String, bool) + Send + Sync {
+    move |text, is_final| {
+        let emit_to = app.clone();
+        spawn_main(&app, move || {
+            // A result for an already-replaced session must stay silent, or it
+            // would overwrite the new session's transcript.
+            if !is_live(generation) {
                 return;
             }
-            if let Some(error) = unsafe { error.as_ref() } {
-                let Some(session) = claim(generation) else {
-                    return;
-                };
-                let message = error.localizedDescription().to_string();
-                let stopping = session.stopping;
-                teardown(session);
-                if stopping {
-                    // The expected end of a user-requested stop, not a failure.
-                    tracing::debug!(error = %message, "dictation stream ended");
-                    emit_state(&app, generation, State::Stopped, None);
-                } else {
-                    tracing::warn!(error = %message, "dictation failed");
-                    emit_state(&app, generation, State::Error, Some(message));
+            emit_transcript(&emit_to, generation, text, is_final);
+            if is_final {
+                if let Some(session) = claim(generation) {
+                    teardown(session);
+                    emit_state(&emit_to, generation, State::Stopped, None);
                 }
             }
-        },
-    )
+        });
+    }
+}
+
+/// The analyzer's failure callback. After a user's stop it is the expected
+/// tail of the session; before one it is a real error.
+fn on_error(app: AppHandle, generation: u64) -> impl Fn(String) + Send + Sync {
+    move |message| {
+        let emit_to = app.clone();
+        spawn_main(&app, move || {
+            let Some(session) = claim(generation) else {
+                return;
+            };
+            let stopping = session.stopping;
+            teardown(session);
+            if stopping {
+                tracing::debug!(error = %message, "dictation stream ended");
+                emit_state(&emit_to, generation, State::Stopped, None);
+            } else {
+                tracing::warn!(error = %message, "dictation failed");
+                emit_state(&emit_to, generation, State::Error, Some(message));
+            }
+        });
+    }
 }
 
 pub async fn stop(app: AppHandle) -> Result<()> {
@@ -611,8 +548,8 @@ pub async fn stop(app: AppHandle) -> Result<()> {
 /// session and must be a no-op against any other.
 async fn stop_session(app: AppHandle, expect: Option<u64>) -> Result<()> {
     let stopped = on_main(&app, move || {
-        // Clone the handles out before calling into ObjC: the rule for
-        // `SESSION` is that no borrow is ever held across a framework call.
+        // Clone the handles out before calling into the frameworks: the rule
+        // for `SESSION` is that no borrow is ever held across such a call.
         let live = SESSION.with_borrow_mut(|slot| {
             let session = slot.as_mut()?;
             if expect.is_some_and(|g| g != session.generation) {
@@ -629,7 +566,7 @@ async fn stop_session(app: AppHandle, expect: Option<u64>) -> Result<()> {
         let Some((generation, audio, input, sink)) = live else {
             // No session of ours — but a claimed `ACTIVE` with an empty
             // `SESSION` means a `start` is still sitting on the permission
-            // prompts, so leave the request for `begin` to consume. Genuinely
+            // prompt, so leave the request for `begin` to consume. Genuinely
             // idle, record nothing: a flag left behind here would cancel a
             // later start. A generation-scoped stop never leaves one: its own
             // session existed, so this is a session that has already ended, and
@@ -645,15 +582,14 @@ async fn stop_session(app: AppHandle, expect: Option<u64>) -> Result<()> {
             input.removeTapOnBus(BUS);
         }
         match sink {
-            Sink::Speech { request, .. } => {
-                // Deliberately not `task.cancel()`: ending the audio is what
-                // makes the recognizer flush its final result, and that result
-                // is what drives the `stopped` emit. Cancelling would discard
-                // it — so the session stays in `SESSION` for the handler.
-                unsafe { request.endAudio() };
+            Sink::Speech(session) => {
+                // Deliberately not `cancel`: ending the input is what makes
+                // the analyzer finalize, and that final result is what drives
+                // the `stopped` emit. Cancelling would discard it — so the
+                // session stays in `SESSION` for the callback.
+                session.finish();
                 Some(Stopping::Flushing(generation))
             }
-            #[cfg(target_os = "macos")]
             Sink::Pcm(pcm) => {
                 // Nothing will flush, so the session is over here. Claiming it
                 // now gives the transcription sole ownership of the terminal
@@ -678,7 +614,7 @@ async fn stop_session(app: AppHandle, expect: Option<u64>) -> Result<()> {
                 let _ = on_main(&handle, move || {
                     // Still live means the final result never arrived; `claim`
                     // is what keeps this from double-emitting against the
-                    // result handler.
+                    // result callback.
                     if let Some(session) = claim(generation) {
                         tracing::warn!(
                             "dictation: no final result before the flush deadline; forcing stop"
@@ -691,7 +627,6 @@ async fn stop_session(app: AppHandle, expect: Option<u64>) -> Result<()> {
             });
             Ok(())
         }
-        #[cfg(target_os = "macos")]
         Some(Stopping::Captured(generation, pcm)) => {
             // The mic is already closed, but the model still has to run, which
             // is seconds rather than milliseconds — the frontend gets a state

--- a/src-tauri/src/dictation/capture.rs
+++ b/src-tauri/src/dictation/capture.rs
@@ -12,8 +12,6 @@
 //!   allocation behind it. Decimating 48 kHz by taking every third sample would
 //!   be cheap enough for the tap, but folds everything above 8 kHz back into the
 //!   speech band, and the model hears the aliases.
-//!
-//! macOS-only, like `whisper::engine` — iOS keeps the platform recognizer.
 
 use std::cell::Cell;
 use std::ptr::NonNull;
@@ -328,7 +326,7 @@ fn resample(rate: f64, samples: Vec<f32>) -> Result<Vec<f32>> {
 }
 
 /// Deinterleaved float32, one channel, at `rate`.
-fn standard_mono(rate: f64) -> Result<Retained<AVAudioFormat>> {
+pub(super) fn standard_mono(rate: f64) -> Result<Retained<AVAudioFormat>> {
     unsafe {
         AVAudioFormat::initStandardFormatWithSampleRate_channels(AVAudioFormat::alloc(), rate, 1)
     }
@@ -339,7 +337,10 @@ fn standard_mono(rate: f64) -> Result<Retained<AVAudioFormat>> {
     })
 }
 
-fn pcm_buffer(format: &AVAudioFormat, frames: u32) -> Result<Retained<AVAudioPCMBuffer>> {
+pub(super) fn pcm_buffer(
+    format: &AVAudioFormat,
+    frames: u32,
+) -> Result<Retained<AVAudioPCMBuffer>> {
     unsafe {
         AVAudioPCMBuffer::initWithPCMFormat_frameCapacity(AVAudioPCMBuffer::alloc(), format, frames)
     }
@@ -348,7 +349,7 @@ fn pcm_buffer(format: &AVAudioFormat, frames: u32) -> Result<Retained<AVAudioPCM
 
 /// The one channel's samples. Null for a buffer that isn't float32, which the
 /// formats above always are.
-fn channel(buffer: &AVAudioPCMBuffer) -> Result<NonNull<f32>> {
+pub(super) fn channel(buffer: &AVAudioPCMBuffer) -> Result<NonNull<f32>> {
     NonNull::new(unsafe { buffer.floatChannelData() })
         .map(|data| unsafe { *data.as_ptr() })
         .ok_or_else(|| Error::Other("dictation: audio buffer has no float samples".into()))

--- a/src-tauri/src/dictation/mod.rs
+++ b/src-tauri/src/dictation/mod.rs
@@ -12,16 +12,17 @@
 //! would be unreconstructable. Each event replaces the last.
 //!
 //! There are two engines behind these commands, chosen per session by
-//! [`engine`]: Apple's recognizer, which streams revisions while the user
-//! speaks, and local whisper.cpp, which has nothing to say until the mic
-//! closes and so spends the gap in `transcribing`. The commands, the events
-//! and the session-id contract are identical either way — `apple` owns the
-//! microphone for both.
+//! [`engine`]: Apple's on-device `SpeechAnalyzer` (macOS 26+), which streams
+//! revisions while the user speaks, and local whisper.cpp, which has nothing
+//! to say until the mic closes and so spends the gap in `transcribing`. The
+//! commands, the events and the session-id contract are identical either way
+//! — `apple` owns the microphone for both.
 //!
-//! Only Apple platforms have an implementation (`apple`); everywhere else the
-//! commands are stubs that report `supported: false`, which is what keeps the
-//! Linux CI build compiling and lets the frontend hide the mic button without
-//! a platform check of its own.
+//! Only macOS has an implementation (`apple`); everywhere else the commands
+//! are stubs that report `supported: false`, which is what keeps the Linux CI
+//! build compiling and lets the frontend hide the mic button without a
+//! platform check of its own. A Mac below 26 with the local engine off reports
+//! the same, from the real implementation.
 
 use serde::Serialize;
 use tauri::{AppHandle, Emitter};
@@ -30,23 +31,26 @@ use crate::database;
 use crate::error::Result;
 use crate::DbState;
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_os = "macos")]
 mod apple;
-// The local engine's sink for the shared mic tap. macOS-only, like whisper.cpp.
+// The local engine's sink for the shared mic tap.
 #[cfg(target_os = "macos")]
 mod capture;
+// The default engine's `SpeechAnalyzer` bridge (Rust side of
+// `swift/SpeechBridge.swift`).
+#[cfg(target_os = "macos")]
+mod speech;
 // Compiles everywhere (the catalog and download are plain Rust); the engine
 // itself is gated inside. `pub` so `lib.rs` can seed the models root.
 pub mod whisper;
 
-/// A TCC (privacy) permission state, for either the microphone or speech
-/// recognition. Mirrors both `SFSpeechRecognizerAuthorizationStatus` and
-/// `AVAuthorizationStatus`, which share these four cases.
+/// A TCC (privacy) permission state for the microphone. Mirrors
+/// `AVAuthorizationStatus`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
-// The full set is the wire contract on every platform, but only the Apple
+// The full set is the wire contract on every platform, but only the macOS
 // implementation ever reports anything other than `NotDetermined`.
-#[cfg_attr(not(any(target_os = "macos", target_os = "ios")), allow(dead_code))]
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub enum Auth {
     /// Never asked — starting a session will prompt.
     NotDetermined,
@@ -58,15 +62,14 @@ pub enum Auth {
 }
 
 /// Which recognizer a session would use. Reported by `dictation_availability`
-/// so the UI knows, among other things, that the local engine has no use for
-/// the speech-recognition grant.
+/// so the UI knows, among other things, which engine stops itself.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 // Both variants are the wire contract everywhere, but `Whisper` is only ever
 // chosen where whisper.cpp is built.
 #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 pub enum Engine {
-    /// Apple's `SFSpeechRecognizer`, the default.
+    /// Apple's on-device `SpeechAnalyzer` (macOS 26+), the default.
     Apple,
     /// Local whisper.cpp (see [`whisper`]).
     Whisper,
@@ -76,16 +79,17 @@ pub enum Engine {
 /// mic button (or explain why) before the user ever presses it.
 #[derive(Clone, Debug, Serialize)]
 pub struct Availability {
-    /// False on non-Apple platforms — nothing else in this struct matters.
+    /// False where no engine can run — non-Apple platforms, and a Mac below
+    /// macOS 26 (or with a language Apple has no model for) unless the local
+    /// engine is chosen. Nothing else in this struct matters then.
     supported: bool,
-    /// Irrelevant when `engine` is `whisper`: that path never calls Apple's
-    /// recognizer, so it never prompts for this and can't be blocked by it.
+    /// Vestigial: no engine asks for the Speech Recognition grant any more —
+    /// Apple's analyzer is on-device and needs none — so this is always
+    /// `NotDetermined`. Kept so the wire shape is unchanged.
     speech: Auth,
     microphone: Auth,
-    /// The recognizer can transcribe without a network round-trip. When true
-    /// we pin the request on-device, so no audio leaves the machine; when
-    /// false recognition is server-backed and capped at about a minute. Always
-    /// true for the local engine.
+    /// Always true: both engines transcribe on this machine and no audio
+    /// leaves it.
     on_device: bool,
     engine: Engine,
 }
@@ -102,7 +106,7 @@ pub struct Availability {
 /// app-wide, and a session outlives the composer that started it (a stop is
 /// followed by a flush), so a composer that starts the next one needs the id to
 /// tell the old session's stragglers from its own.
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_os = "macos")]
 #[derive(Clone, Serialize)]
 struct TranscriptPayload {
     session: u64,
@@ -113,11 +117,9 @@ struct TranscriptPayload {
 /// The lifecycle of the one live session. `Stopped` and `Error` are both
 /// terminal *and* mean the session is fully torn down, so `dictation_start`
 /// is callable again the moment either arrives.
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_os = "macos")]
 #[derive(Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
-// `Transcribing` belongs to the local engine, which iOS doesn't build.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
 enum State {
     Listening,
     /// The mic is closed and the local engine is running the model. Only the
@@ -128,7 +130,7 @@ enum State {
     Error,
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_os = "macos")]
 #[derive(Clone, Serialize)]
 struct StatePayload {
     /// Same id as on [`TranscriptPayload`].
@@ -146,7 +148,7 @@ fn emit<T: Serialize + Clone>(app: &AppHandle, event: &str, payload: T) {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_os = "macos")]
 fn emit_transcript(app: &AppHandle, session: u64, text: String, is_final: bool) {
     emit(
         app,
@@ -159,7 +161,7 @@ fn emit_transcript(app: &AppHandle, session: u64, text: String, is_final: bool) 
     );
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_os = "macos")]
 fn emit_state(app: &AppHandle, session: u64, state: State, error: Option<String>) {
     emit(
         app,
@@ -362,15 +364,10 @@ fn catalog_entry(id: &str) -> Result<&'static whisper::models::WhisperModel> {
 /// Which engine a session started right now would use. The local one takes
 /// both the opt-in AND a fully downloaded model: dispatching on the setting
 /// alone would let an interrupted download leave the mic button dead.
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(target_os = "macos")]
 fn engine(app: &AppHandle) -> Engine {
     use tauri::Manager;
 
-    // whisper.cpp is built for macOS only, so iOS keeps the platform
-    // recognizer whatever the setting says.
-    if !cfg!(target_os = "macos") {
-        return Engine::Apple;
-    }
     let (enabled, model) = engine_settings(&app.state::<DbState>());
     if enabled && whisper::models::installed_path(model).is_some() {
         Engine::Whisper
@@ -380,14 +377,15 @@ fn engine(app: &AppHandle) -> Engine {
 }
 
 /// Whether dictation works here, and what permissions stand in the way. Cheap
-/// and side-effect free — it never prompts, so the UI can call it on mount.
+/// and side-effect free — it never prompts and never downloads a model, so the
+/// UI can call it on mount.
 #[tauri::command]
 pub async fn dictation_availability(app: AppHandle) -> Availability {
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(target_os = "macos")]
     {
-        apple::availability(engine(&app))
+        apple::availability(engine(&app)).await
     }
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(target_os = "macos"))]
     {
         let _ = app;
         Availability {
@@ -400,9 +398,10 @@ pub async fn dictation_availability(app: AppHandle) -> Availability {
     }
 }
 
-/// Start listening. Requests the permissions the chosen engine needs on first
-/// use — microphone and speech for Apple's recognizer (so the first call can
-/// block on two TCC prompts), microphone alone for the local engine — and
+/// Start listening. Requests the microphone permission on first use (so the
+/// first call can block on a TCC prompt), makes sure Apple's engine has its
+/// speech model for this Mac's language (a missing one starts downloading and
+/// rejects with a readable message; try again once it has landed), and
 /// resolves once audio is actually flowing.
 ///
 /// `Some(id)` means a session is now live and `dictation:state` `listening` has
@@ -410,17 +409,17 @@ pub async fn dictation_availability(app: AppHandle) -> Availability {
 /// carries the same `id`, which is how a caller tells its own session from a
 /// previous one still flushing. `None` means nothing was started and no event
 /// will arrive: either a session was already active (a second start is a
-/// no-op) or a `dictation_stop` issued while the prompts were up cancelled
-/// this one. The caller needs the distinction because `None` leaves nothing
-/// to wait for.
+/// no-op) or a `dictation_stop` issued while the prompt was up cancelled this
+/// one. The caller needs the distinction because `None` leaves nothing to
+/// wait for.
 #[tauri::command]
 pub async fn dictation_start(app: AppHandle) -> Result<Option<u64>> {
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(target_os = "macos")]
     {
         let engine = engine(&app);
         apple::start(app, engine).await
     }
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(target_os = "macos"))]
     {
         let _ = app;
         Err(crate::error::Error::Other(
@@ -438,11 +437,11 @@ pub async fn dictation_start(app: AppHandle) -> Result<Option<u64>> {
 /// permission prompt cancels that pending session.
 #[tauri::command]
 pub async fn dictation_stop(app: AppHandle) -> Result<()> {
-    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    #[cfg(target_os = "macos")]
     {
         apple::stop(app).await
     }
-    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[cfg(not(target_os = "macos"))]
     {
         let _ = app;
         Ok(())

--- a/src-tauri/src/dictation/speech.rs
+++ b/src-tauri/src/dictation/speech.rs
@@ -1,0 +1,274 @@
+//! The Rust side of the `SpeechAnalyzer` bridge. The Swift half is
+//! `swift/SpeechBridge.swift`, compiled by `build.rs` into a static library;
+//! this file declares its C surface and wraps it so `apple` never sees a raw
+//! pointer. Keep the two in sync.
+//!
+//! # Ownership
+//!
+//! A session's callback context is a boxed [`Events`] handed to Swift at start
+//! and freed when Swift reports the session object gone (`on_release`, fired
+//! from its `deinit`). That is after the last callback by construction — the
+//! tasks that call back hold the object alive — so no callback can observe a
+//! freed context. The one-shot replies (`prepare`, `supported`) box a channel
+//! sender the same way and free it in the single reply.
+//!
+//! Callbacks arrive on Swift's executors, never on the main thread. Marshalling
+//! onto it is the caller's job (see `apple::spawn_main`).
+
+use std::ffi::{c_char, c_void, CStr};
+use std::ptr::NonNull;
+
+use objc2_avf_audio::{AVAudioFormat, AVAudioPCMBuffer};
+use tokio::sync::oneshot;
+
+use crate::error::{Error, Result};
+
+type ReadyCallback = unsafe extern "C" fn(*mut c_void, bool, *const c_char);
+type ResultCallback = unsafe extern "C" fn(*mut c_void, *const c_char, bool);
+type ErrorCallback = unsafe extern "C" fn(*mut c_void, *const c_char);
+type ReleaseCallback = unsafe extern "C" fn(*mut c_void);
+
+extern "C" {
+    fn fletch_speech_availability(ctx: *mut c_void, done: ReadyCallback);
+    fn fletch_speech_prepare(ctx: *mut c_void, done: ReadyCallback);
+    fn fletch_speech_start(
+        format: *const AVAudioFormat,
+        ctx: *mut c_void,
+        on_result: ResultCallback,
+        on_error: ErrorCallback,
+        on_release: ReleaseCallback,
+    ) -> *mut c_void;
+    fn fletch_speech_feed(session: *mut c_void, buffer: *const AVAudioPCMBuffer);
+    fn fletch_speech_finish(session: *mut c_void);
+    fn fletch_speech_cancel(session: *mut c_void);
+}
+
+/// A string from the bridge, or `None` for a null pointer.
+///
+/// # Safety
+/// `ptr` is null or a NUL-terminated string valid for the call.
+unsafe fn message(ptr: *const c_char) -> Option<String> {
+    (!ptr.is_null()).then(|| CStr::from_ptr(ptr).to_string_lossy().into_owned())
+}
+
+type Reply = (bool, Option<String>);
+
+/// Ask the bridge a question whose answer arrives on a callback, exactly once.
+async fn ask(question: unsafe extern "C" fn(*mut c_void, ReadyCallback)) -> Reply {
+    let (tx, rx) = oneshot::channel::<Reply>();
+    let ctx = Box::into_raw(Box::new(tx));
+    unsafe { question(ctx.cast(), on_ready) };
+    rx.await
+        .unwrap_or((false, Some("Speech recognition didn't answer.".into())))
+}
+
+unsafe extern "C" fn on_ready(ctx: *mut c_void, ok: bool, why: *const c_char) {
+    // The bridge replies exactly once per request, so this is the box's only
+    // owner and the reply is where it dies.
+    let tx: Box<oneshot::Sender<Reply>> = Box::from_raw(ctx.cast());
+    let _ = tx.send((ok, message(why)));
+}
+
+/// Can the default engine run on this Mac: macOS 26+ with a model for its
+/// language. Never prompts and never downloads.
+pub async fn supported() -> bool {
+    ask(fletch_speech_availability).await.0
+}
+
+/// Settle everything a session needs that is asynchronous — locale, model
+/// assets, audio format — so [`Session::start`] can be synchronous. A missing
+/// model starts its download and is reported as an error with a readable
+/// message; the next attempt succeeds once it has landed.
+pub async fn prepare() -> Result<()> {
+    match ask(fletch_speech_prepare).await {
+        (true, _) => Ok(()),
+        (false, why) => Err(Error::Other(why.unwrap_or_else(|| {
+            "Speech recognition isn't available on this Mac.".into()
+        }))),
+    }
+}
+
+/// What a session reports back. Both arrive on arbitrary threads, `on_result`
+/// with the whole running transcript (`is_final` once, last), `on_error` at
+/// most once and then nothing more.
+pub struct Events {
+    pub on_result: Box<dyn Fn(String, bool) + Send + Sync>,
+    pub on_error: Box<dyn Fn(String) + Send + Sync>,
+}
+
+unsafe extern "C" fn on_result(ctx: *mut c_void, text: *const c_char, is_final: bool) {
+    let events = &*(ctx as *const Events);
+    (events.on_result)(message(text).unwrap_or_default(), is_final);
+}
+
+unsafe extern "C" fn on_error(ctx: *mut c_void, why: *const c_char) {
+    let events = &*(ctx as *const Events);
+    (events.on_error)(message(why).unwrap_or_else(|| "Speech recognition failed.".into()));
+}
+
+unsafe extern "C" fn on_release(ctx: *mut c_void) {
+    drop(Box::from_raw(ctx as *mut Events));
+}
+
+/// A live analyzer session: the bridge's retained handle. Copies are the same
+/// session, so `stop` can lift it out of the session slot the way it does a
+/// `Retained` handle.
+#[derive(Clone, Copy)]
+pub struct Session(NonNull<c_void>);
+
+impl Session {
+    /// Start a session for microphone buffers in `format`. Fails when
+    /// [`prepare`] hasn't succeeded yet.
+    pub fn start(format: &AVAudioFormat, events: Events) -> Result<Self> {
+        let ctx = Box::into_raw(Box::new(events));
+        let handle =
+            unsafe { fletch_speech_start(format, ctx.cast(), on_result, on_error, on_release) };
+        match NonNull::new(handle) {
+            Some(handle) => Ok(Session(handle)),
+            None => {
+                // No session was made, so no `on_release` will come: the box
+                // is ours again.
+                drop(unsafe { Box::from_raw(ctx) });
+                Err(Error::Other(
+                    "Speech recognition isn't ready yet. Try again.".into(),
+                ))
+            }
+        }
+    }
+
+    /// Real-time render thread: hand a tap buffer over and return.
+    pub fn feed(&self, buffer: &AVAudioPCMBuffer) {
+        unsafe { fletch_speech_feed(self.0.as_ptr(), buffer) }
+    }
+
+    /// No more audio. The final result follows on `on_result`.
+    pub fn finish(&self) {
+        unsafe { fletch_speech_finish(self.0.as_ptr()) }
+    }
+
+    /// Drop the session. Must be this handle's (and its copies') last use.
+    pub fn cancel(&self) {
+        unsafe { fletch_speech_cancel(self.0.as_ptr()) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    use super::*;
+    use crate::dictation::capture::{channel, pcm_buffer, standard_mono};
+
+    /// Set to a **16 kHz mono 16-bit** WAV saying "hello world" to have the
+    /// bridge transcribe real speech; otherwise a second of silence goes
+    /// through, which still exercises every entry point and the final result.
+    const WAV_ENV: &str = "FLETCH_SPEECH_TEST_WAV";
+    const RATE: f64 = 16_000.0;
+
+    /// The data chunk of a 16-bit PCM WAV, as float samples.
+    fn wav_samples(bytes: &[u8]) -> Vec<f32> {
+        let mut at = 12;
+        while at + 8 <= bytes.len() {
+            let id = &bytes[at..at + 4];
+            let len = u32::from_le_bytes(bytes[at + 4..at + 8].try_into().unwrap()) as usize;
+            let body = &bytes[at + 8..(at + 8 + len).min(bytes.len())];
+            if id == b"data" {
+                return body
+                    .chunks_exact(2)
+                    .map(|s| i16::from_le_bytes([s[0], s[1]]) as f32 / i16::MAX as f32)
+                    .collect();
+            }
+            at += 8 + len + (len & 1);
+        }
+        panic!("no data chunk in WAV");
+    }
+
+    /// The whole bridge, without a microphone: prepare, start, feed, finish,
+    /// then the final result and the release of the callback context, in that
+    /// order. Skips (rather than fails) where the engine can't run — an older
+    /// macOS, an unsupported language, or a model still downloading — since
+    /// none of those is a defect in this code.
+    #[tokio::test]
+    async fn transcribes_buffers_end_to_end() {
+        if !supported().await {
+            eprintln!("skipping: SpeechAnalyzer isn't available on this Mac");
+            return;
+        }
+        if let Err(e) = prepare().await {
+            eprintln!("skipping: {e}");
+            return;
+        }
+
+        let samples = match std::env::var(WAV_ENV) {
+            Ok(path) => wav_samples(&std::fs::read(path).unwrap()),
+            Err(_) => vec![0.0; RATE as usize],
+        };
+        let expect_speech = std::env::var(WAV_ENV).is_ok();
+
+        let (tx, rx) = mpsc::channel::<(String, bool)>();
+        let (released_tx, released_rx) = mpsc::channel::<()>();
+        struct Released(mpsc::Sender<()>);
+        impl Drop for Released {
+            fn drop(&mut self) {
+                let _ = self.0.send(());
+            }
+        }
+        let released = Released(released_tx);
+        let errors = tx.clone();
+        let session = Session::start(
+            &standard_mono(RATE).unwrap(),
+            Events {
+                on_result: Box::new(move |text, is_final| {
+                    let _ = tx.send((text, is_final));
+                }),
+                on_error: Box::new(move |why| {
+                    // Dropping `released` when Swift frees the context is the
+                    // release signal, whichever closure it travels in.
+                    let _ = &released;
+                    let _ = errors.send((format!("ERROR: {why}"), true));
+                }),
+            },
+        )
+        .unwrap();
+
+        // Tap-sized chunks, the way the mic delivers them.
+        for chunk in samples.chunks(1024) {
+            let buffer = pcm_buffer(&standard_mono(RATE).unwrap(), chunk.len() as u32).unwrap();
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    chunk.as_ptr(),
+                    channel(&buffer).unwrap().as_ptr(),
+                    chunk.len(),
+                );
+                buffer.setFrameLength(chunk.len() as u32);
+            }
+            session.feed(&buffer);
+        }
+        session.finish();
+
+        let deadline = Duration::from_secs(30);
+        let text = loop {
+            let (text, is_final) = rx.recv_timeout(deadline).expect("a final result");
+            assert!(!text.starts_with("ERROR: "), "{text}");
+            if is_final {
+                break text;
+            }
+        };
+        if expect_speech {
+            // Punctuation and casing are the analyzer's call ("Hello, world.");
+            // the words are what matter.
+            let words: String = text
+                .to_lowercase()
+                .chars()
+                .filter(|c| c.is_alphanumeric() || c.is_whitespace())
+                .collect();
+            assert!(words.contains("hello world"), "transcript was {text:?}");
+        }
+
+        session.cancel();
+        released_rx
+            .recv_timeout(Duration::from_secs(10))
+            .expect("the callback context to be released after cancel");
+    }
+}

--- a/src-tauri/swift/SpeechBridge.swift
+++ b/src-tauri/swift/SpeechBridge.swift
@@ -1,0 +1,350 @@
+// The Swift half of the default dictation engine: Apple's `SpeechAnalyzer`
+// (macOS 26+). It has no Objective-C surface — Swift concurrency and
+// `AsyncSequence` throughout — so it can't be reached from `objc2` the way the
+// rest of `dictation/apple.rs` reaches AVFoundation. `build.rs` compiles this
+// file into a static library that is linked into the Rust binary; the surface
+// is plain C (`@_cdecl`), declared on the Rust side in `dictation/speech.rs`.
+// Keep the two in sync.
+//
+// Rust owns every session: it opens the microphone, decides when a session
+// starts and stops, and holds the handle `fletch_speech_start` returns. What
+// lives here is only what has to be Swift — the analyzer and transcriber, the
+// audio-format conversion, the model-asset check, and the running-transcript
+// bookkeeping.
+//
+// Every entry point is guarded with `#available(macOS 26, *)`: the binary
+// still launches on older macOS, where dictation reports unsupported and the
+// composer hides the mic button.
+
+import AVFAudio
+import Foundation
+import Speech
+
+// MARK: - C surface
+
+/// `(ctx, ok, message)`. Exactly one reply per request; `message` is set when
+/// `ok` is false and is fit to show the user.
+public typealias FletchSpeechReady = @convention(c) (UnsafeMutableRawPointer?, Bool, UnsafePointer<CChar>?) -> Void
+/// `(ctx, text, is_final)`. `text` is the whole running transcript so far —
+/// finalized prefix plus the current volatile tail — never a delta.
+public typealias FletchSpeechResult = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?, Bool) -> Void
+/// `(ctx, message)`. The session failed; no result follows.
+public typealias FletchSpeechError = @convention(c) (UnsafeMutableRawPointer?, UnsafePointer<CChar>?) -> Void
+/// `(ctx)`. The session object is gone and no callback will follow, so Rust
+/// may free `ctx`. Fired from `deinit`, which is after every task that could
+/// call back has ended.
+public typealias FletchSpeechRelease = @convention(c) (UnsafeMutableRawPointer?) -> Void
+
+private let unsupportedOS = "Dictation needs macOS 26 or later."
+private let unsupportedLocale = "Dictation doesn't support this Mac's language."
+
+/// Can the default engine run here at all: macOS 26+, and a model for this
+/// Mac's language. Doesn't touch the model assets, so it is safe to call on
+/// every mount of the composer.
+@_cdecl("fletch_speech_availability")
+public func fletchSpeechAvailability(_ ctx: UnsafeMutableRawPointer?, _ done: FletchSpeechReady) {
+    guard #available(macOS 26, *) else {
+        reply(done, ctx, ok: false, unsupportedOS)
+        return
+    }
+    Task {
+        let ok = await Bridge.matchedLocale() != nil
+        reply(done, ctx, ok: ok, ok ? nil : unsupportedLocale)
+    }
+}
+
+/// Everything a session needs that is asynchronous: the locale, the model
+/// assets (downloaded on demand — a missing model is reported as a readable
+/// failure while the download runs in the background), and the audio format
+/// the analyzer wants. Runs before the mic opens, so `fletch_speech_start`
+/// itself can be synchronous.
+@_cdecl("fletch_speech_prepare")
+public func fletchSpeechPrepare(_ ctx: UnsafeMutableRawPointer?, _ done: FletchSpeechReady) {
+    guard #available(macOS 26, *) else {
+        reply(done, ctx, ok: false, unsupportedOS)
+        return
+    }
+    Task {
+        let failure = await Bridge.prepare()
+        reply(done, ctx, ok: failure == nil, failure)
+    }
+}
+
+/// Start a session that accepts microphone buffers in `format` (an
+/// `AVAudioFormat`, unretained). Returns a retained handle for the other
+/// entry points, or nil when `fletch_speech_prepare` hasn't succeeded yet.
+/// On nil no callback — `onRelease` included — is ever made.
+@_cdecl("fletch_speech_start")
+public func fletchSpeechStart(
+    _ format: UnsafeMutableRawPointer,
+    _ ctx: UnsafeMutableRawPointer?,
+    _ onResult: FletchSpeechResult,
+    _ onError: FletchSpeechError,
+    _ onRelease: FletchSpeechRelease
+) -> UnsafeMutableRawPointer? {
+    guard #available(macOS 26, *), let prepared = Bridge.prepared() else { return nil }
+    let input = Unmanaged<AVAudioFormat>.fromOpaque(format).takeUnretainedValue()
+    guard
+        let session = Session(
+            input: input, prepared: prepared, ctx: ctx,
+            onResult: onResult, onError: onError, onRelease: onRelease)
+    else { return nil }
+    session.run()
+    return Unmanaged.passRetained(session).toOpaque()
+}
+
+/// Hand the analyzer one tap buffer (an `AVAudioPCMBuffer`, unretained, valid
+/// only for the duration of the call). Real-time render thread.
+@_cdecl("fletch_speech_feed")
+public func fletchSpeechFeed(_ handle: UnsafeMutableRawPointer, _ buffer: UnsafeMutableRawPointer) {
+    guard #available(macOS 26, *) else { return }
+    Unmanaged<Session>.fromOpaque(handle).takeUnretainedValue()
+        .feed(Unmanaged<AVAudioPCMBuffer>.fromOpaque(buffer).takeUnretainedValue())
+}
+
+/// The user stopped: no more audio. The analyzer finalizes what it has and
+/// the results sequence ends, which is what produces the final `onResult`.
+@_cdecl("fletch_speech_finish")
+public func fletchSpeechFinish(_ handle: UnsafeMutableRawPointer) {
+    guard #available(macOS 26, *) else { return }
+    Unmanaged<Session>.fromOpaque(handle).takeUnretainedValue().finish()
+}
+
+/// Drop the session without waiting for anything. Must be the handle's last
+/// use: this balances the retain from `fletch_speech_start`. The session's own
+/// tasks keep the object alive until they wind down, and `onRelease` fires
+/// only then.
+@_cdecl("fletch_speech_cancel")
+public func fletchSpeechCancel(_ handle: UnsafeMutableRawPointer) {
+    guard #available(macOS 26, *) else { return }
+    Unmanaged<Session>.fromOpaque(handle).takeRetainedValue().cancel()
+}
+
+private func reply(
+    _ done: FletchSpeechReady, _ ctx: UnsafeMutableRawPointer?, ok: Bool, _ message: String?
+) {
+    if let message {
+        message.withCString { done(ctx, ok, $0) }
+    } else {
+        done(ctx, ok, nil)
+    }
+}
+
+// MARK: - Process-wide state
+
+/// What `prepare` settles once and every session then reads: which locale to
+/// transcribe in and which audio format the analyzer wants.
+@available(macOS 26, *)
+private enum Bridge {
+    struct Prepared {
+        let locale: Locale
+        let format: AVAudioFormat
+    }
+
+    private static let lock = NSLock()
+    private static var current: Prepared?
+    /// The running model download, if any. One at a time: a second `prepare`
+    /// while it runs reports the same download rather than starting another.
+    private static var download: Progress?
+
+    static func prepared() -> Prepared? {
+        lock.withLock { current }
+    }
+
+    static func transcriber(for locale: Locale) -> SpeechTranscriber {
+        // Volatile results are what make the composer's text move while the
+        // user is still speaking; nothing else (timing, confidence) is used.
+        SpeechTranscriber(
+            locale: locale, transcriptionOptions: [], reportingOptions: [.volatileResults],
+            attributeOptions: [])
+    }
+
+    /// The supported locale to transcribe in: this Mac's locale exactly, else
+    /// any variant of its language (a Mac set to English/Poland still dictates
+    /// in English). Nil means no model speaks the language at all.
+    static func matchedLocale() async -> Locale? {
+        let wanted = Locale.current
+        let supported = await SpeechTranscriber.supportedLocales
+        let id = wanted.identifier(.bcp47)
+        if let exact = supported.first(where: { $0.identifier(.bcp47) == id }) {
+            return exact
+        }
+        guard let language = wanted.language.languageCode else { return nil }
+        return supported.first { $0.language.languageCode == language }
+    }
+
+    /// Nil on success; otherwise a message for the user.
+    static func prepare() async -> String? {
+        guard let locale = await matchedLocale() else { return unsupportedLocale }
+        let module = transcriber(for: locale)
+        // Ask the OS to keep this locale's model resident. `false` means the
+        // per-app reservation cap is full, which only makes a later eviction
+        // possible — not a reason to refuse the session.
+        _ = try? await AssetInventory.reserve(locale: locale)
+        do {
+            // Nil means every asset the transcriber needs is already installed.
+            if let request = try await AssetInventory.assetInstallationRequest(supporting: [module]) {
+                return downloading(request, for: locale)
+            }
+        } catch {
+            return "Couldn't check the speech model: \(error.localizedDescription)"
+        }
+        guard let format = await SpeechAnalyzer.bestAvailableAudioFormat(compatibleWith: [module]) else {
+            return "Speech recognition has no usable audio format on this Mac."
+        }
+        lock.withLock { current = Prepared(locale: locale, format: format) }
+        return nil
+    }
+
+    /// Start the download unless one is running, and describe it. The session
+    /// is refused rather than made to wait: the model is hundreds of megabytes
+    /// and a mic button that hangs reads as broken.
+    private static func downloading(_ request: AssetInstallationRequest, for locale: Locale) -> String {
+        let progress = lock.withLock { () -> Progress in
+            if let running = download { return running }
+            download = request.progress
+            Task {
+                do {
+                    try await request.downloadAndInstall()
+                } catch {
+                    NSLog("dictation: speech model download failed: %@", error.localizedDescription)
+                }
+                lock.withLock { download = nil }
+            }
+            return request.progress
+        }
+        let code = locale.language.languageCode?.identifier ?? ""
+        let language = Locale.current.localizedString(forLanguageCode: code) ?? "this Mac's language"
+        let percent = Int(progress.fractionCompleted * 100)
+        return "Downloading the speech model for \(language) (\(percent)%). Try again in a moment."
+    }
+}
+
+// MARK: - One session
+
+/// One analyzer run, alive from `fletch_speech_start` to the end of its tasks.
+///
+/// Threading: `feed` runs on the render thread and touches only the converter
+/// and the stream continuation; `finalized` is touched only by the results
+/// task; `finish`/`cancel` only finish the continuation and spawn a task.
+/// Nothing here needs a lock, which is what `@unchecked Sendable` asserts.
+@available(macOS 26, *)
+private final class Session: @unchecked Sendable {
+    private let ctx: UnsafeMutableRawPointer?
+    private let onResult: FletchSpeechResult
+    private let onError: FletchSpeechError
+    private let onRelease: FletchSpeechRelease
+
+    private let transcriber: SpeechTranscriber
+    private let analyzer: SpeechAnalyzer
+    private let format: AVAudioFormat
+    private let converter: AVAudioConverter
+    private let stream: AsyncStream<AnalyzerInput>
+    private let input: AsyncStream<AnalyzerInput>.Continuation
+    /// Text the transcriber has committed to, in order. Volatile results are
+    /// appended to this for display but never stored.
+    private var finalized = ""
+
+    init?(
+        input: AVAudioFormat, prepared: Bridge.Prepared, ctx: UnsafeMutableRawPointer?,
+        onResult: FletchSpeechResult, onError: FletchSpeechError, onRelease: FletchSpeechRelease
+    ) {
+        guard let converter = AVAudioConverter(from: input, to: prepared.format) else { return nil }
+        // No priming: the first buffer should come out as soon as it goes in,
+        // not after the converter has buffered a filter's worth of latency.
+        converter.primeMethod = .none
+        self.converter = converter
+        self.format = prepared.format
+        self.ctx = ctx
+        self.onResult = onResult
+        self.onError = onError
+        self.onRelease = onRelease
+        transcriber = Bridge.transcriber(for: prepared.locale)
+        analyzer = SpeechAnalyzer(modules: [transcriber])
+        (stream, self.input) = AsyncStream<AnalyzerInput>.makeStream()
+    }
+
+    deinit {
+        onRelease(ctx)
+    }
+
+    func run() {
+        // Subscribe to results before starting the analyzer so nothing is
+        // missed. The loop ends when the analyzer finishes — after `finish`'s
+        // finalization or `cancel` — and its normal end is the final result.
+        Task { [self] in
+            do {
+                for try await result in transcriber.results {
+                    let text = String(result.text.characters)
+                    if result.isFinal {
+                        finalized += text
+                        report(finalized, final: false)
+                    } else {
+                        report(finalized + text, final: false)
+                    }
+                }
+                report(finalized, final: true)
+            } catch {
+                fail(error)
+            }
+        }
+        Task { [self] in
+            do {
+                try await analyzer.start(inputSequence: stream)
+            } catch {
+                fail(error)
+            }
+        }
+    }
+
+    /// Convert one tap buffer to the analyzer's format and queue it. The
+    /// conversion doubles as the copy: the engine reuses the tap's buffer
+    /// once the tap returns, and the converted buffer is a fresh allocation.
+    func feed(_ buffer: AVAudioPCMBuffer) {
+        let ratio = format.sampleRate / buffer.format.sampleRate
+        let capacity = AVAudioFrameCount((Double(buffer.frameLength) * ratio).rounded(.up)) + 1
+        guard let out = AVAudioPCMBuffer(pcmFormat: format, frameCapacity: capacity) else { return }
+        var consumed = false
+        var error: NSError?
+        let status = converter.convert(to: out, error: &error) { _, inputStatus in
+            // One buffer in per call; `noDataNow` (not `endOfStream`) keeps
+            // the converter's resampling state alive for the next one.
+            if consumed {
+                inputStatus.pointee = .noDataNow
+                return nil
+            }
+            consumed = true
+            inputStatus.pointee = .haveData
+            return buffer
+        }
+        if status != .error, out.frameLength > 0 {
+            input.yield(AnalyzerInput(buffer: out))
+        }
+    }
+
+    func finish() {
+        input.finish()
+        Task { [self] in
+            do {
+                try await analyzer.finalizeAndFinishThroughEndOfInput()
+            } catch {
+                fail(error)
+            }
+        }
+    }
+
+    func cancel() {
+        input.finish()
+        Task { [self] in
+            await analyzer.cancelAndFinishNow()
+        }
+    }
+
+    private func report(_ text: String, final: Bool) {
+        text.withCString { onResult(ctx, $0, final) }
+    }
+
+    private func fail(_ error: Error) {
+        error.localizedDescription.withCString { onError(ctx, $0) }
+    }
+}

--- a/src/api/types/dictation.ts
+++ b/src/api/types/dictation.ts
@@ -1,30 +1,33 @@
-// Voice dictation: the composer's mic button, backed by the platform's native
-// speech recognizer (Apple's SFSpeechRecognizer on macOS/iOS). Mirrors the Rust
-// `dictation` module's serde shapes — keep the two in sync.
+// Voice dictation: the composer's mic button, backed by Apple's on-device
+// SpeechAnalyzer on macOS 26+ (or the local whisper engine the user can opt
+// into). Mirrors the Rust `dictation` module's serde shapes — keep the two in
+// sync.
 
-/** Apple's authorization states for the mic and for speech recognition.
- *  `not_determined` means the OS hasn't asked the user yet; the first
- *  `dictation_start` triggers the prompt. `restricted` is a parental-control /
- *  MDM lock the user can't lift from the app. */
+/** Apple's authorization states for the microphone. `not_determined` means the
+ *  OS hasn't asked the user yet; the first `dictation_start` triggers the
+ *  prompt. `restricted` is a parental-control / MDM lock the user can't lift
+ *  from the app. */
 export type DictationAuthorization = "not_determined" | "authorized" | "denied" | "restricted";
 
-/** Which recognizer a session would use: the platform's (`apple`) or the local
- *  whisper.cpp model the user can opt into in Settings (`whisper`). The backend
- *  picks per session — `whisper` only once its model is fully downloaded — so
- *  this is what the engine *would* be, not just what the setting says. */
+/** Which recognizer a session would use: Apple's `SpeechAnalyzer` (`apple`) or
+ *  the local whisper.cpp model the user can opt into in Settings (`whisper`).
+ *  The backend picks per session — `whisper` only once its model is fully
+ *  downloaded — so this is what the engine *would* be, not just what the
+ *  setting says. */
 export type DictationEngine = "apple" | "whisper";
 
 export interface DictationAvailability {
-  /** False on platforms with no native recognizer (Linux, Windows). The
-   *  composer hides the mic button entirely when this is false. */
+  /** False where no engine can run: Linux and Windows, and a Mac below
+   *  macOS 26 (or with a language Apple has no model for) when the local
+   *  engine isn't chosen. The composer hides the mic button when this is
+   *  false. */
   supported: boolean;
-  /** Meaningless when `engine` is `whisper`: that engine never calls Apple's
-   *  recognizer, so it neither prompts for this grant nor is blocked by it. */
+  /** Vestigial: no engine asks for the Speech Recognition grant any more, so
+   *  this is always `not_determined`. Kept so the wire shape is unchanged. */
   speech: DictationAuthorization;
   microphone: DictationAuthorization;
-  /** The recognizer for the current locale can run without sending audio to
-   *  Apple. When false, recognition uses Apple's servers and sessions are
-   *  capped at roughly one minute. Always true for `whisper`. */
+  /** Always true: both engines transcribe on this machine and no audio leaves
+   *  it. */
   on_device: boolean;
   engine: DictationEngine;
 }

--- a/src/components/Composer/dictation/DictationButton.tsx
+++ b/src/components/Composer/dictation/DictationButton.tsx
@@ -5,13 +5,9 @@ import { Spinner } from "@/components/ui/Spinner";
 
 /** What the user has to do outside the app. The backend answers a blocked start
  *  with the same guidance, so the tooltip reads identically whether we knew up
- *  front or found out on the attempt. */
-const SETTINGS_HINT =
-  "Enable Microphone and Speech Recognition for Fletch in System Settings → Privacy & Security";
-
-/** The local engine never calls Apple's recognizer, so don't send the user
- *  looking for a permission it doesn't use. */
-const MIC_HINT = "Enable Microphone for Fletch in System Settings → Privacy & Security";
+ *  front or found out on the attempt. Both engines run on-device and need the
+ *  microphone alone — neither asks for the Speech Recognition grant. */
+const SETTINGS_HINT = "Enable Microphone for Fletch in System Settings → Privacy & Security";
 
 /** The local engine ends the session itself once the user stops talking, so the
  *  tooltip has to say so — a mic that stops on its own otherwise reads as a bug,
@@ -51,12 +47,10 @@ export function DictationButton({
   // only ever error is worse than no mic (Linux/Windows have none).
   if (!availability?.supported) return null;
 
-  // The speech grant gates only Apple's recognizer; the local engine is blocked
-  // by the microphone alone — and it's the only one that stops itself.
+  // The microphone is the only grant either engine needs. The local engine is
+  // the one that stops itself.
   const isLocal = availability.engine === "whisper";
-  const blocked =
-    BLOCKED.includes(availability.microphone) ||
-    (!isLocal && BLOCKED.includes(availability.speech));
+  const blocked = BLOCKED.includes(availability.microphone);
   const label = transcribing ? "Transcribing…" : listening ? "Stop dictation" : "Dictate";
 
   // The last failure outranks the standing permission hint, which outranks
@@ -65,7 +59,7 @@ export function DictationButton({
   // failed start is what surfaces the reason.
   function tip() {
     if (error) return error;
-    if (blocked) return isLocal ? MIC_HINT : SETTINGS_HINT;
+    if (blocked) return SETTINGS_HINT;
     if (listening && isLocal) return AUTO_STOP_HINT;
     return label;
   }


### PR DESCRIPTION
## Summary

Swaps the default dictation engine on macOS from `SFSpeechRecognizer` to Apple's on-device `SpeechAnalyzer` (macOS 26+), per the implementer hand-off. The command surface, events, session-id contract and whisper opt-in are unchanged; only the `Sink::Speech` arm in `apple.rs` is new.

## What changed

- **`src-tauri/swift/SpeechBridge.swift`** (new): `SpeechAnalyzer` + `SpeechTranscriber`, locale match (exact, then same language), on-demand model download via `AssetInventory` (a missing model rejects `dictation_start` with "Downloading the speech model for English (12%). Try again in a moment." and downloads in the background), `AVAudioConverter` to the analyzer's format inside `feed`, and the finalized-prefix + volatile-tail running transcript. Six `@_cdecl` functions; every entry point guarded by `#available(macOS 26, *)`.
- **`src-tauri/src/dictation/speech.rs`** (new): the C surface and safe wrappers. Callback contexts are boxed `Events` freed on a release callback fired from the Swift object's `deinit`, after the last callback by construction.
- **`apple.rs`**: mic, session, `claim`/`teardown`, `STOP_PENDING`, and the flush deadline are untouched. Callbacks hop to the main thread via `run_on_main_thread` with the generation stamped. `stop` calls `finish` (→ `finalizeAndFinishThroughEndOfInput`), teardown calls `cancel` (→ `cancelAndFinishNow`).
- **No Speech Recognition grant.** Verified: a throwaway app bundle with a fresh bundle id and no `NSSpeechRecognitionUsageDescription` transcribed with `SFSpeechRecognizer.authorizationStatus()` still `notDetermined` before and after, no prompt. The speech prompt, the plist key and `objc2-speech` are removed. `Availability.speech` stays in the wire shape, documented as vestigial.
- **`dictation_availability`**: `supported` is false below macOS 26 or for a language with no model, unless whisper is chosen; `on_device` is always true.
- **`build.rs`**: compiles the Swift file with `swiftc -emit-library -static` per target arch (arm64 and x86_64), fails early with an install message when `xcrun`/the macOS 26 SDK is missing, links the SDK's `usr/lib/swift` stubs, and adds the `/usr/lib/swift` rpath (the concurrency runtime is `@rpath`-referenced; without it the binary aborts at load).
- **iOS cfg removed** from the dictation module. Nothing built it (no CI target; the mobile crate doesn't depend on this one), and keeping it would have meant an untestable iOS Swift build.
- **Frontend**: the button blocks on the microphone grant only; doc comments in `types/dictation.ts` updated. `useDictation.ts` / `spliceTranscript.ts` untouched.
- **`docs/dictation.md`**: platform support (macOS 26+), one grant, "The default engine", "Building the Swift bridge"; the servers section is gone.

## Also: the whisper.cpp build hang

Cargo builds have intermittently hung for 20+ minutes with no output. Root cause (confirmed with `sample`): ggml's cmake ARM feature detection compiles probes with `-mcpu=native+sve` / `+sme` and *runs* them. They fault with SIGILL by design on hardware without the feature; under a sandbox that stalls macOS crash handling, the probe sits suspended at the faulting instruction forever. The new repo-root **`.cargo/config.toml`** pre-answers those two probes via `GGML_MACHINE_SUPPORTS_sve` / `_sme`, which whisper-rs-sys forwards to cmake as defines and `check_cxx_source_runs` then skips. The configure log now runs only the compile-only `nosve`/`nosme` checks; a full build finished in 74 s.

## Verification

- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test` green (1589 passed).
- New `speech::tests::transcribes_buffers_end_to_end` drives the bridge from Rust without a mic: with `FLETCH_SPEECH_TEST_WAV` set to a 16 kHz WAV it transcribed "Hello, world. This is a dictation test."; without it, a second of silence still yields the final result and the release callback.
- `tsc --noEmit` and biome clean.
- x86_64 slice of the Swift library compiles from the same file.

## Not verified here

- A live microphone session in the running app and the below-macOS-26 launch (this machine is on macOS 27 with no mic in the sandbox). The Rust test covers the same `feed`/`finish`/callback path the tap uses.
- The Intel release build end to end (only the x86_64 Swift compile was exercised).

Out of scope, noted for later: whisper.cpp still builds with `-mcpu=native` of whichever machine compiles it, so release binaries are tuned to the CI runner's CPU.