### PR TITLE
fix(panels): read the provisioning guard off the live status

### DIFF
--- a/src-tauri/src/commands/files.rs
+++ b/src-tauri/src/commands/files.rs
@@ -12,7 +12,7 @@ use crate::error::{Error, Result};
 use crate::git;
 use crate::git_state::{self, FileStatus, StatusKind};
 use crate::supervisor::Supervisor;
-use crate::workspace::{AgentRecord, AgentStatus, TrackedRepo};
+use crate::workspace::{AgentStatus, TrackedRepo};
 
 /// The ref a checkout's *committed* changes are diffed against: the immutable
 /// fork-point SHA captured at spawn when known, else the parent branch name
@@ -289,11 +289,16 @@ pub(super) fn agent_repo_checkout_opt(
 /// panels would flash a thousand phantom changes before settling. Provisioning
 /// is the first phase of `Spawning`, so that status is the readiness signal.
 ///
+/// Read through [`Supervisor::status_of`], never off a stored record: runtime
+/// status lives only in the supervisor's in-memory map, and the DB-derived
+/// status on a record rests at `Idle` (`workspace::derive_status`), so a
+/// record-based check would never see `Spawning`.
+///
 /// Read-only surfaces only. The git *write* paths (commit / push / PR) resolve
 /// their checkouts through [`agent_repo_checkout`] and must keep working
 /// throughout a spawn, so they deliberately don't consult this.
-pub(super) fn checkout_pending(agent: &AgentRecord) -> bool {
-    agent.status == AgentStatus::Spawning
+pub(super) fn checkout_pending(supervisor: &Supervisor, agent_id: &str) -> bool {
+    matches!(supervisor.status_of(agent_id), Some(AgentStatus::Spawning))
 }
 
 /// The agent's branch name, or an error if the checkout has no branch yet.
@@ -431,7 +436,7 @@ pub(crate) async fn list_checkout_tree_impl(
     let record = supervisor.workspace.agent(agent_id)?;
     // Still cloning: fail rather than list a half-written tree. The explorer
     // treats a failed listing as "keep waiting" and holds its Loading… state.
-    if checkout_pending(&record) {
+    if checkout_pending(supervisor, agent_id) {
         return Err(Error::Other("workspace is still being provisioned".into()));
     }
     if record.repos.len() <= 1 {
@@ -1006,5 +1011,93 @@ mod safe_join_tests {
     fn allows_paths_that_do_not_exist_yet() {
         let (_td, checkout, _outside) = checkout_and_outside();
         assert!(safe_join(&checkout, "src/deeply/nested/new.ts").is_ok());
+    }
+}
+
+#[cfg(test)]
+mod checkout_pending_tests {
+    use super::checkout_pending;
+    use crate::supervisor::Supervisor;
+    use crate::workspace::{
+        new_agent_record, AgentStatus, AgentView, TrackedRepo, WorkspaceManager,
+    };
+    use std::path::PathBuf;
+    use std::sync::Arc;
+
+    /// A supervisor over a fresh DB holding one agent row. The stored row has no
+    /// runtime status: `workspace.agent()` derives it to `Idle` no matter what
+    /// the spawn is actually doing — that's what the guard must not rely on.
+    fn supervisor_with_agent(id: &str) -> Supervisor {
+        let dir = tempfile::tempdir().unwrap();
+        let db = crate::database::init(dir.path()).unwrap();
+        {
+            let conn = db.lock();
+            let now = chrono::Utc::now().timestamp_millis();
+            conn.execute(
+                "INSERT INTO projects (id, name, created_at) VALUES ('p1', 'r', ?1)",
+                [now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO repos (id, project_id, path, created_at) VALUES ('r1', 'p1', '/r', ?1)",
+                [now],
+            )
+            .unwrap();
+        }
+        let wm = Arc::new(WorkspaceManager::new(db));
+        let mut record = new_agent_record(
+            id.to_string(),
+            id.to_string(),
+            "claude".to_string(),
+            TrackedRepo {
+                repo_path: PathBuf::from("/r"),
+                subdir: "r".to_string(),
+                branch: None,
+                parent_branch: None,
+                base_sha: None,
+                pr_number: None,
+                pr_url: None,
+                pr_title: None,
+                pr_state: None,
+                label: None,
+                adopted_checkout: None,
+            },
+            String::new(),
+            AgentView::Custom,
+        );
+        wm.add_agent(&mut record).unwrap();
+        // Precondition of the regression: the stored record rests at Idle.
+        assert_eq!(wm.agent(id).unwrap().status, AgentStatus::Idle);
+        Supervisor::new(wm)
+    }
+
+    /// The bug this guards: the spawn path records `Spawning` only in the
+    /// supervisor's in-memory map, so a guard keyed off the DB-derived record
+    /// status never fired and the panels listed the half-written clone.
+    #[test]
+    fn pending_while_the_live_status_is_spawning() {
+        let sup = supervisor_with_agent("yosemite");
+        sup.statuses
+            .lock()
+            .insert("yosemite".to_string(), AgentStatus::Spawning);
+        assert!(checkout_pending(&sup, "yosemite"));
+    }
+
+    #[test]
+    fn not_pending_once_the_live_status_leaves_spawning() {
+        let sup = supervisor_with_agent("yosemite");
+        sup.statuses
+            .lock()
+            .insert("yosemite".to_string(), AgentStatus::Idle);
+        assert!(!checkout_pending(&sup, "yosemite"));
+    }
+
+    /// No live entry (an agent that was never spawned this launch) falls back
+    /// to the stored record, which is never `Spawning`.
+    #[test]
+    fn not_pending_with_no_live_entry_or_unknown_agent() {
+        let sup = supervisor_with_agent("yosemite");
+        assert!(!checkout_pending(&sup, "yosemite"));
+        assert!(!checkout_pending(&sup, "no-such-agent"));
     }
 }

--- a/src-tauri/src/commands/git_state.rs
+++ b/src-tauri/src/commands/git_state.rs
@@ -46,11 +46,7 @@ pub(crate) async fn get_git_state_impl(
     // Still cloning: no checkout to describe yet. `None` is what an unresolvable
     // agent already returns, and the panel renders it as Loading… rather than
     // as a status full of phantom deletions.
-    if supervisor
-        .workspace
-        .agent(agent_id)
-        .is_ok_and(|a| checkout_pending(&a))
-    {
+    if checkout_pending(supervisor, agent_id) {
         return Ok(None);
     }
     let Some((repo, checkout)) = agent_repo_checkout_opt(supervisor, agent_id, subdir)? else {
@@ -87,7 +83,7 @@ pub async fn get_all_shortstats(
         // Omitted while provisioning for the same reason as archived agents:
         // there is nothing to count yet, and counting a half-written clone
         // would flash a phantom file count on the badge.
-        if agent.archive.is_some() || checkout_pending(&agent) {
+        if agent.archive.is_some() || checkout_pending(&supervisor, &agent.id) {
             continue;
         }
         // One shortstat per checkout; a multi-repo agent's badge shows the
@@ -144,7 +140,7 @@ pub async fn get_all_git_meta(
     };
     let mut set = tokio::task::JoinSet::new();
     for agent in workspace.agents {
-        if agent.archive.is_some() || checkout_pending(&agent) {
+        if agent.archive.is_some() || checkout_pending(&supervisor, &agent.id) {
             continue;
         }
         for (i, repo) in agent.repos.iter().enumerate() {


### PR DESCRIPTION
## Summary

The Code and Git panels still flashed a tree full of phantom changes for about a second when a new workspace was spawned, even after #e93c9304 added a "hold off git reads while provisioning" guard.

**Root cause:** the guard compared `record.status == Spawning` on a record loaded from the database. Runtime status is never persisted (`derive_status` hardcodes `running = false`), so a fresh agent's stored record always derives to `Idle` and the guard never fired. `Spawning` exists only in the supervisor's in-memory `statuses` map.

**Fix:** `checkout_pending` now takes the supervisor and agent id and reads `Supervisor::status_of`, which prefers the live map and falls back to the stored record. All four read surfaces use it: the tree listing, single-agent git state, and both fleet sweeps (shortstats, git meta). Write paths (commit / push / PR) are deliberately untouched, as before.

The window between the clone finishing and the fork-point SHA being recorded is covered too: status stays `Spawning` until the process starts.

## Tests

New `checkout_pending_tests` module in `commands/files.rs`:
- seeds an agent row, asserts the stored record derives to `Idle`, sets the live map to `Spawning`, and checks the guard reports pending (the regression)
- live status leaving `Spawning` → not pending
- no live entry / unknown agent → not pending

`cargo test --lib checkout_pending` passes; rustfmt and clippy clean on the edited files.

## Manual check

Spawn a workspace: the Code and Git panels should sit on "Loading…" until the clone completes, then render the clean tree with no intermediate flash.