### PR TITLE
fix(panels): hold off git reads while a workspace is provisioning

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -12,7 +12,7 @@ use crate::error::{Error, Result};
 use crate::git;
 use crate::git_state::{self, FileStatus, StatusKind};
 use crate::supervisor::Supervisor;
-use crate::workspace::TrackedRepo;
+use crate::workspace::{AgentRecord, AgentStatus, TrackedRepo};
 
 /// The ref a checkout's *committed* changes are diffed against: the immutable
 /// fork-point SHA captured at spawn when known, else the parent branch name
@@ -278,6 +278,24 @@ pub(super) fn agent_repo_checkout_opt(
     Ok(Some((repo, checkout)))
 }
 
+/// Whether `agent`'s checkouts are still being provisioned, and so can't be
+/// described yet.
+///
+/// The spawn path writes the agent row and announces it — so the panels start
+/// polling — before the provisioning task has finished cloning (see
+/// `supervisor::lifecycle::spawn`). A `git status` inside that window is
+/// accurate but meaningless: every file the clone hasn't written yet reads as
+/// deleted, and the ones it just wrote read as untracked, so the Git and Code
+/// panels would flash a thousand phantom changes before settling. Provisioning
+/// is the first phase of `Spawning`, so that status is the readiness signal.
+///
+/// Read-only surfaces only. The git *write* paths (commit / push / PR) resolve
+/// their checkouts through [`agent_repo_checkout`] and must keep working
+/// throughout a spawn, so they deliberately don't consult this.
+pub(super) fn checkout_pending(agent: &AgentRecord) -> bool {
+    agent.status == AgentStatus::Spawning
+}
+
 /// The agent's branch name, or an error if the checkout has no branch yet.
 pub(super) fn repo_branch(repo: &TrackedRepo) -> Result<&str> {
     repo.branch
@@ -411,6 +429,11 @@ pub(crate) async fn list_checkout_tree_impl(
     agent_id: &str,
 ) -> Result<Vec<CheckoutFile>> {
     let record = supervisor.workspace.agent(agent_id)?;
+    // Still cloning: fail rather than list a half-written tree. The explorer
+    // treats a failed listing as "keep waiting" and holds its Loading… state.
+    if checkout_pending(&record) {
+        return Err(Error::Other("workspace is still being provisioned".into()));
+    }
     if record.repos.len() <= 1 {
         let (checkout, parent) = primary_checkout(supervisor, agent_id)?;
         return Ok(checkout_tree_files(&checkout, &parent, None).await);

--- a/src-tauri/src/commands/git_state.rs
+++ b/src-tauri/src/commands/git_state.rs
@@ -12,7 +12,7 @@ use crate::git_state::{self, GitState, ShortStats};
 use crate::github as gh;
 use crate::supervisor::Supervisor;
 
-use super::files::agent_repo_checkout_opt;
+use super::files::{agent_repo_checkout_opt, checkout_pending};
 
 /// The base branch a checkout is measured against. Every repo tracked since the
 /// spawn path started resolving a default has one recorded; the fallback only
@@ -43,6 +43,16 @@ pub(crate) async fn get_git_state_impl(
     agent_id: &str,
     subdir: Option<&str>,
 ) -> Result<Option<GitState>> {
+    // Still cloning: no checkout to describe yet. `None` is what an unresolvable
+    // agent already returns, and the panel renders it as Loading… rather than
+    // as a status full of phantom deletions.
+    if supervisor
+        .workspace
+        .agent(agent_id)
+        .is_ok_and(|a| checkout_pending(&a))
+    {
+        return Ok(None);
+    }
     let Some((repo, checkout)) = agent_repo_checkout_opt(supervisor, agent_id, subdir)? else {
         return Ok(None);
     };
@@ -74,7 +84,10 @@ pub async fn get_all_shortstats(
     };
     let mut set = tokio::task::JoinSet::new();
     for agent in workspace.agents {
-        if agent.archive.is_some() {
+        // Omitted while provisioning for the same reason as archived agents:
+        // there is nothing to count yet, and counting a half-written clone
+        // would flash a phantom file count on the badge.
+        if agent.archive.is_some() || checkout_pending(&agent) {
             continue;
         }
         // One shortstat per checkout; a multi-repo agent's badge shows the
@@ -131,7 +144,7 @@ pub async fn get_all_git_meta(
     };
     let mut set = tokio::task::JoinSet::new();
     for agent in workspace.agents {
-        if agent.archive.is_some() {
+        if agent.archive.is_some() || checkout_pending(&agent) {
             continue;
         }
         for (i, repo) in agent.repos.iter().enumerate() {

--- a/src/components/RightPanel/FilePanel/index.tsx
+++ b/src/components/RightPanel/FilePanel/index.tsx
@@ -73,10 +73,14 @@ export function FilePanel({ agent, openPath, onOpenPath, diffBase }: FilePanelPr
   const refresh = useCallback(async () => {
     try {
       setFiles(await api.listCheckoutTree(agent.id));
+      // Only a listing that actually came back counts as loaded: a workspace
+      // still being provisioned rejects the call, and the tree should keep
+      // saying Loading… until its checkout exists rather than claiming the
+      // checkout is empty.
+      setLoaded(true);
     } catch {
       // Keep the previous tree on a transient IPC error rather than blanking it.
     }
-    setLoaded(true);
   }, [agent.id]);
 
   // Poll the tree at 2s, but only while the explorer is showing — no point


### PR DESCRIPTION
## Problem

Creating an agent with the Git or Code panel open flashed a large list of deleted/modified files before settling.

Spawn writes the agent row and fires `emit_workspace_changed` (`supervisor/lifecycle.rs:454-479`), so the panels begin polling, and *then* hands provisioning to a detached task that clones straight into the final checkout path (`sandbox/provision.rs:390-428`). A `git status` inside that window is accurate but meaningless: files the clone hasn't written yet read as deleted, files it just wrote read as untracked.

Reproduced by polling `git status --porcelain` during a `--shared` clone of this repo:

```
  11 ??   1246 D
  ...
  21 ??   1246 D
```

1246 staged deletions plus a growing untracked set, over a ~250ms window against a 1s poll — roughly a one-in-four chance of being caught per spawn, which matches "flashes sometimes."

## Fix

The backend was answering "what is this checkout's git state?" with a confident, well-formed `GitState` describing a directory that isn't a workspace yet. One shared predicate, `checkout_pending`, makes it say *not yet* instead, applied to the four read surfaces:

| Surface | While provisioning |
|---|---|
| `get_git_state_impl` | `None` → panel shows "Loading… / Fetching git state" |
| `list_checkout_tree_impl` | `Err` → file tree holds "Loading…" |
| `get_all_shortstats` | agent omitted → no phantom count on the tab badge |
| `get_all_git_meta` | agent omitted → no phantom staleness/overlap chips |

Provisioning is strictly the first phase of `Spawning` (everything downstream in `lifecycle.rs` is sequenced after `provision_result`), so the agent's own status is the readiness signal — no new state, no schema change, nothing to keep in sync.

Putting the gate in the backend rather than in React also covers the paired phone, which reaches `get_git_state` and `list_checkout_tree` through `remote/dispatch.rs`.

## Why the UI barely changed

It already had the right rendering contract: `deriveState(null)` returns `"loading"` (`primaryActions.ts:26-27`) and `TreeBrowser` renders `!loaded` as "Loading…". Given nothing, the panels already do the right thing. The only change is that `setLoaded(true)` now runs on success rather than unconditionally, so a rejected listing keeps waiting instead of claiming the checkout is empty.

Write paths (commit/push/PR) resolve through `agent_repo_checkout` and are deliberately untouched, so they keep working throughout a spawn.

## Considered and rejected

Provisioning into a temp path and `rename`ing it into place. It lands on the same UI state, but only via an error path: `git_state::query` is written to *degrade rather than error* (zero-state on unresolvable HEAD at `git_state.rs:106-120`, empty file list on failed status at `:132`), so it depends on git failing to spawn against a missing cwd. If that ever shifts, the flash becomes a confident "All clean" — worse than the bug. Its other benefit, protecting non-UI readers from the half-built tree, is moot: every backend consumer is already sequenced after provisioning.

## Verification

- `cargo test --lib` — 1607 passed, 0 failed
- `vitest run` — 1125 passed, 0 failed
- `cargo fmt --check` clean; clippy clean on both touched files; `tsc --noEmit` clean

Recovery is by poll: Git panel within 1s, file tree within 2s, badge within 5s. A *failed* spawn moves to `Error`, not `Spawning`, so the gate releases rather than latching.

Not done: I couldn't watch this in the running app (the Tauri build needs env keys not shared with the agent sandbox). Worth a spawn with both panels open to confirm.