### PR TITLE
fix(mobile): even composer margins and let the field grow with the text

### DIFF
--- a/mobile/src/screens/Agent/Composer/index.tsx
+++ b/mobile/src/screens/Agent/Composer/index.tsx
@@ -24,8 +24,11 @@ const SEND_ARM_MS = 450;
  *  which fades over 1.1 s. */
 const FRESH_TTL_MS = 1200;
 
-/** Field height cap before it scrolls internally. */
-const MAX_FIELD_PX = 160;
+/** Field height cap before it scrolls internally: the field follows the text
+ *  up to 40% of the visible viewport, so a long draft stays readable while the
+ *  log keeps most of the screen. Read per call, since the keyboard changes the
+ *  viewport. Mirrors the `40dvh` max-height in agent.css. */
+const fieldCap = () => Math.round(window.innerHeight * 0.4);
 
 /** The phone's composer: the field, and a footer whose primary control is one
  *  44 pt disc that morphs in place — mic → send → done → stop — with the mic
@@ -68,7 +71,7 @@ export function Composer({
       freshTimer.current = null;
       setFresh(null);
     }, FRESH_TTL_MS);
-    requestAnimationFrame(() => autosize(ta.current, 0, MAX_FIELD_PX));
+    requestAnimationFrame(() => autosize(ta.current, 0, fieldCap()));
   });
 
   useEffect(
@@ -101,7 +104,7 @@ export function Composer({
     const value = text.trim();
     if (!value || busy || dictation.phase !== "idle") return;
     setText("");
-    requestAnimationFrame(() => autosize(ta.current, 0, MAX_FIELD_PX));
+    requestAnimationFrame(() => autosize(ta.current, 0, fieldCap()));
     setArmed(false);
     if (armTimer.current !== null) window.clearTimeout(armTimer.current);
     armTimer.current = window.setTimeout(() => {
@@ -159,7 +162,7 @@ export function Composer({
             value={text}
             onChange={(e) => {
               setText(e.target.value);
-              autosize(e.currentTarget, 0, MAX_FIELD_PX);
+              autosize(e.currentTarget, 0, fieldCap());
             }}
           />
           {(listening || fresh !== null) && (

--- a/mobile/src/styles/agent.css
+++ b/mobile/src/styles/agent.css
@@ -370,9 +370,12 @@
   padding-top: 2px;
 }
 
+/* The box sits as far from the bottom as from the sides. The home indicator
+   overlays the bottom ~14px of the inset, so on a phone the gap is the inset
+   minus that; anywhere without an inset it's just the side margin. */
 .composer {
   flex-shrink: 0;
-  padding: 8px 12px calc(var(--safe-bottom) + 4px);
+  padding: 8px 12px max(12px, calc(env(safe-area-inset-bottom, 0px) - 14px));
   background: var(--bg-0);
   border-top: 1px solid var(--bd-soft);
 }
@@ -413,7 +416,7 @@
   font-size: 16px;
   line-height: 1.4;
   min-height: 48px;
-  max-height: 160px;
+  max-height: 40dvh; /* keep in step with fieldCap() in Composer/index.tsx */
   letter-spacing: -0.005em;
   display: block;
 }


### PR DESCRIPTION
## Summary

Two tweaks to the mobile agent composer, from a screenshot review.

**Even margins.** The composer box sat about 38px off the bottom of the screen on an iPhone (safe-area inset + 4px) against 12px on the sides. Its bottom padding is now `max(12px, env(safe-area-inset-bottom) - 14px)`: exactly the side margin on devices with no inset, and about 20px on an iPhone so the box stays just clear of the home indicator.

**Auto-grow.** The field already resized to its content, but capped at a fixed 160px (~6 lines). The cap is now 40% of the visible viewport, computed per keystroke via `fieldCap()` so it tracks the keyboard, with a matching `40dvh` max-height in `agent.css`. Past that the field scrolls internally so the log keeps most of the screen.

## Files

- `mobile/src/styles/agent.css` — composer bottom padding; textarea/ghost max-height
- `mobile/src/screens/Agent/Composer/index.tsx` — `MAX_FIELD_PX` constant → `fieldCap()`

## Verification

- `bun run check` and `bun run lint` pass in `mobile/`.
- Not verified on a device; needs an iOS rebuild to see the result.