### PR TITLE
fix(mobile): delegate commit & PR to the agent, keep the form as the manual path

### DIFF
--- a/mobile/src/screens/Agent/ChangesTab.tsx
+++ b/mobile/src/screens/Agent/ChangesTab.tsx
@@ -26,11 +26,14 @@ export function ChangesTab({
   // its own (the desktop queues it until idle); v1 on the phone simply waits.
   const busy = sending || isBusy(agent);
 
-  // Mirrors the desktop's default: the agent commits and opens a PR; with a PR
-  // already open, "open PR" degrades to push (that's what updates it); with
-  // everything committed but no PR, the agent names the branch and opens one.
+  // Mirrors the desktop's default. The commit-* playbooks start with a commit,
+  // so a clean tree (only unpushed commits) gets the plain push / open-pr
+  // playbook instead; with a PR already open, "open PR" degrades to push,
+  // since that's what updates it.
   const action = pr
-    ? { name: "commit-push", label: `Commit & push to #${pr.number}` }
+    ? files.length
+      ? { name: "commit-push", label: `Commit & push to #${pr.number}` }
+      : { name: "push", label: `Push to #${pr.number}` }
     : files.length
       ? { name: "commit-pr", label: "Commit & open PR" }
       : { name: "open-pr", label: "Open PR" };

--- a/mobile/src/screens/Agent/ChangesTab.tsx
+++ b/mobile/src/screens/Agent/ChangesTab.tsx
@@ -1,17 +1,44 @@
 import type { AgentRecord } from "@desktop/api/types/agent";
 import { Icon } from "../../components/Icon";
 import { PrPill } from "../../components/ui";
-import { branchOf } from "../../lib/agents";
+import { baseOf, branchOf, isBusy } from "../../lib/agents";
 import { STATUS_LETTER } from "../../lib/diff";
 import { useStore } from "../../store";
 import { PrCard } from "./PrCard";
 
-export function ChangesTab({ agent }: { agent: AgentRecord }) {
+export function ChangesTab({
+  agent,
+  onDelegated,
+}: {
+  agent: AgentRecord;
+  /** Called once a git action has been handed to the agent, so the screen can
+   *  show the chat where the agent's turn plays out. */
+  onDelegated?: () => void;
+}) {
   const git = useStore((s) => s.gitStates[agent.id]);
   const pr = useStore((s) => s.prStates[agent.id]);
   const push = useStore((s) => s.push);
   const openSheet = useStore((s) => s.openSheet);
+  const delegateGit = useStore((s) => s.delegateGit);
+  const sending = useStore((s) => !!s.busy[agent.id]);
   const files = git?.files ?? [];
+  // A trigger sent mid-turn folds into the running turn instead of running as
+  // its own (the desktop queues it until idle); v1 on the phone simply waits.
+  const busy = sending || isBusy(agent);
+
+  // Mirrors the desktop's default: the agent commits and opens a PR; with a PR
+  // already open, "open PR" degrades to push (that's what updates it); with
+  // everything committed but no PR, the agent names the branch and opens one.
+  const action = pr
+    ? { name: "commit-push", label: `Commit & push to #${pr.number}` }
+    : files.length
+      ? { name: "commit-pr", label: "Commit & open PR" }
+      : { name: "open-pr", label: "Open PR" };
+
+  const delegate = async () => {
+    await delegateGit(agent.id, action.name, { base: baseOf(agent) });
+    onDelegated?.();
+  };
 
   return (
     <>
@@ -91,10 +118,18 @@ export function ChangesTab({ agent }: { agent: AgentRecord }) {
           <button
             type="button"
             className="btn primary"
-            onClick={() => openSheet("pr", { agentId: agent.id })}
+            onClick={() => void delegate()}
+            disabled={busy}
           >
             <Icon name="pr" size={17} />
-            {pr ? `Commit & push to #${pr.number}` : "Commit & open PR"}
+            {busy ? "Agent is busy…" : `${action.label} with agent`}
+          </button>
+          <button
+            type="button"
+            className="alt"
+            onClick={() => openSheet("pr", { agentId: agent.id })}
+          >
+            Write the message yourself
           </button>
         </div>
       )}

--- a/mobile/src/screens/Agent/index.tsx
+++ b/mobile/src/screens/Agent/index.tsx
@@ -151,7 +151,7 @@ export function AgentScreen({ agentId }: { agentId: string }) {
           >
             {tab === "chat" && <ChatTab agent={agent} pinRef={pinnedToBottom} />}
             {tab === "code" && <CodeTab agent={agent} />}
-            {tab === "changes" && <ChangesTab agent={agent} />}
+            {tab === "changes" && <ChangesTab agent={agent} onDelegated={() => go("chat")} />}
           </div>
         )}
       </div>

--- a/mobile/src/sheets/PrSheet.tsx
+++ b/mobile/src/sheets/PrSheet.tsx
@@ -6,8 +6,10 @@ import { agentOf, useStore } from "../store";
 
 type Stage = "form" | "run" | "done" | "error";
 
-/** Commit + push + open PR, or push to an existing one. Each step is a real
- *  remote op; the progress list is just the three of them. */
+/** The manual alternative to handing the git action to the agent (Changes tab):
+ *  commit + push + open PR, or push to an existing one, with the user's own
+ *  title and description. Each step is a real remote op; the progress list is
+ *  just the three of them. */
 export function PrSheet({
   open,
   onClose,
@@ -33,8 +35,10 @@ export function PrSheet({
 
   useEffect(() => {
     if (!open || !agent) return;
-    setTitle(pr?.title ?? agent.task.split("\n")[0].slice(0, 72));
-    setBody(agent.task);
+    // The form is the user's own text, never the agent's task: seeding it from
+    // the task made the original prompt the commit message and PR body.
+    setTitle(pr?.title ?? "");
+    setBody("");
     setStage("form");
     setStep(0);
     setError(null);

--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -3,6 +3,7 @@ import type { CheckoutFile, DirListing } from "@desktop/api/types/checkout";
 import type { DiffStats, GitState } from "@desktop/api/types/git";
 import type { PrChecks, PrState } from "@desktop/api/types/pr";
 import type { GhRepoSummary, GhStatus } from "@desktop/api/types/providers";
+import { appActionMessage } from "@desktop/delegation";
 import { create } from "zustand";
 import type { ChatItem, RawEvent } from "../adapters";
 import { createApi } from "../api";
@@ -137,6 +138,12 @@ export interface MobileState {
   /** `null` clears the pinned model, leaving the provider CLI's own default. */
   setModel(agentId: string, model: string | null): Promise<void>;
   setEffort(agentId: string, effort: string): Promise<void>;
+  /** Hand a git action to the coding agent, as the desktop git panel does: the
+   *  agent writes the commit message / PR description itself. `action` is a
+   *  playbook name from `instructions/git_actions.md` (`commit-pr`, `open-pr`,
+   *  `commit-push`, …); `params` carry only what the playbook can't know. */
+  delegateGit(agentId: string, action: string, params?: Record<string, string>): Promise<void>;
+  /** Manual path: commit + push + open a PR with the user's own text. */
   publish(agentId: string, title: string, body: string): Promise<void>;
   pushToPr(agentId: string): Promise<void>;
 
@@ -726,6 +733,14 @@ export const useStore = create<MobileState>()((set, get) => ({
 
   async setEffort(agentId, effort) {
     await guard(set, () => api.setAgentEffort(agentId, effort));
+  },
+
+  async delegateGit(agentId, action, params) {
+    // Delivered as a normal user turn: the host's `send_user_message` is the
+    // same op the desktop uses, and the agent already carries the playbooks.
+    // Completion needs no tracking here — `agent:git-action` and
+    // `pr:state_changed` (events.ts) reload the git/PR state when it lands.
+    await get().send(agentId, appActionMessage(action, params));
   },
 
   async publish(agentId, title, body) {

--- a/mobile/src/styles/agent.css
+++ b/mobile/src/styles/agent.css
@@ -1142,6 +1142,17 @@
   height: 50px;
   border-radius: 16px;
 }
+/* The manual alternative under the delegated primary: a quiet text link. */
+.ch-foot .alt {
+  display: block;
+  width: 100%;
+  margin-top: 10px;
+  padding: 6px;
+  font-size: 13.5px;
+  font-weight: 500;
+  color: var(--fg-2);
+  text-align: center;
+}
 .pr-card {
   background: var(--bg-1);
   border: 1px solid var(--bd-soft);


### PR DESCRIPTION
## Summary

On the phone, "Commit & open PR" ran the direct `commit_agent` / `push_agent` / `create_pr` ops with a form pre-filled from the agent's task, so the original prompt ended up as the commit message (first 72 chars) and the PR description (the whole prompt). The agent was never involved.

This mirrors the desktop git panel: the primary action sends the same `[app-action]` trigger and the agent writes the commit message and PR description. The manual form stays as a secondary path.

## Changes

- **Store**: new `delegateGit(agentId, action, params)` that builds the trigger with the desktop's `appActionMessage` and sends it through the existing chat `send`. No host/Rust changes: `send_user_message` is already a remote op and the agent already carries the playbooks.
- **Changes tab**: primary button delegates and switches to the Chat tab. Picks `commit-pr` (uncommitted files), `commit-push` (PR already open), or `open-pr` (committed, no PR), passing `base`. Disabled while the agent is running, since a mid-turn trigger folds into the running turn.
- **Manual path**: a quiet "Write the message yourself" link opens the existing PR sheet, which no longer pre-fills title/body from the task (keeps the PR title in the push-to-PR case).
- **Style**: one rule for the text link.

## Not in this PR

- Chat renders the trigger line as a plain user bubble (desktop folds it into a chip).
- No hold-until-idle queueing; the button just waits while the agent is busy.

## Verification

- `tsc --noEmit` (mobile): clean
- `biome check` (mobile): clean
- `vitest run` (mobile): 133 passed