### PR TITLE
feat(dictation): emit a microphone level while a session listens

### DIFF
--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -28,9 +28,10 @@ The flow, end to end:
 | Button | `src/components/Composer/dictation/DictationButton.tsx` |
 | Session state | `src/components/Composer/dictation/useDictation.ts` |
 | IPC | `src/api/domains/dictation.ts` → `dictation_availability` / `dictation_start` / `dictation_stop` |
-| Events | `src/api/events.ts` — `dictation:transcript`, `dictation:state` |
+| Events | `src/api/events.ts` — `dictation:transcript`, `dictation:state`, `dictation:level` |
 | Commands + contract | `src-tauri/src/dictation/mod.rs` |
 | Microphone (both engines) | `src-tauri/src/dictation/apple.rs` |
+| Level meter (both engines) | `src-tauri/src/dictation/level.rs` |
 | Default engine | `src-tauri/src/dictation/speech.rs` (Rust side), `src-tauri/swift/SpeechBridge.swift` (Swift side) |
 | Local engine | `src-tauri/src/dictation/capture.rs`, `src-tauri/src/dictation/whisper/` |
 
@@ -127,6 +128,32 @@ unchanged: hand the buffer over and return. The conversion from the mic's
 format to the analyzer's (an `AVAudioConverter`, which also serves as the copy
 the tap's reused buffer needs) happens inside the bridge's `feed`, on the render
 thread — the same thing Apple's own `SpeechAnalyzer` sample does.
+
+## The level meter
+
+While the mic is open the composer shows level bars, fed by `dictation:level`:
+a value from 0 (silence) to 1 (loud, close speech), stamped with the session
+id like every other dictation event, about every 90 ms (`level::LEVEL_POLL`).
+It is display only — nothing about the session depends on it — and it stops
+when the mic closes, so on Apple's engine the last few events precede the
+flushed final transcript and `stopped`.
+
+Both engines feed the same `level::Meter`, which is one atomic holding the most
+recent tap buffer's RMS. The local engine already computes that RMS in the tap
+for the [silence gate](#hands-free-auto-stop) and hands it over; Apple's path,
+which otherwise passes the buffer to the bridge untouched, measures it in the
+same callback. The tap does nothing else there — one pass over the samples and
+one relaxed store — and a tokio task off the render thread samples the atomic
+and emits. Should a microphone ever deliver something other than deinterleaved
+float32, the meter reads nothing and reports silence rather than read the wrong
+memory (the local engine refuses such a format outright; Apple's engine
+converts it in the bridge and works regardless).
+
+The mapping to 0–1 is linear in dBFS between −50 dB and −15 dB
+(`level::normalize`): a quiet room on a laptop mic sits under the floor,
+conversational speech lands mid-range, and only close, loud speech pins the
+bars. That range is a display choice and is the one thing to tune if the bars
+read too shy or too hot on common hardware.
 
 ## Building the Swift bridge
 

--- a/src-tauri/src/dictation/apple.rs
+++ b/src-tauri/src/dictation/apple.rs
@@ -32,6 +32,7 @@
 use std::cell::{Cell, RefCell};
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 
 use block2::RcBlock;
@@ -42,6 +43,7 @@ use objc2_avf_audio::{
 };
 use tauri::AppHandle;
 
+use super::level::{self, Meter};
 use super::{emit_state, emit_transcript, speech, Auth, Availability, Engine, State};
 use crate::error::{Error, Result};
 
@@ -119,6 +121,9 @@ struct Session {
     audio: Retained<AVAudioEngine>,
     input: Retained<AVAudioInputNode>,
     sink: Sink,
+    /// The mic's loudness, fed by the tap whichever sink it has, and read by
+    /// the `dictation:level` emitter until the mic closes.
+    meter: Arc<Meter>,
     /// Kept alive for the tap's lifetime. `installTapOnBus` is documented to
     /// take ownership, but holding our own reference costs nothing and takes
     /// a use-after-free off the table.
@@ -204,6 +209,7 @@ fn teardown(session: Session) {
         session.input.removeTapOnBus(BUS);
     }
     session.sink.cancel();
+    session.meter.close();
     ACTIVE.store(false, Ordering::SeqCst);
 }
 
@@ -347,12 +353,17 @@ pub async fn start(app: AppHandle, engine: Engine) -> Result<Option<u64>> {
             return Err(e);
         }
     };
+    let Some((generation, meter)) = started else {
+        return Ok(None);
+    };
+    // The level bars run for every session; the meter closes with the mic.
+    level::watch(app.clone(), generation, meter);
     // Hands-free stop is the local engine's alone: Apple's analyzer decides
     // for itself when an utterance has ended, and we have no PCM to measure.
-    if let (Some(generation), Engine::Whisper) = (started, engine) {
+    if engine == Engine::Whisper {
         watch_for_silence(app, generation);
     }
-    Ok(started)
+    Ok(Some(generation))
 }
 
 /// Poll a local-engine session's speech tracker and stop it once the user has
@@ -384,7 +395,10 @@ fn watch_for_silence(app: AppHandle, generation: u64) {
     });
 }
 
-fn begin(app: AppHandle, engine: Engine) -> Result<Option<u64>> {
+/// `Some((generation, meter))` for a session that came up: its id, and the
+/// level meter its tap feeds, handed out so the emitter can be started off the
+/// main thread.
+fn begin(app: AppHandle, engine: Engine) -> Result<Option<(u64, Arc<Meter>)>> {
     // The user asked to stop while the permission prompt was up. Honour it
     // instead of opening the mic behind their back. No state event: the
     // session never came up, so there is nothing to close out — the `None`
@@ -394,7 +408,7 @@ fn begin(app: AppHandle, engine: Engine) -> Result<Option<u64>> {
         return Ok(None);
     }
     match build_session(app, engine) {
-        Ok(generation) => Ok(Some(generation)),
+        Ok(started) => Ok(Some(started)),
         Err(e) => {
             // `build_session` unwinds whatever it installed, so releasing the
             // claim here is what lets the user retry. No state event — the
@@ -409,14 +423,15 @@ fn begin(app: AppHandle, engine: Engine) -> Result<Option<u64>> {
 /// keys events on. Main thread; permissions are already granted, which matters
 /// because reading `inputNode`'s format before that yields a zero-rate format
 /// and installing a tap with it throws in ObjC.
-fn build_session(app: AppHandle, engine: Engine) -> Result<u64> {
+fn build_session(app: AppHandle, engine: Engine) -> Result<(u64, Arc<Meter>)> {
     let (audio, input, format) = open_microphone()?;
     let generation = NEXT_GENERATION.fetch_add(1, Ordering::SeqCst);
 
+    let meter = Meter::new(&format);
     let (sink, tap) = match engine {
-        Engine::Apple => speech_sink(&app, generation, &format)?,
+        Engine::Apple => speech_sink(&app, generation, &format, meter.clone())?,
         Engine::Whisper => {
-            let (pcm, tap) = super::capture::sink(&format)?;
+            let (pcm, tap) = super::capture::sink(&format, meter.clone())?;
             (Sink::Pcm(pcm), tap)
         }
     };
@@ -446,12 +461,13 @@ fn build_session(app: AppHandle, engine: Engine) -> Result<u64> {
         audio,
         input,
         sink,
+        meter: meter.clone(),
         _tap: tap,
         stopping: false,
     }));
     // Audio is flowing. Only now can the frontend show a live mic.
     emit_state(&app, generation, State::Listening, None);
-    Ok(generation)
+    Ok((generation, meter))
 }
 
 /// The input node and the format its tap will deliver.
@@ -477,7 +493,12 @@ fn open_microphone() -> Result<(
 
 /// Apple's analyzer, plus the tap that streams the mic straight into it. The
 /// format conversion the analyzer needs happens in the bridge, not here.
-fn speech_sink(app: &AppHandle, generation: u64, format: &AVAudioFormat) -> Result<(Sink, Tap)> {
+fn speech_sink(
+    app: &AppHandle,
+    generation: u64,
+    format: &AVAudioFormat,
+    meter: Arc<Meter>,
+) -> Result<(Sink, Tap)> {
     let session = speech::Session::start(
         format,
         speech::Events {
@@ -487,9 +508,12 @@ fn speech_sink(app: &AppHandle, generation: u64, format: &AVAudioFormat) -> Resu
     )?;
     let tap = RcBlock::new(
         move |buffer: NonNull<AVAudioPCMBuffer>, _when: NonNull<AVAudioTime>| {
-            // Real-time audio thread. Handing the buffer over is the only
-            // thing that may happen here — no session state, no emit.
-            session.feed(unsafe { buffer.as_ref() });
+            // Real-time audio thread. Measuring the buffer (one pass, one
+            // atomic store) and handing it over are the only things that may
+            // happen here — no session state, no emit.
+            let buffer = unsafe { buffer.as_ref() };
+            meter.record_buffer(buffer);
+            session.feed(buffer);
         },
     );
     Ok((Sink::Speech(session), tap))
@@ -561,9 +585,10 @@ async fn stop_session(app: AppHandle, expect: Option<u64>) -> Result<()> {
                 session.audio.clone(),
                 session.input.clone(),
                 session.sink.clone(),
+                session.meter.clone(),
             ))
         });
-        let Some((generation, audio, input, sink)) = live else {
+        let Some((generation, audio, input, sink, meter)) = live else {
             // No session of ours — but a claimed `ACTIVE` with an empty
             // `SESSION` means a `start` is still sitting on the permission
             // prompt, so leave the request for `begin` to consume. Genuinely
@@ -581,6 +606,9 @@ async fn stop_session(app: AppHandle, expect: Option<u64>) -> Result<()> {
             audio.stop();
             input.removeTapOnBus(BUS);
         }
+        // No more buffers, so no more levels — even while Apple's flush keeps
+        // the session alive for its final result.
+        meter.close();
         match sink {
             Sink::Speech(session) => {
                 // Deliberately not `cancel`: ending the input is what makes

--- a/src-tauri/src/dictation/capture.rs
+++ b/src-tauri/src/dictation/capture.rs
@@ -29,6 +29,7 @@ use objc2_avf_audio::{
 use parking_lot::Mutex;
 
 use super::apple::Tap;
+use super::level::Meter;
 use super::whisper::engine;
 use crate::error::{Error, Result};
 
@@ -154,8 +155,9 @@ impl Pcm {
     }
 }
 
-/// Build the accumulator and the tap block that fills it.
-pub(super) fn sink(format: &AVAudioFormat) -> Result<(Arc<Pcm>, Tap)> {
+/// Build the accumulator and the tap block that fills it. The tap also feeds
+/// `meter`, the session's level indicator, with the RMS it computes anyway.
+pub(super) fn sink(format: &AVAudioFormat, meter: Arc<Meter>) -> Result<(Arc<Pcm>, Tap)> {
     // The input node hands out deinterleaved float32 on every OS that has
     // shipped. Reading a buffer in any other layout would be reading the wrong
     // memory, so refuse the session instead of guessing at it.
@@ -192,31 +194,32 @@ pub(super) fn sink(format: &AVAudioFormat) -> Result<(Arc<Pcm>, Tap)> {
     let tap_pcm = pcm.clone();
     let tap = RcBlock::new(
         move |buffer: NonNull<AVAudioPCMBuffer>, _when: NonNull<AVAudioTime>| {
-            append_mono(&tap_pcm, unsafe { buffer.as_ref() });
+            if let Some(rms) = append_mono(&tap_pcm, unsafe { buffer.as_ref() }) {
+                meter.record(rms);
+            }
         },
     );
     Ok((pcm, tap))
 }
 
 /// Real-time audio thread: average the channels down, note how loud the result
-/// was, and return. The only other lock holder is the one-shot take in
+/// was, and return it. The only other lock holder is the one-shot take in
 /// [`transcribe`], so `try_lock` all but never fails — and dropping one buffer
-/// beats blocking the render thread if it ever does.
+/// beats blocking the render thread if it ever does. `None` when the buffer
+/// was dropped, whichever reason.
 ///
-/// The RMS rides along in the same pass because the silence monitor needs it
-/// and the samples are already in registers here.
-fn append_mono(pcm: &Pcm, buffer: &AVAudioPCMBuffer) {
+/// The RMS rides along in the same pass because the silence monitor (and the
+/// level meter) need it and the samples are already in registers here.
+fn append_mono(pcm: &Pcm, buffer: &AVAudioPCMBuffer) -> Option<f32> {
     let frames = unsafe { buffer.frameLength() } as usize;
     let channels = unsafe { buffer.format().channelCount() } as usize;
     let data = unsafe { buffer.floatChannelData() };
     if data.is_null() || frames == 0 || channels == 0 {
-        return;
+        return None;
     }
-    let Some(mut samples) = pcm.samples.try_lock() else {
-        return;
-    };
+    let mut samples = pcm.samples.try_lock()?;
     if samples.len() + frames > pcm.limit {
-        return;
+        return None;
     }
     let mut squares = 0.0f64;
     for frame in 0..frames {
@@ -230,7 +233,9 @@ fn append_mono(pcm: &Pcm, buffer: &AVAudioPCMBuffer) {
         squares += f64::from(mono) * f64::from(mono);
         samples.push(mono);
     }
-    pcm.track_speech(((squares / frames as f64).sqrt()) as f32);
+    let rms = ((squares / frames as f64).sqrt()) as f32;
+    pcm.track_speech(rms);
+    Some(rms)
 }
 
 /// Take the session's audio and transcribe it with `model`. Consumes the

--- a/src-tauri/src/dictation/level.rs
+++ b/src-tauri/src/dictation/level.rs
@@ -1,0 +1,165 @@
+//! How loud the microphone is right now, for the composer's listening
+//! indicator (the level bars in the primary control).
+//!
+//! The tap on the render thread folds each buffer's RMS into a [`Meter`] — one
+//! atomic store, nothing else — and a task off that thread samples it every
+//! [`LEVEL_POLL`] and emits `dictation:level`. Both engines share the meter:
+//! the local engine already computes the RMS for its silence gate and hands it
+//! over; Apple's path reads the buffer once more on the way to the bridge. The
+//! meter is a display value only — nothing about the session (its auto-stop,
+//! its transcript) depends on it.
+
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use objc2_avf_audio::{AVAudioCommonFormat, AVAudioFormat, AVAudioPCMBuffer};
+use tauri::AppHandle;
+
+/// How often a level is emitted while the mic is open. Matches the lerp tick of
+/// the bars that display it; anything faster is wasted IPC.
+pub(super) const LEVEL_POLL: Duration = Duration::from_millis(90);
+
+/// The dBFS range the bars span. Below the floor is silence (a quiet room on a
+/// laptop mic sits around −60 dB); the ceiling is loud, close speech. Linear in
+/// dB between the two, because that is how loudness reads.
+const FLOOR_DB: f32 = -50.0;
+const CEIL_DB: f32 = -15.0;
+
+/// The latest buffer's loudness, written by the render thread and read by the
+/// emitter task.
+pub(super) struct Meter {
+    /// RMS of the most recent buffer, as `f32` bits.
+    rms: AtomicU32,
+    /// Whether the tap's buffers can be read as deinterleaved float32 — the
+    /// layout every shipped input node delivers. A meter on any other layout
+    /// simply reports silence rather than read the wrong memory.
+    readable: bool,
+    /// Set when the mic is closed, so the emitter stops.
+    closed: AtomicBool,
+}
+
+impl Meter {
+    pub(super) fn new(format: &AVAudioFormat) -> Arc<Self> {
+        let readable = unsafe { format.commonFormat() } == AVAudioCommonFormat::PCMFormatFloat32
+            && !unsafe { format.isInterleaved() };
+        Arc::new(Self {
+            rms: AtomicU32::new(0.0f32.to_bits()),
+            readable,
+            closed: AtomicBool::new(false),
+        })
+    }
+
+    /// Render thread: note one buffer's RMS.
+    pub(super) fn record(&self, rms: f32) {
+        self.rms.store(rms.to_bits(), Ordering::Relaxed);
+    }
+
+    /// Render thread: measure one buffer and note it. For the path that doesn't
+    /// otherwise read the samples (Apple's analyzer takes the buffer whole).
+    pub(super) fn record_buffer(&self, buffer: &AVAudioPCMBuffer) {
+        if !self.readable {
+            return;
+        }
+        if let Some(rms) = buffer_rms(buffer) {
+            self.record(rms);
+        }
+    }
+
+    /// The current level, 0 (silence) to 1 (loud speech).
+    pub(super) fn level(&self) -> f32 {
+        normalize(f32::from_bits(self.rms.load(Ordering::Relaxed)))
+    }
+
+    pub(super) fn close(&self) {
+        self.closed.store(true, Ordering::Relaxed);
+    }
+
+    fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::Relaxed)
+    }
+}
+
+/// RMS of a deinterleaved float32 buffer, channels averaged to mono first.
+/// `None` for an empty buffer. Same pass `capture::append_mono` makes, minus the
+/// copy.
+pub(super) fn buffer_rms(buffer: &AVAudioPCMBuffer) -> Option<f32> {
+    let frames = unsafe { buffer.frameLength() } as usize;
+    let channels = unsafe { buffer.format().channelCount() } as usize;
+    let data = unsafe { buffer.floatChannelData() };
+    if data.is_null() || frames == 0 || channels == 0 {
+        return None;
+    }
+    let mut squares = 0.0f64;
+    for frame in 0..frames {
+        let mut sum = 0.0f32;
+        for channel in 0..channels {
+            sum += unsafe { *(*data.add(channel)).as_ptr().add(frame) };
+        }
+        let mono = sum / channels as f32;
+        squares += f64::from(mono) * f64::from(mono);
+    }
+    Some((squares / frames as f64).sqrt() as f32)
+}
+
+/// Map a linear RMS onto the bars' 0–1 range: dBFS, linear between
+/// [`FLOOR_DB`] and [`CEIL_DB`], clamped.
+pub(super) fn normalize(rms: f32) -> f32 {
+    if rms <= 0.0 {
+        return 0.0;
+    }
+    let db = 20.0 * rms.log10();
+    ((db - FLOOR_DB) / (CEIL_DB - FLOOR_DB)).clamp(0.0, 1.0)
+}
+
+/// Emit the level every [`LEVEL_POLL`] until the meter is closed. Emitted on
+/// every tick rather than on change, so a consumer that keeps a short history
+/// of samples (a scrolling waveform) sees steady time.
+pub(super) fn watch(app: AppHandle, session: u64, meter: Arc<Meter>) {
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(LEVEL_POLL).await;
+            if meter.is_closed() {
+                return;
+            }
+            super::emit_level(&app, session, meter.level());
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn from_db(db: f32) -> f32 {
+        10f32.powf(db / 20.0)
+    }
+
+    #[test]
+    fn silence_and_the_floor_are_zero() {
+        assert_eq!(normalize(0.0), 0.0);
+        assert_eq!(normalize(-1.0), 0.0);
+        assert_eq!(normalize(from_db(FLOOR_DB)), 0.0);
+        assert_eq!(normalize(from_db(FLOOR_DB - 20.0)), 0.0);
+    }
+
+    #[test]
+    fn the_ceiling_and_above_are_one() {
+        assert!((normalize(from_db(CEIL_DB)) - 1.0).abs() < 1e-5);
+        assert_eq!(normalize(1.0), 1.0);
+    }
+
+    #[test]
+    fn linear_in_decibels_between() {
+        let mid = (FLOOR_DB + CEIL_DB) / 2.0;
+        assert!((normalize(from_db(mid)) - 0.5).abs() < 1e-5);
+        let quarter = FLOOR_DB + (CEIL_DB - FLOOR_DB) / 4.0;
+        assert!((normalize(from_db(quarter)) - 0.25).abs() < 1e-5);
+    }
+
+    #[test]
+    fn louder_is_never_lower() {
+        let levels: Vec<f32> = (0..100).map(|i| normalize(i as f32 / 100.0)).collect();
+        assert!(levels.windows(2).all(|w| w[0] <= w[1]));
+    }
+}

--- a/src-tauri/src/dictation/mod.rs
+++ b/src-tauri/src/dictation/mod.rs
@@ -36,6 +36,9 @@ mod apple;
 // The local engine's sink for the shared mic tap.
 #[cfg(target_os = "macos")]
 mod capture;
+// The mic's loudness, for the composer's level bars.
+#[cfg(target_os = "macos")]
+mod level;
 // The default engine's `SpeechAnalyzer` bridge (Rust side of
 // `swift/SpeechBridge.swift`).
 #[cfg(target_os = "macos")]
@@ -151,12 +154,29 @@ struct StatePayload {
     error: Option<String>,
 }
 
+/// How loud the mic is right now. Display only: the composer's level bars.
+/// Emitted every `level::LEVEL_POLL` from the moment audio flows until the mic
+/// closes, then never again for that session.
+#[cfg(target_os = "macos")]
+#[derive(Clone, Serialize)]
+struct LevelPayload {
+    /// Same id as on [`TranscriptPayload`].
+    session: u64,
+    /// 0 (silence) to 1 (loud speech) — see `level::normalize`.
+    level: f32,
+}
+
 /// Emit one event, logging (not propagating) failure — same posture as
 /// `supervisor::events`: no event is delivery-guaranteed.
 fn emit<T: Serialize + Clone>(app: &AppHandle, event: &str, payload: T) {
     if let Err(e) = app.emit(event, payload) {
         tracing::warn!(error = %e, event, "emit failed");
     }
+}
+
+#[cfg(target_os = "macos")]
+fn emit_level(app: &AppHandle, session: u64, level: f32) {
+    emit(app, "dictation:level", LevelPayload { session, level });
 }
 
 #[cfg(target_os = "macos")]

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -13,6 +13,7 @@ import type {
   ShellOutputEvent,
 } from "./types/agent";
 import type {
+  DictationLevelEvent,
   DictationModelProgressEvent,
   DictationStateEvent,
   DictationTranscriptEvent,
@@ -194,6 +195,13 @@ export function onDictationTranscript(
  *  unmounted mid-session leaves its terminal event to land on the next one). */
 export function onDictationState(cb: (e: DictationStateEvent) => void): Promise<UnlistenFn> {
   return listen<DictationStateEvent>("dictation:state", (event) => cb(event.payload));
+}
+
+/** The microphone's loudness while a dictation session listens, about every
+ *  90 ms (see `DictationLevelEvent`). App-wide and session-stamped like the
+ *  other dictation events. */
+export function onDictationLevel(cb: (e: DictationLevelEvent) => void): Promise<UnlistenFn> {
+  return listen<DictationLevelEvent>("dictation:level", (event) => cb(event.payload));
 }
 
 /** Progress of the local engine's model download, ending in `installed` or

--- a/src/api/types/dictation.ts
+++ b/src/api/types/dictation.ts
@@ -50,6 +50,18 @@ export interface DictationTranscriptEvent {
   is_final: boolean;
 }
 
+/** Payload of the `dictation:level` event: how loud the microphone is right
+ *  now, from 0 (silence) to 1 (loud, close speech), linear in decibels between
+ *  the two. Emitted about every 90 ms from the moment audio flows until the mic
+ *  closes — so it stops at `dictationStop`, before the session's final
+ *  transcript and terminal state arrive. Display only, for the composer's
+ *  level bars; nothing about the session depends on it. Session-stamped like
+ *  every other dictation event, and to be matched the same way. */
+export interface DictationLevelEvent {
+  session: DictationSessionId;
+  level: number;
+}
+
 /** `transcribing` only happens on the `whisper` engine: the mic is closed but
  *  the model is still running, so the session is alive and its final transcript
  *  is still coming. It always precedes a terminal `stopped` or `error`. */


### PR DESCRIPTION
## Summary

Groundwork for the composer's new primary control (mic / send / stop pill): while a dictation session listens, the backend now emits a microphone level for the pill's level bars.

- New `dictation::level` module: a `Meter` holding the latest tap buffer's RMS in one atomic, a dBFS normalisation to 0..1 (linear between −50 and −15 dB), and a tokio task that emits `dictation:level` every 90 ms until the mic closes.
- Both engines feed the same meter. The local engine hands over the RMS it already computes for the silence gate; Apple's path measures the buffer in the tap on its way to the Swift bridge. The tap does one pass and one relaxed store, nothing else.
- The meter closes with the mic, so on Apple's engine the last level precedes the flushed final transcript and `stopped`.
- Frontend: `DictationLevelEvent` type and `onDictationLevel` listener. No consumer yet; the pill lands in the next PR.
- Docs: `docs/dictation.md` gains a "level meter" section.

## Test plan

- [x] `cargo test dictation::` — 26 pass, including 4 new `level` tests (silence/floor, ceiling, linearity, monotonic)
- [x] `cargo clippy --tests -D warnings`, `cargo fmt --check`
- [x] `tsc --noEmit`; Biome clean on the changed files
- [ ] Manual: start dictation on macOS, watch `dictation:level` events arrive ~11/s and stop at `dictation_stop` (verified end-to-end once the pill in the next PR renders them)