### PR TITLE
feat(mobile): dictate the first prompt on the new-agent sheet

### DIFF
--- a/mobile/src/dictation/VoiceRow.tsx
+++ b/mobile/src/dictation/VoiceRow.tsx
@@ -3,16 +3,18 @@ import {
   type PrimaryState,
 } from "@desktop/components/Composer/PrimaryControl/primaryState";
 import { useElapsed } from "@desktop/components/Composer/PrimaryControl/useElapsed";
-import { Icon } from "../../../components/Icon";
+import { Icon } from "../components/Icon";
 
 /** Bar height range, in px: silence sits at the floor, loud speech fills. */
 const MIN_PX = 3;
 const RANGE_PX = 19;
 
-/** What the footer's leading row becomes while the mic is open: ✕ cancel on
- *  the far left, a full-width waveform of recent microphone levels with the
- *  elapsed clock, and — once the mic has closed — the "Transcribing" label in
- *  their place. Every exit has a button; there is no esc key here. */
+/** What a composer's tool row becomes while the mic is open: ✕ cancel on the
+ *  far left, a full-width waveform of recent microphone levels with the elapsed
+ *  clock, and — once the mic has closed — the "Transcribing" label in their
+ *  place. Every exit has a button; there is no esc key here. The host row sizes
+ *  it through `className` (the chat footer and the new-agent prompt give it
+ *  different room). */
 export function VoiceRow({
   className,
   state,

--- a/mobile/src/dictation/index.ts
+++ b/mobile/src/dictation/index.ts
@@ -1,2 +1,3 @@
 export { LEVEL_BARS, normalizeLevel } from "./level";
 export { type DictationPhase, useDictation } from "./useDictation";
+export { VoiceRow } from "./VoiceRow";

--- a/mobile/src/screens/Agent/Composer/index.tsx
+++ b/mobile/src/screens/Agent/Composer/index.tsx
@@ -8,13 +8,12 @@ import { primaryState } from "@desktop/components/Composer/PrimaryControl/primar
 import { useEffect, useRef, useState } from "react";
 import { Icon } from "../../../components/Icon";
 import { ProviderMark } from "../../../components/ui";
-import { useDictation } from "../../../dictation";
+import { useDictation, VoiceRow } from "../../../dictation";
 import { isBusy, modelLabel } from "../../../lib/agents";
 import { autosize } from "../../../lib/autosize";
 import { ignore } from "../../../lib/ignore";
 import { useStore } from "../../../store";
 import { PrimaryPair } from "./PrimaryPair";
-import { VoiceRow } from "./VoiceRow";
 
 /** Stop ignores taps this long after send, so a double-tap can't kill the run
  *  it just started. Taps are swallowed, not queued. */

--- a/mobile/src/sheets/NewAgentSheet/PromptField.tsx
+++ b/mobile/src/sheets/NewAgentSheet/PromptField.tsx
@@ -1,0 +1,119 @@
+import { spliceTranscript } from "@desktop/components/Composer/dictation/spliceTranscript";
+import { primaryState } from "@desktop/components/Composer/PrimaryControl/primaryState";
+import { type ReactNode, useEffect, useRef } from "react";
+import { Icon } from "../../components/Icon";
+import { useDictation, VoiceRow } from "../../dictation";
+import { autosize } from "../../lib/autosize";
+
+/** The heights the field grows between, in px. Mirrors `.na-prompt textarea`
+ *  in screens.css, which sets the resting one. */
+const MIN_PX = 120;
+const MAX_PX = 260;
+
+/** The first prompt for a new agent: the field, and the row of pickers along
+ *  its foot. The mic sits at the right of that row and, while it is open, the
+ *  pickers give way to the waveform — the same dictation the chat composer
+ *  offers, in the shape this box has room for. */
+export function PromptField({
+  value,
+  onChange,
+  onDictating,
+  children,
+}: {
+  value: string;
+  onChange: (next: string) => void;
+  /** Fires as a session opens and closes, so the sheet can hold its Start
+   *  button until the words have landed in the draft. */
+  onDictating: (live: boolean) => void;
+  /** The pickers under the field (the runner chip). Hidden while the waveform
+   *  has the row. */
+  children: ReactNode;
+}) {
+  const ta = useRef<HTMLTextAreaElement>(null);
+  // Read in the dictation callback, which lands whenever the host answers —
+  // against whatever the box holds by then, not what it held at the tap.
+  const valueRef = useRef(value);
+  valueRef.current = value;
+
+  // The transcript arrives once, at the end (whisper has no partials), and is
+  // appended with the same join rule as the desktop so a dictated list item
+  // keeps its newline.
+  const dictation = useDictation((spoken) => {
+    onChange(spliceTranscript(valueRef.current, spoken).text);
+    requestAnimationFrame(() => autosize(ta.current, MIN_PX, MAX_PX));
+  });
+
+  const state = primaryState({
+    sttError: dictation.error !== null,
+    dictation: dictation.phase,
+    agentRunning: false,
+    hasDraft: value.trim().length > 0,
+    micDenied: dictation.blocked,
+  });
+  const listening = state === "listening";
+  const voice = listening || state === "transcribing";
+
+  useEffect(() => {
+    onDictating(dictation.phase !== "idle");
+  }, [dictation.phase, onDictating]);
+
+  return (
+    <>
+      <div className={`na-prompt${listening ? " is-listening" : ""}`}>
+        <textarea
+          ref={ta}
+          rows={4}
+          placeholder={
+            dictation.supported
+              ? "Describe the task, or tap the mic — this becomes the agent's first message."
+              : "Describe the task — this becomes the agent's first message."
+          }
+          value={value}
+          onChange={(e) => {
+            onChange(e.target.value);
+            autosize(e.currentTarget, MIN_PX, MAX_PX);
+          }}
+        />
+        <div className="na-tools">
+          {voice ? (
+            <VoiceRow
+              className="na-voice"
+              state={state}
+              levels={dictation.levels}
+              startedAt={dictation.startedAt}
+              onCancel={dictation.cancel}
+            />
+          ) : (
+            <>
+              {children}
+              <span className="grow" />
+            </>
+          )}
+          {dictation.supported && (
+            <button
+              type="button"
+              className={`na-mic${listening ? " on" : ""}`}
+              aria-label={
+                listening
+                  ? "Done — stop and transcribe"
+                  : dictation.blocked
+                    ? "Dictation is off"
+                    : "Dictate"
+              }
+              // Nothing to do while the host transcribes; the row says so.
+              disabled={state === "transcribing"}
+              onClick={() => void dictation.toggle()}
+            >
+              {listening ? (
+                <Icon name="check" size={16} sw={2.2} />
+              ) : (
+                <Icon name={dictation.blocked ? "micOff" : "mic"} size={16} />
+              )}
+            </button>
+          )}
+        </div>
+      </div>
+      {dictation.error && <div className="err na-err">{dictation.error}</div>}
+    </>
+  );
+}

--- a/mobile/src/sheets/NewAgentSheet/index.tsx
+++ b/mobile/src/sheets/NewAgentSheet/index.tsx
@@ -1,11 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Icon } from "../../components/Icon";
 import { PickerSheet, ProviderMark, Sheet, Swatch } from "../../components/ui";
 import { modelLabel, providerLabel } from "../../lib/agents";
-import { autosize } from "../../lib/autosize";
 import { ignore } from "../../lib/ignore";
 import { modelsFor, useModels } from "../../lib/models";
 import { api, useStore } from "../../store";
+import { PromptField } from "./PromptField";
 import { RunnerSheet } from "./RunnerSheet";
 
 type Picker = "project" | "branch" | "runner" | null;
@@ -40,7 +40,9 @@ export function NewAgentSheet({
   const [name, setName] = useState("");
   const [picker, setPicker] = useState<Picker>(null);
   const [starting, setStarting] = useState(false);
-  const ta = useRef<HTMLTextAreaElement>(null);
+  // A live mic holds the Start button: the words are still on their way into
+  // the draft, and spawning now would send it without them.
+  const [dictating, setDictating] = useState(false);
 
   const project = projects.find((p) => p.project_id === pid) ?? projects[0];
 
@@ -89,7 +91,7 @@ export function NewAgentSheet({
   const chosenBase = base ?? defaultBase;
   const providerModels = modelsFor(models, provider);
   const start = () => {
-    if (!prompt.trim() || starting) return;
+    if (!prompt.trim() || starting || dictating) return;
     setStarting(true);
     clearError();
     void spawn({
@@ -123,7 +125,7 @@ export function NewAgentSheet({
           <button
             type="button"
             className="btn primary block"
-            disabled={!prompt.trim() || starting}
+            disabled={!prompt.trim() || starting || dictating}
             onClick={start}
           >
             <Icon name="play" size={15} />
@@ -160,30 +162,17 @@ export function NewAgentSheet({
           </button>
           .
         </p>
-        <div className="na-prompt">
-          <textarea
-            ref={ta}
-            rows={4}
-            placeholder="Describe the task — this becomes the agent's first message."
-            value={prompt}
-            onChange={(e) => {
-              setPrompt(e.target.value);
-              autosize(e.currentTarget, 120, 260);
-            }}
-          />
-          <div className="na-tools">
-            <button type="button" className="chip runner" onClick={() => setPicker("runner")}>
-              <ProviderMark id={provider} />
-              <span>{providerLabel(provider)}</span>
-              <span className="sep">·</span>
-              <span>{modelLabel(model)}</span>
-              <span className="sep">·</span>
-              <span>{effort}</span>
-              <Icon name="chevD" size={11} style={{ color: "var(--fg-3)" }} />
-            </button>
-            <span className="grow" />
-          </div>
-        </div>
+        <PromptField value={prompt} onChange={setPrompt} onDictating={setDictating}>
+          <button type="button" className="chip runner" onClick={() => setPicker("runner")}>
+            <ProviderMark id={provider} />
+            <span>{providerLabel(provider)}</span>
+            <span className="sep">·</span>
+            <span>{modelLabel(model)}</span>
+            <span className="sep">·</span>
+            <span>{effort}</span>
+            <Icon name="chevD" size={11} style={{ color: "var(--fg-3)" }} />
+          </button>
+        </PromptField>
         {lastError && <div className="err na-err">{lastError}</div>}
         <div className="na-ctx">
           <button type="button" className="chip" onClick={() => setPicker("project")}>

--- a/mobile/src/styles/screens.css
+++ b/mobile/src/styles/screens.css
@@ -494,6 +494,61 @@
 .na-tools .grow {
   flex: 1;
 }
+/* Dictation in the prompt box: the mic keeps the row's right end in every
+   state, and the pickers to its left are replaced by the waveform while the
+   mic is open. The voice row is the chat composer's, sized down to the band
+   this box leaves under the field. */
+.na-prompt.is-listening {
+  border-color: var(--accent-line);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.na-mic {
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  background: var(--bg-3);
+  color: var(--fg-1);
+}
+.na-mic.on {
+  background: var(--accent);
+  color: var(--accent-ink);
+}
+.na-mic:disabled {
+  opacity: 0.5;
+}
+.na-mic:active:not(:disabled) {
+  background: oklch(from var(--bg-3) calc(l + 0.04) c h);
+}
+.na-voice {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+}
+.na-voice .m-cancel,
+.na-voice .m-cancel .circ {
+  width: 30px;
+  height: 30px;
+}
+.na-voice .m-wave {
+  padding: 0 4px;
+  gap: 8px;
+}
+.na-voice .m-wave .bars {
+  height: 18px;
+}
+.na-voice .m-wave .clock {
+  font-size: 12px;
+}
+.na-voice .m-wave.tx {
+  font-size: 13px;
+  padding-left: 6px;
+}
 .na-ctx {
   display: flex;
   gap: 6px;


### PR DESCRIPTION
On the phone, the chat composer has a mic but the **New agent** sheet did not — the first prompt had to be typed. (On desktop both views render the same `Composer`, so this gap was mobile-only.)

## What changed

- **`mobile/src/dictation/VoiceRow.tsx`** — moved out of `screens/Agent/Composer/` (its CSS was already global) and exported from the `dictation` module, so both composers share the one cancel + waveform + clock row.
- **`mobile/src/sheets/NewAgentSheet/PromptField.tsx`** (new) — the prompt box now owns dictation: a mic at the right end of the tools row, the pickers giving way to the waveform while the mic is open, the transcript appended through the same `spliceTranscript` join rule as chat, and the dictation error line under the box. Reuses `primaryState` for the mic / listening / transcribing states.
- **`NewAgentSheet/index.tsx`** — renders `PromptField` with the runner chip as its children; **Start** is held while a session is live, so nothing spawns before the words land in the draft.
- **`styles/screens.css`** — mic disc and a sized-down voice row for the 44px band under the field; the box picks up the accent ring while listening.

## Testing

`tsc --noEmit`, biome, and the 122 mobile tests pass. Not yet run on a device — the flow to eyeball is: New agent → mic at the bottom-right of the prompt box → speak → tap ✓ (or just stop talking; silence ends the session) → text appends to the draft.