### PR TITLE
fix(mobile): keep the live log when an agent is re-opened mid-turn

### DIFF
--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -6,6 +6,7 @@ import type { GhRepoSummary, GhStatus } from "@desktop/api/types/providers";
 import { create } from "zustand";
 import type { ChatItem, RawEvent } from "../adapters";
 import { createApi } from "../api";
+import { isBusy } from "../lib/agents";
 import { ignore } from "../lib/ignore";
 import {
   type ConnectionState,
@@ -446,7 +447,14 @@ export const useStore = create<MobileState>()((set, get) => ({
   },
 
   async loadAgent(agentId) {
-    await get().rebuildLog(agentId);
+    // A running turn's log is built from live events; the host's records only
+    // catch up at turn end (see rebuildLog). Rebuilding now would replace it
+    // with the prompt alone, so a re-open or reconnect mid-turn keeps what the
+    // stream rendered. The turn-end `session:records-appended` rebuild — which
+    // calls rebuildLog directly — is the authoritative one.
+    const agent = agentOf(get().workspace, agentId);
+    const midTurn = agent !== undefined && isBusy(agent) && get().logs[agentId] !== undefined;
+    if (!midTurn) await get().rebuildLog(agentId);
     await get().loadGit(agentId);
   },
 

--- a/mobile/tests/store.test.ts
+++ b/mobile/tests/store.test.ts
@@ -211,6 +211,51 @@ describe("spawn flow", () => {
     expect(fresh?.name).toBeTruthy();
   });
 
+  it("keeps the live log when the agent is re-opened mid-turn", async () => {
+    await state().spawn({
+      repoPath: state().workspace?.projects[0].path ?? "",
+      provider: "claude",
+      model: "claude-opus-5",
+      effort: "high",
+      base: "main",
+      prompt: "Wire the dictation engine picker",
+      name: "lofoten",
+    });
+    const id = state().workspace?.agents[0]?.id ?? "";
+    // A tool call has streamed in and the turn is still running.
+    await vi.waitFor(
+      () => {
+        expect(agentOf(state().workspace, id)?.status).toBe("running");
+        expect((state().logs[id] ?? []).some((i) => i.kind === "tool_call")).toBe(true);
+      },
+      { timeout: 10_000 },
+    );
+    const live = state().logs[id] ?? [];
+    // The real host ingests a turn's transcript only at turn end, so mid-turn its
+    // records stop at the prompt. The mock persists every step, so hold it back.
+    const records = await api.readSessionRecords(id);
+    const read = vi.spyOn(api, "readSessionRecords").mockResolvedValue(records.slice(0, 1));
+    try {
+      // Back to the list, then into the agent again: what openAgent runs.
+      state().pop();
+      await state().loadAgent(id);
+    } finally {
+      read.mockRestore();
+    }
+    const after = state().logs[id] ?? [];
+    expect(after.length).toBeGreaterThanOrEqual(live.length);
+    for (const item of live) expect(after).toContainEqual(item);
+
+    // Once the turn ends the host's records are complete and authoritative:
+    // re-opening then does rebuild from them.
+    await vi.waitFor(() => expect(agentOf(state().workspace, id)?.status).toBe("idle"), {
+      timeout: 10_000,
+    });
+    useStore.setState((s) => ({ logs: { ...s.logs, [id]: (s.logs[id] ?? []).slice(0, 1) } }));
+    await state().loadAgent(id);
+    expect((state().logs[id] ?? []).some((i) => i.kind === "tool_call")).toBe(true);
+  }, 30_000);
+
   it("rejects and rolls back when the first message fails, so the prompt can be retried", async () => {
     const send = vi
       .spyOn(api, "sendUserMessage")


### PR DESCRIPTION
## Problem

On the phone, leaving an agent for the list and coming back while a turn was running wiped the transcript: only the first message remained, and only new rows appeared afterwards.

`openAgent` (and the reconnect / return-to-foreground refresh) run `loadAgent` → `rebuildLog`, which replaces the in-memory log with the host's session records. For a custom-view agent the host ingests the transcript only at turn end, so mid-turn the records stop at the prompt and the rebuild dropped everything the live stream had rendered. The desktop never hits this because `useTranscript` only loads history when no log exists yet.

## Fix

`loadAgent` skips the records rebuild while the agent is running/spawning and a live log already exists. Idle agents and agents with no log still reload as before, and the turn-end `session:records-appended` handler calls `rebuildLog` directly, so the authoritative rebuild is unchanged.

Trade-off: a socket drop mid-turn no longer replaces the log with the host's partial records; missed events are recovered at turn end by the records-appended rebuild (previously that path recovered nothing either, and wiped the screen).

## Validation

- New store test spawns an agent through the mock host, waits for a tool call to stream in mid-turn, holds the host's records back to the prompt, simulates back → reopen, and asserts every live item survives. It then waits for idle, truncates the log, reloads, and asserts the records rebuild still happens.
- The test failed before the fix (log shrank from 6 items to 1) and passes after.
- `bun run test` (123 passed), `bun run check`, `bun run lint` all clean in `mobile/`.