### PR TITLE
chore(release): bump version to 0.7.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fletch",
   "private": true,
-  "version": "0.7.25",
+  "version": "0.7.26",
   "license": "AGPL-3.0-only",
   "author": "Alex Chaplinsky and fwdai.org",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "fletch"
-version = "0.7.25"
+version = "0.7.26"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fletch"
-version = "0.7.25"
+version = "0.7.26"
 description = "Spawn coding agents in isolated sandboxes"
 authors = ["Alex Chaplinsky", "fwdai.org"]
 license = "AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Fletch",
   "mainBinaryName": "Fletch",
-  "version": "0.7.25",
+  "version": "0.7.26",
   "identifier": "com.fletch.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Bumps the app version 0.7.25 → 0.7.26 (patch — the commits since the last release are mobile transcript/live-log fixes).

Updates all three files `docs/RELEASING.md` requires to stay identical, plus the lockfile entry:

- `package.json`
- `src-tauri/Cargo.toml`
- `src-tauri/tauri.conf.json` (the release tag/name is derived from this one)
- `src-tauri/Cargo.lock` (via `cargo update -p fletch`)

`mobile/package.json` tracks its own version (`0.1.0`) and is untouched.

Once merged, the **Release** workflow can be run to produce the draft release.