### PR TITLE
fix(dictation): let the noise floor recover so a pause can end the session

### DIFF
--- a/mobile/src/dictation/level.ts
+++ b/mobile/src/dictation/level.ts
@@ -11,9 +11,15 @@ export const LEVEL_BARS = 12;
 
 /** The dBFS range the bars span: below the floor is silence, the ceiling is
  *  loud, close speech. Linear in dB between, because that is how loudness
- *  reads. */
-const FLOOR_DB = -50;
-const CEIL_DB = -15;
+ *  reads.
+ *
+ *  −54 dBFS is where the silence detector's `MIN_RMS` (0.002) sits — the
+ *  quietest a buffer can be and still be called speech. At −50 the bars
+ *  rendered empty for audio the detector was hearing as speech, so the waveform
+ *  contradicted the session's own behaviour: the user watched a flat line while
+ *  the mic stayed open on them. Move it with `level.rs`'s. */
+export const FLOOR_DB = -54;
+export const CEIL_DB = -15;
 
 /** Map a linear RMS onto the bars' 0–1 range. */
 export function normalizeLevel(rms: number): number {

--- a/mobile/src/dictation/silence.ts
+++ b/mobile/src/dictation/silence.ts
@@ -35,6 +35,27 @@ const SPEECH_OVER_FLOOR = 3;
  *  threshold at zero and make the first faint buffer an utterance. */
 const NOISE_FLOOR_MIN = 0.000_5;
 
+/** How fast the floor is allowed to climb back towards the room it is hearing.
+ *
+ *  The floor used to be a running minimum over the whole session, which meant a
+ *  single quiet buffer — the mic warming up, a breath between words — pinned it
+ *  there for good. Every later buffer of ordinary room tone then sat three
+ *  times above that pin, so the room itself read as speech, `lastSpeech` was
+ *  refreshed on every buffer, and the session could never observe the pause
+ *  that ends it. Slow enough that a stretch of speech can't walk the floor up
+ *  into its own range and mute itself: an utterance is a second or two, and
+ *  6 dB/s over that is well under the 9.5 dB of headroom
+ *  [`SPEECH_OVER_FLOOR`] gives it. */
+const FLOOR_RISE_DB_PER_SEC = 6;
+
+/** Longest gap the floor is aged across. Quanta arrive a few milliseconds
+ *  apart, so a gap far longer than that is not a quiet room — it is a webview
+ *  the OS suspended while the user took a call, or an `AudioContext` that
+ *  stalled. Ageing the floor across the whole of such a gap would teleport it
+ *  up to whatever the first quantum back happens to be and cut the next
+ *  utterance short. Matches `capture.rs`'s `MAX_FLOOR_AGE`. */
+const MAX_FLOOR_AGE_MS = 250;
+
 /** The host's clip gate (`whisper::engine::MIN_RMS`): audio too quiet for the
  *  Mac to transcribe can't be worth waiting for silence after. */
 export const MIN_RMS = 0.002;
@@ -53,17 +74,39 @@ export function isSpeech(level: number, floor: number): boolean {
   return level >= Math.max(floor * SPEECH_OVER_FLOOR, MIN_RMS);
 }
 
-/** Fold a buffer's loudness into the noise floor: the running minimum, never
- *  below `NOISE_FLOOR_MIN`. */
-export function settleFloor(floor: number, level: number): number {
-  return Math.min(floor, Math.max(level, NOISE_FLOOR_MIN));
+/** Multiplicative factor the floor may climb by over `dtMs`. Capped at
+ *  `MAX_FLOOR_AGE_MS`, so a stall can't hand the floor a jump. */
+function riseFactor(dtMs: number): number {
+  return 10 ** ((FLOOR_RISE_DB_PER_SEC * (Math.min(dtMs, MAX_FLOOR_AGE_MS) / 1000)) / 20);
+}
+
+/** Fold a buffer's loudness into the noise floor, never below
+ *  `NOISE_FLOOR_MIN`.
+ *
+ *  Fast attack, slow release: a quieter buffer *is* the new floor immediately,
+ *  because the quietest thing the room has just done is the best evidence of
+ *  what the room is; a louder one only lets the floor creep up at
+ *  [`FLOOR_RISE_DB_PER_SEC`], and never past what is actually being heard. That
+ *  asymmetry is what makes the floor un-pinnable without letting it chase a
+ *  voice. */
+export function settleFloor(floor: number, level: number, dtMs: number): number {
+  const heard = Math.max(level, NOISE_FLOOR_MIN);
+  if (heard <= floor) return heard;
+  return Math.min(floor * riseFactor(dtMs), heard);
 }
 
 /** Classify one buffer against the floor as it stood *before* this buffer, then
  *  fold the buffer in. Judging a buffer against a floor it has just lowered
- *  would make the first loud buffer of a session its own noise floor. */
-export function track(floor: number, level: number): [speech: boolean, floor: number] {
-  return [isSpeech(level, floor), settleFloor(floor, level)];
+ *  would make the first loud buffer of a session its own noise floor. `dtMs` is
+ *  how long since the previous buffer, which is what the floor's climb is
+ *  measured in — the rate is per second of wall clock, not per buffer, so it is
+ *  the same whatever quantum size the device hands us. */
+export function track(
+  floor: number,
+  level: number,
+  dtMs: number,
+): [speech: boolean, floor: number] {
+  return [isSpeech(level, floor), settleFloor(floor, level, dtMs)];
 }
 
 /** Should the session end itself now? `lastSpeech` is how far into the session
@@ -77,24 +120,32 @@ export function shouldAutoStop(lastSpeech: number | null, elapsed: number): bool
 /** The detector with the state a session accumulates: the room's noise floor
  *  and when speech was last heard. `now` is injected so tests need no timers. */
 export class SilenceMonitor {
-  /** A running minimum has to start above anything it will see; the first
-   *  buffer sets it, and can't be speech against itself. */
+  /** Starts above anything it will see, so the first buffer drops it to the
+   *  room and can't be speech against itself. */
   private floor = 1;
   /** Milliseconds into the session, or null for never. */
   private lastSpeech: number | null = null;
   private readonly start: number;
+  /** When the previous buffer arrived. The floor's climb is a rate per second,
+   *  so the tracker needs the gap; taking it from the clock rather than from
+   *  the frame count means a device that hands us a different quantum size, or
+   *  a render thread that stalled, still ages the floor by real time. */
+  private lastHeard: number;
 
   constructor(private readonly now: () => number = Date.now) {
     this.start = now();
+    this.lastHeard = this.start;
   }
 
   /** Fold one render quantum's frames into the tracker. Returns the quantum's
    *  RMS, which the level meter displays — one pass over the samples for both. */
   hear(frames: Float32Array): number {
     const level = rms(frames);
-    const [speech, floor] = track(this.floor, level);
+    const now = this.now();
+    const [speech, floor] = track(this.floor, level, now - this.lastHeard);
+    this.lastHeard = now;
     this.floor = floor;
-    if (speech) this.lastSpeech = this.now() - this.start;
+    if (speech) this.lastSpeech = now - this.start;
     return level;
   }
 

--- a/mobile/tests/level.test.ts
+++ b/mobile/tests/level.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { normalizeLevel } from "../src/dictation/level";
+import { CEIL_DB, FLOOR_DB, normalizeLevel } from "../src/dictation/level";
 
 const fromDb = (db: number) => 10 ** (db / 20);
+
+/** Derived from the range rather than written out, so moving the floor — as
+ *  aligning it with the detector's `MIN_RMS` did — can't leave the expectations
+ *  behind asserting the old one. `level.rs`'s tests read the constants the same
+ *  way. */
+const span = CEIL_DB - FLOOR_DB;
 
 /** The same mapping as the Mac's `level::normalize`, so the bars read the same
  *  on both ends. */
@@ -9,18 +15,18 @@ describe("normalizeLevel", () => {
   it("reads silence and anything under the floor as zero", () => {
     expect(normalizeLevel(0)).toBe(0);
     expect(normalizeLevel(-1)).toBe(0);
-    expect(normalizeLevel(fromDb(-50))).toBeCloseTo(0, 5);
-    expect(normalizeLevel(fromDb(-70))).toBe(0);
+    expect(normalizeLevel(fromDb(FLOOR_DB))).toBeCloseTo(0, 5);
+    expect(normalizeLevel(fromDb(FLOOR_DB - 20))).toBe(0);
   });
 
   it("pins at the ceiling", () => {
-    expect(normalizeLevel(fromDb(-15))).toBeCloseTo(1, 5);
+    expect(normalizeLevel(fromDb(CEIL_DB))).toBeCloseTo(1, 5);
     expect(normalizeLevel(1)).toBe(1);
   });
 
   it("is linear in decibels between", () => {
-    expect(normalizeLevel(fromDb(-32.5))).toBeCloseTo(0.5, 5);
-    expect(normalizeLevel(fromDb(-41.25))).toBeCloseTo(0.25, 5);
+    expect(normalizeLevel(fromDb(FLOOR_DB + span / 2))).toBeCloseTo(0.5, 5);
+    expect(normalizeLevel(fromDb(FLOOR_DB + span / 4))).toBeCloseTo(0.25, 5);
   });
 
   it("never goes down as the input goes up", () => {

--- a/mobile/tests/silence.test.ts
+++ b/mobile/tests/silence.test.ts
@@ -6,11 +6,23 @@ import {
   rms,
   SILENCE_STOP_MS,
   SilenceMonitor,
+  settleFloor,
   shouldAutoStop,
   track,
 } from "../src/dictation/silence";
 
 const repeat = <T>(times: number, value: T): T[] => Array.from({ length: times }, () => value);
+
+/** How far apart the buffers in these cases are taken to be: one render quantum
+ *  of 128 frames at 48 kHz, which is what the phone actually hands the capture
+ *  path. The floor's climb is a rate per second, so the cases below need a gap
+ *  to age it by — and at this gap a handful of buffers moves it by hundredths
+ *  of a decibel, which is why the pre-existing expectations are untouched. */
+const QUANTUM_MS = 3;
+
+/** How many quanta fill `ms`, for the cases that have to run long enough for
+ *  the floor to travel. */
+const quanta = (ms: number) => Math.round(ms / QUANTUM_MS);
 
 /** Walk a sequence of buffer RMS values through the detector the way the
  *  capture path would, and report which of them counted as speech. Mirrors the
@@ -19,7 +31,7 @@ const repeat = <T>(times: number, value: T): T[] => Array.from({ length: times }
 function detect(sequence: number[]): boolean[] {
   let floor = 1;
   return sequence.map((level) => {
-    const [speech, next] = track(floor, level);
+    const [speech, next] = track(floor, level, QUANTUM_MS);
     floor = next;
     return speech;
   });
@@ -75,6 +87,20 @@ describe("silence detector", () => {
     expect(isSpeech(MIN_RMS / 2, 0)).toBe(false);
   });
 
+  /** The bug this detector shipped with: the floor was a running minimum over
+   *  the session, so the one near-silent buffer below pinned it at its lower
+   *  bound and left every later buffer of ordinary room tone sitting three
+   *  times above it. The room read as speech on every buffer, forever, and no
+   *  session could ever see the pause that ends it. The floor now climbs back
+   *  out of the pin, so the tone stops counting about a second in. */
+  it("stops calling room tone speech after a quiet buffer pins the floor", () => {
+    const tone = 0.003; // about −50 dBFS: a quiet room, not a voice.
+    const speech = detect([0, ...repeat(quanta(3_000), tone)]);
+
+    expect(speech[1]).toBe(true); // the pin does still fool the first buffers,
+    expect(speech.slice(1 + quanta(2_000)).some(Boolean)).toBe(false); // but not for long.
+  });
+
   it("auto-stops on a pause but not before speech", () => {
     const long = NO_SPEECH_TIMEOUT_MS + 1_000;
     const spokeAt = 1_000;
@@ -87,6 +113,26 @@ describe("silence detector", () => {
     // ends it.
     expect(shouldAutoStop(null, SILENCE_STOP_MS * 2)).toBe(false);
     expect(shouldAutoStop(null, long)).toBe(true);
+  });
+
+  /** The other half of the fix, on its own: the floor is not a ratchet. It
+   *  climbs out of a pin towards whatever it is hearing, and stops there —
+   *  going above the room would put the speech threshold out of a voice's reach
+   *  and deafen the session instead of deafening the pause. */
+  it("lets the floor climb back out of a pin, never past the room", () => {
+    const room = 0.01;
+    const pinned = settleFloor(1, 0, QUANTUM_MS); // one silent buffer, floor at its minimum.
+
+    let floor = pinned;
+    for (let i = 0; i < quanta(6_000); i++) {
+      const next = settleFloor(floor, room, QUANTUM_MS);
+      expect(next).toBeGreaterThanOrEqual(floor);
+      expect(next).toBeLessThanOrEqual(room);
+      floor = next;
+    }
+
+    expect(floor).toBeGreaterThan(pinned);
+    expect(floor).toBe(room);
   });
 
   it("measures a buffer's loudness", () => {
@@ -129,11 +175,35 @@ describe("SilenceMonitor", () => {
     expect(m.done()).toBe(true);
   });
 
+  /** The fixture feeds a real stream: quanta a few milliseconds apart, words
+   *  with the gaps between them. It used to hand the monitor one quantum every
+   *  `SILENCE_STOP_MS - 100`, which no microphone does — that only passed while
+   *  the floor ignored time entirely, and against a floor that ages it reads as
+   *  1.9 seconds of room per buffer. Words and gaps are also what the rule
+   *  needs: a held, gapless level is deliberately the room and not a voice (see
+   *  "never reads steady noise as speech"). */
   it("holds a session open while the speech keeps coming", () => {
     const m = monitor();
-    m.hear(0.001, 20);
-    for (let i = 0; i < 20; i++) m.hear(0.05, SILENCE_STOP_MS - 100);
+    m.hear(0.001, QUANTUM_MS);
+    for (let word = 0; word < 18; word++) {
+      for (let i = 0; i < quanta(300); i++) m.hear(0.05, QUANTUM_MS);
+      for (let i = 0; i < quanta(120); i++) m.hear(0.004, QUANTUM_MS);
+      expect(m.done()).toBe(false);
+    }
+  });
+
+  /** The bug as a session rather than as a sequence: a dip at the top (the mic
+   *  warming up), a sentence, and then the room the user is sitting in. The
+   *  dip used to pin the floor low enough that the room refreshed the speech
+   *  clock on every buffer and the mic stayed open until the user tapped it. */
+  it("ends a session whose tail is room tone, not silence", () => {
+    const m = monitor();
+    m.hear(0, QUANTUM_MS);
+    for (let i = 0; i < quanta(500); i++) m.hear(0.05, QUANTUM_MS);
     expect(m.done()).toBe(false);
+
+    for (let i = 0; i < quanta(5_000); i++) m.hear(0.003, QUANTUM_MS);
+    expect(m.done()).toBe(true);
   });
 
   it("ends a session nobody ever spoke in on the longer deadline", () => {

--- a/src-tauri/src/dictation/capture.rs
+++ b/src-tauri/src/dictation/capture.rs
@@ -39,9 +39,9 @@ use super::MAX_CAPTURE_SECS;
 /// to end itself — long enough to think mid-sentence, short enough that the
 /// text lands while the user is still looking at the composer.
 ///
-/// This and the two constants below are the whole of the hands-free policy, so
-/// a Settings opt-out would gate the monitor that reads them rather than change
-/// them.
+/// This and the two constants below are the whole of the hands-free policy. The
+/// Settings opt-out (`dictation_auto_stop`) gates the monitor that reads them
+/// rather than changing them — see [`should_auto_stop`].
 const SILENCE_STOP: Duration = Duration::from_secs(2);
 
 /// How long a session in which nothing was ever said stays open: the user
@@ -53,6 +53,31 @@ const NO_SPEECH_TIMEOUT: Duration = Duration::from_secs(10);
 /// relaxed atomic loads.
 pub(super) const SILENCE_POLL: Duration = Duration::from_millis(100);
 
+/// How fast the floor may climb back toward the room once a quiet moment has
+/// pulled it down, in dB per second.
+///
+/// The floor drops to a quieter buffer instantly but recovers only at this
+/// rate, which is what keeps a transient dropout from pinning it: the mic's
+/// first buffers after `startAndReturnError` are commonly near-silent, and
+/// before this existed that one moment set the threshold for the whole session
+/// (see `a_quiet_dip_does_not_pin_the_floor`).
+///
+/// The rate is the whole of the tradeoff. Too slow and the room reads as speech
+/// for seconds after a dip, holding the session open; too fast and an unbroken
+/// stretch of talking lifts the floor into its own range and the session cuts
+/// out mid-sentence. Six dB/s forgets a dropout in about a second and would
+/// need tens of seconds of gapless speech to reach it — and real speech is not
+/// gapless, so the instant drop wins there on every stop consonant.
+const FLOOR_RISE_DB_PER_SEC: f32 = 6.0;
+
+/// Longest gap the floor is aged across. Buffers arrive a few milliseconds
+/// apart, so a gap far longer than that is not a quiet room — it is an audio
+/// graph that stalled (or, on the phone's port, a webview the OS suspended).
+/// Ageing the floor across the whole of such a gap would teleport it up to
+/// whatever the first buffer back happens to be and cut the next utterance
+/// short.
+const MAX_FLOOR_AGE: Duration = Duration::from_millis(250);
+
 /// How far above the room's own noise a buffer has to be to count as speech.
 ///
 /// Deliberately the only loudness rule: an absolute "this loud is always
@@ -63,7 +88,8 @@ pub(super) const SILENCE_POLL: Duration = Duration::from_millis(100);
 const SPEECH_OVER_FLOOR: f32 = 3.0;
 
 /// Floor under the noise floor. Digital silence would otherwise put the speech
-/// threshold at zero and make the first faint buffer an utterance.
+/// threshold at zero and make the first faint buffer an utterance — and, since
+/// the floor climbs back by multiplication, leave it stuck at zero for good.
 const NOISE_FLOOR_MIN: f32 = 0.000_5;
 
 /// A session's captured audio: mono f32 at the microphone's own sample rate.
@@ -80,9 +106,16 @@ pub(super) struct Pcm {
     /// the monitor can't read a flag that says "spoken" next to a timestamp
     /// that hasn't landed yet and take the whole session so far for a pause.
     last_speech: AtomicU64,
-    /// The quietest buffer heard so far (`f32` bits), i.e. this room on this
-    /// microphone with nobody talking. Adaptive because a threshold that suits
-    /// a laptop's built-in mic is silence on a hot USB interface.
+    /// When the previous buffer arrived, as microseconds since [`Pcm::start`],
+    /// so the floor's rise can be paced in real time rather than in buffers —
+    /// the tap's buffer size is the device's to choose, and the phone's port
+    /// works in much smaller quanta.
+    last_buffer_us: AtomicU64,
+    /// This room on this microphone with nobody talking (`f32` bits). Adaptive
+    /// because a threshold that suits a laptop's built-in mic is silence on a
+    /// hot USB interface — and *recovering* (see [`settle_floor`]) because a
+    /// floor that only ever fell would be pinned by the first quiet moment of
+    /// the session and never rise back to the room.
     floor: AtomicU32,
     /// Set by `apple`'s `Sink::cancel` when the session is torn down, so the
     /// silence monitor stops polling a buffer nothing will fill again.
@@ -99,17 +132,34 @@ fn is_speech(rms: f32, floor: f32) -> bool {
     rms >= (floor * SPEECH_OVER_FLOOR).max(engine::MIN_RMS)
 }
 
-/// Fold a buffer's loudness into the noise floor: the running minimum, never
-/// below [`NOISE_FLOOR_MIN`].
-fn settle_floor(floor: f32, rms: f32) -> f32 {
-    floor.min(rms.max(NOISE_FLOOR_MIN))
+/// How much the floor may climb over `dt`, as a multiplier. Capped at
+/// [`MAX_FLOOR_AGE`], so a stalled graph can't hand the floor a jump.
+fn rise_factor(dt: Duration) -> f32 {
+    10f32.powf(FLOOR_RISE_DB_PER_SEC * dt.min(MAX_FLOOR_AGE).as_secs_f32() / 20.0)
+}
+
+/// Fold a buffer's loudness into the noise floor: instantly down to anything
+/// quieter, back up only at [`FLOOR_RISE_DB_PER_SEC`], and never above what is
+/// actually being heard.
+///
+/// The lower bound matters on the way down and not only for tidiness: digital
+/// silence would otherwise put the floor at zero, where a multiplicative rise
+/// can never lift it again.
+fn settle_floor(floor: f32, rms: f32, dt: Duration) -> f32 {
+    let heard = rms.max(NOISE_FLOOR_MIN);
+    if heard <= floor {
+        heard
+    } else {
+        (floor * rise_factor(dt)).min(heard)
+    }
 }
 
 /// Classify one buffer against the floor as it stood *before* this buffer, then
 /// fold the buffer in. Judging a buffer against a floor it has just lowered
-/// would make the first loud buffer of a session its own noise floor.
-fn track(floor: f32, rms: f32) -> (bool, f32) {
-    (is_speech(rms, floor), settle_floor(floor, rms))
+/// would make the first loud buffer of a session its own noise floor. `dt` is
+/// how long since the previous buffer, which is what paces the floor's rise.
+fn track(floor: f32, rms: f32, dt: Duration) -> (bool, f32) {
+    (is_speech(rms, floor), settle_floor(floor, rms, dt))
 }
 
 /// Should the session end itself now? `last_speech` is when speech was last
@@ -132,11 +182,16 @@ impl Pcm {
     /// render thread is the only writer, so a load and a store are enough —
     /// no read-modify-write to lose.
     fn track_speech(&self, rms: f32) {
-        let (speech, floor) = track(f32::from_bits(self.floor.load(Ordering::Relaxed)), rms);
+        let now = self.start.elapsed();
+        let now_us = now.as_micros() as u64;
+        let dt = Duration::from_micros(
+            now_us.saturating_sub(self.last_buffer_us.swap(now_us, Ordering::Relaxed)),
+        );
+        let (speech, floor) = track(f32::from_bits(self.floor.load(Ordering::Relaxed)), rms, dt);
         self.floor.store(floor.to_bits(), Ordering::Relaxed);
         if speech {
-            let ms = self.start.elapsed().as_millis() as u64;
-            self.last_speech.store(ms + 1, Ordering::Relaxed);
+            self.last_speech
+                .store(now.as_millis() as u64 + 1, Ordering::Relaxed);
         }
     }
 
@@ -190,8 +245,9 @@ pub(super) fn sink(format: &AVAudioFormat, meter: Arc<Meter>) -> Result<(Arc<Pcm
         samples: Mutex::new(Vec::with_capacity(limit)),
         start: Instant::now(),
         last_speech: AtomicU64::new(0),
-        // A running minimum has to start above anything it will see; the first
-        // buffer sets it, and can't be speech against itself.
+        last_buffer_us: AtomicU64::new(0),
+        // The floor has to start above anything it will see; the first buffer
+        // sets it, and can't be speech against itself.
         floor: AtomicU32::new(1.0f32.to_bits()),
         closed: AtomicBool::new(false),
     });
@@ -394,18 +450,28 @@ mod tests {
         assert!(rms > 0.5, "tone was lost: rms {rms}");
     }
 
+    /// One tap buffer, near enough: 1024 frames at 44.1 kHz.
+    const BUFFER: Duration = Duration::from_millis(23);
+
     /// Walk a sequence of buffer RMS values through the detector the way the
-    /// render thread would, and report which of them counted as speech.
+    /// render thread would, and report which of them counted as speech. The
+    /// buffers arrive one [`BUFFER`] apart, which is what paces the floor.
     fn detect(sequence: &[f32]) -> Vec<bool> {
         let mut floor = 1.0;
         sequence
             .iter()
             .map(|rms| {
-                let (speech, next) = track(floor, *rms);
+                let (speech, next) = track(floor, *rms, BUFFER);
                 floor = next;
                 speech
             })
             .collect()
+    }
+
+    /// `seconds` of buffers at a steady `rms`, for the cases about what a room
+    /// sounds like over time rather than what one buffer means.
+    fn steady(seconds: f32, rms: f32) -> Vec<f32> {
+        vec![rms; (seconds / BUFFER.as_secs_f32()) as usize]
     }
 
     /// The shape every session has: a quiet room, an utterance, then quiet
@@ -458,6 +524,109 @@ mod tests {
     fn silence_is_never_speech() {
         assert_eq!(detect(&[0.0; 4]), [false; 4]);
         assert!(!is_speech(engine::MIN_RMS / 2.0, 0.0));
+    }
+
+    /// The regression this whole tracker exists for. One near-silent buffer —
+    /// the mic warming up, a breath between words — used to pull the floor to
+    /// [`NOISE_FLOOR_MIN`] and leave it there for the rest of the session,
+    /// because the floor was a minimum that could only ever fall. From then on
+    /// the threshold was the absolute lower bound, ordinary room tone cleared
+    /// it on every buffer, and the pause the session was waiting for could
+    /// never arrive: dictation ran until the user clicked stop.
+    ///
+    /// Room tone at 0.003 is about −50 dBFS: a fan, an air conditioner, traffic
+    /// through a window.
+    #[test]
+    fn a_quiet_dip_does_not_pin_the_floor() {
+        let mut sequence = vec![0.0];
+        sequence.extend(steady(3.0, 0.003));
+
+        let speech = detect(&sequence);
+
+        // The floor needs a moment to climb back to the room, so the tone may
+        // read as speech at first. What matters is that it stops.
+        let recovered = speech.iter().rposition(|s| *s).unwrap_or(0);
+        let took = BUFFER.as_secs_f32() * recovered as f32;
+        assert!(
+            took < SILENCE_STOP.as_secs_f32(),
+            "room tone still read as speech after {took:.1}s — the floor is pinned again"
+        );
+    }
+
+    /// A pause has to survive the floor's recovery: the session may not be held
+    /// open by the room, however long it goes on.
+    #[test]
+    fn steady_room_tone_after_speech_still_ends_the_session() {
+        let mut sequence = vec![0.0];
+        sequence.extend(steady(1.0, 0.05));
+        sequence.extend(steady(6.0, 0.003));
+
+        let speech = detect(&sequence);
+        let last = speech.iter().rposition(|s| *s).unwrap();
+        let quiet_for = BUFFER.as_secs_f32() * (speech.len() - 1 - last) as f32;
+
+        assert!(
+            quiet_for >= SILENCE_STOP.as_secs_f32(),
+            "only {quiet_for:.1}s of quiet observed; the session would not stop"
+        );
+    }
+
+    /// The other side of the tradeoff: the floor must not climb fast enough to
+    /// swallow the voice that is lifting it, or a long sentence would cut out
+    /// mid-word.
+    ///
+    /// Speech, not a tone — words with the gaps between them, which is what
+    /// keeps pulling the floor back down. A held, gapless level is deliberately
+    /// *not* speech here however loud it is (see
+    /// [`steady_noise_is_never_speech`]), so a constant RMS would be testing
+    /// the opposite rule.
+    #[test]
+    fn a_long_sentence_is_heard_all_the_way_through() {
+        let mut sequence = vec![0.001];
+        for _ in 0..18 {
+            sequence.extend(steady(0.30, 0.05));
+            sequence.extend(steady(0.12, 0.004));
+        }
+
+        let speech = detect(&sequence);
+        let words = speech.len() - 14;
+
+        assert!(
+            speech[words..].iter().any(|s| *s),
+            "after {:.0}s the floor had caught up with the voice and the session \
+             would have stopped mid-sentence",
+            BUFFER.as_secs_f32() * words as f32
+        );
+    }
+
+    /// Instantly down, gradually up, and never past what is actually being
+    /// heard — a floor that overshot the room would stop hearing it.
+    #[test]
+    fn the_floor_falls_at_once_and_climbs_slowly() {
+        assert_eq!(settle_floor(0.05, 0.001, BUFFER), 0.001);
+
+        let climbed = settle_floor(NOISE_FLOOR_MIN, 0.05, BUFFER);
+        assert!(climbed > NOISE_FLOOR_MIN, "the floor never recovers");
+        assert!(climbed < 0.001, "the floor jumped rather than climbed");
+
+        // A whole second of it still can't pass the level it is climbing towards.
+        let mut floor = NOISE_FLOOR_MIN;
+        for _ in 0..43 {
+            floor = settle_floor(floor, 0.002, BUFFER);
+        }
+        assert!(floor <= 0.002, "the floor overshot the room: {floor}");
+    }
+
+    /// A suspended webview or a stalled graph hands the tracker one buffer with
+    /// minutes on it. Ageing the floor across all of that would put it at the
+    /// level of whatever came back and swallow the utterance in progress.
+    #[test]
+    fn a_stalled_graph_does_not_teleport_the_floor() {
+        let stalled = settle_floor(NOISE_FLOOR_MIN, 0.05, Duration::from_secs(120));
+        let capped = settle_floor(NOISE_FLOOR_MIN, 0.05, MAX_FLOOR_AGE);
+
+        assert_eq!(stalled, capped);
+        assert!(is_speech(0.05, stalled), "the voice was lost to the stall");
     }
 
     #[test]

--- a/src-tauri/src/dictation/level.rs
+++ b/src-tauri/src/dictation/level.rs
@@ -23,7 +23,13 @@ pub(super) const LEVEL_POLL: Duration = Duration::from_millis(90);
 /// The dBFS range the bars span. Below the floor is silence (a quiet room on a
 /// laptop mic sits around −60 dB); the ceiling is loud, close speech. Linear in
 /// dB between the two, because that is how loudness reads.
-const FLOOR_DB: f32 = -50.0;
+///
+/// The floor is where `whisper::engine::MIN_RMS` sits — the quietest audio the
+/// silence detector will ever call speech. Any higher and the bars would render
+/// empty for audio the session was still hearing as speech, so the waveform
+/// would flatly contradict a mic that refused to stop (see `the_bars_start_
+/// where_speech_can`).
+const FLOOR_DB: f32 = -54.0;
 const CEIL_DB: f32 = -15.0;
 
 /// The latest buffer's loudness, written by the render thread and read by the
@@ -155,6 +161,19 @@ mod tests {
         assert!((normalize(from_db(mid)) - 0.5).abs() < 1e-5);
         let quarter = FLOOR_DB + (CEIL_DB - FLOOR_DB) / 4.0;
         assert!((normalize(from_db(quarter)) - 0.25).abs() < 1e-5);
+    }
+
+    /// The bars and the silence detector have to agree about what silence is.
+    /// While the floor sat above `MIN_RMS` there was a band where the waveform
+    /// read empty and the detector still heard speech — the exact combination
+    /// that makes a session which won't end look like a frozen UI instead of a
+    /// mic that thinks you're talking.
+    #[test]
+    fn the_bars_start_where_speech_can() {
+        use crate::dictation::whisper::engine::MIN_RMS;
+
+        assert_eq!(normalize(MIN_RMS * 0.99), 0.0);
+        assert!(normalize(MIN_RMS * 1.5) > 0.0);
     }
 
     #[test]


### PR DESCRIPTION
## The bug

Dictation would not stop after a pause, intermittently, even with **Settings › Dictation › "Stop after a pause"** on and the Whisper engine downloaded and enabled.

The wiring turned out to be fine — setting → `AUTO_STOP` atomic → `should_auto_stop` → `watch_for_silence` is all intact. The defect is in the detector's arithmetic.

`settle_floor` made the noise floor a running minimum over the whole session — it could only ever ratchet **down**, never recover:

```rust
fn settle_floor(floor: f32, rms: f32) -> f32 { floor.min(rms.max(NOISE_FLOOR_MIN)) }
fn is_speech(rms: f32, floor: f32) -> bool { rms >= (floor * SPEECH_OVER_FLOOR).max(engine::MIN_RMS) }
```

One near-silent buffer — the mic warming up after `startAndReturnError`, a breath between words — pins the floor at `NOISE_FLOOR_MIN`. Since `floor * 3 = 0.0015` is below `MIN_RMS = 0.002`, the adaptive rule is then dead and the threshold locks at the absolute bound for the rest of the session. Ordinary room tone clears it on every buffer, `last_speech` is refreshed continuously, and `elapsed - last_speech` never reaches `SILENCE_STOP`.

Simulating the three functions, the only difference between these two rows is one silent buffer at the front:

| input | final floor | threshold | result |
|---|---|---|---|
| steady 0.003 room tone | 0.00300 | 0.00900 | pause observed |
| **one silent buffer**, then identical 0.003 tone | 0.00050 | 0.00200 | **never pauses** |

That partition is why it was intermittent: the outcome depends on whether a quiet dip happened at all, and on whether the room sits above `MIN_RMS`. Same setup auto-stops one minute and hangs the next.

## The fix

Fast attack, slow release. The floor drops to a quieter buffer instantly, but climbs back toward the room only at `FLOOR_RISE_DB_PER_SEC = 6`, which makes it un-pinnable while staying far too slow to chase a voice.

The rate is per second of wall clock rather than per buffer, so the Mac's 1024-frame tap and the phone's 128-frame quanta age it identically. It is capped at `MAX_FLOOR_AGE` (250 ms) so a stalled audio graph — or a webview iOS suspended mid-session — cannot hand the tracker one buffer with minutes on it, teleport the floor up, and cut the next utterance short.

Also moves the level meter's floor from −50 to −54 dBFS, where `MIN_RMS` sits. Above it the bars rendered empty for audio the detector still heard as speech, so the waveform contradicted a mic that refused to stop.

## Two existing tests changed rather than the implementation

- **`holds a session open while the speech keeps coming`** fed one buffer every `SILENCE_STOP_MS - 100` (1900 ms). No microphone does that — it only passed while the floor ignored time, and against a floor that ages it reads as 1.9 s of room per buffer. It also asserted a gapless constant RMS is speech, which is the exact opposite of `never reads steady noise as speech`. Rewritten at real pacing with words and gaps; the assertion is unchanged.
- **`mobile/tests/level.test.ts`** hardcoded `-50`/`-32.5`/`-41.25`. Now derives its expectations from the exported constants so it cannot drift behind the floor again.

## On the duplication

`capture.rs` and `silence.ts` both carry this detector, so this change is hand-carried across two ports. That is by necessity — the phone streams ~1 s chunks, so the Mac never sees its render quanta and cannot judge a 2 s pause on its behalf. Moving the decision host-side was considered and rejected: 1 s resolution against a 2 s deadline, and stopping would depend on connectivity.

Transcription itself is **not** duplicated: `remote::end` → `remote::transcribe` → `capture::resample` → `whisper::engine::transcribe` are the same functions the desktop's stop calls.

What keeps the two ports aligned today is convention plus seven shared test cases that pass identically on both. A shared `(sequence, dt, expected)` fixture consumed by both suites would make drift a test failure instead of a review catch — worth a follow-up.

## Testing

1613 Rust tests, 136 mobile tests, `cargo fmt` and `biome` clean. Every pre-existing detector expectation passes **unchanged** on both ports — the fix is backward-compatible with the whole existing suite.

New coverage: `a_quiet_dip_does_not_pin_the_floor`, `steady_room_tone_after_speech_still_ends_the_session`, `a_long_sentence_is_heard_all_the_way_through`, `the_floor_falls_at_once_and_climbs_slowly`, `a_stalled_graph_does_not_teleport_the_floor`, `the_bars_start_where_speech_can`, and their mobile counterparts.

Worth a real-room check before merge — the failure is environment-dependent, so a live mic is the only real verdict.

## Not in scope

Three follow-ups from the same investigation, deliberately left out:

1. **Apple's recognizer never auto-stops at all** — `watch_for_silence` is only spawned for `Engine::Whisper` (`apple.rs:363`), so with the default engine the setting does nothing. The Apple sink already feeds a per-buffer meter, so the tracker can be shared.
2. **iOS ignores the setting entirely** — `mobile/src/dictation/useDictation.ts` always passes `onAutoStop`, and `remote::Status` carries only `{available, reason}`, so the phone has no way to learn it.
3. **The listening tooltip keys on the engine, not the setting** — with Whisper on and auto-stop off it still promises "stops when you pause".