### PR TITLE
fix(supervisor): mirror new agents to other clients immediately

### DIFF
--- a/src-tauri/src/supervisor/lifecycle.rs
+++ b/src-tauri/src/supervisor/lifecycle.rs
@@ -21,6 +21,7 @@ use crate::workspace::{
 
 use super::events::{
     emit_agent_event, emit_agent_output, emit_effort, emit_model, emit_repo_added, emit_view,
+    emit_workspace_changed,
 };
 use super::messaging::{
     drain_message_queue, flush_queued, mark_user_turn_started, on_first_user_message,
@@ -469,6 +470,13 @@ impl Supervisor {
             }),
         );
         self.set_status(&app, &agent_id, AgentStatus::Spawning, None);
+        // A new row is a structural change: `agent:status` alone is dropped by
+        // any view that doesn't have the agent yet (the desktop window when a
+        // paired phone spawned it, and vice versa). Announce it so every other
+        // client refetches the workspace now rather than on its next focus. The
+        // caller that issued the spawn refetches on its own; the generation
+        // guard in `refreshWorkspace` makes the extra fetch harmless.
+        emit_workspace_changed(&app);
         arm_spawn_timeout(self.clone(), app.clone(), agent_id.clone());
 
         let sup = self.clone();


### PR DESCRIPTION
## Problem

Starting an agent from the mobile app did not show up in the desktop sidebar until the desktop window regained focus or changed visibility, which could be a long time. The same gap existed in reverse for phones.

## Root cause

`spawn_agent` only emitted `agent:status` (`Spawning`). The desktop's status handler patches the existing agents array by id, so an event for an agent the view has never seen is silently dropped. `workspace:changed`, the event that makes every client refetch, was only emitted by archive, restore, and project add/remove — never by spawn. The desktop's own spawn path never noticed because it refetches after its invoke returns.

## Fix

Emit `workspace:changed` from `Supervisor::spawn_agent` right after the row is written. One site covers desktop spawns, phone spawns, forks (which build a `SpawnRequest`), and workflow steps. The remote layer already forwards this event to paired phones and the mobile store already reloads on it.

The originating client still refetches on its own; the generation guard in `refreshWorkspace` makes the extra fetch harmless.

## Verification

- `cargo check` clean
- `cargo test remote::` 98 passed, `cargo test supervisor::` 64 passed, `cargo test lifecycle` 2 passed
- Checked the desktop draft-launch ordering: the draft row is removed synchronously when the invoke returns, well before the event-triggered `get_workspace` roundtrip resolves, so no duplicate row.

## Manual test

Spawn from the phone with the desktop window focused and idle. The agent should appear in the sidebar within a second.