### PR TITLE
fix(mobile): wrap long unbroken tokens instead of panning the transcript

### DIFF
--- a/mobile/src/styles/agent.css
+++ b/mobile/src/styles/agent.css
@@ -18,9 +18,36 @@
   display: flex;
   flex-direction: column;
   gap: 12px;
+  /* `.scroll` sets overflow-y only, which computes overflow-x to `auto` rather
+     than leaving it visible — so a single unbreakable row pans the whole
+     transcript sideways. The wrap rule below is the real fix; this is the
+     backstop that stops a future row type from re-opening the gesture. Code
+     blocks and tables carry their own overflow-x and still swipe. */
+  overflow-x: hidden;
 }
 .chat > * {
   flex-shrink: 0;
+}
+/* Transcript text is arbitrary: a URL, a $PATH dump, a base64 blob, a stack
+   frame. Those carry no space to break at, and `.msg-user` is sized to
+   fit-content — so its min-content width (the whole token) beats its 88%
+   max-width and the bubble grows past the viewport. `anywhere` breaks mid-token
+   as a last resort; unlike `break-word` its break points count toward
+   min-content sizing, which is what pulls the bubble back inside. And because
+   `overflow-wrap` inherits, one declaration per row root also covers that row's
+   paragraphs, list items, links and inline code. */
+.msg-user,
+.msg-text,
+.reasoning,
+.notice {
+  overflow-wrap: anywhere;
+}
+/* Tables opt back out: they scroll sideways by design (see `.msg-text table`),
+   and mid-word breaks would shrink the columns instead of letting the table
+   scroll. Fenced code needs no opt-out — `white-space: pre` already disables
+   wrapping there, so the inherited value has no effect. */
+.msg-text table {
+  overflow-wrap: normal;
 }
 .msg-user {
   align-self: flex-end;


### PR DESCRIPTION
## What

A long string with no spaces in the transcript — a URL, a `$PATH` dump, a base64 blob, a stack frame — put the mobile chat view into horizontal scroll. Now it wraps.

## Root cause

Two things combined:

1. **No break rule on any prose row.** `.msg-user`, `.msg-text`, `.reasoning` and `.notice` in `mobile/src/styles/agent.css` had no `overflow-wrap`/`word-break` at all. The only break declarations in the mobile transcript were on `.tool-out` and `.appr .cmd`, both of which already sit inside clipped containers and so were never the ones exposed.
2. **The pane is a horizontal scroller by accident.** `.scroll` (`base.css:282`) sets only `overflow-y: auto`. Per the overflow spec, when one axis is `visible` and the other is not, the `visible` one computes to `auto` — so `overflow-x` was `auto`, and a single overflowing row panned the whole transcript.

The likely trigger is `.msg-user`: it is `align-self: flex-end; max-width: 88%`, so it is not stretched and its used width is fit-content, floored at min-content. With no break rule an unbroken token’s min-content *is* the whole token, so the bubble itself grew past 88% and past the viewport. `.msg-text`/`.reasoning`/`.notice` are stretched, so their boxes stayed put but the glyphs painted outside — same scrollbar, different route.

## The fix

- `overflow-wrap: anywhere` on the four prose row roots. `anywhere` rather than `break-word` on purpose: only `anywhere` contributes its break points to min-content sizing, which is what pulls the fit-content bubble back inside its max-width. `break-word` would have wrapped the text but left the bubble oversized.
- `overflow-wrap: normal` on `.msg-text table` to opt back out. `overflow-wrap` inherits, and tables scroll sideways by design (`agent.css:160-166`); mid-word breaks would shrink the columns instead of letting the table scroll.
- `overflow-x: hidden` on `.chat` as a backstop, so a future row type cannot re-open the gesture.

Fenced code is deliberately untouched: `.msg-text pre code` is `white-space: pre`, which disables wrapping outright, so the inherited value is inert there and code still swipes rather than reflowing at 390px.

The backstop is scoped to `.chat` rather than the shared `.scroll` class. Seven other screens use `.scroll`; Diff and File turned out to have their own `overflow: auto` (`agent.css:983`, `:1166`) so they would have been safe either way, but narrowing it keeps the blast radius at the reported bug.

## Testing

`bun run build`, `biome check` and all 122 tests pass, and the three rules were confirmed to survive minification into the output bundle with the table opt-out still winning.

**Not verified on device.** This was derived from reading the CSS — I could not launch the app to reproduce the scroll or watch it go away. Worth a look on a simulator with a long unbroken token in a user bubble, in agent prose, and in a `reasoning` line, since those are three different overflow routes.

## Note

The desktop transcript (`src/`) has carried the equivalent rule since it hit this same bug (`Chat.css:513-519`); mobile never got it. Desktop does still have adjacent gaps of its own — four inline `word-break: break-word` styles in the tool presenters, and an unshrinkable `.t-name` flex item — left alone here as a separate surface.