### PR TITLE
fix(mobile): re-read the open thread's log on reconnect and foreground

### DIFF
--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -234,17 +234,27 @@ export const useStore = create<MobileState>()((set, get) => ({
         via: client.via,
       }),
     );
+    // The log of an open thread is kept current by live events, which a
+    // dropped socket or a backgrounded webview silently misses — so every
+    // reconnect and every return to the foreground re-reads it from the host.
+    const refreshOpenAgent = () => {
+      const agentId = [...get().nav].reverse().find((n) => n.props.agentId)?.props.agentId;
+      if (agentId) void get().loadAgent(agentId).catch(ignore);
+    };
     client.onSnapshot((snapshot) => {
       set({ hostInfo: snapshot.host });
       if (snapshot.workspace) set({ workspace: snapshot.workspace });
       else void get().refreshWorkspace();
+      refreshOpenAgent();
       // Every handshake — the first pairing and every reconnect — is when the
       // host is told the APNs token again.
       void syncPush().catch(ignore);
     });
     if (typeof document !== "undefined") {
       document.addEventListener("visibilitychange", () => {
-        if (!document.hidden && client.state === "connected") void get().refreshWorkspace();
+        if (document.hidden || client.state !== "connected") return;
+        void get().refreshWorkspace();
+        refreshOpenAgent();
       });
     }
     const saved = await loadSettings();


### PR DESCRIPTION
## Problem

A thread's log on the phone is loaded when the screen opens, then kept current only by live events (`session:records-appended`, `turn:sent`, `agent:event`). A locked phone or backgrounded webview drops the socket, so any exchange that happens on the desktop in the meantime is announced to nobody — and on reconnect the app refreshed the workspace but never the open thread. The thread kept rendering its stale log until the user navigated away and back.

## Fix

`init()` now re-reads the open agent's log and git state (`loadAgent`) on:

- every handshake snapshot — the first pairing and every reconnect, and
- every `visibilitychange` back to the foreground while connected.

The open agent is the deepest nav item carrying an `agentId`, so file/diff screens pushed on top of a thread refresh it too. No-op when no thread is open.

## Verification

Reproduced on device: exchange a message on the desktop while the phone is locked → unlock → thread was missing the exchange; leaving and reopening the thread showed it (confirming the log was stale, not the host DB). With this fix the thread catches up on unlock. `tsc --noEmit`, `biome check`, and all 120 mobile vitest tests pass.