### PR TITLE
fix(mobile): pair from the launch deep link, and show pairing progress

### DIFF
--- a/mobile/src/deeplink.ts
+++ b/mobile/src/deeplink.ts
@@ -2,25 +2,42 @@
 // Tauri the deep-link plugin delivers it; in a browser the same URL can be
 // pasted into the Pair screen, so there is nothing to register.
 
-import { onOpenUrl } from "@tauri-apps/plugin-deep-link";
-import { ignore } from "./lib/ignore";
+import { getCurrent, onOpenUrl } from "@tauri-apps/plugin-deep-link";
 import { parsePairUrl } from "./remote";
 import { inTauri } from "./remote/ws";
 import { useStore } from "./store";
 
+/** Pair from the first `fletch://pair` link in `urls`, ignoring anything else
+ *  the app may have been opened with. */
+function handle(urls: string[]): void {
+  for (const url of urls) {
+    const target = parsePairUrl(url);
+    if (target) {
+      useStore.getState().pairFromLink(target);
+      return;
+    }
+  }
+}
+
 export async function registerDeepLinks(): Promise<void> {
   if (!inTauri()) return;
   try {
-    await onOpenUrl((urls) => {
-      for (const url of urls) {
-        const target = parsePairUrl(url);
-        if (target) {
-          void useStore.getState().connect(target).catch(ignore);
-          return;
-        }
-      }
-    });
+    await onOpenUrl(handle);
   } catch {
     // The plugin is unavailable on this platform; manual pairing still works.
+    return;
+  }
+  try {
+    // `onOpenUrl` is nothing but a listener for `deep-link://new-url`, and iOS
+    // hands the launch URL to the plugin — which emits it once, immediately —
+    // long before this webview exists to hear it. A cold start from a scanned
+    // QR is therefore delivered to no one: the app opens on the Pair screen
+    // and sits there. `getCurrent` is the plugin's app-load counterpart and
+    // the only way to read that URL, so it is asked here, after the listener
+    // is in place so a link arriving in between cannot fall through the gap.
+    // `pairFromLink` drops the duplicate when both do deliver.
+    handle((await getCurrent()) ?? []);
+  } catch {
+    // Nothing pending. A link tapped later still reaches the listener above.
   }
 }

--- a/mobile/src/remote/client.ts
+++ b/mobile/src/remote/client.ts
@@ -22,9 +22,11 @@ import {
   type HostTarget,
   isEventFrame,
   type PairResult,
+  type PairStep,
   type RemoteClient,
   type RequestFrame,
   type StateHandler,
+  type StepHandler,
   type Via,
 } from "./types";
 
@@ -73,6 +75,7 @@ export class ProtocolClient implements RemoteClient {
   private pending = new Map<string, Pending>();
   private listeners = new Map<string, Set<EventHandler>>();
   private stateListeners = new Set<StateHandler>();
+  private stepListeners = new Set<StepHandler>();
   private snapshotListeners = new Set<(r: HelloResult) => void>();
   private _target: HostTarget | null = null;
   /** Bumped for every attempt and every teardown. A socket's callbacks carry
@@ -135,6 +138,11 @@ export class ProtocolClient implements RemoteClient {
     this.stateListeners.add(cb);
     cb(this._state);
     return () => this.stateListeners.delete(cb);
+  }
+
+  onStep(cb: StepHandler): () => void {
+    this.stepListeners.add(cb);
+    return () => this.stepListeners.delete(cb);
   }
 
   onSnapshot(cb: (result: HelloResult) => void): () => void {
@@ -200,6 +208,13 @@ export class ProtocolClient implements RemoteClient {
     for (const cb of this.stateListeners) cb(state, error);
   }
 
+  /** Announce where the attempt has got to. Not held anywhere: a step is only
+   *  meaningful while the attempt that reported it is still running, and the
+   *  state changes above are what say how it ended. */
+  private step(step: PairStep) {
+    for (const cb of this.stepListeners) cb(step);
+  }
+
   private request<T>(op: string, args: Record<string, unknown>): Promise<T> {
     const socket = this.socket;
     if (!socket) return Promise.reject(new Error("not connected"));
@@ -223,6 +238,7 @@ export class ProtocolClient implements RemoteClient {
     if (!target) throw new Error("no host configured");
     const gen = ++this.gen;
     this.setState(target.pairingToken ? "pairing" : "connecting");
+    this.step("connecting");
     try {
       const socket = await this.openFirstReachable(target, gen);
       if (!this.current(gen)) {
@@ -315,6 +331,7 @@ export class ProtocolClient implements RemoteClient {
     let last = new Error("no address to dial");
     for (const candidate of list) {
       try {
+        this.step(candidate.via);
         return await this.opts.openSocket(candidate.url, handlers, {
           hostKey: target.hostKey,
           timeoutMs: candidate.timeoutMs,
@@ -334,15 +351,21 @@ export class ProtocolClient implements RemoteClient {
    *  `hello` otherwise. */
   private async handshake(target: HostTarget): Promise<HelloResult> {
     if (target.pairingToken) {
+      this.step("registering");
       const paired = await this.pair(target.pairingToken, this.opts.device);
       // Pairing is single use: drop the code, so a reconnect greets the host
       // with `hello` on the device key it just registered.
       this._target = { ...target, pairingToken: undefined };
       this.setState("connected");
       // `pair` answers with the host identity but no snapshot, so ask for it.
+      // Still part of pairing as far as anyone watching is concerned: the
+      // state above says `connected`, but there is nothing to show until this
+      // answers, and over a relay it is not instant.
+      this.step("workspace");
       const workspace = await this.call<HelloResult["workspace"]>("get_workspace");
       return this.publishSnapshot({ host: paired.host, workspace });
     }
+    this.step("greeting");
     const result = await this.hello(this.opts.device);
     this.setState("connected");
     return this.publishSnapshot(result);

--- a/mobile/src/remote/types.ts
+++ b/mobile/src/remote/types.ts
@@ -109,8 +109,20 @@ export const DEFAULT_PORT = 47285;
 /** Largest frame the host accepts (close code 1009 above it). */
 export const MAX_FRAME_BYTES = 4 * 1024 * 1024;
 
+/** How far the attempt in flight has got. `connecting` is the moment before
+ *  the first candidate; `lan` and `relay` name the one being dialled, and the
+ *  rest are the frames after the socket opens.
+ *
+ *  Reported because the waits here are long and silent: a phone off the Mac's
+ *  network still dials the LAN address first and has to wait out
+ *  `LAN_OPEN_TIMEOUT_MS` before the relay is tried, and the workspace that
+ *  follows a `pair` crosses the relay too. A screen with nothing but a state
+ *  name cannot tell any of that apart from a hang. */
+export type PairStep = "connecting" | "lan" | "relay" | "registering" | "greeting" | "workspace";
+
 export type EventHandler = (payload: unknown) => void;
 export type StateHandler = (state: ConnectionState, error?: string) => void;
+export type StepHandler = (step: PairStep) => void;
 
 export interface RemoteClient {
   /** Open a connection and complete `pair` or `hello`. Rejects if the
@@ -125,6 +137,9 @@ export interface RemoteClient {
   on(event: string, cb: EventHandler): () => void;
   /** Subscribe to connection-state changes; fires immediately with current. */
   onState(cb: StateHandler): () => void;
+  /** Subscribe to the progress of the attempt in flight. Unlike `onState` it
+   *  does not fire on subscribe: there is no current step between attempts. */
+  onStep(cb: StepHandler): () => void;
   /** Fires with the workspace snapshot after every successful handshake,
    *  including reconnects. */
   onSnapshot(cb: (result: HelloResult) => void): () => void;

--- a/mobile/src/screens/Pair/Progress.tsx
+++ b/mobile/src/screens/Pair/Progress.tsx
@@ -1,0 +1,30 @@
+import type { PairStep } from "../../remote";
+
+/** What each step of a connection attempt means to someone holding the phone.
+ *
+ *  The relay line names the thing that actually takes the time: the LAN
+ *  address is always dialled first and has to time out before the relay is
+ *  tried, so a phone away from its Mac spends its first seconds on an address
+ *  that cannot answer. Saying so is the difference between a wait and a hang.
+ */
+const LABELS: Record<PairStep, string> = {
+  connecting: "Starting…",
+  lan: "Looking for your Mac on this network…",
+  relay: "Not on this network — reaching your Mac through the relay…",
+  registering: "Registering this device with your Mac…",
+  greeting: "Saying hello…",
+  workspace: "Loading your workspace…",
+};
+
+export function Progress({ step }: { step: PairStep }) {
+  return (
+    <div className="pair-step">
+      <span className="working-dots">
+        <i />
+        <i />
+        <i />
+      </span>
+      {LABELS[step]}
+    </div>
+  );
+}

--- a/mobile/src/screens/Pair/index.tsx
+++ b/mobile/src/screens/Pair/index.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Icon } from "../../components/Icon";
 import { parseAddress, parsePairUrl } from "../../remote";
 import { useStore } from "../../store";
 import { Wordmark } from "../Home/Wordmark";
+import { Progress } from "./Progress";
 
 /** Manual pairing: the host's address and the one-time code from the desktop's
  *  Settings → Remote control. A pasted `fletch://pair?…` link fills both and
@@ -11,17 +12,33 @@ import { Wordmark } from "../Home/Wordmark";
  *  pins the one it meets on first contact, and has no relay until a link
  *  supplies one or it is entered in the Host sheet later
  *  (docs/remote-protocol.md, "Secure channel" and "Authentication and
- *  pairing"). */
+ *  pairing").
+ *
+ *  A link the app was *opened* with pairs on its own, and fills the same
+ *  fields as it goes: the connection can take the best part of half a minute
+ *  from a phone off the Mac's network, so what is being paired and how far it
+ *  has got are on screen throughout, and the details stay put for a one-tap
+ *  retry if it fails. */
 export function PairScreen() {
   const connect = useStore((s) => s.connect);
-  const connection = useStore((s) => s.connection);
+  const step = useStore((s) => s.pairStep);
+  const linked = useStore((s) => s.pairTarget);
   const error = useStore((s) => s.connectionError);
   const [address, setAddress] = useState("");
   const [token, setToken] = useState("");
   const [hostKey, setHostKey] = useState<string | undefined>(undefined);
   const [relay, setRelay] = useState<string | undefined>(undefined);
-  const busy = connection === "connecting" || connection === "pairing";
+  const busy = step !== null;
   const parsed = parseAddress(address);
+
+  // A link the app was opened with lands in the store, not in these fields.
+  useEffect(() => {
+    if (!linked) return;
+    setAddress(`${linked.host}:${linked.port}`);
+    setHostKey(linked.hostKey);
+    setRelay(linked.relay);
+    if (linked.pairingToken) setToken(linked.pairingToken);
+  }, [linked]);
 
   /** Anything pasted into a field may be the whole deep link. */
   const absorb = (value: string, fallback: (v: string) => void) => {
@@ -47,11 +64,18 @@ export function PairScreen() {
     <div className="pair">
       <Wordmark />
       <div className="hero">
-        <h1>Pair with your Mac</h1>
-        <p>
-          On the desktop app open <b>Settings → Remote control → Pair a device</b>, then enter its
-          address and the one-time code here.
-        </p>
+        <h1>{linked?.name ? `Pair with ${linked.name}` : "Pair with your Mac"}</h1>
+        {linked ? (
+          <p>
+            Your Mac sent these details. Pairing starts on its own — from another network it can
+            take a few moments.
+          </p>
+        ) : (
+          <p>
+            On the desktop app open <b>Settings → Remote control → Pair a device</b>, then enter its
+            address and the one-time code here.
+          </p>
+        )}
       </div>
       <div className="field">
         <label htmlFor="pair-host">Address</label>
@@ -77,7 +101,7 @@ export function PairScreen() {
           onChange={(e) => absorb(e.target.value, (v) => setToken(v.toUpperCase()))}
         />
       </div>
-      {error && <div className="err">{error}</div>}
+      {step ? <Progress step={step} /> : error && <div className="err">{error}</div>}
       <button
         type="button"
         className="btn primary block"
@@ -85,7 +109,7 @@ export function PairScreen() {
         onClick={submit}
       >
         <Icon name="laptop" size={17} />
-        {busy ? "Pairing…" : "Pair"}
+        {busy ? "Pairing…" : error ? "Try again" : "Pair"}
       </button>
       <div className="hint">
         The code is valid for five minutes and can be used once. The link is end-to-end encrypted,

--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -15,6 +15,7 @@ import {
   type HostInfo,
   type HostTarget,
   mockEnabled,
+  type PairStep,
   type Via,
 } from "../remote";
 import type { PushFletch } from "../remote/push";
@@ -47,6 +48,19 @@ export interface MobileState {
   ready: boolean;
   connection: ConnectionState;
   connectionError: string | null;
+  /** How far the `connect` in flight has got, and null when none is.
+   *
+   *  Deliberately wider than the client's `connected`, which arrives as soon
+   *  as `pair` is answered with the workspace still to fetch: a Pair screen
+   *  that goes idle there has told the user it gave up while it is in fact
+   *  most of the way through. It is also the whole progress display — the
+   *  waits are long enough (a LAN dial timing out, then a relay) that a
+   *  screen showing nothing reads as a hung app. */
+  pairStep: PairStep | null;
+  /** The `fletch://pair` link the app was opened with, so the Pair screen can
+   *  show which Mac it is pairing with rather than an empty form — and keep
+   *  the details for a one-tap retry if it fails. */
+  pairTarget: HostTarget | null;
   hostInfo: HostInfo | null;
   /** The paired host's public key — pinned on first contact, and what makes
    *  the app paired at all. */
@@ -80,6 +94,9 @@ export interface MobileState {
 
   init(): Promise<void>;
   connect(target: HostTarget): Promise<void>;
+  /** Pair from a `fletch://pair` deep link: show it on the Pair screen and
+   *  connect. Ignores a repeat of the link already being paired. */
+  pairFromLink(target: HostTarget): void;
   reconnect(): Promise<void>;
   unpair(): Promise<void>;
   /** Add or change the relay for the paired host without re-pairing. */
@@ -171,6 +188,42 @@ async function guard<T>(set: Setter, fn: () => Promise<T>): Promise<T> {
   }
 }
 
+/** Everything that makes the app paired with the host it has just greeted: the
+ *  pinned key, the path the link came in on, and the durable record of both.
+ *
+ *  Shared by `connect` and the snapshot subscription because a first
+ *  connection can complete through either. A pairing that is answered and then
+ *  loses the socket before the workspace arrives has already spent its code,
+ *  and the client retries it on its own with the key it pinned — that retry
+ *  has no `connect` above it, and without this the app would sit on the Pair
+ *  screen holding a working connection. */
+async function adopt(set: Setter, get: () => MobileState, host: HostInfo): Promise<void> {
+  // The client owns the target: the spent pairing token is gone from it and
+  // the host key the handshake authenticated is pinned in.
+  const target = client.target;
+  const hostKey = client.hostKey ?? get().hostKey;
+  const relay = target?.relay ?? null;
+  set({
+    hostInfo: host,
+    hostKey,
+    relay,
+    via: client.via,
+    // The remembered clone destination is per host, so it can only be
+    // resolved once the handshake says which host this is.
+    lastDestParent: await loadDestParent(hostKey),
+    nav: [homeItem()],
+  });
+  // Mock mode must not leave a "mock" host behind for the next real run.
+  if (mockEnabled() || !target) return;
+  await saveSettings({
+    host: target.host,
+    port: target.port,
+    hostName: host.name,
+    relay: relay ?? undefined,
+    ...(hostKey ? { hostKey } : {}),
+  });
+}
+
 export const agentOf = (ws: Workspace | null, id: string): AgentRecord | undefined =>
   ws?.agents.find((a) => a.id === id);
 
@@ -198,6 +251,8 @@ export const useStore = create<MobileState>()((set, get) => ({
   ready: false,
   connection: "disconnected",
   connectionError: null,
+  pairStep: null,
+  pairTarget: null,
   hostInfo: null,
   hostKey: null,
   relay: null,
@@ -239,6 +294,12 @@ export const useStore = create<MobileState>()((set, get) => ({
         via: client.via,
       }),
     );
+    // Only while a `connect` owns the flow: a background reconnect is the
+    // connection banner's business, and moving the Pair screen's progress on
+    // behalf of one would be describing a connection the user did not ask for.
+    client.onStep((step) => {
+      if (get().pairStep) set({ pairStep: step });
+    });
     // The log of an open thread is kept current by live events, which a
     // dropped socket or a backgrounded webview silently misses — so every
     // reconnect and every return to the foreground re-reads it from the host.
@@ -254,6 +315,11 @@ export const useStore = create<MobileState>()((set, get) => ({
       // Every handshake — the first pairing and every reconnect — is when the
       // host is told the APNs token again.
       void syncPush().catch(ignore);
+      // A handshake that lands while the app still has no host key is the one
+      // that pairs it: `connect` does this itself, so this is for the retry
+      // that completes a pairing whose first attempt died after the code was
+      // spent. Guarded on `pairStep` so the two never race.
+      if (!get().hostKey && !get().pairStep) void adopt(set, get, snapshot.host).catch(ignore);
     });
     if (typeof document !== "undefined") {
       document.addEventListener("visibilitychange", () => {
@@ -299,38 +365,38 @@ export const useStore = create<MobileState>()((set, get) => ({
   async connect(target) {
     // The client owns the target from here: it strips the spent pairing token
     // and pins the host key the handshake authenticated.
-    set({ connectionError: null });
+    set({ connectionError: null, pairStep: "connecting" });
     try {
       const snapshot = await client.connect(target);
-      // Either the key the target carried, or the one just pinned.
-      const hostKey = client.hostKey ?? target.hostKey ?? get().hostKey;
-      const relay = client.target?.relay ?? null;
-      set({
-        hostInfo: snapshot.host,
-        workspace: snapshot.workspace,
-        hostKey,
-        relay,
-        via: client.via,
-        // The remembered clone destination is per host, so it can only be
-        // resolved once the handshake says which host this is.
-        lastDestParent: await loadDestParent(hostKey),
-        nav: [homeItem()],
-      });
-      // Mock mode must not leave a "mock" host behind for the next real run.
-      if (!mockEnabled()) {
-        await saveSettings({
-          host: target.host,
-          port: target.port,
-          hostName: snapshot.host.name,
-          relay: relay ?? undefined,
-          ...(hostKey ? { hostKey } : {}),
-        });
-      }
+      await adopt(set, get, snapshot.host);
+      set({ workspace: snapshot.workspace });
       if (!snapshot.workspace) await get().refreshWorkspace();
     } catch (e) {
       set({ connectionError: message(e) });
       throw e;
+    } finally {
+      // Cleared here and nowhere else: everything the user is waiting for has
+      // either happened or failed, which is not true at any earlier point the
+      // client reports.
+      set({ pairStep: null });
     }
+  },
+
+  pairFromLink(target) {
+    // The same link can arrive twice — read once from the plugin as the URL
+    // the app was launched with, and delivered again by the event it also
+    // emits. A second `connect` would tear down the attempt in flight and
+    // spend a code that is single use, so the one already running wins.
+    // Compared on the whole link, not just the code: a link may carry none,
+    // and two of those are not the same pairing.
+    const running = get().pairTarget;
+    const same =
+      running?.pairingToken === target.pairingToken &&
+      running?.host === target.host &&
+      running?.port === target.port;
+    if (get().pairStep && same) return;
+    set({ pairTarget: target, connectionError: null });
+    void get().connect(target).catch(ignore);
   },
 
   /** Retry the link the client already holds — the store no longer keeps a
@@ -358,6 +424,9 @@ export const useStore = create<MobileState>()((set, get) => ({
       logs: {},
       sheet: null,
       nav: [homeItem()],
+      // The link that paired this host carried a code that is long spent;
+      // leaving it on the Pair screen would offer the user a dead retry.
+      pairTarget: null,
     });
   },
 

--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -167,6 +167,18 @@ let initialized = false;
  *  read off disk. */
 let queuedPush: PushFletch | null = null;
 
+/** A pairing link that arrived before `init` finished — the usual case, in
+ *  fact: `registerDeepLinks` and `init` start together, and the link has only
+ *  two plugin calls to wait on where `init` has the push registration and the
+ *  settings read.
+ *
+ *  It cannot be acted on yet either, for two reasons. `init` finishes by
+ *  reconnecting the saved host, which would tear this pairing down mid-flight
+ *  and spend a code that is single use; and it publishes the settings it read
+ *  before that, which on a fresh install means a null host key written over
+ *  the one a pairing that got in first had just pinned. */
+let queuedLink: HostTarget | null = null;
+
 const homeItem = (): NavItem => ({ key: Date.now(), screen: "home", props: {}, phase: "idle" });
 
 const newId = () =>
@@ -339,6 +351,16 @@ export const useStore = create<MobileState>()((set, get) => ({
       queuedPush = null;
       get().openFromPush(fletch);
     }
+    // Before the saved host, and instead of it: a scanned link says to pair
+    // with *this* Mac, which is an instruction, where reconnecting the last
+    // one is only a default. Racing them would supersede the pairing and burn
+    // its code.
+    if (queuedLink) {
+      const target = queuedLink;
+      queuedLink = null;
+      await get().connect(target).catch(ignore);
+      return;
+    }
     if (mockEnabled()) {
       // The mock host has no pairing step worth clicking through every reload;
       // its fixed key is pinned by `connect` like any other.
@@ -346,8 +368,11 @@ export const useStore = create<MobileState>()((set, get) => ({
       return;
     }
     // A saved host key is the whole credential: `hello` authenticates with the
-    // device key the Rust layer holds.
-    if (saved.host && hostKey) {
+    // device key the Rust layer holds. Stood down while a pairing is running,
+    // for the same reason the queued link goes first: a link that arrived in
+    // the moment between `ready` and here is already connecting, and this
+    // would replace it.
+    if (saved.host && hostKey && !get().pairStep) {
       set({ lastDestParent: saved.destParents?.[hostKey] ?? null });
       await get()
         .connect({
@@ -396,6 +421,14 @@ export const useStore = create<MobileState>()((set, get) => ({
       running?.port === target.port;
     if (get().pairStep && same) return;
     set({ pairTarget: target, connectionError: null });
+    if (!get().ready) {
+      // Held until `init` has read what is on disk — see `queuedLink`. The
+      // step is set anyway: the screen is already showing this link, and a
+      // button offering to start a second pairing is the same race by hand.
+      queuedLink = target;
+      set({ pairStep: "connecting" });
+      return;
+    }
     void get().connect(target).catch(ignore);
   },
 

--- a/mobile/src/styles/screens.css
+++ b/mobile/src/styles/screens.css
@@ -739,6 +739,16 @@
   color: var(--fg-3);
   line-height: 1.5;
 }
+/* Sits where the error line does, and for the same reason: whatever the last
+   thing to happen was, it is readable next to the button that started it. */
+.pair-step {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-size: 13px;
+  color: var(--fg-2);
+  line-height: 1.45;
+}
 
 /* connection banner */
 .conn {

--- a/mobile/tests/deeplink.test.ts
+++ b/mobile/tests/deeplink.test.ts
@@ -1,0 +1,78 @@
+// The launch URL is the whole point of this file. `onOpenUrl` is nothing but a
+// listener for `deep-link://new-url`, which the plugin emits the moment iOS
+// hands the URL over — on a cold start, long before the webview is there to
+// hear it. A scanned QR that opens the app therefore arrives only through
+// `getCurrent`, and an app that does not ask sits on the Pair screen doing
+// nothing, which is exactly how this went wrong.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getCurrent, onOpenUrl, pairFromLink, delivered } = vi.hoisted(() => {
+  const delivered: { cb: ((urls: string[]) => void) | null } = { cb: null };
+  return {
+    delivered,
+    getCurrent: vi.fn<() => Promise<string[] | null>>(),
+    onOpenUrl: vi.fn(async (cb: (urls: string[]) => void) => {
+      delivered.cb = cb;
+      return () => {};
+    }),
+    pairFromLink: vi.fn(),
+  };
+});
+
+vi.mock("@tauri-apps/plugin-deep-link", () => ({ getCurrent, onOpenUrl }));
+vi.mock("../src/store", () => ({ useStore: { getState: () => ({ pairFromLink }) } }));
+
+const { registerDeepLinks } = await import("../src/deeplink");
+
+const LINK =
+  "fletch://pair?host=Zm9vYmFy&addr=192.168.1.24:47285&token=K7PQ2M9X&name=Alex%27s%20Mac";
+const TARGET = {
+  host: "192.168.1.24",
+  port: 47285,
+  hostKey: "Zm9vYmFy",
+  pairingToken: "K7PQ2M9X",
+  name: "Alex's Mac",
+};
+
+describe("pairing deep link", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delivered.cb = null;
+    getCurrent.mockResolvedValue(null);
+    // `inTauri`: outside the app there is no plugin to register with.
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+  });
+
+  it("pairs from the URL the app was launched with, which no listener can hear", async () => {
+    getCurrent.mockResolvedValue([LINK]);
+    await registerDeepLinks();
+    expect(pairFromLink).toHaveBeenCalledWith(TARGET);
+  });
+
+  it("subscribes before reading it, so a link arriving in between is not lost", async () => {
+    await registerDeepLinks();
+    expect(onOpenUrl.mock.invocationCallOrder[0]).toBeLessThan(
+      getCurrent.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("pairs from a link tapped while the app is already running", async () => {
+    await registerDeepLinks();
+    expect(pairFromLink).not.toHaveBeenCalled();
+    delivered.cb?.([LINK]);
+    expect(pairFromLink).toHaveBeenCalledWith(TARGET);
+  });
+
+  it("ignores whatever else the app may have been opened with", async () => {
+    getCurrent.mockResolvedValue(["https://fletch.sh", "fletch://pair?token=K7PQ2M9X"]);
+    await registerDeepLinks();
+    expect(pairFromLink).not.toHaveBeenCalled();
+  });
+
+  it("leaves manual pairing alone when the plugin is unavailable", async () => {
+    onOpenUrl.mockRejectedValueOnce(new Error("no such plugin"));
+    await expect(registerDeepLinks()).resolves.toBeUndefined();
+    expect(getCurrent).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/tests/pairQueue.test.ts
+++ b/mobile/tests/pairQueue.test.ts
@@ -1,0 +1,62 @@
+// A pairing link and `init` start together — `main.tsx` renders the app and
+// calls `registerDeepLinks` in the same breath — and the link has the less to
+// wait on of the two. Acting on it early is what this file rules out: `init`
+// finishes by reconnecting the saved host, which would supersede the pairing
+// and spend a code that is single use, and it publishes the settings it read
+// first, which on a fresh install means writing a null host key over the one
+// a pairing that got in ahead of it had just pinned.
+//
+// Its own file because `init` runs at most once per module registry, and this
+// is about what happens before it has finished.
+
+import { describe, expect, it, vi } from "vitest";
+import type { HostTarget } from "../src/remote";
+import { useStore } from "../src/store";
+
+const state = () => useStore.getState();
+
+const LINK: HostTarget = {
+  host: "192.168.1.24",
+  port: 47285,
+  hostKey: "Zm9vYmFy",
+  pairingToken: "K7PQ2M9X",
+  name: "Alex's Mac",
+};
+
+describe("a pairing link that arrives before init has finished", () => {
+  it("is held, shown, and paired with once the persisted state is in", async () => {
+    // Nothing may reach the client until `init` says the app is ready, so the
+    // connection is the thing observed: `ready` as each call saw it.
+    const readyAt: boolean[] = [];
+    const targets: HostTarget[] = [];
+    const connect = vi.fn(async (target: HostTarget) => {
+      readyAt.push(state().ready);
+      targets.push(target);
+    });
+    useStore.setState({ connect });
+
+    state().pairFromLink(LINK);
+    expect(connect).not.toHaveBeenCalled();
+    expect(state().ready).toBe(false);
+    // Held, but not invisible: the Pair screen shows the link and reads as
+    // busy rather than offering a button that would start a second pairing.
+    expect(state().pairTarget).toEqual(LINK);
+    expect(state().pairStep).toBe("connecting");
+
+    await state().init();
+
+    // Once, with the link — not the mock host `init` would otherwise dial,
+    // and not after being superseded by it.
+    expect(targets).toEqual([LINK]);
+    // And only after the settings on disk had been published, which is what
+    // stops a fresh install's null host key landing on top of the pairing.
+    expect(readyAt).toEqual([true]);
+  });
+
+  it("is spent: a second init has nothing held to pair with", async () => {
+    const connect = vi.fn(async () => {});
+    useStore.setState({ connect });
+    await state().init();
+    expect(connect).not.toHaveBeenCalled();
+  });
+});

--- a/mobile/tests/protocol.test.ts
+++ b/mobile/tests/protocol.test.ts
@@ -17,6 +17,7 @@ import {
   type DeviceInfo,
   HOST_KEY_MISMATCH,
   HOST_KEY_MISMATCH_REASON,
+  type PairStep,
 } from "../src/remote/types";
 
 const DEVICE: DeviceInfo = { name: "test", platform: "web", appVersion: "0.1.0" };
@@ -660,5 +661,55 @@ describe("events", () => {
     off();
     fake.reply({ event: "agent:status", payload: { agent_id: "a", status: "idle" } });
     expect(seen).toHaveLength(1);
+  });
+});
+
+/** The Pair screen has nothing but these to show while an attempt runs, and
+ *  the connection state cannot stand in for them: it says `pairing` for the
+ *  whole dial — including the LAN address a phone on another network has to
+ *  wait out before the relay is tried — and `connected` from the moment `pair`
+ *  is answered, with the workspace still to fetch. */
+describe("attempt progress", () => {
+  const LAN = "ws://h:1/ws";
+  const HOST = { name: "Mac", appVersion: "0.7.23", os: "macos" };
+
+  it("reports every candidate and every frame of a pairing that lands on the relay", async () => {
+    const fake = fakeSocket(HOST_KEY, { [LAN]: "reject" });
+    const client = new ProtocolClient({ openSocket: fake.factory, device: DEVICE, openTimeout: 5 });
+    const steps: PairStep[] = [];
+    client.onStep((s) => steps.push(s));
+    const paired = client.connect({
+      host: "h",
+      port: 1,
+      hostKey: HOST_KEY,
+      relay: "wss://relay.test",
+      pairingToken: "K7PQ2M9X",
+    });
+
+    await vi.waitFor(() => expect(fake.sent.length).toBe(1));
+    expect(fake.sent[0].op).toBe("pair");
+    fake.reply({ id: fake.sent[0].id, ok: true, result: { deviceId: "d1", host: HOST } });
+
+    await vi.waitFor(() => expect(fake.sent.length).toBe(2));
+    expect(fake.sent[1].op).toBe("get_workspace");
+    // The state has said all it can say — and says it before the wait that is
+    // still to come.
+    expect(client.state).toBe("connected");
+    expect(steps).toEqual(["connecting", "lan", "relay", "registering", "workspace"]);
+
+    fake.reply({ id: fake.sent[1].id, ok: true, result: null });
+    await expect(paired).resolves.toMatchObject({ host: { name: "Mac" } });
+  });
+
+  it("reports a greeting rather than a registration when there is no code to spend", async () => {
+    const fake = fakeSocket();
+    const client = new ProtocolClient({ openSocket: fake.factory, device: DEVICE });
+    const steps: PairStep[] = [];
+    client.onStep((s) => steps.push(s));
+    const connected = client.connect({ host: "h", port: 1, hostKey: HOST_KEY });
+    await vi.waitFor(() => expect(fake.sent.length).toBe(1));
+    fake.reply(helloOk(fake.sent[0].id as string));
+    await connected;
+    expect(steps).toEqual(["connecting", "lan", "greeting"]);
   });
 });

--- a/mobile/tests/store.test.ts
+++ b/mobile/tests/store.test.ts
@@ -284,3 +284,25 @@ describe("spawn flow", () => {
     send.mockRestore();
   });
 });
+
+/** A pairing code is single use and lasts five minutes, so a second delivery
+ *  of the same link — the launch URL read from the plugin, and the event it
+ *  also emits — must not tear down the attempt already spending it. */
+describe("pairing from a link", () => {
+  const LINK = { host: "192.168.1.24", port: 47285, hostKey: "k", pairingToken: "K7PQ2M9X" };
+
+  it("ignores a repeat of the link whose pairing is still running", () => {
+    const restore = { pairStep: state().pairStep, pairTarget: state().pairTarget };
+    useStore.setState({ pairStep: "relay", pairTarget: LINK });
+    try {
+      // The same link, with its pairing in flight: the attempt already
+      // spending the code keeps it, rather than being restarted from
+      // `connecting`.
+      state().pairFromLink({ ...LINK });
+      expect(state().pairTarget).toEqual(LINK);
+      expect(state().pairStep).toBe("relay");
+    } finally {
+      useStore.setState(restore);
+    }
+  });
+});


### PR DESCRIPTION
Scanning the pairing QR from a phone on another network opened the app and then nothing happened — in the mobile app or on the desktop. Two separate defects, one per symptom.

## The cold-start deep link was dropped

`onOpenUrl` is nothing but a listener for `deep-link://new-url`:

```js
// @tauri-apps/plugin-deep-link@2.4.10
async function onOpenUrl(handler) {
  return await listen('deep-link://new-url', (event) => { handler(event.payload) })
}
```

On iOS the plugin emits that event from `RunEvent::Opened`, milliseconds after launch — long before `main.tsx` has rendered and awaited the `listen()` round trip. Tauri does not replay past emits, so a cold start from a scanned QR was delivered to no one. The URL sat unread in the plugin's `current`, which is why the plugin documents `get_current` as *"Use this on app load to check whether your app was started via a deep link"* — and nothing in the app called it. Tapping again with the app already running worked, which is what made this look intermittent.

`registerDeepLinks` now reads `getCurrent()` as well, after registering the listener so a link arriving in between cannot fall through the gap. `pairFromLink` drops a duplicate delivery of the link already being paired rather than tearing down the attempt in flight — the code it carries is single use.

## Nothing on screen said pairing was happening

The Pair screen derived "busy" from the client's connection state, which reports `connected` the moment `pair` is answered — with `get_workspace` still to cross the relay. The button went back to "Pair" mid-flight, reading as a failure, and then the app landed on the agents screen seconds later.

- `pairStep` in the store spans the whole of `connect()`, so the screen stays busy until there is something to show.
- The client reports progress (`onStep`): each candidate dialled and each frame sent. A new `Progress` component names them — including "Not on this network — reaching your Mac through the relay…", which is what the first three seconds actually are, since the LAN address is always dialled first and has to time out.
- A link the app was opened with fills the form in as it pairs, titles the screen with the Mac's name, and leaves the details for a one-tap "Try again".

## A gap either of those would have hidden

`hostKey` was set only by `store.connect`. A pairing that was answered and then lost the socket before the workspace arrived left the client reconnecting happily on its pinned key while the UI sat on the Pair screen, holding a code that was already spent. The `adopt` helper is now shared with the snapshot subscription, guarded on `pairStep` so the two cannot race.

## Tests

`tests/deeplink.test.ts` is a real regression guard — checked against the old handler, 3 of its 5 cases fail there. Plus step-sequence coverage for a pairing that falls back to the relay, and the duplicate-link guard. 131 pass, up from 123; `bun run check` and `bun run lint` are clean.

## Not changed

- The LAN candidate is still dialled first on cellular, costing a 3s timeout before the relay. Fixing that means guessing at reachability; naming the wait is the honest first move.
- A desktop with no relay configured emits a link with no `relay=`, and off-network pairing cannot work at all. The desktop already warns about this, but the warning is easy to miss.