### PR TITLE
fix(mobile): keep the thread's log when the host has no session records

### DIFF
--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -411,6 +411,7 @@ allowlist; any op not listed returns `{ ok: false, error: "unknown op" }`.
 | `set_agent_effort` | `{ agentId, effort }` | `null` |
 | `read_session_records` | `{ agentId }` | `SessionRecord[]` |
 | `read_user_turns` | `{ agentId }` | `UserTurn[]` |
+| `sync_session` | `{ agentId }` | `null` |
 | `get_git_state` | `{ agentId }` | `GitState \| null` |
 | `get_agent_diff_stats` | `{ agentId }` | `DiffStats` |
 | `list_checkout_tree` | as command | `CheckoutFile[]` |
@@ -534,7 +535,10 @@ Never forwarded: `agent:output`, `shell:output` (raw PTY bytes), `run:*`,
 
 Delivery is best effort, exactly like the desktop frontend: the phone must
 refetch `get_workspace` on reconnect and on returning to the foreground, and
-`read_session_records` when it opens an agent.
+`read_session_records` when it opens an agent. An empty record list is not
+proof of an empty conversation — the turn-end ingest can lag or miss — so the
+phone then asks the host to `sync_session` and reads once more, and keeps
+whatever log it already rendered from live events if that is still empty.
 
 ## Errors
 

--- a/mobile/src/api/index.ts
+++ b/mobile/src/api/index.ts
@@ -73,6 +73,7 @@ export function createApi(client: RemoteClient) {
     readSessionRecords: (agentId: string) =>
       call<SessionRecord[]>("read_session_records", { agentId }),
     readUserTurns: (agentId: string) => call<UserTurn[]>("read_user_turns", { agentId }),
+    syncSession: (agentId: string) => call<null>("sync_session", { agentId }),
     getGitState: (agentId: string, subdir?: string) =>
       call<GitState | null>("get_git_state", { agentId, subdir }),
     getAgentDiffStats: (agentId: string) => call<DiffStats>("get_agent_diff_stats", { agentId }),

--- a/mobile/src/remote/mock/index.ts
+++ b/mobile/src/remote/mock/index.ts
@@ -368,6 +368,8 @@ export class MockHost {
         return this.state.records[id] ?? [];
       case "read_user_turns":
         return fx.userTurns[id] ?? [];
+      case "sync_session":
+        return null;
       case "get_git_state":
         return fx.gitStates[id] ?? null;
       case "get_agent_diff_stats": {

--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -448,10 +448,26 @@ export const useStore = create<MobileState>()((set, get) => ({
 
   async rebuildLog(agentId) {
     return guard(set, async () => {
-      const [records, turns] = await Promise.all([
+      let [records, turns] = await Promise.all([
         api.readSessionRecords(agentId),
         api.readUserTurns(agentId),
       ]);
+      // The host ingests a turn's transcript into session_records only at
+      // turn-end, and that ingest can insert nothing (session id not captured
+      // yet, transcript not located). Mirror the desktop's readReducedLog: ask
+      // for a backfill and read again before concluding there is no history.
+      if (records.length === 0) {
+        await api.syncSession(agentId);
+        [records, turns] = await Promise.all([
+          api.readSessionRecords(agentId),
+          api.readUserTurns(agentId),
+        ]);
+      }
+      // Still nothing stored: keep the log the live events built rather than
+      // wiping the conversation the user was just looking at (the desktop's
+      // records-appended handler makes the same call). A brand-new agent has
+      // no log either way, so the empty state still renders for it.
+      if (records.length === 0) return;
       const provider = agentOf(get().workspace, agentId)?.provider;
       const items = applyUserTurns(reduceRecords(provider, records), turns);
       set((s) => ({ logs: { ...s.logs, [agentId]: items } }));

--- a/src-tauri/src/remote/dispatch.rs
+++ b/src-tauri/src/remote/dispatch.rs
@@ -64,6 +64,7 @@ pub const OPS: &[&str] = &[
     "set_agent_effort",
     "read_session_records",
     "read_user_turns",
+    "sync_session",
     "get_git_state",
     "get_agent_diff_stats",
     "list_checkout_tree",
@@ -228,6 +229,15 @@ impl Dispatch for SupervisorDispatch {
                 "read_user_turns" => {
                     let a: AgentArgs = parse(args)?;
                     res(sup.workspace.read_user_turns(&a.agent_id))
+                }
+
+                // Lazy backfill, same as the `sync_session` command: the phone
+                // calls it when `read_session_records` comes back empty for an
+                // agent that plainly has a transcript on disk.
+                "sync_session" => {
+                    let a: AgentArgs = parse(args)?;
+                    sup.sync_session(&a.agent_id);
+                    res::<()>(Ok(()))
                 }
 
                 "get_git_state" => {

--- a/src-tauri/src/remote/tests.rs
+++ b/src-tauri/src/remote/tests.rs
@@ -352,7 +352,7 @@ fn the_pairing_url_carries_the_host_id_and_an_address() {
 
 #[test]
 fn allowlist_matches_the_protocol_table() {
-    // The 37 rows of docs/remote-protocol.md's op table, spelled out here so a
+    // The 38 rows of docs/remote-protocol.md's op table, spelled out here so a
     // silent widening of the wire surface fails this test. `register_push` is
     // the one the session layer answers itself (it needs the connection's
     // device identity), so it lives in `SESSION_OPS`; the two together are what
@@ -370,6 +370,7 @@ fn allowlist_matches_the_protocol_table() {
         "set_agent_effort",
         "read_session_records",
         "read_user_turns",
+        "sync_session",
         "get_git_state",
         "get_agent_diff_stats",
         "list_checkout_tree",


### PR DESCRIPTION
## Problem

On the phone, opening an agent, going back to the list, and reopening it showed an empty conversation: every previous turn was gone.

`rebuildLog` fetched the host's `session_records` and wrote the result back unconditionally. The host ingests a turn's transcript only at turn-end, and that ingest can insert nothing (session id not captured yet, transcript not located) — in which case it also emits no `session:records-appended`, so the live-event log survived the turn but was wiped by the first explicit rebuild. Since cf6051a0 that rebuild also runs on every reconnect and return to the foreground, widening the wipe.

## Fix

Mirror the desktop's two safeguards (`readReducedLog` in `src/store/workspace.ts` and the empty-guard in `src/store/eventListeners.ts`):

- **New `sync_session` remote op** — added to the dispatcher allowlist and op table; calls the supervisor's existing lazy-backfill routine, the same one the desktop Tauri command uses. Exposed on the mobile API facade, with a no-op handler in the mock host.
- **`rebuildLog`** — when records come back empty, ask the host to `sync_session` and read again. If still empty, keep the log the live events built instead of replacing it. A brand-new agent still renders the empty state since it has no log either way.
- Protocol doc and allowlist test updated for the new op.

## Verification

- `cargo test --lib remote::` — 98 passed
- mobile `tsc --noEmit`, `biome check` — clean
- mobile `vitest run` — 120 passed

Not verified on a device: open an agent on the phone, go back to the list, reopen it, and confirm the turns are still there.