### PR TITLE
fix(mobile): launch the agent under the name the New Agent sheet shows

### DIFF
--- a/mobile/src/sheets/NewAgentSheet/index.tsx
+++ b/mobile/src/sheets/NewAgentSheet/index.tsx
@@ -99,6 +99,7 @@ export function NewAgentSheet({
       effort,
       base: chosenBase,
       prompt: prompt.trim(),
+      name,
     })
       // Only a spawn that actually started the agent has consumed the prompt.
       // A failed one keeps it, so the button below can just be pressed again.

--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -136,6 +136,10 @@ export interface SpawnInput {
   effort: string | null;
   base: string;
   prompt: string;
+  /** The workspace name the New Agent sheet showed. Empty when the sheet
+   *  never got one (its allocation failed), in which case one is allocated
+   *  here so the spawn still goes through. */
+  name: string;
 }
 
 let initialized = false;
@@ -510,9 +514,11 @@ export const useStore = create<MobileState>()((set, get) => ({
     });
   },
 
-  async spawn({ repoPath, provider, model, effort, base, prompt }) {
+  async spawn({ repoPath, provider, model, effort, base, prompt, name: shown }) {
     return guard(set, async () => {
-      const name = await api.allocateDraftName([]);
+      // The user has been looking at (and possibly rerolled) this name; the
+      // agent must launch under it, not a fresh draw.
+      const name = shown || (await api.allocateDraftName([]));
       const record = await api.spawnAgent(repoPath, provider, name, effort, model, base);
       const turnId = newId();
       set((s) => ({

--- a/mobile/tests/store.test.ts
+++ b/mobile/tests/store.test.ts
@@ -169,7 +169,7 @@ describe("answering a tool-use prompt", () => {
 });
 
 describe("spawn flow", () => {
-  it("allocates a name, spawns, waits for spawning to clear, then sends the prompt", async () => {
+  it("spawns under the name the sheet showed, waits for spawning to clear, then sends the prompt", async () => {
     const before = state().workspace?.agents.length ?? 0;
     await state().spawn({
       repoPath: state().workspace?.projects[0].path ?? "",
@@ -178,9 +178,12 @@ describe("spawn flow", () => {
       effort: "high",
       base: "main",
       prompt: "Add a settings row for the dictation engine",
+      name: "zermatt",
     });
     expect(state().workspace?.agents.length).toBe(before + 1);
     const fresh = state().workspace?.agents[0];
+    // The sheet's name, not a fresh allocation (which would have been "tasman").
+    expect(fresh?.name).toBe("zermatt");
     expect(fresh?.status).not.toBe("spawning");
     await vi.waitFor(
       () =>
@@ -191,6 +194,21 @@ describe("spawn flow", () => {
         ).toBe(true),
       { timeout: 5000 },
     );
+  });
+
+  it("allocates a name itself only when the sheet had none", async () => {
+    const before = new Set((state().workspace?.agents ?? []).map((a) => a.id));
+    await state().spawn({
+      repoPath: state().workspace?.projects[0].path ?? "",
+      provider: "claude",
+      model: "claude-opus-5",
+      effort: "high",
+      base: "main",
+      prompt: "The sheet never got a name for this one",
+      name: "",
+    });
+    const fresh = (state().workspace?.agents ?? []).find((a) => !before.has(a.id));
+    expect(fresh?.name).toBeTruthy();
   });
 
   it("rejects and rolls back when the first message fails, so the prompt can be retried", async () => {
@@ -207,6 +225,7 @@ describe("spawn flow", () => {
         effort: "high",
         base: "main",
         prompt: "This one never reaches the agent",
+        name: "sedona",
       }),
     ).rejects.toThrow("host refused the message");
 


### PR DESCRIPTION
## Summary

The mobile New Agent sheet shows an allocated workspace name in its heading and Start button, but the agent launched under a different name. The store's `spawn` action was asking the host for a second fresh draft name instead of using the one the sheet displayed. Since the allocator only excludes live agents, the second draw almost always differed from the first.

## Changes

- `NewAgentSheet` passes its displayed (possibly rerolled) name through `SpawnInput`.
- The store's `spawn` uses that name verbatim, and only allocates one itself when the sheet never got a name (its own allocation call failed), so the spawn still goes through in that edge case.
- No host-side change: `spawn_agent` already accepts the name as passed.

## Tests

- Updated the spawn flow tests to pass a name, and the first one now asserts the launched agent carries the sheet's name rather than a fresh allocation.
- Added a test for the empty-name fallback.
- `bun run lint` clean, `bun run test` 121 passing, `tsc` clean for mobile sources.