### PR TITLE
fix(chat): stop the first prompt rendering twice on a new agent

### DIFF
--- a/src/helpers/transcript.ts
+++ b/src/helpers/transcript.ts
@@ -38,20 +38,40 @@ export function reduceRecords(provider: string | undefined, records: SessionReco
   return items;
 }
 
-/** Overlay Fletch-origin outgoing-turn metadata (attachments) onto the
- *  transcript-rendered conversation. Additive only — never replaces transcript
- *  content (which stays the canonical, re-ingestable history):
+/** Overlay one turn's Fletch-origin metadata (run timing, attachments) onto the
+ *  rendered user message it belongs to. */
+function overlayTurn(item: Extract<ChatItem, { kind: "user_message" }>, t: UserTurn): void {
+  if (t.started_at != null) item.startedAt = t.started_at;
+  if (t.ended_at != null) item.endedAt = t.ended_at;
+  if (t.attachments.length > 0) {
+    item.attachments = t.attachments;
+    // Render the clean text the user actually typed (what the live render
+    // showed) rather than the transcript's copy, which the runner padded
+    // with `Attached file: <path>` reference lines. The stored turn text is
+    // verbatim what was sent, so it matches the optimistic render exactly.
+    // Prefix-guard so a mis-aligned match can't rewrite an unrelated message.
+    if (item.text.startsWith(t.text)) {
+      item.text = t.text;
+    }
+  }
+}
+
+/** The turn's distinctive marker, mirroring the backend matcher: an attachment
+ *  path beats the prompt text (paths are unique; text can be empty). */
+function turnNeedle(t: UserTurn): string | undefined {
+  return t.text || t.attachments[0];
+}
+
+/** Overlay Fletch-origin outgoing-turn metadata (attachments, run timing) onto
+ *  the transcript-rendered conversation. Additive only — never replaces
+ *  transcript content (which stays the canonical, re-ingestable history):
  *  - Matched turns (`native_id` set) hang their attachments on the rendered
  *    user message. Aligned from the end, so older turns that predate this
  *    feature (no row) simply keep no attachments instead of mis-grabbing them.
- *  - Pending turns (`native_id` null — the agent never logged them, e.g. a
- *    failed send) render standalone so the message survives reload + retry. */
-/** Copy a turn's run timing onto its rendered user message, if present. */
-function applyTurnTiming(item: Extract<ChatItem, { kind: "user_message" }>, t: UserTurn): void {
-  if (t.started_at != null) item.startedAt = t.started_at;
-  if (t.ended_at != null) item.endedAt = t.ended_at;
-}
-
+ *  - Pending turns (`native_id` null) overlay the rendered message that
+ *    accounts for them when there is one — the matcher failing to stamp a turn
+ *    does not mean the transcript lacks it — and render standalone otherwise,
+ *    so a genuinely failed send survives reload + retry. */
 export function applyUserTurns(items: ChatItem[], turns: UserTurn[]): ChatItem[] {
   if (turns.length === 0) return items;
 
@@ -69,26 +89,43 @@ export function applyUserTurns(items: ChatItem[], turns: UserTurn[]): ChatItem[]
   for (let k = 1; k <= n; k++) {
     const t = matched[matched.length - k];
     const item = result[userIdxs[userIdxs.length - k]];
-    if (item.kind === "user_message") {
-      applyTurnTiming(item, t);
-      if (t.attachments.length > 0) {
-        item.attachments = t.attachments;
-        // Render the clean text the user actually typed (what the live render
-        // showed) rather than the transcript's copy, which the runner padded
-        // with `Attached file: <path>` reference lines. The stored turn text is
-        // verbatim what was sent, so it matches the optimistic render exactly.
-        // Prefix-guard so a mis-aligned match can't rewrite an unrelated message.
-        if (item.text.startsWith(t.text)) {
-          item.text = t.text;
-        }
-      }
-    }
+    if (item.kind === "user_message") overlayTurn(item, t);
   }
 
+  // A pending turn is one the backend matcher couldn't associate with a record
+  // (`native_id IS NULL`) — which does NOT mean the transcript lacks it: the
+  // matcher only stamps a turn whose needle appears verbatim in a record body,
+  // and it never succeeds for providers whose records don't quote the prompt
+  // that way. Pushing every pending turn therefore renders the same message
+  // twice, permanently (unlike the store-only optimistic bubble, this survives
+  // every reload). So claim each one against a rendered user message the
+  // end-alignment above left unclaimed, oldest first, by the same substring
+  // association the matcher uses — and push only the turns the transcript
+  // genuinely doesn't carry (a failed send), which is what standalone
+  // rendering is for.
+  const unclaimed = userIdxs.slice(0, userIdxs.length - n);
   for (const t of pending) {
-    const item: ChatItem = { kind: "user_message", text: t.text };
-    if (t.attachments.length > 0) item.attachments = t.attachments;
-    applyTurnTiming(item, t);
+    const needle = turnNeedle(t);
+    const hit = needle
+      ? unclaimed.findIndex((idx) => {
+          const item = result[idx];
+          return (
+            item.kind === "user_message" &&
+            (item.text.includes(needle) || (item.attachments?.includes(needle) ?? false))
+          );
+        })
+      : -1;
+    if (hit !== -1) {
+      const item = result[unclaimed[hit]];
+      unclaimed.splice(hit, 1);
+      if (item.kind === "user_message") overlayTurn(item, t);
+      continue;
+    }
+    const item: Extract<ChatItem, { kind: "user_message" }> = {
+      kind: "user_message",
+      text: t.text,
+    };
+    overlayTurn(item, t);
     result.push(item);
   }
 

--- a/src/store/draftSpawnMirror.test.ts
+++ b/src/store/draftSpawnMirror.test.ts
@@ -1,0 +1,101 @@
+// The bug this pins: `spawnFromDraft` seeded its optimistic first bubble without
+// the `turnId` it then sent the prompt under. The host announces every accepted
+// message to every client (`turn:sent`), and the mirror that folds it in dedupes
+// *by turn id only* — so the sender's own first prompt came back as a second,
+// visually identical bubble. Launching an agent by typing a prompt was the only
+// path with this flaw: the composer's `sendUserMessage` has always stamped the id.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+
+const { spawnAgent, sendUserMessage, getWorkspace } = vi.hoisted(() => ({
+  spawnAgent: vi.fn(),
+  sendUserMessage: vi.fn(),
+  getWorkspace: vi.fn(),
+}));
+vi.mock("@/api", () => ({ api: { spawnAgent, sendUserMessage, getWorkspace } }));
+vi.mock("@/storage/settings", () => ({ setSetting: vi.fn() }));
+vi.mock("@/data/slashCommands", () => ({ discoverCommands: vi.fn() }));
+
+import type { ChatItem } from "@/adapters";
+import type { TurnSentEvent } from "@/api";
+import { mirrorSentTurn } from "@/helpers";
+import { createDraftsSlice } from "./drafts";
+import type { AppState } from "./types";
+
+const PROMPT = "reorganize the settings pane";
+
+const makeStore = () => {
+  const store = create<AppState>()((...a) => ({ ...createDraftsSlice(...a) }) as AppState);
+  store.setState({
+    drafts: [
+      {
+        id: "d1",
+        repoPath: "/repos/app",
+        name: "chimborazo",
+        provider: "claude",
+        base: "main",
+      },
+    ],
+    composerDrafts: {},
+    customAgents: [],
+    modelsByAgent: {},
+    skills: [],
+    managedLogs: {},
+    managedBusy: {},
+    // biome-ignore lint/suspicious/noExplicitAny: partial store seed
+  } as any);
+  return store;
+};
+
+/** The `turn:sent` the host emits for the prompt the store just sent. At spawn
+ *  the agent is still `Spawning`, which the backend reports as busy — hence
+ *  `follow_up: true`, the variant that renders as a badge-less user bubble. */
+const hostEcho = (turnId: string): TurnSentEvent => ({
+  agent_id: "a1",
+  turn_id: turnId,
+  text: PROMPT,
+  attachments: [],
+  follow_up: true,
+});
+
+describe("spawning an agent from a typed prompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spawnAgent.mockResolvedValue({ id: "a1" });
+    sendUserMessage.mockResolvedValue(false);
+    getWorkspace.mockResolvedValue(null);
+  });
+
+  it("seeds the first bubble under the same turn id it sends the prompt with", async () => {
+    const store = makeStore();
+
+    await store.getState().spawnFromDraft("d1", PROMPT, "claude", undefined);
+
+    const [, sentTurnId, sentText] = sendUserMessage.mock.calls[0];
+    expect(sentText).toBe(PROMPT);
+    expect(store.getState().managedLogs.a1).toEqual([
+      { kind: "user_message", text: PROMPT, turnId: sentTurnId },
+    ]);
+  });
+
+  it("shows one bubble, not two, once the host echoes the send back", async () => {
+    const store = makeStore();
+
+    await store.getState().spawnFromDraft("d1", PROMPT, "claude", undefined);
+
+    const log = store.getState().managedLogs.a1 as ChatItem[];
+    const turnId = sendUserMessage.mock.calls[0][1] as string;
+    // Same reference back = the mirror recognized the bubble as ours.
+    expect(mirrorSentTurn(log, hostEcho(turnId))).toBe(log);
+  });
+
+  it("still mirrors a prompt this client didn't send (a phone, a git action)", async () => {
+    const store = makeStore();
+
+    await store.getState().spawnFromDraft("d1", PROMPT, "claude", undefined);
+
+    const log = store.getState().managedLogs.a1 as ChatItem[];
+    expect(mirrorSentTurn(log, hostEcho("someone-elses-turn"))).toHaveLength(log.length + 1);
+  });
+});

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -379,9 +379,13 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
           managedLogs: {
             ...state.managedLogs,
             [rec.id]: [
+              // Carries `turnId` (the one the send below uses) so the `turn:sent`
+              // mirror recognizes this bubble as ours and skips it — see
+              // `hasSentTurn`. Without it the host's announcement of our own
+              // send appends a second, identical bubble for the first prompt.
               attachments.length > 0
-                ? { kind: "user_message", text: prompt, attachments }
-                : { kind: "user_message", text: prompt },
+                ? { kind: "user_message", text: prompt, attachments, turnId }
+                : { kind: "user_message", text: prompt, turnId },
             ],
           },
           managedBusy: { ...state.managedBusy, [rec.id]: true },

--- a/tests/helpers/user-turns.test.ts
+++ b/tests/helpers/user-turns.test.ts
@@ -41,6 +41,67 @@ describe("applyUserTurns", () => {
     expect(out[2]).toEqual({ kind: "user_message", text: "new", attachments: ["/tmp/x"] });
   });
 
+  it("claims a pending turn the transcript already carries instead of duplicating it", () => {
+    // The backend matcher only stamps `native_id` when the turn's needle appears
+    // verbatim in a record body; where it can't (a provider whose records don't
+    // quote the prompt that way), the turn stays pending forever even though the
+    // transcript renders it. Pushing it then showed the prompt twice on every
+    // reload — the bug this pins.
+    const items = [userMsg("delivered"), agentMsg("reply")];
+    const turns = [turn({ native_id: null, text: "delivered", started_at: 10, ended_at: 90 })];
+
+    const out = applyUserTurns(items, turns);
+
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual({
+      kind: "user_message",
+      text: "delivered",
+      startedAt: 10,
+      endedAt: 90,
+    });
+  });
+
+  it("claims each pending turn once, so a genuinely repeated prompt still shows twice", () => {
+    // Only one "Proceed" reached the transcript; the second send never landed.
+    const items = [userMsg("Proceed"), agentMsg("done")];
+    const turns = [
+      turn({ native_id: null, text: "Proceed" }),
+      turn({ native_id: null, text: "Proceed" }),
+    ];
+
+    const out = applyUserTurns(items, turns);
+
+    expect(out.filter((it) => it.kind === "user_message")).toHaveLength(2);
+    expect(out[out.length - 1]).toEqual({ kind: "user_message", text: "Proceed" });
+  });
+
+  it("claims a pending turn by its attachment path when the prompt text is empty", () => {
+    // Attachment-only send: the transcript carries just the runner's injected
+    // reference line, which is what the matcher's needle keys off.
+    const items = [userMsg("Attached file: /tmp/shot.png")];
+    const turns = [turn({ native_id: null, text: "", attachments: ["/tmp/shot.png"] })];
+
+    const out = applyUserTurns(items, turns);
+
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ attachments: ["/tmp/shot.png"] });
+  });
+
+  it("leaves matched turns' messages for them, so a pending turn can't steal one", () => {
+    const items = [userMsg("first"), agentMsg("a"), userMsg("second"), agentMsg("b")];
+    const turns = [
+      turn({ native_id: null, text: "second" }), // pending, but "second" is claimed below
+      turn({ native_id: "rec-2", text: "second" }),
+    ];
+
+    const out = applyUserTurns(items, turns);
+
+    // The pending turn found no unclaimed message that accounts for it, so it
+    // renders standalone rather than folding into the matched turn's bubble.
+    expect(out).toHaveLength(5);
+    expect(out[out.length - 1]).toEqual({ kind: "user_message", text: "second" });
+  });
+
   it("renders a pending (unmatched) turn standalone so a failed send survives", () => {
     const items: ChatItem[] = [userMsg("delivered"), agentMsg("reply")];
     const turns = [


### PR DESCRIPTION
Launching an agent by typing a prompt sometimes showed the opening message twice. Two independent paths caused it; both are render-time artifacts — the persisted `session_records` always held a single first message (verified by replaying a real 1182-record session through `reduceRecords` + `applyUserTurns`), so no stored data is wrong and no cleanup is needed.

## The spawn-time duplicate

`spawnFromDraft` seeded its optimistic first bubble without the `turnId` it then sent the prompt under. The host announces every accepted message to every client via `turn:sent` (`supervisor/messaging.rs`), and the mirror that folds it in dedupes **by turn id alone** (`hasSentTurn`) — so the sender saw its own prompt come back as a second bubble. At spawn the agent is `Spawning`, which the backend reports as busy, so the echo arrived as a `queued_message`: rendered through the same `UserBubble`, badge-less, visually identical.

Fix: stamp the id on the seed, exactly as the composer’s `sendUserMessage` already does. That is why only the new-agent path was affected.

## The duplicate that survived reloads

`applyUserTurns` pushed every pending turn (`native_id IS NULL`) as a standalone bubble, on the assumption that unmatched means “not in the transcript”. It does not: `associate_pending_user_turns` only stamps a turn whose needle appears verbatim in a record body, and never succeeds for providers whose records do not quote the prompt that way — so the message rendered twice on every reload, permanently. In the DB I inspected, 60/1465 turns were unmatched and 8 sessions had an unmatched *first* turn.

Fix: claim each pending turn against a rendered user message the matched end-alignment left unclaimed, oldest first, using the same substring association the backend matcher uses. Only turns the transcript genuinely lacks still render standalone — which is what that path exists for (a failed send, kept for retry). A claimed turn now also hands over its timing and attachments, which it previously could not.

## Tests

- `src/store/draftSpawnMirror.test.ts` (new) — drives the real `spawnFromDraft` against mocked IPC: the seeded bubble carries the id passed to `sendUserMessage`, the mirror leaves the log untouched for that id, and a turn *another* client sent is still mirrored.
- `tests/helpers/user-turns.test.ts` — 4 cases: a pending turn the transcript carries is claimed rather than duplicated; claims are one-per-message so two identical sends where only one landed still show twice; an attachment-only turn is claimed by its path; and a pending turn cannot steal a matched turn’s bubble.

3 of the 4 turn cases and 2 of the 3 spawn cases fail on the old code (verified by reverting each fix in turn). Full suite: 105 files / 1132 tests green, `tsc --noEmit` and Biome clean.