### PR TITLE
fix(store): chat model picker showed the archived agent's settings after a recycled name

### DIFF
--- a/src/store/adoptSpawnedAgent.test.ts
+++ b/src/store/adoptSpawnedAgent.test.ts
@@ -1,0 +1,127 @@
+// The bug this pins: agent ids are landmark names, and the backend recycles the
+// names of archived agents. Spawning a draft under a recycled name returned a
+// record whose id the store ALREADY held — as the archived predecessor. The
+// spawn path selected that id before the workspace refresh landed, so the chat
+// mounted against the archived record (its provider/model/effort/custom agent),
+// and since the id — and so the React key — never changed, the composer's
+// mount-time picker state was never corrected until the user switched chats.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+
+const { spawnAgent, sendUserMessage, getWorkspace } = vi.hoisted(() => ({
+  spawnAgent: vi.fn(),
+  sendUserMessage: vi.fn(),
+  getWorkspace: vi.fn(),
+}));
+vi.mock("@/api", () => ({ api: { spawnAgent, sendUserMessage, getWorkspace } }));
+vi.mock("@/storage/settings", () => ({ setSetting: vi.fn() }));
+vi.mock("@/data/slashCommands", () => ({ discoverCommands: vi.fn() }));
+
+import type { AgentRecord, Workspace } from "@/api";
+import { adoptSpawnedAgent } from "./adoptSpawnedAgent";
+import { createDraftsSlice } from "./drafts";
+import type { AppState } from "./types";
+
+const NAME = "chimborazo";
+
+const record = (over: Partial<AgentRecord>): AgentRecord =>
+  ({
+    id: NAME,
+    project_id: "p1",
+    name: NAME,
+    provider: "claude",
+    repos: [{ repo_path: "/repos/app", subdir: "app" }],
+    task: "",
+    status: "idle",
+    view: "custom",
+    created_at: "2026-01-01T00:00:00Z",
+    ...over,
+  }) as AgentRecord;
+
+/** The archived agent that used to own this name — a different provider, model
+ *  and custom agent than the one about to be spawned. */
+const archived = record({
+  provider: "codex",
+  model: "gpt-5-codex",
+  custom_agent_id: "reviewer",
+  effort: "high",
+  archive: { archived_at: "2026-01-02T00:00:00Z", repos: [], diff_stats: {} as never },
+});
+
+const unrelated = record({ id: "eiger", name: "eiger" });
+
+/** What the backend returns for the fresh spawn under the recycled name. */
+const fresh = record({ provider: "claude", model: "claude-opus-5", status: "spawning" });
+
+const workspaceWith = (agents: AgentRecord[]): Workspace => ({
+  repos: ["/repos/app"],
+  projects: [],
+  agents,
+});
+
+const makeStore = (workspace: Workspace) => {
+  const store = create<AppState>()((...a) => ({ ...createDraftsSlice(...a) }) as AppState);
+  store.setState({
+    workspace,
+    drafts: [{ id: "d1", repoPath: "/repos/app", name: NAME, provider: "claude", base: "main" }],
+    composerDrafts: {},
+    customAgents: [],
+    modelsByAgent: {},
+    skills: [],
+    managedLogs: {},
+    managedBusy: {},
+    // biome-ignore lint/suspicious/noExplicitAny: partial store seed
+  } as any);
+  return store;
+};
+
+describe("adoptSpawnedAgent", () => {
+  it("replaces an archived record that still holds the recycled id", () => {
+    const next = adoptSpawnedAgent(workspaceWith([unrelated, archived]), fresh);
+    expect(next?.agents).toEqual([fresh, unrelated]);
+  });
+
+  it("adds the record when the snapshot has never seen the id", () => {
+    const next = adoptSpawnedAgent(workspaceWith([unrelated]), fresh);
+    expect(next?.agents).toEqual([fresh, unrelated]);
+  });
+
+  it("is a no-op before the workspace has loaded", () => {
+    expect(adoptSpawnedAgent(null, fresh)).toBeNull();
+  });
+});
+
+describe("spawning a draft under a recycled landmark name", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    spawnAgent.mockResolvedValue(fresh);
+    sendUserMessage.mockResolvedValue(false);
+    // The refresh yields nothing, so the store is exactly what the spawn path
+    // itself committed — the window the chat mounts in before a snapshot lands.
+    getWorkspace.mockResolvedValue(null);
+  });
+
+  it("selects the fresh record, not the archived one that shared its id", async () => {
+    const store = makeStore(workspaceWith([unrelated, archived]));
+
+    await store.getState().spawnFromDraft("d1", "ship it", "claude", "claude-opus-5");
+
+    const { selectedAgentId, workspace } = store.getState();
+    expect(selectedAgentId).toBe(NAME);
+    const selected = workspace?.agents.find((a) => a.id === selectedAgentId);
+    expect(selected).toEqual(fresh);
+    // The archived predecessor is gone entirely — one record per id.
+    expect(workspace?.agents.filter((a) => a.id === NAME)).toHaveLength(1);
+    expect(workspace?.agents).toContainEqual(unrelated);
+  });
+
+  it("makes the new record visible immediately on a never-used name too", async () => {
+    const store = makeStore(workspaceWith([unrelated]));
+
+    await store.getState().spawnFromDraft("d1", "ship it", "claude", "claude-opus-5");
+
+    const { selectedAgentId, workspace } = store.getState();
+    expect(workspace?.agents.find((a) => a.id === selectedAgentId)).toEqual(fresh);
+  });
+});

--- a/src/store/adoptSpawnedAgent.ts
+++ b/src/store/adoptSpawnedAgent.ts
@@ -1,0 +1,22 @@
+import type { AgentRecord, Workspace } from "@/api";
+
+/**
+ * Fold a just-spawned agent's record into the workspace snapshot, replacing any
+ * record that already holds its id.
+ *
+ * Agent ids are landmark names, and the backend recycles the names of archived
+ * agents: when a spawn reuses one, it evicts the archived row and inserts the
+ * new one under the same primary key. Until the next `getWorkspace()` lands,
+ * this store still holds the *archived* record under that id — so selecting the
+ * new agent would mount its chat against the old record (wrong provider, model,
+ * effort, custom agent), and because the id (and so the React key) never
+ * changes, the composer's mount-time state would then never catch up. Every
+ * spawn site applies the returned record here in the same update that selects
+ * it, so the chat only ever mounts against the real record. The refresh that
+ * follows is still authoritative for everything else in the snapshot.
+ */
+export function adoptSpawnedAgent(workspace: Workspace | null, rec: AgentRecord): Workspace | null {
+  if (!workspace) return workspace;
+  const others = workspace.agents.filter((a) => a.id !== rec.id);
+  return { ...workspace, agents: [rec, ...others] };
+}

--- a/src/store/drafts.ts
+++ b/src/store/drafts.ts
@@ -11,6 +11,7 @@ import {
   sendWhenAgentReady,
 } from "@/helpers";
 import { setSetting } from "@/storage/settings";
+import { adoptSpawnedAgent } from "./adoptSpawnedAgent";
 import { refreshWorkspace } from "./refreshWorkspace";
 import type { AppState, SliceCreator } from "./types";
 
@@ -368,10 +369,14 @@ export const createDraftsSlice: SliceCreator<DraftsSlice> = (set, get) => ({
       }
       // Apply the selection, draft cleanup and log seed immediately, ahead of
       // the guarded workspace refresh, so this user-intent state can never be
-      // dropped if a concurrent refresh supersedes ours.
+      // dropped if a concurrent refresh supersedes ours. The record lands in the
+      // same update: selecting an id the snapshot still holds an *archived*
+      // record for (a recycled name) would otherwise open the chat against
+      // that stale record — see adoptSpawnedAgent.
       set((state) => {
         const { [id]: _droppedDraft, ...restComposerDrafts } = state.composerDrafts;
         const patches: Partial<AppState> = {
+          workspace: adoptSpawnedAgent(state.workspace, rec),
           selectedAgentId: rec.id,
           drafts: state.drafts.filter((d) => d.id !== id),
           activeDraftId: null,

--- a/src/store/workspace.ts
+++ b/src/store/workspace.ts
@@ -26,6 +26,7 @@ import {
 import { clearOutputBuffer, dropAgentPty } from "@/pty/buffers";
 import { recordUsageSnapshot } from "@/storage/usageDaily";
 import { createKeyedQueue } from "@/util/keyedQueue";
+import { adoptSpawnedAgent } from "./adoptSpawnedAgent";
 import { forkContextDigest } from "./forkDigest";
 import { interruptedAgents } from "./interrupted";
 import { refreshWorkspace } from "./refreshWorkspace";
@@ -387,9 +388,14 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
       );
       // Apply the selection (and custom-view log seeds) immediately, ahead of the
       // guarded workspace refresh, so this user-intent state can never be dropped
-      // if a concurrent refresh supersedes ours.
+      // if a concurrent refresh supersedes ours. The record rides along so a
+      // recycled name can't open the chat against its archived predecessor
+      // (see adoptSpawnedAgent).
       set((state) => {
-        const patches: Partial<AppState> = { selectedAgentId: rec.id };
+        const patches: Partial<AppState> = {
+          workspace: adoptSpawnedAgent(state.workspace, rec),
+          selectedAgentId: rec.id,
+        };
         if (view === "custom") {
           patches.managedLogs = { ...state.managedLogs, [rec.id]: [] };
           patches.managedBusy = { ...state.managedBusy, [rec.id]: false };
@@ -437,8 +443,14 @@ export const createWorkspaceSlice: SliceCreator<WorkspaceSlice> = (set, get) => 
       // created with a non-empty task, so opening it triggers
       // loadHistoryTranscript to render the copied history; a context-less fork
       // opens as an empty chat. Set the selection ahead of the guarded refresh
-      // so it survives a superseding concurrent refresh.
-      set({ selectedAgentId: rec.id, activeDraftId: null });
+      // so it survives a superseding concurrent refresh, with the record in the
+      // same update so a recycled name can't mount against its archived
+      // predecessor (see adoptSpawnedAgent).
+      set((state) => ({
+        workspace: adoptSpawnedAgent(state.workspace, rec),
+        selectedAgentId: rec.id,
+        activeDraftId: null,
+      }));
       await refreshWorkspace(set);
       return rec;
     } catch (e) {


### PR DESCRIPTION
## Problem

Sometimes the model picker in a freshly spawned chat showed the wrong provider/model (and effort / custom agent). Switching to another chat and back fixed it.

## Root cause

Agent ids are landmark names, and the backend recycles the names of archived agents: it evicts the archived row and inserts the new agent under the same primary key (`insert_agent` in `src-tauri/src/workspace/agents.rs`).

On the frontend, every spawn path set `selectedAgentId` **before** the workspace refresh landed (deliberately, so the selection survives a superseded refresh). When the name was recycled, the store still held the *archived* record under that id, so `Workspace` resolved the selection to it and `ChatView` mounted against the old record. `Composer` seeds its provider/model/custom-agent/effort state once at mount, and since the id (and React key) never changed, the later refresh swapped in the real record without a remount — the picker kept the archived agent's settings until the user switched chats.

## Fix

- New `src/store/adoptSpawnedAgent.ts`: upserts a spawn's returned record into the workspace snapshot, replacing any record that already holds its id.
- The three spawn sites (`spawnFromDraft` in `drafts.ts`, `spawn` and `forkAgent` in `workspace.ts`) apply the record in the same `set` that selects the agent, so the chat only ever mounts against the real record. The follow-up refresh remains authoritative for the rest of the snapshot.

## Verification

- `src/store/adoptSpawnedAgent.test.ts` reproduces the collision at the store level (archived record with the recycled id and a different provider/model/effort/custom agent, then a draft spawn under that name). Run against the pre-fix store (source edits stashed) it fails exactly as diagnosed; with the fix it passes.
- Full suite: 106 files / 1137 tests pass. `tsc --noEmit` clean. `biome check` clean at error level.

## Not in this PR

`ThreadComposer` (run thread) has the same class of issue: it swaps the live step agent under an unkeyed `Composer`, so the picker keeps the first step's provider/model. Separate surface; a `key` on that Composer would address it in a follow-up.