### PR TITLE
feat(composer): dictate from anywhere, insert at the caret, one control everywhere

### DIFF
--- a/docs/dictation.md
+++ b/docs/dictation.md
@@ -16,7 +16,10 @@ secondary once there is a draft, and collapses while listening or running.
 Widths per state, tones, and timings follow the design spec; the CSS is the
 source of those numbers.
 
-Keys, all handled on the textarea (`Composer/index.tsx`):
+Keys, handled on the textarea (`Composer/index.tsx`). ⌘⇧D also works with
+the focus anywhere else in the window that isn't an editable field
+(`useDictationHotkey`): it toggles dictation in the composer and brings the
+caret there.
 
 | Key | empty | draft | listening | agent running |
 | --- | --- | --- | --- | --- |
@@ -33,9 +36,10 @@ While the mic is open the recognizer's running transcript is **not** written
 into the textarea. It is shown by `InterimGhost`, a layer over the textarea
 with identical metrics (the textarea's own text repeated invisibly, then the
 interim words in italic with a pulsing dot), so undo history stays clean and
-esc is a no-op on the draft. The final result is spliced onto whatever the box
-holds when it arrives (`spliceTranscript`), the caret moves to its end, and the
-new span carries a short wash. A session that ends without a final result
+esc is a no-op on the draft. The final result is inserted at the caret of
+whatever the box holds when it arrives (`insertTranscript`, space-normalised on
+both sides; the ghost previews exactly that join), the caret moves to its end,
+and the new span carries a short wash. A session that ends without a final result
 (Apple's flush deadline, an error mid-utterance) commits what was last heard.
 
 A failed transcription turns the pill danger-tinted with a retry glyph for
@@ -43,7 +47,8 @@ A failed transcription turns the pill danger-tinted with a retry glyph for
 shows an outlined mic-off pill whose click opens System Settings › Privacy &
 Security › Microphone — the shell plugin's open scope in `tauri.conf.json`
 admits that URL scheme for this. Where no engine exists at all the mic is never
-offered and the empty slot degrades to a plain, disabled send arrow.
+offered and the empty slot degrades to a plain, disabled send arrow — which is
+also the form the workflow and roadmap composers use, having no dictation.
 
 ## Platform support
 

--- a/src/components/Composer/Composer.css
+++ b/src/components/Composer/Composer.css
@@ -237,8 +237,9 @@
   padding: 6px 8px 6px 10px;
 }
 /* Right-side insert actions (attach, issue) — square icon buttons sized to
- * pair with .send, so they read as first-class actions rather than stray
- * glyphs. Rides .btn-i (IconButton) for base behavior + tooltip. */
+ * pair with the 28px primary control, so they read as first-class actions
+ * rather than stray glyphs. Rides .btn-i (IconButton) for base behavior +
+ * tooltip. */
 .composer-foot .composer-action {
   width: 28px;
   height: 28px;
@@ -328,44 +329,6 @@
   min-width: 0;
   max-width: 170px;
   color: var(--fg-2);
-}
-
-/* The plain send button of the workflow and roadmap composers. The agent
-   composer's slot is the primary control (PrimaryControl.css). */
-.send {
-  width: 28px;
-  height: 28px;
-  border-radius: var(--r-sm);
-  background: var(--accent);
-  color: var(--btn-fg-dark-alt);
-  justify-content: center;
-  transition:
-    background 0.12s,
-    transform 0.08s;
-}
-.theme-light .send {
-  color: var(--btn-fg-light);
-}
-.send:hover:not(:disabled) {
-  background: oklch(from var(--accent) calc(l + 0.04) c h);
-}
-.send:active:not(:disabled) {
-  transform: scale(0.94);
-}
-.send svg {
-  width: 13px;
-  height: 13px;
-}
-.send:disabled {
-  background: var(--hover);
-  color: var(--fg-3);
-}
-.send.is-stop {
-  background: var(--danger);
-  color: var(--btn-fg-light);
-}
-.send.is-stop:hover:not(:disabled) {
-  background: oklch(from var(--danger) calc(l + 0.04) c h);
 }
 
 /* composer · token usage meter */

--- a/src/components/Composer/ComposerFrame.tsx
+++ b/src/components/Composer/ComposerFrame.tsx
@@ -20,7 +20,7 @@ interface Props {
   /** Dictation's view of the field: the interim transcript to preview over the
    *  text, whether the mic is open (the frame glows accent), and the span a
    *  commit just inserted. Omit for a composer without dictation. */
-  dictation?: Omit<GhostProps, "text">;
+  dictation?: Omit<GhostProps, "text" | "caret">;
 }
 
 /** The shared composer chrome: the `.composer` shell, drop overlay, autocomplete
@@ -95,7 +95,7 @@ export function ComposerFrame({
         />
         {showGhost && dictation && (
           <div ref={ghostRef} className="cmp-ghost-clip">
-            <InterimGhost text={input.text} {...dictation} />
+            <InterimGhost text={input.text} caret={input.caret} {...dictation} />
           </div>
         )}
       </div>

--- a/src/components/Composer/InterimGhost.tsx
+++ b/src/components/Composer/InterimGhost.tsx
@@ -1,9 +1,11 @@
-import { type FreshSpan, separator } from "./dictation";
+import { type FreshSpan, splitForTranscript } from "./dictation";
 
 export interface GhostProps {
   /** The textarea's own value, repeated invisibly so the interim text lands
-   *  exactly where the caret is. */
+   *  exactly where it will be inserted. */
   text: string;
+  /** Where the transcript will be inserted — the textarea's caret. */
+  caret: number;
   /** The recognizer's running transcript, not yet in the box. */
   interim: string;
   /** The mic is open. With nothing typed and nothing heard yet, the layer says
@@ -15,11 +17,12 @@ export interface GhostProps {
 }
 
 /** A layer over the textarea with identical metrics. Interim tokens render
- *  inline at the end of the text, italic, with a pulsing accent dot; they are
- *  not in the textarea's value, so undo history stays clean and a cancel is a
- *  no-op on the draft. After a commit the same layer carries the wash over the
- *  new span. Pointer events pass through to the textarea beneath. */
-export function InterimGhost({ text, interim, listening, fresh }: GhostProps) {
+ *  inline at the caret, italic, with a pulsing accent dot — spaced exactly as
+ *  the commit will space them; they are not in the textarea's value, so undo
+ *  history stays clean and a cancel is a no-op on the draft. After a commit the
+ *  same layer carries the wash over the new span. Pointer events pass through
+ *  to the textarea beneath. */
+export function InterimGhost({ text, caret, interim, listening, fresh }: GhostProps) {
   if (fresh) {
     return (
       <div className="cmp-ghost text-base" aria-hidden="true">
@@ -29,15 +32,18 @@ export function InterimGhost({ text, interim, listening, fresh }: GhostProps) {
       </div>
     );
   }
+  const { before, lead, trail, after } = splitForTranscript(text, caret, interim);
   return (
     <div className="cmp-ghost text-base" aria-live="polite">
-      {text}
-      {separator(text, interim)}
+      {before}
+      {lead}
       {interim ? (
         <span className="interim">{interim}</span>
       ) : listening && !text ? (
         <span className="listen-hint">Listening…</span>
       ) : null}
+      {trail}
+      {after}
     </div>
   );
 }

--- a/src/components/Composer/PrimaryControl/index.tsx
+++ b/src/components/Composer/PrimaryControl/index.tsx
@@ -13,34 +13,42 @@ export { type DictationPhase, type PrimaryState, primaryState } from "./primaryS
  *  front or found out on the attempt. */
 export const SETTINGS_HINT = "Microphone is off — allow it in System Settings";
 
+const NO_LEVELS: number[] = [0, 0, 0, 0, 0];
+
+/** Everything but `state`, `dictationAvailable` and `onSend` is optional so a
+ *  composer without dictation (the workflow launcher, the roadmap chat) can
+ *  render the same control in its empty/draft states with nothing to wire. */
 interface Props {
   state: PrimaryState;
   /** False where no engine exists (Linux, Windows, a Mac below 26 without the
-   *  local engine): the mic is never offered, and the empty pill degrades to a
-   *  plain send arrow — the control the composer had before. */
+   *  local engine) or the composer has no dictation at all: the mic is never
+   *  offered, and the empty pill degrades to a plain send arrow. */
   dictationAvailable: boolean;
   /** The local engine ends the session itself once the user pauses, and the
    *  tooltip has to say so — a mic that stops on its own otherwise reads as a
    *  bug. */
-  autoStops: boolean;
+  autoStops?: boolean;
   /** Recent microphone levels, oldest first, each 0–1. */
-  levels: number[];
+  levels?: number[];
   /** When the mic opened (epoch ms), for the clock; null when it isn't open. */
-  startedAt: number | null;
+  startedAt?: number | null;
   /** Why sending is blocked right now, if it is (a provider the sandbox engine
    *  can't run). Shown as the tooltip in `draft`; the arrow is disabled. */
   sendBlocked?: string;
   /** The last failure's reason, shown as the error pill's tooltip. */
-  error: string | null;
+  error?: string | null;
   /** The composer can't take input (agent not ready, transcript loading). The
    *  mic and send are inert; stopping a run stays possible. */
   disabled?: boolean;
-  onMic: () => void;
+  /** What the send arrow is called — "Send" unless the composer launches
+   *  something else. */
+  sendLabel?: string;
+  onMic?: () => void;
   onSend: () => void;
-  onStopDictation: () => void;
-  onStopRun: () => void;
-  onRetry: () => void;
-  onUnavailable: () => void;
+  onStopDictation?: () => void;
+  onStopRun?: () => void;
+  onRetry?: () => void;
+  onUnavailable?: () => void;
 }
 
 /** The composer's primary control: the mic when the field is empty, the send
@@ -54,12 +62,13 @@ interface Props {
 export function PrimaryControl({
   state,
   dictationAvailable,
-  autoStops,
-  levels,
-  startedAt,
+  autoStops = false,
+  levels = NO_LEVELS,
+  startedAt = null,
   sendBlocked,
-  error,
+  error = null,
   disabled = false,
+  sendLabel = "Send",
   onMic,
   onSend,
   onStopDictation,
@@ -79,14 +88,14 @@ export function PrimaryControl({
   const showSend = split || (!dictationAvailable && is("empty"));
   const sendDisabled = disabled || !!sendBlocked || !is("draft");
 
-  const tip = tipFor(state, { dictationAvailable, autoStops, sendBlocked, error });
+  const tip = tipFor(state, { dictationAvailable, autoStops, sendBlocked, error, sendLabel });
 
   // The whole pill is one target in the states that have one action.
   function onPillClick() {
-    if (is("listening")) onStopDictation();
-    else if (is("running")) onStopRun();
-    else if (is("error") && !disabled) onRetry();
-    else if (is("unavailable")) onUnavailable();
+    if (is("listening")) onStopDictation?.();
+    else if (is("running")) onStopRun?.();
+    else if (is("error") && !disabled) onRetry?.();
+    else if (is("unavailable")) onUnavailable?.();
   }
 
   const pillClass = [
@@ -107,7 +116,7 @@ export function PrimaryControl({
         aria-label={micAside ? "Dictate more" : "Dictate"}
         tabIndex={micHome || micAside ? 0 : -1}
         disabled={disabled || !(micHome || micAside)}
-        onClick={onMic}
+        onClick={() => onMic?.()}
       >
         <Icon name="mic" size={14} />
       </button>
@@ -141,17 +150,22 @@ export function PrimaryControl({
           on={is("listening")}
           className="sq stopd"
           label="Stop dictation"
-          onClick={onStopDictation}
+          onClick={() => onStopDictation?.()}
         >
           <span className="pc-stop-sq" />
         </SegButton>
-        <SegButton on={is("running")} className="sq stopr" label="Stop agent" onClick={onStopRun}>
+        <SegButton
+          on={is("running")}
+          className="sq stopr"
+          label="Stop agent"
+          onClick={() => onStopRun?.()}
+        >
           <span className="pc-stop-sq" />
         </SegButton>
         <SegButton
           on={showSend}
           className="sq send"
-          label="Send"
+          label={sendLabel}
           disabled={sendDisabled}
           onClick={onSend}
         >
@@ -219,14 +233,17 @@ function tipFor(
     autoStops: boolean;
     sendBlocked?: string;
     error: string | null;
+    sendLabel: string;
   },
 ): string {
   switch (state) {
     case "empty":
-      return o.dictationAvailable ? "Dictate · ⌘⇧D" : "Send · ↵";
+      return o.dictationAvailable ? "Dictate · ⌘⇧D" : `${o.sendLabel} · ↵`;
     case "draft":
       if (o.sendBlocked) return o.sendBlocked;
-      return o.dictationAvailable ? "Send · ↵  ·  Dictate more · ⌘⇧D" : "Send · ↵";
+      return o.dictationAvailable
+        ? `${o.sendLabel} · ↵  ·  Dictate more · ⌘⇧D`
+        : `${o.sendLabel} · ↵`;
     case "listening":
       return o.autoStops
         ? "Listening… stops when you pause  ·  Esc cancels"

--- a/src/components/Composer/dictation/index.ts
+++ b/src/components/Composer/dictation/index.ts
@@ -1,2 +1,8 @@
-export { separator, spliceTranscript } from "./spliceTranscript";
+export {
+  insertTranscript,
+  separator,
+  spliceTranscript,
+  splitForTranscript,
+} from "./spliceTranscript";
 export { type FreshSpan, useDictation } from "./useDictation";
+export { isDictationHotkey, useDictationHotkey } from "./useDictationHotkey";

--- a/src/components/Composer/dictation/spliceTranscript.test.ts
+++ b/src/components/Composer/dictation/spliceTranscript.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { spliceTranscript } from "./spliceTranscript";
+import { insertTranscript, spliceTranscript, splitForTranscript } from "./spliceTranscript";
 
 describe("spliceTranscript", () => {
   it("uses the transcript alone when the box was empty", () => {
-    expect(spliceTranscript("", "hello there")).toEqual({ text: "hello there", caret: 11 });
+    expect(spliceTranscript("", "hello there")).toEqual({
+      text: "hello there",
+      start: 0,
+      caret: 11,
+    });
   });
 
   it("adds the missing word boundary after typed text", () => {
@@ -26,11 +30,52 @@ describe("spliceTranscript", () => {
 
   it("leaves the base untouched while nothing has been heard", () => {
     expect(spliceTranscript("draft", "").text).toBe("draft");
-    expect(spliceTranscript("", "")).toEqual({ text: "", caret: 0 });
+    expect(spliceTranscript("", "")).toEqual({ text: "", start: 0, caret: 0 });
   });
 
   it("lands the caret at the end of the spliced text", () => {
     const { text, caret } = spliceTranscript("draft ", "hello world");
     expect(caret).toBe(text.length);
+  });
+
+  it("marks where the transcript starts, after the added boundary", () => {
+    expect(spliceTranscript("draft", "hello").start).toBe("draft ".length);
+    expect(spliceTranscript("draft ", "hello").start).toBe("draft ".length);
+  });
+});
+
+describe("insertTranscript", () => {
+  it("inserts at the caret, adding a boundary on each side that lacks one", () => {
+    expect(insertTranscript("one two", 3, "and")).toEqual({
+      text: "one and two",
+      start: 4,
+      caret: 7,
+    });
+  });
+
+  it("adds no boundary where the user already left one", () => {
+    expect(insertTranscript("one  two", 4, "and").text).toBe("one and two");
+    expect(insertTranscript("one\ntwo", 4, "and").text).toBe("one\nand two");
+  });
+
+  it("puts the caret after the dictated words, before the trailing text", () => {
+    const { text, caret } = insertTranscript("one two", 3, "and");
+    expect(text.slice(caret)).toBe(" two");
+  });
+
+  it("clamps a caret outside the text", () => {
+    expect(insertTranscript("one", 99, "two").text).toBe("one two");
+    expect(insertTranscript("one", -1, "two").text).toBe("two one");
+  });
+
+  it("changes nothing when nothing was heard, whatever the caret", () => {
+    expect(insertTranscript("one two", 3, "")).toEqual({ text: "one two", start: 3, caret: 3 });
+  });
+});
+
+describe("splitForTranscript", () => {
+  it("previews the same join the insert will make", () => {
+    const { before, lead, trail, after } = splitForTranscript("one two", 3, "and");
+    expect(`${before}${lead}and${trail}${after}`).toBe(insertTranscript("one two", 3, "and").text);
   });
 });

--- a/src/components/Composer/dictation/spliceTranscript.ts
+++ b/src/components/Composer/dictation/spliceTranscript.ts
@@ -1,28 +1,69 @@
 export interface SplicedTranscript {
   text: string;
-  /** Caret offset after the splice — always the end, so typing continues after
-   *  the dictated words. */
+  /** Offset where the transcript begins in `text` — the span to mark as fresh. */
+  start: number;
+  /** Caret offset after the splice — the end of the transcript, so typing
+   *  continues right after the dictated words. */
   caret: number;
 }
 
 /** The word boundary between `base` and a transcript that follows it: one
  *  space, unless there is nothing to join or the user already left one.
  *  Keeping their trailing space or newline intact matters for a dictated list
- *  item. Shared with the ghost layer, which previews the join before it lands. */
+ *  item. */
 export function separator(base: string, transcript: string): string {
   if (!transcript || !base || /\s$/.test(base)) return "";
   return " ";
 }
 
-/** Where a transcript lands in the composer, given `base` (the text in the box
- *  when it arrives).
+/** The pieces of inserting `transcript` into `text` at `caret`: the text either
+ *  side, and the one space added on each side where a word boundary is missing.
+ *  Shared by the splice itself and by the ghost layer, which previews exactly
+ *  this before it lands. */
+export interface TranscriptSplit {
+  before: string;
+  lead: string;
+  trail: string;
+  after: string;
+}
+
+export function splitForTranscript(
+  text: string,
+  caret: number,
+  transcript: string,
+): TranscriptSplit {
+  const at = Math.max(0, Math.min(caret, text.length));
+  const before = text.slice(0, at);
+  const after = text.slice(at);
+  return {
+    before,
+    lead: separator(before, transcript),
+    trail: transcript && after && !/^\s/.test(after) ? " " : "",
+    after,
+  };
+}
+
+/** Insert a transcript into the composer text at the caret, space-normalised
+ *  on both sides. Nothing heard leaves the text untouched — no dangling space.
  *
  *  Apple's recognizer revises earlier words as it hears more, so the session's
  *  transcript is one whole text, not a delta — the caller shows it beside the
- *  box while it changes and splices it once, at the end. This function is the
- *  one place that decides how the two are joined. Nothing heard leaves the base
- *  untouched — no dangling space. */
+ *  box while it changes and inserts it once, at the end. This is the one place
+ *  that decides how the pieces are joined. */
+export function insertTranscript(
+  text: string,
+  caret: number,
+  transcript: string,
+): SplicedTranscript {
+  const { before, lead, trail, after } = splitForTranscript(text, caret, transcript);
+  if (!transcript) return { text, start: before.length, caret: before.length };
+  const start = before.length + lead.length;
+  const end = start + transcript.length;
+  return { text: before + lead + transcript + trail + after, start, caret: end };
+}
+
+/** [`insertTranscript`] at the end of `base` — for a composer with no caret to
+ *  speak of (the phone's, where the transcript arrives once, after the fact). */
 export function spliceTranscript(base: string, transcript: string): SplicedTranscript {
-  const text = base + separator(base, transcript) + transcript;
-  return { text, caret: text.length };
+  return insertTranscript(base, base.length, transcript);
 }

--- a/src/components/Composer/dictation/useDictation.ts
+++ b/src/components/Composer/dictation/useDictation.ts
@@ -9,7 +9,7 @@ import {
 } from "@/api";
 import type { DictationPhase } from "../PrimaryControl/primaryState";
 import { type ComposerInput, grow } from "../useComposerInput";
-import { spliceTranscript } from "./spliceTranscript";
+import { insertTranscript } from "./spliceTranscript";
 
 /** What we assume when the availability probe itself fails — an older backend
  *  without the command, or a non-Tauri environment (tests, storybook-ish
@@ -52,9 +52,9 @@ let lastAvailability: DictationAvailability | null = null;
  *  (Apple revises earlier words as it hears more), so `interim` is REPLACED on
  *  each event. It is not written into the box: the composer renders it in a
  *  ghost layer over the textarea, so undo history stays clean and a cancel is
- *  a no-op on the draft. The final result is spliced onto whatever the box
- *  holds at that moment (see [`spliceTranscript`]) — the user may have kept
- *  typing — and the inserted span is reported as `fresh` for a moment. */
+ *  a no-op on the draft. The final result is inserted at the caret of whatever
+ *  the box holds at that moment (see [`insertTranscript`]) — the user may have
+ *  kept typing — and the inserted span is reported as `fresh` for a moment. */
 export function useDictation(input: ComposerInput) {
   const [availability, setAvailability] = useState<DictationAvailability | null>(lastAvailability);
   const [phase, setPhase] = useState<DictationPhase>("idle");
@@ -131,16 +131,17 @@ export function useDictation(input: ComposerInput) {
     }, ERROR_TTL_MS);
   }
 
-  /** Splice what the session heard onto the box. Once per session at most;
+  /** Insert what the session heard at the caret. Once per session at most;
    *  nothing heard leaves the box untouched — no dangling space, no toast. */
   function commit(transcript: string) {
     committedRef.current = true;
     if (!transcript) return;
     const ip = inputRef.current;
-    const { text, caret } = spliceTranscript(ip.text, transcript);
+    const { text, start, caret } = insertTranscript(ip.text, ip.caret, transcript);
     lastWrittenRef.current = text;
     ip.setText(text);
-    setFresh({ start: text.length - transcript.length, end: text.length });
+    ip.setCaret(caret);
+    setFresh({ start, end: caret });
     if (freshTimer.current !== null) window.clearTimeout(freshTimer.current);
     freshTimer.current = window.setTimeout(() => {
       freshTimer.current = null;

--- a/src/components/Composer/dictation/useDictationHotkey.ts
+++ b/src/components/Composer/dictation/useDictationHotkey.ts
@@ -1,0 +1,49 @@
+import { useEffect, useRef } from "react";
+
+/** Is this ⌘⇧D (⌃⇧D on a PC keyboard)? Shared with the textarea's handler so
+ *  the two can't drift. */
+export function isDictationHotkey(e: {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  key: string;
+}): boolean {
+  return (e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === "d" || e.key === "D");
+}
+
+/** Every mounted composer's toggle, most recently mounted last — the one on
+ *  top gets the key. Normally that is the only one; a view that stacks two
+ *  composers hands the shortcut to the newer. */
+const stack: { current: () => void }[] = [];
+
+function onWindowKey(e: KeyboardEvent) {
+  if (!isDictationHotkey(e)) return;
+  // The composer's own textarea saw it first and acted (it prevents default).
+  if (e.defaultPrevented) return;
+  // Any other editable field keeps its keys: dictating into the chat while the
+  // caret sits in a commit message would be a surprise.
+  const target = e.target as HTMLElement | null;
+  const tag = target?.tagName ?? "";
+  if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable) return;
+  const top = stack[stack.length - 1];
+  if (!top) return;
+  e.preventDefault();
+  top.current();
+}
+
+/** ⌘⇧D from anywhere in the window — the hands are on the keyboard but the
+ *  focus is elsewhere in the chat. One window listener for however many
+ *  composers are mounted; the textarea's own handling takes precedence. */
+export function useDictationHotkey(toggle: () => void) {
+  const ref = useRef(toggle);
+  ref.current = toggle;
+  useEffect(() => {
+    if (stack.length === 0) window.addEventListener("keydown", onWindowKey);
+    stack.push(ref);
+    return () => {
+      const i = stack.indexOf(ref);
+      if (i >= 0) stack.splice(i, 1);
+      if (stack.length === 0) window.removeEventListener("keydown", onWindowKey);
+    };
+  }, []);
+}

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -18,7 +18,7 @@ import { isContainerEngine, sandboxEngineLabel } from "@/storage/preferences";
 import type { UsageSnapshot } from "@/store";
 import { useAppStore } from "@/store";
 import { ComposerFrame } from "./ComposerFrame";
-import { useDictation } from "./dictation";
+import { isDictationHotkey, useDictation, useDictationHotkey } from "./dictation";
 import { IssuePicker } from "./IssuePicker";
 import { ModelPicker } from "./ModelPicker";
 import { PrimaryControl, primaryState } from "./PrimaryControl";
@@ -366,12 +366,19 @@ export function Composer({
     dictation.toggle();
   }
 
+  // ⌘⇧D with the focus elsewhere in the window still dictates into this box —
+  // and brings the caret here, so the interim text is where the eye goes.
+  useDictationHotkey(() => {
+    toggleDictation();
+    input.ta.current?.focus();
+  });
+
   // ↵ sends; ⇧↵ is a newline (falls through to the textarea); ⌘⇧D toggles
   // dictation; esc backs out of whatever is live. While listening, ↵ stops and
   // transcribes rather than sending — the operator is already reaching for it.
   keysRef.current = (e) => {
     const mod = e.metaKey || e.ctrlKey;
-    if (mod && e.shiftKey && (e.key === "d" || e.key === "D")) {
+    if (isDictationHotkey(e)) {
       e.preventDefault();
       toggleDictation();
       return true;

--- a/src/components/Composer/useComposerInput.ts
+++ b/src/components/Composer/useComposerInput.ts
@@ -67,8 +67,10 @@ export function useComposerInput(cfg: ComposerInputConfig) {
   const [text, setText] = useState(() =>
     draftKey ? (useAppStore.getState().composerDrafts[draftKey] ?? "") : "",
   );
-  // Caret offset, tracked so triggers can be detected at the cursor.
-  const [caret, setCaret] = useState(0);
+  // Caret offset, tracked so triggers can be detected at the cursor and
+  // dictation can insert there. Starts at the end of the restored draft, which
+  // is where the browser puts the caret of a textarea given a value.
+  const [caret, setCaret] = useState(text.length);
   const [attachments, setAttachments] = useState<string[]>([]);
   const ta = useRef<HTMLTextAreaElement>(null);
 
@@ -187,6 +189,9 @@ export function useComposerInput(cfg: ComposerInputConfig) {
     setText,
     append,
     caret,
+    /** For a caller that writes text itself (dictation's commit) and has to
+     *  tell the input where the caret ended up; `placeCaret` moves the DOM's. */
+    setCaret,
     attachments,
     addPaths,
     removePath,

--- a/src/components/ProjectScreen/Roadmap/Thread/Composer.tsx
+++ b/src/components/ProjectScreen/Roadmap/Thread/Composer.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 import { useState } from "react";
-import { Icon } from "@/components/Icon";
+import { PrimaryControl } from "@/components/Composer/PrimaryControl";
 
 /** The PM composer. Reuses the agent composer's skin, but not its input core:
  *  this thread has no attachments, no mentions and no model picker — the agent
@@ -63,15 +63,13 @@ export function Composer({
           />
           <div className="composer-foot flex-center">
             <span className="grow" />
-            <button
-              type="button"
-              className="send flex-center"
-              disabled={disabled || !draft.trim()}
-              onClick={send}
-              aria-label="Send"
-            >
-              <Icon name="arrowUp" size={13} />
-            </button>
+            {/* The agent composer's primary control in its no-dictation form. */}
+            <PrimaryControl
+              state={draft.trim() ? "draft" : "empty"}
+              dictationAvailable={false}
+              disabled={disabled}
+              onSend={send}
+            />
           </div>
         </div>
       </div>

--- a/src/workflows/run/WorkflowComposer.tsx
+++ b/src/workflows/run/WorkflowComposer.tsx
@@ -13,6 +13,7 @@
 import { type CSSProperties, Fragment, useRef, useState } from "react";
 import { api } from "../../api";
 import { ComposerFrame } from "../../components/Composer/ComposerFrame";
+import { PrimaryControl } from "../../components/Composer/PrimaryControl";
 import { useComposerInput } from "../../components/Composer/useComposerInput";
 import { Icon } from "../../components/Icon";
 import { Chip } from "../../components/ui/Chip";
@@ -197,15 +198,16 @@ export function WorkflowComposer({
         <>
           <WorkflowSelect definitions={definitions} selected={def} onPick={pickDef} />
           <span style={{ flex: 1 }} />
-          <button
-            type="button"
-            className="send"
+          {/* The agent composer's primary control, in its no-dictation form:
+           *  a plain arrow that fills accent once there is a task to launch.
+           *  Held (dimmed) while the launch is in flight. */}
+          <PrimaryControl
+            state={input.text.trim() ? "draft" : "empty"}
+            dictationAvailable={false}
             disabled={!canLaunch}
-            onClick={() => void launch()}
-            aria-label="Launch run"
-          >
-            <Icon name={busy ? "refresh" : "arrowUp"} size={13} />
-          </button>
+            sendLabel="Launch run"
+            onSend={() => void launch()}
+          />
         </>
       }
     />


### PR DESCRIPTION
## Summary

The three desktop follow-ups from #678, stacked on it.

- **⌘⇧D from anywhere.** `useDictationHotkey` installs one window listener for however many composers are mounted (the newest wins) and toggles dictation when the focus is anywhere that isn't an editable field, bringing the caret to the box. The textarea's own handler still takes precedence, so the key never fires twice; a commit message or search box keeps its keys.
- **Insert at the caret.** `insertTranscript(text, caret, transcript)` inserts the final transcript where the caret is, adding a space on each side only where a word boundary is missing. The ghost layer previews exactly that join at the caret (`splitForTranscript` is shared by both), and the caret lands after the dictated words. `spliceTranscript` remains the end-of-text case the phone uses. The input's caret state now starts at the end of a restored draft, which is where the browser puts it, and the input exposes `setCaret` for callers that write text themselves.
- **One control everywhere.** The workflow launcher and the roadmap chat render `PrimaryControl` in its no-dictation form (a plain arrow that fills accent once there is text) instead of the old `.send` button, which is removed. The control's dictation-only props became optional for this; `sendLabel` names the arrow ("Launch run").

## Test plan

- [x] `tsc --noEmit` (desktop and mobile), Biome clean on changed files, `vitest` — 1125 pass, with new `insertTranscript` / `splitForTranscript` cases
- [ ] Manual: click into the chat log so the textarea loses focus, press ⌘⇧D → the mic opens and the caret returns to the box; press again → stop
- [ ] Manual: place the caret mid-sentence, dictate → words land there with single spaces either side, caret after them, wash on the span
- [ ] Manual: workflow launcher and roadmap chat send arrows look and behave as before (accent once there is text, disabled otherwise)