### PR TITLE
feat(sidebar): arrow-key navigation through agent rows

### DIFF
--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -269,6 +269,11 @@
   background: var(--bd-soft);
   color: var(--fg-0);
 }
+/* Keyboard focus only (arrow stepping, Tab) — mouse clicks don't draw a ring. */
+.agent:focus-visible {
+  outline: 1px solid var(--accent-line);
+  outline-offset: -1px;
+}
 
 /* status rail — the left spine; colored by status, faint grey when idle */
 .ag-rail {

--- a/src/components/Sidebar/SidebarHeader.tsx
+++ b/src/components/Sidebar/SidebarHeader.tsx
@@ -6,10 +6,23 @@ import { Icon } from "@/components/Icon";
 interface Props {
   query: string;
   onChange: (q: string) => void;
+  /** ↓ pressed in the input: hand focus to the agent list below. */
+  onArrowDown: () => void;
 }
 
-export function SidebarHeader({ query, onChange }: Props) {
+export function SidebarHeader({ query, onChange, onArrowDown }: Props) {
   const [focused, setFocused] = useState(false);
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      onArrowDown();
+    } else if (e.key === "Escape") {
+      // First Escape clears the filter, a second one leaves the box.
+      if (query) onChange("");
+      else e.currentTarget.blur();
+    }
+  }
   return (
     <div className="side-head flex-center">
       <div className="search flex-center text-base">
@@ -19,6 +32,7 @@ export function SidebarHeader({ query, onChange }: Props) {
           placeholder="Search agents, branches…"
           value={query}
           onChange={(e) => onChange(e.target.value)}
+          onKeyDown={onKeyDown}
           onFocus={() => setFocused(true)}
           onBlur={() => setFocused(false)}
         />

--- a/src/components/Sidebar/groupOpen.ts
+++ b/src/components/Sidebar/groupOpen.ts
@@ -1,0 +1,20 @@
+/** Per-group expanded state, keyed by group id. Absent means "not decided". */
+export type OpenMap = Record<string, boolean>;
+
+/** Whether a project group renders expanded.
+ *
+ *  Outside a search the user's own choices rule, closed by default. While a
+ *  query is active every remaining group has matches, so they open by default —
+ *  a hit hidden under a collapsed header is invisible, and ↓ from the search
+ *  box would find no row to land on. Toggles made mid-search go to a separate
+ *  map that is dropped with the query, so the user's collapsed/expanded layout
+ *  comes back untouched when the search clears. */
+export function isGroupOpen(
+  key: string,
+  searching: boolean,
+  openMap: OpenMap,
+  searchOpenMap: OpenMap,
+): boolean {
+  if (searching) return searchOpenMap[key] ?? true;
+  return openMap[key] ?? false;
+}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -7,6 +7,7 @@ import { useAppStore } from "@/store";
 import { arrowTarget } from "@/util/arrowNav";
 import { basename } from "@/util/format";
 import { useRuns } from "@/workflows/run/useRuns";
+import { isGroupOpen, type OpenMap } from "./groupOpen";
 import { NewProjectPopover } from "./NewProjectPopover";
 import { ProjectGroup } from "./ProjectGroup";
 import { focusRow, rowOf, visibleRows } from "./rowNav";
@@ -138,7 +139,21 @@ export function Sidebar() {
   const selectedRunId = useAppStore((s) => s.selectedRunId);
 
   const [query, setQuery] = useState("");
-  const [openMap, setOpenMap] = useState<Record<string, boolean>>({});
+  const [openMap, setOpenMap] = useState<OpenMap>({});
+  // Toggles made while searching (see isGroupOpen). Reset with every query
+  // change: the result set changes under the user anyway, and starting each
+  // search with matches fully visible is what makes ⌘K → ↓ land on a row.
+  const [searchOpenMap, setSearchOpenMap] = useState<OpenMap>({});
+  const searching = query.trim().length > 0;
+  function onQueryChange(q: string) {
+    setQuery(q);
+    setSearchOpenMap({});
+  }
+  function toggleGroup(key: string) {
+    const setMap = searching ? setSearchOpenMap : setOpenMap;
+    const fallback = searching; // isGroupOpen's default for the active map
+    setMap((m) => ({ ...m, [key]: !(m[key] ?? fallback) }));
+  }
   const [npOpen, setNpOpen] = useState(false);
   const [npMode, setNpMode] = useState<NewProjectMode | null>(null);
   // Transient drag state for reordering: the group being dragged and the one
@@ -181,7 +196,7 @@ export function Sidebar() {
   const filtered = useMemo(() => applySearch(groups, query), [groups, query]);
 
   // Reordering is only meaningful over the full, unfiltered list.
-  const reorderable = !query.trim();
+  const reorderable = !searching;
   const orderedPaths = useMemo(() => groups.map((g) => g.primaryPath), [groups]);
 
   // Begin a pointer-driven reorder. `markDragged` lets the group swallow the
@@ -283,7 +298,7 @@ export function Sidebar() {
 
   return (
     <>
-      <SidebarHeader query={query} onChange={setQuery} onArrowDown={enterList} />
+      <SidebarHeader query={query} onChange={onQueryChange} onArrowDown={enterList} />
       <div className="side-scroll" ref={listRef} onKeyDown={onListKeyDown}>
         <div className="side-section">
           <button
@@ -317,8 +332,8 @@ export function Sidebar() {
                   agents={g.agents}
                   drafts={g.drafts}
                   runs={g.runs}
-                  open={openMap[g.key] ?? false}
-                  onToggle={() => setOpenMap((m) => ({ ...m, [g.key]: !m[g.key] }))}
+                  open={isGroupOpen(g.key, searching, openMap, searchOpenMap)}
+                  onToggle={() => toggleGroup(g.key)}
                   reorderable={reorderable}
                   dragging={dragPath === g.primaryPath}
                   dropIndicator={isOver ? (dropAfter ? "after" : "before") : null}

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -4,10 +4,12 @@ import { Icon } from "@/components/Icon";
 import { NewProject, type NewProjectMode } from "@/components/NewProject";
 import type { DraftAgent } from "@/store";
 import { useAppStore } from "@/store";
+import { arrowTarget } from "@/util/arrowNav";
 import { basename } from "@/util/format";
 import { useRuns } from "@/workflows/run/useRuns";
 import { NewProjectPopover } from "./NewProjectPopover";
 import { ProjectGroup } from "./ProjectGroup";
+import { focusRow, rowOf, visibleRows } from "./rowNav";
 import { SidebarFooter } from "./SidebarFooter";
 import { SidebarHeader } from "./SidebarHeader";
 import { useProjectReorder } from "./useProjectReorder";
@@ -241,6 +243,28 @@ export function Sidebar() {
   // so they don't leak past this component's life.
   useEffect(() => () => dragCleanup.current?.(), []);
 
+  // ↑/↓ (Home/End) step through the visible rows and select as they go. Scoped
+  // to keys fired inside the list, so the composer, chat, and dropdowns keep
+  // their arrows; modifier chords pass through (Alt+↑/↓ belongs to ChatNav).
+  const listRef = useRef<HTMLDivElement>(null);
+  function onListKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.altKey || e.metaKey || e.ctrlKey) return;
+    const rows = visibleRows(listRef.current);
+    const row = rowOf(e.target);
+    const target = arrowTarget(rows, row ? rows.indexOf(row) : -1, e.key);
+    if (!target) return;
+    e.preventDefault();
+    focusRow(target);
+  }
+
+  // ↓ in the search box enters the list at the selected row (or the top), so
+  // ⌘K then arrows is the whole keyboard flow.
+  function enterList() {
+    const rows = visibleRows(listRef.current);
+    const row = rows.find((r) => r.classList.contains("active")) ?? rows[0];
+    if (row) focusRow(row);
+  }
+
   // Auto-expand a project when its agent, draft, or run is selected.
   useEffect(() => {
     setOpenMap((prev) => {
@@ -259,8 +283,8 @@ export function Sidebar() {
 
   return (
     <>
-      <SidebarHeader query={query} onChange={setQuery} />
-      <div className="side-scroll">
+      <SidebarHeader query={query} onChange={setQuery} onArrowDown={enterList} />
+      <div className="side-scroll" ref={listRef} onKeyDown={onListKeyDown}>
         <div className="side-section">
           <button
             className="add-proj-cta flex-center text-sm"

--- a/src/components/Sidebar/rowNav.ts
+++ b/src/components/Sidebar/rowNav.ts
@@ -1,0 +1,29 @@
+// Keyboard stepping through the sidebar's selectable rows (drafts, agents,
+// workflow runs). Read from the DOM on each keypress rather than mirrored in
+// state: the rendered rows already reflect search filtering, project order,
+// and collapsed groups, so there is nothing to keep in sync.
+
+const ROW = ".agent[role='button']";
+
+/** Every selectable row the user can currently see, in visual order. Rows in a
+ *  collapsed group stay mounted (the group animates shut), so they're skipped. */
+export function visibleRows(container: HTMLElement | null): HTMLElement[] {
+  return Array.from(container?.querySelectorAll<HTMLElement>(ROW) ?? []).filter(
+    (el) => !el.closest(".agents.closed"),
+  );
+}
+
+/** The row that owns `el`, if it sits inside one (a nested Stop/Archive button
+ *  counts as being on its row). */
+export function rowOf(el: EventTarget | null): HTMLElement | null {
+  return el instanceof HTMLElement ? el.closest<HTMLElement>(ROW) : null;
+}
+
+/** Move keyboard focus to a row and select it, so the transcript follows the
+ *  arrow keys the way a mail or file list does. Clicking reuses the row's own
+ *  onClick, so drafts, agents, and runs all route through their usual select. */
+export function focusRow(row: HTMLElement) {
+  row.focus();
+  row.scrollIntoView({ block: "nearest" });
+  row.click();
+}

--- a/src/components/ui/Select.tsx
+++ b/src/components/ui/Select.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { Icon } from "@/components/Icon";
+import { arrowTarget } from "@/util/arrowNav";
 import { Scrim } from "./Scrim";
 
 export interface SelectOption<T extends string> {
@@ -64,21 +65,11 @@ export function Select<T extends string>({
 
   function onListKeyDown(e: React.KeyboardEvent<HTMLDivElement>) {
     const items = focusableItems(listRef.current);
-    if (items.length === 0) return;
     const current = items.indexOf(document.activeElement as HTMLButtonElement);
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      items[(current + 1) % items.length]?.focus();
-    } else if (e.key === "ArrowUp") {
-      e.preventDefault();
-      items[(current - 1 + items.length) % items.length]?.focus();
-    } else if (e.key === "Home") {
-      e.preventDefault();
-      items[0]?.focus();
-    } else if (e.key === "End") {
-      e.preventDefault();
-      items[items.length - 1]?.focus();
-    }
+    const target = arrowTarget(items, current, e.key, { wrap: true });
+    if (!target) return;
+    e.preventDefault();
+    target.focus();
   }
 
   function pick(v: T) {

--- a/src/util/arrowNav.test.ts
+++ b/src/util/arrowNav.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { arrowTarget } from "./arrowNav";
+
+const items = ["a", "b", "c"];
+
+describe("arrowTarget", () => {
+  it("steps down and up without wrapping by default", () => {
+    expect(arrowTarget(items, 0, "ArrowDown")).toBe("b");
+    expect(arrowTarget(items, 2, "ArrowDown")).toBe("c");
+    expect(arrowTarget(items, 1, "ArrowUp")).toBe("a");
+    expect(arrowTarget(items, 0, "ArrowUp")).toBe("a");
+  });
+
+  it("wraps when asked", () => {
+    expect(arrowTarget(items, 2, "ArrowDown", { wrap: true })).toBe("a");
+    expect(arrowTarget(items, 0, "ArrowUp", { wrap: true })).toBe("c");
+  });
+
+  it("enters the list at the top when focus starts outside it", () => {
+    expect(arrowTarget(items, -1, "ArrowDown")).toBe("a");
+    expect(arrowTarget(items, -1, "ArrowUp")).toBe("a");
+  });
+
+  it("jumps to the ends with Home and End", () => {
+    expect(arrowTarget(items, 1, "Home")).toBe("a");
+    expect(arrowTarget(items, 1, "End")).toBe("c");
+  });
+
+  it("ignores other keys and empty lists", () => {
+    expect(arrowTarget(items, 1, "Enter")).toBeUndefined();
+    expect(arrowTarget([], 0, "ArrowDown")).toBeUndefined();
+  });
+});

--- a/src/util/arrowNav.ts
+++ b/src/util/arrowNav.ts
@@ -1,0 +1,26 @@
+/** Resolve where an ArrowUp/ArrowDown/Home/End keypress should move within an
+ *  ordered list of items. Pure — callers decide what "focus" means. `current`
+ *  is the index of the item that has focus now, or -1 when focus sits outside
+ *  the list (then ArrowDown lands on the first item). Returns undefined for
+ *  keys the helper doesn't handle, so callers can let them through. */
+export function arrowTarget<T>(
+  items: readonly T[],
+  current: number,
+  key: string,
+  opts: { wrap?: boolean } = {},
+): T | undefined {
+  const n = items.length;
+  if (n === 0) return undefined;
+  switch (key) {
+    case "ArrowDown":
+      return opts.wrap ? items[(current + 1) % n] : items[Math.min(current + 1, n - 1)];
+    case "ArrowUp":
+      return opts.wrap ? items[(current - 1 + n) % n] : items[Math.max(current - 1, 0)];
+    case "Home":
+      return items[0];
+    case "End":
+      return items[n - 1];
+    default:
+      return undefined;
+  }
+}

--- a/tests/components/Sidebar/groupOpen.test.ts
+++ b/tests/components/Sidebar/groupOpen.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { isGroupOpen } from "@/components/Sidebar/groupOpen";
+
+describe("isGroupOpen", () => {
+  it("follows the user's choice outside a search, closed by default", () => {
+    expect(isGroupOpen("p", false, { p: true }, {})).toBe(true);
+    expect(isGroupOpen("p", false, { p: false }, {})).toBe(false);
+    expect(isGroupOpen("p", false, {}, {})).toBe(false);
+  });
+
+  it("opens a collapsed project while its rows match a search", () => {
+    // The ⌘K → ↓ flow: the matching agent must be visible for the arrow to land.
+    expect(isGroupOpen("p", true, { p: false }, {})).toBe(true);
+  });
+
+  it("lets a mid-search toggle collapse the group without touching the saved state", () => {
+    const openMap = { p: false };
+    expect(isGroupOpen("p", true, openMap, { p: false })).toBe(false);
+    // Clearing the search drops the search map; the saved layout is unchanged.
+    expect(isGroupOpen("p", false, openMap, {})).toBe(false);
+  });
+
+  it("restores a previously expanded project after the search clears", () => {
+    const openMap = { p: true };
+    expect(isGroupOpen("p", true, openMap, { p: false })).toBe(false);
+    expect(isGroupOpen("p", false, openMap, {})).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds keyboard navigation to the sidebar agent list. Rows were already focusable with Enter/Space, but reaching one meant tabbing through every row and action button, and focused rows had no visible focus style.

- **↑ / ↓ step through visible rows and select as they go**, so the transcript follows the keyboard (mail/file-list behaviour). Home/End jump to the ends.
- **↓ in the search box enters the list** at the selected row (or the top), so `⌘K` then arrows is the whole flow. Escape clears the filter; a second Escape leaves the box.
- **Visible focus ring** on rows for keyboard focus only (`:focus-visible`), matching the history list.

## Design notes

- Handler is scoped to keydown events inside the sidebar list — no global listener, so the composer, chat, autocomplete and dropdowns keep their arrow keys. Alt/⌘/Ctrl chords pass through (Alt+↑/↓ still belongs to ChatNav).
- Rows are read from the DOM on each keypress (`rowNav.ts`) and skip collapsed groups, so search filtering, project order and mixed row kinds (drafts, agents, runs) need no mirrored index state. Selecting reuses each row's own `onClick`.
- Existing ARIA roles are unchanged; rows keep `role="button"` + `aria-current` since they contain nested Stop/Archive buttons.
- The pure arrow-step logic lives in `util/arrowNav.ts` and is now shared with `Select.tsx`, which previously had its own copy.

## Verification

- `tsc --noEmit` clean; vitest 106 files / 1137 tests pass (includes a new unit test for `arrowTarget`).
- Biome reports three pre-existing `noDescendingSpecificity` warnings in `Sidebar.css`, unrelated to this change.

## Follow-ups (not in this PR)

- Rows in a collapsed project stay mounted and Tab-reachable (pre-existing); arrow stepping already skips them.
- A global chord to step agents while typing in the composer (Alt+arrows is taken).