### PR TITLE
feat(composer): attach pasted clipboard images and files

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -752,7 +752,12 @@ pub fn save_pasted_attachment(request: tauri::ipc::Request<'_>) -> Result<String
         .headers()
         .get("name")
         .and_then(|v| v.to_str().ok())
-        .map(|s| Path::new(s).file_name().and_then(|n| n.to_str()).unwrap_or(s))
+        .map(|s| {
+            Path::new(s)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(s)
+        })
         .filter(|s| !s.is_empty())
         .unwrap_or("pasted");
     let dir = crate::data_dir()

--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -732,6 +732,38 @@ pub async fn copy_checkout_file(
     Ok(())
 }
 
+/// Persist a file the user pasted into the composer (a screenshot from the
+/// clipboard, or a file copied in Finder) so it can be attached by path like a
+/// dropped or browsed file. The webview only sees the pasted bytes, never a
+/// path, so the copy lands under `<data_dir>/attachments/<uuid>/<name>` — a
+/// per-paste directory keeps the original name intact without collisions.
+/// Returns the absolute path.
+///
+/// The bytes travel as the raw IPC body (no JSON-encoding a screenshot byte by
+/// byte); the name rides in the `name` header, sanitized by the frontend to a
+/// plain ASCII basename.
+#[tauri::command]
+pub fn save_pasted_attachment(request: tauri::ipc::Request<'_>) -> Result<String> {
+    let bytes = match request.body() {
+        tauri::ipc::InvokeBody::Raw(bytes) => bytes,
+        _ => return Err(Error::Other("expected raw attachment bytes".into())),
+    };
+    let name = request
+        .headers()
+        .get("name")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| Path::new(s).file_name().and_then(|n| n.to_str()).unwrap_or(s))
+        .filter(|s| !s.is_empty())
+        .unwrap_or("pasted");
+    let dir = crate::data_dir()
+        .join("attachments")
+        .join(uuid::Uuid::new_v4().to_string());
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join(name);
+    std::fs::write(&path, bytes)?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
 #[cfg(test)]
 mod split_repo_path_tests {
     use super::split_repo_path;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2055,6 +2055,7 @@ pub fn run() {
             commands::create_checkout_file,
             commands::create_checkout_dir,
             commands::copy_checkout_file,
+            commands::save_pasted_attachment,
             commands::probe_provider_versions,
             commands::check_cli,
             commands::git_dist_install,

--- a/src/api/domains/files.ts
+++ b/src/api/domains/files.ts
@@ -28,4 +28,11 @@ export const filesApi = {
     invoke<void>("create_checkout_dir", { agentId, path }),
   copyCheckoutFile: (agentId: string, from: string, to: string) =>
     invoke<void>("copy_checkout_file", { agentId, from, to }),
+  /** Write pasted clipboard bytes to the app's attachments dir; resolves to the
+   *  absolute path so it can be staged like a dropped file. The name goes in a
+   *  header (raw-body IPC), so it's reduced to a plain ASCII basename here. */
+  savePastedAttachment: (name: string, bytes: Uint8Array) =>
+    invoke<string>("save_pasted_attachment", bytes, {
+      headers: { name: name.replace(/[^A-Za-z0-9._-]/g, "_") },
+    }),
 };

--- a/src/components/Composer/useComposerInput.ts
+++ b/src/components/Composer/useComposerInput.ts
@@ -1,6 +1,6 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { useEffect, useRef, useState } from "react";
-import type { DirListing, PrSummary } from "@/api";
+import { api, type DirListing, type PrSummary } from "@/api";
 import type { LocalCommandAction } from "@/data/slashCommands";
 import { useAppStore } from "@/store";
 import { useCommandSource } from "./autocomplete/sources/commands";
@@ -102,6 +102,24 @@ export function useComposerInput(cfg: ComposerInputConfig) {
     const sel = await open({ multiple: true });
     if (!sel) return;
     addPaths(Array.isArray(sel) ? sel : [sel]);
+  }
+
+  /** Files on the clipboard — a screenshot's image data, or files copied in
+   *  Finder — arrive as bytes with no path, so each is written out by the
+   *  backend and staged by the returned path. Plain text falls through to the
+   *  browser's default paste. */
+  async function pasteFiles(files: FileList) {
+    // Copied image data has no real name (WebKit labels it "image.png"), so
+    // stamp one; a Finder copy keeps its own.
+    const paths = await Promise.all(
+      Array.from(files).map(async (f, i) => {
+        const ext = f.type.split("/")[1] || "bin";
+        const generic = !f.name || f.name === "image.png";
+        const name = generic ? `pasted-${Date.now()}-${i}.${ext}` : f.name;
+        return api.savePastedAttachment(name, new Uint8Array(await f.arrayBuffer()));
+      }),
+    );
+    addPaths(paths);
   }
 
   // Autocompletions share one menu + keyboard mechanics (useAutocomplete);
@@ -209,6 +227,12 @@ export function useComposerInput(cfg: ComposerInputConfig) {
       },
       onSelect: (e: React.SyntheticEvent<HTMLTextAreaElement>) =>
         setCaret(e.currentTarget.selectionStart ?? 0),
+      onPaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+        const files = e.clipboardData.files;
+        if (files.length === 0) return;
+        e.preventDefault();
+        void pasteFiles(files);
+      },
       onKeyDown: (e: React.KeyboardEvent) => {
         if (autocomplete.onKeyDown(e)) return;
         if (onKeyDown?.(e)) return;

--- a/src/components/Composer/useComposerInput.ts
+++ b/src/components/Composer/useComposerInput.ts
@@ -60,6 +60,7 @@ export function grow(el: HTMLTextAreaElement) {
 export function useComposerInput(cfg: ComposerInputConfig) {
   const { draftKey, autoFocus, seed, onSeedConsumed, onEnter, onKeyDown } = cfg;
   const setComposerDraft = useAppStore((s) => s.setComposerDraft);
+  const setLastError = useAppStore((s) => s.setLastError);
 
   // Read the restored draft once at mount via getState (not a subscription) so
   // persisting on each keystroke doesn't re-render; a view switch remounts us
@@ -107,11 +108,12 @@ export function useComposerInput(cfg: ComposerInputConfig) {
   /** Files on the clipboard — a screenshot's image data, or files copied in
    *  Finder — arrive as bytes with no path, so each is written out by the
    *  backend and staged by the returned path. Plain text falls through to the
-   *  browser's default paste. */
+   *  browser's default paste. Files that fail to read or save are reported in
+   *  the global error banner; the rest still attach. */
   async function pasteFiles(files: FileList) {
     // Copied image data has no real name (WebKit labels it "image.png"), so
     // stamp one; a Finder copy keeps its own.
-    const paths = await Promise.all(
+    const results = await Promise.allSettled(
       Array.from(files).map(async (f, i) => {
         const ext = f.type.split("/")[1] || "bin";
         const generic = !f.name || f.name === "image.png";
@@ -119,7 +121,16 @@ export function useComposerInput(cfg: ComposerInputConfig) {
         return api.savePastedAttachment(name, new Uint8Array(await f.arrayBuffer()));
       }),
     );
-    addPaths(paths);
+    addPaths(results.flatMap((r) => (r.status === "fulfilled" ? [r.value] : [])));
+    const failed = results.filter((r) => r.status === "rejected");
+    if (failed.length) {
+      const reason = failed[0].reason;
+      setLastError(
+        `Couldn't attach ${failed.length} pasted file${failed.length > 1 ? "s" : ""}: ${
+          reason instanceof Error ? reason.message : String(reason)
+        }`,
+      );
+    }
   }
 
   // Autocompletions share one menu + keyboard mechanics (useAutocomplete);


### PR DESCRIPTION
## Summary

Pasting into the agent chat composer now attaches files, closing the gap where only the attach button and drag-and-drop worked.

- **Image data on the clipboard** (e.g. a copied screenshot) is written out as a timestamped file and staged as an attachment.
- **Files copied in Finder** are written out under their original name and staged the same way.
- Plain-text pastes are untouched.

## How

- `useComposerInput` gains an `onPaste` handler on the textarea. When the clipboard carries files it intercepts the paste, sends each file's bytes to the backend, and stages the returned paths through the existing `addPaths`. The workflow composer shares this hook, so it gets the behaviour too.
- New `save_pasted_attachment` Tauri command writes the bytes to `<data_dir>/attachments/<uuid>/<name>` and returns the absolute path. Bytes travel as the raw IPC body (no JSON-encoding a screenshot byte by byte); the filename rides in a header, sanitized to an ASCII basename on the frontend.
- Because the result is an ordinary path, the attachment chip, remove, dedupe, send and the agent-facing "Attached file" block all work unchanged.

## Not done

- No cleanup of the attachments folder; it grows slowly with pasted files.
- No error toast if the write fails (the composer has no toast helper today).
- Mobile composer untouched.

## Testing

- `cargo check`, `tsc --noEmit` and `biome check` pass.
- Not exercised in the running app from the sandbox. Worth a manual check of: an image paste, a single Finder-copied file, and a Finder multi-select copy (the last is the one I am least sure WebKit surfaces in full).