### PR TITLE
fix(remote): pair from off-network — rustls provider, relay bounds, fletch:// on iOS

### DIFF
--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -167,10 +167,13 @@ repo); anyone can run their own and point both apps at it.
   from the relay's side; the host's own `4004` goes out first over the virtual
   connections, as on the LAN.
 - **Phone side.** Connection candidates in order: `addr` over `ws://` with a
-  3 s open timeout, then `wss://<relay>/v1/device/<hostId>` with no extra
-  timeout (it is the last resort; the platform's TCP/TLS timeout applies). The
-  relay candidate exists only when the phone holds both the relay URL and the
-  host key, since the key is the route. A host-key mismatch on either path
+  3 s open timeout, then `wss://<relay>/v1/device/<hostId>` with a 15 s one.
+  Both budgets cover the dial and the Noise handshake together; the first
+  frame after the handshake (`pair` or `hello`, and the snapshot request that
+  follows a `pair`) has its own 15 s bound, so a relay that accepted the
+  socket for a Mac that has silently gone away turns into an error rather than
+  an attempt that never ends. The relay candidate exists only when the phone
+  holds both the relay URL and the host key, since the key is the route. A host-key mismatch on either path
   stops the list at once and is not retried: an impostor must not be able to
   steer the phone onto the other path. The relay URL arrives in the pairing
   link and can be added or changed later in the phone's host sheet without

--- a/mobile/src-tauri/Cargo.lock
+++ b/mobile/src-tauri/Cargo.lock
@@ -1175,6 +1175,7 @@ dependencies = [
  "base64 0.22.1",
  "futures-util",
  "objc2",
+ "rustls",
  "serde",
  "serde_json",
  "snow",
@@ -3160,6 +3161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6725596c3f2c3a0aef021139e145d4eafe314a6623e4680ca83852b2c67ab2ba"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -30,6 +30,14 @@ tauri-plugin-push = { path = "plugins/push" }
 # wss:// relay works on iOS without an OpenSSL build.
 snow = "0.10"
 tokio-tungstenite = { version = "0.27", features = ["rustls-tls-webpki-roots"] }
+# tokio-tungstenite's rustls feature brings no crypto backend of its own, and
+# rustls panics at the first `wss://` dial unless exactly one is compiled in or
+# installed — inside a Tauri command that is an `invoke` that never resolves,
+# which is how a relay dial used to leave the Pair screen on "Pairing…" for
+# good. `ring`: already in the tree via `snow`, and it builds for iOS without
+# cmake. `run()` also installs it explicitly, so a future dependency that
+# drags in aws-lc-rs cannot reintroduce the ambiguity.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tokio = { version = "1", features = ["sync", "time"] }
 futures-util = "0.3"
 base64 = "0.22"

--- a/mobile/src-tauri/src/lib.rs
+++ b/mobile/src-tauri/src/lib.rs
@@ -34,6 +34,12 @@ fn own_the_whole_screen(webview: tauri::webview::PlatformWebview) {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // The TLS backend for the relay's `wss://` dial (see `rustls` in
+    // Cargo.toml). Installed here, before any command can run, so the choice
+    // is made once and never at the first dial. `Err` means one is already
+    // installed, which is fine.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     tauri::Builder::default()
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_notification::init())
@@ -58,4 +64,16 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running fletch mobile");
+}
+
+#[cfg(test)]
+mod tests {
+    /// The relay dial builds a rustls client the moment it sees `wss://`. With
+    /// no crypto backend compiled in — or two — rustls panics right there,
+    /// inside a Tauri command, which the webview sees as an `invoke` that never
+    /// resolves. This is the call that panicked; it must not.
+    #[test]
+    fn rustls_can_pick_its_crypto_backend() {
+        let _ = rustls::ClientConfig::builder();
+    }
 }

--- a/mobile/src-tauri/tauri.conf.json
+++ b/mobile/src-tauri/tauri.conf.json
@@ -26,7 +26,7 @@
   },
   "plugins": {
     "deep-link": {
-      "mobile": [{ "host": "pair", "pathPrefix": ["/"] }],
+      "mobile": [{ "scheme": ["fletch"], "host": "pair" }],
       "desktop": { "schemes": ["fletch"] }
     }
   },

--- a/mobile/src/remote/candidates.ts
+++ b/mobile/src/remote/candidates.ts
@@ -10,11 +10,17 @@ import type { HostTarget, Via } from "./types";
  *  is enforced by the transport, not by a timer on this side. */
 export const LAN_OPEN_TIMEOUT_MS = 3000;
 
+/** The relay's open budget: a TLS dial across a cellular network plus the
+ *  Noise handshake through the relay to the Mac. Longer than the LAN's because
+ *  there is nothing after it to move on to, but bounded all the same — a relay
+ *  that accepted the socket for a Mac that has silently gone away never
+ *  answers, and the user has to be told rather than left waiting. */
+export const RELAY_OPEN_TIMEOUT_MS = 15_000;
+
 export interface Candidate {
   url: string;
   via: Via;
-  /** Absent means "no bound" — the relay is the last resort, so waiting on it
-   *  is waiting on the only path left. */
+  /** Bound on the dial plus handshake, enforced by the transport. */
   timeoutMs?: number;
 }
 
@@ -24,7 +30,11 @@ export interface Candidate {
 export function candidatesFor(target: HostTarget, lanTimeoutMs = LAN_OPEN_TIMEOUT_MS): Candidate[] {
   const list: Candidate[] = [{ url: wsUrl(target), via: "lan", timeoutMs: lanTimeoutMs }];
   if (target.relay && target.hostKey) {
-    list.push({ url: relayDeviceUrl(target.relay, target.hostKey), via: "relay" });
+    list.push({
+      url: relayDeviceUrl(target.relay, target.hostKey),
+      via: "relay",
+      timeoutMs: RELAY_OPEN_TIMEOUT_MS,
+    });
   }
   return list;
 }

--- a/mobile/src/remote/client.ts
+++ b/mobile/src/remote/client.ts
@@ -32,6 +32,14 @@ import {
  *  or the host's remote-access switch turned back on. */
 const FATAL_CLOSE = new Set([CLOSE_UNAUTHENTICATED, CLOSE_REMOTE_DISABLED]);
 
+/** Bound on the first frames after the socket opens: `pair` or `hello`, and
+ *  the snapshot that follows a `pair`. The transport's open budget stops once
+ *  the Noise handshake is done, and a relay that has accepted the socket for a
+ *  Mac that has gone quiet forwards the request into nothing — so without a
+ *  bound of its own the attempt would sit in `pairing` for ever. */
+export const HANDSHAKE_TIMEOUT_MS = 15_000;
+const HANDSHAKE_TIMED_OUT = "The Mac did not answer. Check that it is awake and connected.";
+
 interface Pending {
   resolve: (v: unknown) => void;
   reject: (e: Error) => void;
@@ -232,7 +240,11 @@ export class ProtocolClient implements RemoteClient {
         target = { ...target, hostKey: socket.hostKey };
         this._target = target;
       }
-      return await this.handshake(target);
+      return await this.withTimeout(
+        this.handshake(target),
+        HANDSHAKE_TIMEOUT_MS,
+        HANDSHAKE_TIMED_OUT,
+      );
     } catch (e) {
       const message = e instanceof Error ? e.message : String(e);
       // A pairing code is single use and short lived, so a refused pairing
@@ -240,9 +252,34 @@ export class ProtocolClient implements RemoteClient {
       // is never worth retrying either: only re-pairing can clear it.
       const retryable = !this._target?.pairingToken && !message.includes(HOST_KEY_MISMATCH);
       const shown = reportable(message);
-      if (this.current(gen)) this.fail(shown, retryable);
+      if (this.current(gen)) {
+        // A socket whose handshake did not complete is no use, and after a
+        // timeout it is still open with the host yet to answer.
+        const socket = this.socket;
+        this.socket = null;
+        socket?.close();
+        this.fail(shown, retryable);
+      }
       throw shown === message && e instanceof Error ? e : new Error(shown);
     }
+  }
+
+  /** `promise`, or `message` as an error once `ms` have passed. Runs on the
+   *  client's injectable timer so tests can drive it. */
+  private withTimeout<T>(promise: Promise<T>, ms: number, message: string): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const handle = this.setTimer(() => reject(new Error(message)), ms);
+      promise.then(
+        (value) => {
+          this.clearTimer(handle);
+          resolve(value);
+        },
+        (error: unknown) => {
+          this.clearTimer(handle);
+          reject(error);
+        },
+      );
+    });
   }
 
   private current(gen: number): boolean {

--- a/mobile/src/remote/index.ts
+++ b/mobile/src/remote/index.ts
@@ -3,7 +3,12 @@ import { mockSocket } from "./mock";
 import type { DeviceInfo, RemoteClient } from "./types";
 import { openWebSocket } from "./ws";
 
-export { type Candidate, candidatesFor, LAN_OPEN_TIMEOUT_MS } from "./candidates";
+export {
+  type Candidate,
+  candidatesFor,
+  LAN_OPEN_TIMEOUT_MS,
+  RELAY_OPEN_TIMEOUT_MS,
+} from "./candidates";
 export { ProtocolClient } from "./client";
 export { parseAddress, parsePairUrl, relayDeviceUrl, wsUrl } from "./pairing";
 export * from "./types";

--- a/mobile/tests/protocol.test.ts
+++ b/mobile/tests/protocol.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import { backoffDelay } from "../src/remote/backoff";
-import { candidatesFor, LAN_OPEN_TIMEOUT_MS } from "../src/remote/candidates";
-import { ProtocolClient } from "../src/remote/client";
+import {
+  candidatesFor,
+  LAN_OPEN_TIMEOUT_MS,
+  RELAY_OPEN_TIMEOUT_MS,
+} from "../src/remote/candidates";
+import { HANDSHAKE_TIMEOUT_MS, ProtocolClient } from "../src/remote/client";
 import { parseAddress, parsePairUrl, relayDeviceUrl, wsUrl } from "../src/remote/pairing";
 import type { Socket, SocketHandlers, SocketOptions } from "../src/remote/socket";
 import {
@@ -76,6 +80,27 @@ function fakeSocket(hostKey = HOST_KEY, unreachable: Record<string, "reject" | "
     },
     reply: (frame: unknown) => handlers?.onMessage(JSON.stringify(frame)),
     hangup: (code: number) => handlers?.onClose(code),
+  };
+}
+
+/** The client's timers, captured instead of scheduled: what it has set and
+ *  not yet cleared. A handle is the entry itself, so clearing removes exactly
+ *  that one — the handshake bound, cleared on every answered `hello`, must not
+ *  show up next to the retry a test is looking for. */
+function captureTimers() {
+  type Timer = { fn: () => void; ms: number };
+  const timers: Timer[] = [];
+  return {
+    timers,
+    setTimer: (fn: () => void, ms: number): unknown => {
+      const timer: Timer = { fn, ms };
+      timers.push(timer);
+      return timer;
+    },
+    clearTimer: (handle: unknown) => {
+      const at = timers.indexOf(handle as Timer);
+      if (at >= 0) timers.splice(at, 1);
+    },
   };
 }
 
@@ -169,12 +194,16 @@ describe("pairing URL", () => {
 });
 
 describe("connection candidates", () => {
-  it("dials the LAN address first, with a 3 s open budget, then the relay", () => {
+  it("dials the LAN address first, with a 3 s open budget, then the relay with a longer one", () => {
     expect(
       candidatesFor({ host: "h", port: 1, hostKey: HOST_KEY, relay: "wss://relay.test" }),
     ).toEqual([
       { url: "ws://h:1/ws", via: "lan", timeoutMs: LAN_OPEN_TIMEOUT_MS },
-      { url: `wss://relay.test/v1/device/${HOST_KEY}`, via: "relay" },
+      {
+        url: `wss://relay.test/v1/device/${HOST_KEY}`,
+        via: "relay",
+        timeoutMs: RELAY_OPEN_TIMEOUT_MS,
+      },
     ]);
   });
 
@@ -295,15 +324,12 @@ describe("envelope", () => {
 
   it("refuses a host presenting a key other than the pinned one, and never retries", async () => {
     const fake = fakeSocket("hostkey-bbb");
-    const timers: { fn: () => void; ms: number }[] = [];
+    const { timers, setTimer, clearTimer } = captureTimers();
     const client = new ProtocolClient({
       openSocket: fake.factory,
       device: DEVICE,
-      setTimer: (fn, ms) => {
-        timers.push({ fn, ms });
-        return timers.length;
-      },
-      clearTimer: () => {},
+      setTimer,
+      clearTimer,
     });
     await expect(client.connect({ host: "h", port: 1, hostKey: HOST_KEY })).rejects.toThrow(
       HOST_KEY_MISMATCH_REASON,
@@ -320,7 +346,7 @@ describe("envelope", () => {
 describe("connection lifecycle", () => {
   /** A client whose socket never opens, plus the timers it schedules. */
   function unreachable() {
-    const timers: { fn: () => void; ms: number }[] = [];
+    const { timers, setTimer, clearTimer } = captureTimers();
     let attempts = 0;
     const client = new ProtocolClient({
       openSocket: async () => {
@@ -328,11 +354,8 @@ describe("connection lifecycle", () => {
         throw new Error("Cannot reach ws://h:1/ws");
       },
       device: DEVICE,
-      setTimer: (fn, ms) => {
-        timers.push({ fn, ms });
-        return timers.length;
-      },
-      clearTimer: () => {},
+      setTimer,
+      clearTimer,
     });
     return { client, timers, attempts: () => attempts };
   }
@@ -361,19 +384,47 @@ describe("connection lifecycle", () => {
     expect(timers).toHaveLength(0);
   });
 
+  it("gives up on a pairing the host never answers, instead of waiting for ever", async () => {
+    // The relay accepts a device link whenever it believes a host link is up,
+    // and a Mac that went to sleep leaves it believing that: the socket opens,
+    // `pair` goes out, and nothing ever comes back.
+    const fake = fakeSocket();
+    const { timers, setTimer, clearTimer } = captureTimers();
+    const client = new ProtocolClient({
+      openSocket: fake.factory,
+      device: DEVICE,
+      setTimer,
+      clearTimer,
+    });
+    const pairing = client.connect({
+      host: "h",
+      port: 1,
+      hostKey: HOST_KEY,
+      pairingToken: "K7PQ2M9X",
+    });
+    await vi.waitFor(() => expect(fake.sent.length).toBe(1));
+    expect(fake.sent[0].op).toBe("pair");
+    expect(client.state).toBe("pairing");
+    expect(timers.map((t) => t.ms)).toEqual([HANDSHAKE_TIMEOUT_MS]);
+
+    timers[0].fn();
+    await expect(pairing).rejects.toThrow("did not answer");
+    // Back to a state the Pair button can act on, and no retry: the code is
+    // single use, so the next attempt is the user's.
+    expect(client.state).toBe("error");
+    expect(timers.filter((t) => t.ms !== HANDSHAKE_TIMEOUT_MS)).toHaveLength(0);
+  });
+
   it("ignores a close from a socket it has already replaced", async () => {
     const first = fakeSocket();
     const second = fakeSocket();
-    const timers: { fn: () => void; ms: number }[] = [];
+    const { timers, setTimer, clearTimer } = captureTimers();
     let opens = 0;
     const client = new ProtocolClient({
       openSocket: (url, h) => (opens++ === 0 ? first.factory(url, h) : second.factory(url, h)),
       device: DEVICE,
-      setTimer: (fn, ms) => {
-        timers.push({ fn, ms });
-        return timers.length;
-      },
-      clearTimer: () => {},
+      setTimer,
+      clearTimer,
     });
     const stale = client.connect({ host: "h", port: 1, hostKey: HOST_KEY });
     await vi.waitFor(() => expect(first.sent.length).toBe(1));
@@ -382,28 +433,28 @@ describe("connection lifecycle", () => {
     await expect(stale).rejects.toThrow();
     await vi.waitFor(() => expect(second.sent.length).toBe(1));
 
-    // Socket one's close finally arrives. It must not tear down socket two.
+    // Socket one's close finally arrives. It must not tear down socket two,
+    // nor schedule a retry: the only timer live is socket two's handshake
+    // bound (socket one's was cleared when its handshake was abandoned).
     first.hangup(1006);
-    expect(timers).toHaveLength(0);
+    expect(timers.map((t) => t.ms)).toEqual([HANDSHAKE_TIMEOUT_MS]);
     expect(client.state).toBe("connecting");
     second.reply(helloOk(second.sent[0].id as string));
     await expect(live).resolves.toMatchObject({ host: { name: "Mac" } });
     expect(client.state).toBe("connected");
+    expect(timers).toHaveLength(0);
   });
 });
 
 describe("reconnect", () => {
   it("retries with backoff after an unexpected close and re-sends hello", async () => {
     const fake = fakeSocket();
-    const timers: { fn: () => void; ms: number }[] = [];
+    const { timers, setTimer, clearTimer } = captureTimers();
     const client = new ProtocolClient({
       openSocket: fake.factory,
       device: DEVICE,
-      setTimer: (fn, ms) => {
-        timers.push({ fn, ms });
-        return timers.length;
-      },
-      clearTimer: () => {},
+      setTimer,
+      clearTimer,
     });
     const connected = client.connect({ host: "h", port: 1, hostKey: HOST_KEY });
     await vi.waitFor(() => expect(fake.sent.length).toBe(1));
@@ -427,15 +478,12 @@ describe("reconnect", () => {
 
   it("retries a relay 4404 and says what it means: the Mac is offline", async () => {
     const fake = fakeSocket();
-    const timers: { fn: () => void; ms: number }[] = [];
+    const { timers, setTimer, clearTimer } = captureTimers();
     const client = new ProtocolClient({
       openSocket: fake.factory,
       device: DEVICE,
-      setTimer: (fn, ms) => {
-        timers.push({ fn, ms });
-        return timers.length;
-      },
-      clearTimer: () => {},
+      setTimer,
+      clearTimer,
     });
     const reported: (string | undefined)[] = [];
     client.onState((_state, error) => reported.push(error));
@@ -457,15 +505,12 @@ describe("reconnect", () => {
 
   it("does not retry after a 4003 close — the device has to be paired again", async () => {
     const fake = fakeSocket();
-    const timers: { fn: () => void; ms: number }[] = [];
+    const { timers, setTimer, clearTimer } = captureTimers();
     const client = new ProtocolClient({
       openSocket: fake.factory,
       device: DEVICE,
-      setTimer: (fn, ms) => {
-        timers.push({ fn, ms });
-        return timers.length;
-      },
-      clearTimer: () => {},
+      setTimer,
+      clearTimer,
     });
     const connected = client.connect({ host: "h", port: 1, hostKey: HOST_KEY });
     await vi.waitFor(() => expect(fake.sent.length).toBe(1));
@@ -504,16 +549,13 @@ describe("relay fallback", () => {
   /** A client with a tiny open budget and captured timers, so a hanging dial
    *  and a scheduled retry are both observable without real waiting. */
   function relayClient(fake: ReturnType<typeof fakeSocket>) {
-    const timers: { fn: () => void; ms: number }[] = [];
+    const { timers, setTimer, clearTimer } = captureTimers();
     const client = new ProtocolClient({
       openSocket: fake.factory,
       device: DEVICE,
       openTimeout: 5,
-      setTimer: (fn, ms) => {
-        timers.push({ fn, ms });
-        return timers.length;
-      },
-      clearTimer: () => {},
+      setTimer,
+      clearTimer,
     });
     return { client, timers };
   }
@@ -543,7 +585,7 @@ describe("relay fallback", () => {
     // `hello` on the same pinned key.
     expect(fake.urls).toEqual([LAN, RELAY]);
     expect(fake.asked).toEqual([HOST_KEY, HOST_KEY]);
-    expect(fake.budgets).toEqual([5, undefined]);
+    expect(fake.budgets).toEqual([5, RELAY_OPEN_TIMEOUT_MS]);
     expect(client.via).toBe("relay");
   });
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1372,6 +1372,7 @@ dependencies = [
  "rfd",
  "rusqlite",
  "rusqlite_migration",
+ "rustls",
  "security-framework",
  "sentry",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -83,6 +83,14 @@ tokio-tungstenite = { version = "0.27", default-features = false, features = [
   "connect",
   "rustls-tls-webpki-roots",
 ] }
+# rustls ends up with *both* crypto backends enabled in this tree (reqwest 0.12
+# via sentry wants aws-lc-rs, reqwest 0.13 wants ring), and with two it refuses
+# to pick: the first `ClientConfig::builder()` panics unless a process-level
+# provider was installed beforehand. The relay link was that first caller on
+# autostart, and its task died with the panic. `run()` installs `ring` before
+# anything dials; this direct dependency is only what gives `run()` the path to
+# name it — it enables nothing that was not already on.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 # The remote secure channel (`remote/secure.rs`):
 # `Noise_XX_25519_ChaChaPoly_BLAKE2s`, the pattern the protocol doc fixes.
 snow = "0.10"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1305,6 +1305,14 @@ fn setup_tray(app: &tauri::AppHandle, status_slot: &TrayStatusSlot) -> tauri::Re
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // rustls has two crypto backends compiled in (see `rustls` in Cargo.toml)
+    // and panics on the first TLS client it is asked to build unless one has
+    // been installed as the process default. The relay link was that first
+    // client on autostart, and its task died with the panic — so the relay
+    // only ever came up when switched on by hand, after something else had
+    // installed a provider. `Err` means one is already installed; fine.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
     // Error/crash reporting. The DSN is baked in at build time via
     // `QUORUM_SENTRY_DSN` (empty/unset → a disabled, no-op client, so dev and
     // unconfigured builds send nothing). This captures app health — Rust

--- a/src/components/SettingsScreen/RemoteControl/PairingCard.tsx
+++ b/src/components/SettingsScreen/RemoteControl/PairingCard.tsx
@@ -34,11 +34,15 @@ function useCountdown(iso: string): number {
 export function PairingCard({
   invite,
   hostId,
+  lanOnly,
   onRegenerate,
   onDismiss,
 }: {
   invite: PairingInvite;
   hostId?: string;
+  /** No relay link is up, so the link carries no relay and the phone can
+   *  only reach this Mac from the same network. */
+  lanOnly?: boolean;
   onRegenerate: () => void;
   onDismiss: () => void;
 }) {
@@ -55,6 +59,13 @@ export function PairingCard({
             ? "This code has expired. Generate a new one."
             : "Enter this code in Fletch on your phone, or scan the code."}
         </div>
+        {!expired && lanOnly && (
+          <div className="set-inline-warn text-sm">
+            The relay is not connected, so this pairing only works while the phone is on the same
+            network as this Mac. Turn on “Reach this Mac from anywhere” and generate a new code to
+            pair from anywhere.
+          </div>
+        )}
         <div className="set-pair-meta text-xs flex-center">
           <span className={`set-pair-clock mono ${left <= 30 ? "urgent" : ""}`}>
             {expired ? "expired" : `expires in ${mmss}`}

--- a/src/components/SettingsScreen/RemoteControl/index.tsx
+++ b/src/components/SettingsScreen/RemoteControl/index.tsx
@@ -88,6 +88,7 @@ export function RemoteControlPane() {
           <PairingCard
             invite={invite}
             hostId={status?.hostId}
+            lanOnly={status?.relay.state !== "connected"}
             onRegenerate={() => void beginPairing()}
             onDismiss={clearInvite}
           />


### PR DESCRIPTION
## Why

Pairing a phone only worked on the LAN: from cellular the Pair button sat on "Pairing…" for ever, and scanning the QR on iOS showed "No usable data found". The relay also never came up on its own after a desktop relaunch.

## Root causes

1. **Mobile: rustls had no crypto backend.** `tokio-tungstenite`'s `rustls-tls-webpki-roots` brings none, so the first `wss://` dial panicked inside the `remote_connect` Tauri command. A panicked command is an `invoke` that never resolves — hence the endless "Pairing…" exactly when the relay was tried.
2. **Desktop: rustls had two backends** (ring via reqwest 0.13, aws-lc-rs via sentry's reqwest 0.12) and panics the same way unless a provider is installed first. The relay link was the first TLS caller on autostart and its task died silently (`ERROR fletch_lib: panic … crypto/mod.rs:249` right after every `remote: listening` in the logs). The relay only ever came up when toggled by hand, after something else had installed a provider.
3. **Mobile deep link declared an https app link** (`host: pair`), which made the plugin strip `CFBundleURLTypes` from Info.plist. iOS had no app for `fletch://`, so the Camera had nothing to open.

## Changes

- Mobile: add `rustls` with `ring`, install it in `run()`; unit test builds a `ClientConfig`, the call that panicked.
- Desktop: install `ring` at the top of `run()` (direct `rustls` dep only to name it; enables nothing new).
- Mobile deep-link config: `{ "scheme": ["fletch"], "host": "pair" }`. **Needs an iOS rebuild** — Info.plist is regenerated at build time.
- Relay path is now bounded: 15 s to open (dial + Noise handshake, enforced in Rust) and 15 s for the first frame after it, so a relay that accepted a socket for a Mac that has gone quiet fails with "The Mac did not answer" instead of never. Socket closed on a failed handshake.
- Settings pairing card warns when the relay is not connected (that link is LAN-only).
- `docs/remote-protocol.md` updated for the new budgets.

## Verification

- Mobile vitest: 121 pass (2 new: relay budget on the candidate, pairing that is never answered fails and does not retry).
- Mobile `cargo test`: 14 pass, including the new rustls backend test.
- Desktop `cargo check`, both `tsc`, both `biome`: clean.
- Not verified here: an iOS build and a real cellular pairing.