### PR TITLE
feat(dictation): let the phone honour "Stop after a pause"

### DIFF
--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -434,7 +434,7 @@ allowlist; any op not listed returns `{ ok: false, error: "unknown op" }`.
 | `clone_repo` | `{ spec, destParent }` | `Workspace` |
 | `gh_status` | `{}` | `GhStatus` |
 | `gh_repo_list` | `{}` | `GhRepoSummary[]` |
-| `dictation_status` | `{}` (remote-only, see "Dictation") | `{ available: boolean, reason: string \| null }` |
+| `dictation_status` | `{}` (remote-only, see "Dictation") | `{ available: boolean, reason: string \| null, auto_stop: boolean }` |
 | `dictation_begin` | `{}` (remote-only) | `{ session: string }` |
 | `dictation_audio` | `{ session, rate: number, pcm: string }` — base64 of 16-bit little-endian mono PCM at `rate` Hz (remote-only) | `null` |
 | `dictation_end` | `{ session }` (remote-only) | `{ text: string }` |
@@ -484,6 +484,17 @@ device is asking.
   false ("Local dictation is off on your Mac. Turn on the Whisper engine in
   Settings › Dictation."). There is no fallback to Apple's recognizer on this
   path: it needs a microphone the Mac does not have.
+- **Ending a session.** `dictation_status` also carries `auto_stop`, the Mac's
+  "Stop after a pause" setting (Settings › Dictation). The pause is heard in
+  frames that never cross the wire — the host only ever sees the chunks the
+  phone chose to send — so the phone is the only side that can honour it: with
+  `auto_stop: false` it never arms its silence monitor, and nothing but a tap
+  ends the session, matching what the setting does to a desktop session
+  (neither the pause nor the never-spoke deadline fires). The host is not
+  relying on the phone to be well-behaved about it: an abandoned session is
+  still swept after 60 s and its audio still capped (see "Bounds"). The phone
+  reads the field when it connects, so a setting flipped mid-connection reaches
+  it on the next reconnect; there is no push for it.
 - **Flow.** `dictation_begin` re-checks the preconditions (so the phone learns
   before its mic opens) and answers with a host-minted `session` id. While the
   user talks, the phone sends `dictation_audio` about once a second with the

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -434,8 +434,8 @@ allowlist; any op not listed returns `{ ok: false, error: "unknown op" }`.
 | `clone_repo` | `{ spec, destParent }` | `Workspace` |
 | `gh_status` | `{}` | `GhStatus` |
 | `gh_repo_list` | `{}` | `GhRepoSummary[]` |
-| `dictation_status` | `{}` (remote-only, see "Dictation") | `{ available: boolean, reason: string \| null, auto_stop: boolean }` |
-| `dictation_begin` | `{}` (remote-only) | `{ session: string }` |
+| `dictation_status` | `{}` (remote-only, see "Dictation") | `{ available: boolean, reason: string \| null }` |
+| `dictation_begin` | `{}` (remote-only) | `{ session: string, auto_stop: boolean }` |
 | `dictation_audio` | `{ session, rate: number, pcm: string }` — base64 of 16-bit little-endian mono PCM at `rate` Hz (remote-only) | `null` |
 | `dictation_end` | `{ session }` (remote-only) | `{ text: string }` |
 | `dictation_cancel` | `{ session }` (remote-only) | `null` |
@@ -484,17 +484,26 @@ device is asking.
   false ("Local dictation is off on your Mac. Turn on the Whisper engine in
   Settings › Dictation."). There is no fallback to Apple's recognizer on this
   path: it needs a microphone the Mac does not have.
-- **Ending a session.** `dictation_status` also carries `auto_stop`, the Mac's
-  "Stop after a pause" setting (Settings › Dictation). The pause is heard in
-  frames that never cross the wire — the host only ever sees the chunks the
-  phone chose to send — so the phone is the only side that can honour it: with
-  `auto_stop: false` it never arms its silence monitor, and nothing but a tap
-  ends the session, matching what the setting does to a desktop session
-  (neither the pause nor the never-spoke deadline fires). The host is not
-  relying on the phone to be well-behaved about it: an abandoned session is
-  still swept after 60 s and its audio still capped (see "Bounds"). The phone
-  reads the field when it connects, so a setting flipped mid-connection reaches
-  it on the next reconnect; there is no push for it.
+- **Ending a session.** `dictation_begin` answers with `auto_stop`, the Mac's
+  "Stop after a pause" setting (Settings › Dictation) as it stands at that
+  moment. The pause is heard in frames that never cross the wire — the host
+  only ever sees the chunks the phone chose to send — so the phone is the only
+  side that can honour it: with `auto_stop: false` it never arms its silence
+  monitor, and nothing but a tap ends the session, matching what the setting
+  does to a desktop session (neither the pause nor the never-spoke deadline
+  fires).
+
+  It rides on `begin` rather than `dictation_status` because the phone probes
+  status on mount and reconnect only; answering it per session means a setting
+  flipped on the Mac takes hold on the phone's next session instead of waiting
+  for it to reconnect, and costs no extra round trip.
+
+  With `auto_stop` off, nothing on the host ends the session either. The idle
+  sweep does not apply to a phone that is still streaming — every chunk
+  refreshes it — so what stays bounded is the audio, not the session: an
+  abandoned one holds the phone's mic until the user taps, leaves the screen,
+  or the link drops. That is the same deal the desktop offers with the setting
+  off.
 - **Flow.** `dictation_begin` re-checks the preconditions (so the phone learns
   before its mic opens) and answers with a host-minted `session` id. While the
   user talks, the phone sends `dictation_audio` about once a second with the

--- a/mobile/src/api/index.ts
+++ b/mobile/src/api/index.ts
@@ -118,7 +118,7 @@ export function createApi(client: RemoteClient) {
      *  16-bit little-endian mono samples at `rate` Hz; the transcript is the
      *  reply to `dictationEnd`. */
     dictationStatus: () => call<DictationStatus>("dictation_status"),
-    dictationBegin: () => call<{ session: string }>("dictation_begin"),
+    dictationBegin: () => call<DictationBegun>("dictation_begin"),
     dictationAudio: (session: string, rate: number, pcm: string) =>
       call<null>("dictation_audio", { session, rate, pcm }),
     dictationEnd: (session: string) => call<{ text: string }>("dictation_end", { session }),
@@ -131,11 +131,21 @@ export function createApi(client: RemoteClient) {
 export interface DictationStatus {
   available: boolean;
   reason: string | null;
-  /** Settings › Dictation's "Stop after a pause", as the Mac has it. The pause
-   *  is heard here — the Mac only ever sees the chunks this phone chose to send
-   *  — so honouring the setting is the phone's job; see `useDictation`. Absent
-   *  from a host too old to report it, which is why the reading is
-   *  `!== false`: the behaviour those hosts have always had is auto-stop on. */
+}
+
+/** A session the Mac has opened for us. */
+export interface DictationBegun {
+  session: string;
+  /** Settings › Dictation's "Stop after a pause", as the Mac had it the moment
+   *  this session opened. The pause is heard here — the Mac only ever sees the
+   *  chunks this phone chose to send — so honouring the setting is the phone's
+   *  job; see `DictationSession.start`.
+   *
+   *  It arrives per session rather than with the availability probe because the
+   *  probe only runs on mount and reconnect: a phone left connected would
+   *  answer every session from one stale read. Absent from a host too old to
+   *  report it, which is why the reading is `!== false` — auto-stop on is what
+   *  those hosts have always done. */
   auto_stop?: boolean;
 }
 

--- a/mobile/src/api/index.ts
+++ b/mobile/src/api/index.ts
@@ -131,6 +131,12 @@ export function createApi(client: RemoteClient) {
 export interface DictationStatus {
   available: boolean;
   reason: string | null;
+  /** Settings › Dictation's "Stop after a pause", as the Mac has it. The pause
+   *  is heard here — the Mac only ever sees the chunks this phone chose to send
+   *  — so honouring the setting is the phone's job; see `useDictation`. Absent
+   *  from a host too old to report it, which is why the reading is
+   *  `!== false`: the behaviour those hosts have always had is auto-stop on. */
+  auto_stop?: boolean;
 }
 
 export type Api = ReturnType<typeof createApi>;

--- a/mobile/src/dictation/session.ts
+++ b/mobile/src/dictation/session.ts
@@ -38,18 +38,23 @@ export class DictationSession {
    *
    *  `onAutoStop` fires when the mic hears the pause that ends a session. It is
    *  the caller's job to run the same `stop` a tap on the button runs, so that
-   *  hands-free and by-hand take one code path. `onLevel` reports the mic's
+   *  hands-free and by-hand take one code path. Whether it fires at all is the
+   *  Mac's to say — `begin` answers with "Stop after a pause" as it stands
+   *  right now, and withholding `onDoneTalking` is the whole of the opt-out:
+   *  `watchForSilence` starts no timer without it, so neither the pause nor the
+   *  never-spoke deadline is ever consulted. `onLevel` reports the mic's
    *  loudness for the waveform while it is open. */
   async start(onAutoStop?: () => void, onLevel?: (level: number) => void): Promise<void> {
-    const { session } = await this.api.dictationBegin();
+    const { session, auto_stop } = await this.api.dictationBegin();
     this.session = session;
     // A pause that lands while the session is already ending — the user tapped
     // stop at the same moment — is nobody's to act on: `done` says so.
-    const onDoneTalking = onAutoStop
-      ? () => {
-          if (!this.done) onAutoStop();
-        }
-      : undefined;
+    const onDoneTalking =
+      onAutoStop && auto_stop !== false
+        ? () => {
+            if (!this.done) onAutoStop();
+          }
+        : undefined;
     try {
       this.capture = await this.startCapture((pcm, rate) => this.send(pcm, rate), {
         onDoneTalking,

--- a/mobile/src/dictation/useDictation.ts
+++ b/mobile/src/dictation/useDictation.ts
@@ -14,28 +14,6 @@ export const ERROR_TTL_MS = 2600;
 
 const IDLE_LEVELS: number[] = Array(LEVEL_BARS).fill(0);
 
-/** Should a session end itself after a pause? The Mac owns the setting (Settings
- *  › Dictation, "Stop after a pause") and reports it with the availability
- *  probe; only the phone can act on it, because the silence is in frames that
- *  never leave the device.
- *
- *  Withholding `onAutoStop` is the whole of the opt-out, and deliberately so:
- *  `capture.ts`'s `watchForSilence` no-ops without the callback, so neither the
- *  pause nor the never-spoke deadline (`NO_SPEECH_TIMEOUT_MS`) is ever
- *  consulted — exactly what `should_auto_stop(false, …)` does on the desktop,
- *  where turning it off means nothing but a tap ends a session. What that costs
- *  is a mic that stays open: the host caps the audio it will hold, but
- *  `SESSION_IDLE` only sweeps a phone that has stopped sending, and this one
- *  keeps streaming a chunk a second. So an abandoned session runs until the
- *  user taps, leaves the screen, or the link drops — the same deal the desktop
- *  offers with the setting off.
- *
- *  A host too old to report the field leaves it undefined, which reads as on —
- *  the behaviour every phone had before the field existed. */
-export function autoStopWanted(status: DictationStatus | null): boolean {
-  return status?.auto_stop !== false;
-}
-
 /** Voice dictation for one composer. Owns the session and reports its phase,
  *  the mic's loudness and when it opened; the transcript is handed to `onText`
  *  once, when the host answers.
@@ -45,10 +23,11 @@ export function autoStopWanted(status: DictationStatus | null): boolean {
  *
  *  A session usually ends itself: the mic reports the pause after the user
  *  stops talking (`silence.ts`), and that runs the same stop a tap would, so
- *  dictating is one tap. Unless the Mac says otherwise — see
- *  [`autoStopWanted`], which is what the host's `auto_stop` buys us. Failures
- *  are the composer's to show (`error`), in a banner above the footer, and
- *  clear on their own. */
+ *  dictating is one tap — unless the Mac's "Stop after a pause" is off, which
+ *  `dictationBegin` reports per session and `DictationSession` acts on, so a
+ *  setting flipped on the Mac takes hold on the very next session rather than
+ *  waiting for this phone to reconnect. Failures are the composer's to show
+ *  (`error`), in a banner above the footer, and clear on their own. */
 export function useDictation(onText: (text: string) => void) {
   const connection = useStore((s) => s.connection);
   // null while the probe is in flight; `available: false` with no reason is a
@@ -86,15 +65,11 @@ export function useDictation(onText: (text: string) => void) {
     setError(null);
   }, []);
 
-  // Probe on mount and on every reconnect: the answer depends on the Mac's
-  // settings, which can change between one connection and the next.
-  //
-  // Mount and reconnect are the only two moments, by choice: a setting flipped
-  // on the Mac while this phone stays connected is not seen until it comes back
-  // (the app is backgrounded, the link drops, the screen is re-entered). That
-  // window is known, not an oversight — nothing here is worth a push channel
-  // and a subscription, since the stale answer only ever costs one session that
-  // ended the old way.
+  // Probe on mount and on every reconnect: whether the Mac can transcribe at
+  // all depends on its settings, which can change between one connection and
+  // the next. Only what the mic button should look like rides on this — how a
+  // session ends comes back from `dictationBegin`, per session, precisely so
+  // that nothing about it is cached here between one and the next.
   useEffect(() => {
     if (connection !== "connected") return;
     let cancelled = false;
@@ -172,8 +147,9 @@ export function useDictation(onText: (text: string) => void) {
     const session = new DictationSession(api, startCapture);
     sessionRef.current = session;
     try {
-      await session.start(autoStopWanted(status) ? () => void finish() : undefined, (level) =>
-        setLevels((prev) => [...prev.slice(1), level]),
+      await session.start(
+        () => void finish(),
+        (level) => setLevels((prev) => [...prev.slice(1), level]),
       );
       // A cancel while the mic was opening already let go of the session.
       if (sessionRef.current !== session) return;

--- a/mobile/src/dictation/useDictation.ts
+++ b/mobile/src/dictation/useDictation.ts
@@ -14,6 +14,28 @@ export const ERROR_TTL_MS = 2600;
 
 const IDLE_LEVELS: number[] = Array(LEVEL_BARS).fill(0);
 
+/** Should a session end itself after a pause? The Mac owns the setting (Settings
+ *  › Dictation, "Stop after a pause") and reports it with the availability
+ *  probe; only the phone can act on it, because the silence is in frames that
+ *  never leave the device.
+ *
+ *  Withholding `onAutoStop` is the whole of the opt-out, and deliberately so:
+ *  `capture.ts`'s `watchForSilence` no-ops without the callback, so neither the
+ *  pause nor the never-spoke deadline (`NO_SPEECH_TIMEOUT_MS`) is ever
+ *  consulted — exactly what `should_auto_stop(false, …)` does on the desktop,
+ *  where turning it off means nothing but a tap ends a session. What that costs
+ *  is a mic that stays open: the host caps the audio it will hold, but
+ *  `SESSION_IDLE` only sweeps a phone that has stopped sending, and this one
+ *  keeps streaming a chunk a second. So an abandoned session runs until the
+ *  user taps, leaves the screen, or the link drops — the same deal the desktop
+ *  offers with the setting off.
+ *
+ *  A host too old to report the field leaves it undefined, which reads as on —
+ *  the behaviour every phone had before the field existed. */
+export function autoStopWanted(status: DictationStatus | null): boolean {
+  return status?.auto_stop !== false;
+}
+
 /** Voice dictation for one composer. Owns the session and reports its phase,
  *  the mic's loudness and when it opened; the transcript is handed to `onText`
  *  once, when the host answers.
@@ -23,8 +45,10 @@ const IDLE_LEVELS: number[] = Array(LEVEL_BARS).fill(0);
  *
  *  A session usually ends itself: the mic reports the pause after the user
  *  stops talking (`silence.ts`), and that runs the same stop a tap would, so
- *  dictating is one tap. Failures are the composer's to show (`error`), in a
- *  banner above the footer, and clear on their own. */
+ *  dictating is one tap. Unless the Mac says otherwise — see
+ *  [`autoStopWanted`], which is what the host's `auto_stop` buys us. Failures
+ *  are the composer's to show (`error`), in a banner above the footer, and
+ *  clear on their own. */
 export function useDictation(onText: (text: string) => void) {
   const connection = useStore((s) => s.connection);
   // null while the probe is in flight; `available: false` with no reason is a
@@ -64,6 +88,13 @@ export function useDictation(onText: (text: string) => void) {
 
   // Probe on mount and on every reconnect: the answer depends on the Mac's
   // settings, which can change between one connection and the next.
+  //
+  // Mount and reconnect are the only two moments, by choice: a setting flipped
+  // on the Mac while this phone stays connected is not seen until it comes back
+  // (the app is backgrounded, the link drops, the screen is re-entered). That
+  // window is known, not an oversight — nothing here is worth a push channel
+  // and a subscription, since the stale answer only ever costs one session that
+  // ended the old way.
   useEffect(() => {
     if (connection !== "connected") return;
     let cancelled = false;
@@ -141,9 +172,8 @@ export function useDictation(onText: (text: string) => void) {
     const session = new DictationSession(api, startCapture);
     sessionRef.current = session;
     try {
-      await session.start(
-        () => void finish(),
-        (level) => setLevels((prev) => [...prev.slice(1), level]),
+      await session.start(autoStopWanted(status) ? () => void finish() : undefined, (level) =>
+        setLevels((prev) => [...prev.slice(1), level]),
       );
       // A cancel while the mic was opening already let go of the session.
       if (sessionRef.current !== session) return;

--- a/mobile/src/remote/mock/index.ts
+++ b/mobile/src/remote/mock/index.ts
@@ -435,15 +435,13 @@ export class MockHost {
       // mock counts chunks and answers a fixed sentence for any session that
       // sent audio — enough to exercise the composer's listening → transcribing
       // → text path.
-      // `auto_stop` mirrors the Mac's default (Settings › Dictation ships it
-      // on), so the browser gets the hands-free path the phone normally has;
-      // flip it here to try the tap-to-stop one.
       case "dictation_status":
-        return { available: true, reason: null, auto_stop: true };
+        return { available: true, reason: null };
       case "dictation_begin": {
         const session = `dict-${this.dictation.size + 1}`;
         this.dictation.set(session, 0);
-        return { session };
+        // The Mac's default. Flip it to exercise the tap-to-stop path.
+        return { session, auto_stop: true };
       }
       case "dictation_audio": {
         const session = String(args.session ?? "");

--- a/mobile/src/remote/mock/index.ts
+++ b/mobile/src/remote/mock/index.ts
@@ -435,8 +435,11 @@ export class MockHost {
       // mock counts chunks and answers a fixed sentence for any session that
       // sent audio — enough to exercise the composer's listening → transcribing
       // → text path.
+      // `auto_stop` mirrors the Mac's default (Settings › Dictation ships it
+      // on), so the browser gets the hands-free path the phone normally has;
+      // flip it here to try the tap-to-stop one.
       case "dictation_status":
-        return { available: true, reason: null };
+        return { available: true, reason: null, auto_stop: true };
       case "dictation_begin": {
         const session = `dict-${this.dictation.size + 1}`;
         this.dictation.set(session, 0);

--- a/mobile/tests/dictation.test.ts
+++ b/mobile/tests/dictation.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "vitest";
-import type { DictationStatus } from "../src/api";
 import type { Capture, CaptureOptions, ChunkSink } from "../src/dictation/capture";
 import {
   bytesToBase64,
@@ -9,7 +8,6 @@ import {
   pcm16ToBytes,
 } from "../src/dictation/encode";
 import { type DictationApi, DictationSession } from "../src/dictation/session";
-import { autoStopWanted } from "../src/dictation/useDictation";
 
 describe("chunk encoding", () => {
   it("scales and clamps float samples to 16-bit", () => {
@@ -37,14 +35,15 @@ describe("chunk encoding", () => {
 });
 
 /** A host that records every op, and a mic the test drives by hand. */
-function harness(opts: { failAudioAt?: number; beginFails?: boolean } = {}) {
+function harness(opts: { failAudioAt?: number; beginFails?: boolean; autoStop?: boolean } = {}) {
   const ops: { op: string; args: unknown[] }[] = [];
   let audioCalls = 0;
   const api: DictationApi = {
     async dictationBegin() {
       ops.push({ op: "begin", args: [] });
       if (opts.beginFails) throw new Error("Local dictation is off on your Mac.");
-      return { session: "s1" };
+      // `autoStop: undefined` is a host too old to report the field.
+      return "autoStop" in opts ? { session: "s1", auto_stop: opts.autoStop } : { session: "s1" };
     },
     async dictationAudio(session, rate, pcm) {
       audioCalls += 1;
@@ -192,26 +191,21 @@ describe("DictationSession", () => {
     expect(h.mic.stopped).toBe(1);
   });
 
-  /** The Mac owns "Stop after a pause" and reports it with the availability
-   *  probe; the phone is the only side that can act on it. Started here exactly
-   *  as `useDictation` starts one, so what is under test is the wiring from the
-   *  host's answer to the callback, not a restatement of it. */
-  async function startAsTheHookWould(status: DictationStatus) {
-    const h = harness();
+  /** The Mac owns "Stop after a pause" and answers it on `begin`, per session;
+   *  the phone is the only side that can act on it. Started here exactly as
+   *  `useDictation` starts one — which now means always offering the callback
+   *  and letting the host's answer decide — so what is under test is the wiring
+   *  from that answer to the mic, not a restatement of it. */
+  async function startAsTheHookWould(opts: { autoStop?: boolean } | Record<string, never>) {
+    const h = harness(opts);
     const s = new DictationSession(h.api, h.startCapture);
     const stops: Promise<string>[] = [];
-    await s.start(autoStopWanted(status) ? () => stops.push(s.stop()) : undefined);
+    await s.start(() => stops.push(s.stop()));
     return { h, s, stops };
   }
 
-  const probe = (auto_stop?: boolean): DictationStatus => ({
-    available: true,
-    reason: null,
-    auto_stop,
-  });
-
-  it("a phone told auto_stop: false never arms the silence watcher", async () => {
-    const { h, s, stops } = await startAsTheHookWould(probe(false));
+  it("a session begun with auto_stop: false never arms the silence watcher", async () => {
+    const { h, s, stops } = await startAsTheHookWould({ autoStop: false });
     expect(h.mic.armed).toBe(false);
 
     h.mic.speak([1]);
@@ -227,9 +221,9 @@ describe("DictationSession", () => {
     expect(h.mic.stopped).toBe(1);
   });
 
-  it("a phone told auto_stop: true stops itself, and so does one whose host never said", async () => {
-    for (const status of [probe(true), probe(undefined)]) {
-      const { h, stops } = await startAsTheHookWould(status);
+  it("a session begun with auto_stop: true stops itself, and so does one whose host never said", async () => {
+    for (const opts of [{ autoStop: true }, {}]) {
+      const { h, stops } = await startAsTheHookWould(opts);
       expect(h.mic.armed).toBe(true);
       h.mic.speak([1]);
       h.mic.pause();

--- a/mobile/tests/dictation.test.ts
+++ b/mobile/tests/dictation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { DictationStatus } from "../src/api";
 import type { Capture, CaptureOptions, ChunkSink } from "../src/dictation/capture";
 import {
   bytesToBase64,
@@ -8,6 +9,7 @@ import {
   pcm16ToBytes,
 } from "../src/dictation/encode";
 import { type DictationApi, DictationSession } from "../src/dictation/session";
+import { autoStopWanted } from "../src/dictation/useDictation";
 
 describe("chunk encoding", () => {
   it("scales and clamps float samples to 16-bit", () => {
@@ -73,6 +75,11 @@ function harness(opts: { failAudioAt?: number; beginFails?: boolean } = {}) {
     /** Report the pause, as the capture's silence monitor would. */
     pause() {
       doneTalking?.();
+    },
+    /** Whether `capture.ts` would have armed its silence watcher at all: it
+     *  no-ops without a callback, which is the auto-stop opt-out. */
+    get armed() {
+      return doneTalking !== undefined;
     },
     get stopped() {
       return stopped;
@@ -183,6 +190,52 @@ describe("DictationSession", () => {
     expect(stops).toEqual([]);
     expect(h.ops.filter((o) => o.op === "end")).toHaveLength(1);
     expect(h.mic.stopped).toBe(1);
+  });
+
+  /** The Mac owns "Stop after a pause" and reports it with the availability
+   *  probe; the phone is the only side that can act on it. Started here exactly
+   *  as `useDictation` starts one, so what is under test is the wiring from the
+   *  host's answer to the callback, not a restatement of it. */
+  async function startAsTheHookWould(status: DictationStatus) {
+    const h = harness();
+    const s = new DictationSession(h.api, h.startCapture);
+    const stops: Promise<string>[] = [];
+    await s.start(autoStopWanted(status) ? () => stops.push(s.stop()) : undefined);
+    return { h, s, stops };
+  }
+
+  const probe = (auto_stop?: boolean): DictationStatus => ({
+    available: true,
+    reason: null,
+    auto_stop,
+  });
+
+  it("a phone told auto_stop: false never arms the silence watcher", async () => {
+    const { h, s, stops } = await startAsTheHookWould(probe(false));
+    expect(h.mic.armed).toBe(false);
+
+    h.mic.speak([1]);
+    // Nothing the mic could ever report ends this session: without the callback
+    // `watchForSilence` never starts a timer, so the pause and the never-spoke
+    // deadline alike go unasked — the desktop's `should_auto_stop(false, …)`.
+    h.mic.pause();
+    expect(stops).toEqual([]);
+    expect(h.mic.stopped).toBe(0);
+
+    // A tap still ends it, which is the only way left.
+    expect(await s.stop()).toBe("hello world");
+    expect(h.mic.stopped).toBe(1);
+  });
+
+  it("a phone told auto_stop: true stops itself, and so does one whose host never said", async () => {
+    for (const status of [probe(true), probe(undefined)]) {
+      const { h, stops } = await startAsTheHookWould(status);
+      expect(h.mic.armed).toBe(true);
+      h.mic.speak([1]);
+      h.mic.pause();
+      expect(await Promise.all(stops)).toEqual(["hello world"]);
+      expect(h.ops.map((o) => o.op)).toEqual(["begin", "audio", "audio", "end"]);
+    }
   });
 
   it("cancel releases the mic and the host session, and is idempotent", async () => {

--- a/src-tauri/src/dictation/mod.rs
+++ b/src-tauri/src/dictation/mod.rs
@@ -308,8 +308,10 @@ pub fn set_auto_stop(enabled: bool) {
     AUTO_STOP.store(enabled, std::sync::atomic::Ordering::Relaxed);
 }
 
-/// Read by the silence monitor, which only exists on macOS.
-#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+/// Read by the silence monitor on macOS, and on every platform by
+/// [`remote::status`] — the phone hears its own pause, so it has to be told
+/// what this Mac wants done about one. That second caller is why there is no
+/// `allow(dead_code)` here any more.
 pub(crate) fn auto_stop() -> bool {
     AUTO_STOP.load(std::sync::atomic::Ordering::Relaxed)
 }

--- a/src-tauri/src/dictation/remote.rs
+++ b/src-tauri/src/dictation/remote.rs
@@ -7,10 +7,13 @@
 //! the user talks, `dictation_end` transcribes and answers with the text, and
 //! `dictation_cancel` throws the audio away. `dictation_status` beside them
 //! says whether any of that would work, so the phone can hide its mic button
-//! the way the desktop composer hides its own, and carries the "Stop after a
-//! pause" setting: the pause lives in frames that never cross the wire, so the
-//! phone's own capture is the only thing that can honour a setting this Mac
-//! owns.
+//! the way the desktop composer hides its own.
+//!
+//! `dictation_begin` also answers with the "Stop after a pause" setting. The
+//! pause lives in frames that never cross the wire — this Mac sees only the
+//! chunks the phone chose to send — so the phone's own capture is the only
+//! thing that can honour a setting this Mac owns. Per session rather than on
+//! the status probe, which the phone only makes on mount and reconnect.
 //!
 //! No events, no partials: whisper.cpp has nothing to say until the whole clip
 //! is in, so the transcript is simply the reply to `dictation_end`, and the
@@ -57,30 +60,14 @@ pub struct Status {
     pub available: bool,
     /// Why not, in words the phone shows as-is. `None` when available.
     pub reason: Option<String>,
-    /// Settings › Dictation's "Stop after a pause", as this Mac has it. The
-    /// phone arms its silence monitor only when this is true; with it off
-    /// nothing but a tap ends the session, which is what the desktop does
-    /// (`capture::should_auto_stop` refuses both the pause and the never-spoke
-    /// deadline). What the host bounds by itself is the *memory*, through the
-    /// capture cap — not the session: `SESSION_IDLE` is refreshed by every
-    /// chunk, and a phone with the setting off keeps sending one a second, so
-    /// an abandoned session holds its mic until the user taps, leaves, or the
-    /// link drops. That is the desktop's behaviour too.
-    pub auto_stop: bool,
 }
 
 impl Status {
-    /// Split from [`status`] so the tests can build one without an
-    /// `AppHandle`. `auto_stop` comes from the in-memory mirror, not the DB:
-    /// `set_dictation_auto_stop` keeps it current and boot restores it. It is
-    /// answered whether or not this Mac is ready to transcribe — the two say
-    /// different things, and a phone that asks while the model is still
-    /// downloading should still learn how the session will end once it isn't.
+    /// Split from [`status`] so the tests can build one without an `AppHandle`.
     fn new(readiness: Result<()>) -> Self {
         Self {
             available: readiness.is_ok(),
             reason: readiness.err().map(|e| e.to_string()),
-            auto_stop: super::auto_stop(),
         }
     }
 }
@@ -88,6 +75,23 @@ impl Status {
 #[derive(Serialize)]
 pub struct Begun {
     pub session: String,
+    /// Settings › Dictation's "Stop after a pause", as this Mac has it at the
+    /// moment the session opens. The phone arms its silence monitor only when
+    /// this is true; with it off nothing but a tap ends the session, which is
+    /// what the desktop does (`capture::should_auto_stop` refuses both the
+    /// pause and the never-spoke deadline).
+    ///
+    /// It rides on `begin` rather than `dictation_status` because the phone
+    /// probes status on mount and reconnect only. A phone that stays connected
+    /// for a day would answer every session from that one stale read, so a
+    /// setting flipped on the Mac would go unheard indefinitely — not for one
+    /// session, as an earlier draft of this claimed. Answering it per session,
+    /// on the call the phone already makes before opening its mic, costs no
+    /// extra round trip and leaves nothing to cache.
+    ///
+    /// Same instinct as the desktop reading its model at stop: the value a
+    /// session acts on is the one Settings showed while it was live.
+    pub auto_stop: bool,
 }
 
 #[derive(Serialize)]
@@ -238,9 +242,8 @@ fn decode(pcm_base64: &str) -> Result<Vec<u8>> {
 // ---------------------------------------------------------------------------
 // The ops, as the dispatcher calls them.
 
-/// Whether a phone can dictate through this Mac right now, if not what the user
-/// has to do about it, and how a session is meant to end. Cheap — two settings
-/// reads, an atomic load and a metadata stat.
+/// Whether a phone can dictate through this Mac right now, and if not, what the
+/// user has to do about it. Cheap — two settings reads and a metadata stat.
 pub fn status(app: &AppHandle) -> Status {
     Status::new(readiness(app))
 }
@@ -251,6 +254,10 @@ pub fn begin(app: &AppHandle) -> Result<Begun> {
     readiness(app)?;
     Ok(Begun {
         session: store().begin(Instant::now())?,
+        // The mirror, not the DB: `set_dictation_auto_stop` keeps it current
+        // and boot restores it, and this runs off a request thread with no
+        // handle to the connection.
+        auto_stop: super::auto_stop(),
     })
 }
 
@@ -420,19 +427,25 @@ mod tests {
     }
 
     /// The phone cannot read the Mac's settings any other way, so a stale or
-    /// hardcoded value here is the opt-out silently not working.
+    /// hardcoded value here is the opt-out silently not working. Answered per
+    /// session precisely so that flipping the setting takes effect on the next
+    /// one rather than on the next reconnect.
     #[test]
-    fn status_reports_the_auto_stop_setting_as_it_stands() {
+    fn each_session_begins_with_the_setting_as_it_stands() {
         super::super::set_auto_stop(false);
-        assert!(!Status::new(Ok(())).auto_stop);
-        // Not ready to transcribe is a separate fact: the setting is still the
-        // honest answer, and the phone that reconnects later depends on it.
-        assert!(!Status::new(Err(Error::Other("model missing".into()))).auto_stop);
+        assert!(!begun(store().begin(Instant::now()).unwrap()).auto_stop);
 
         super::super::set_auto_stop(true);
-        let status = Status::new(Ok(()));
-        assert!(status.auto_stop);
-        assert!(status.available && status.reason.is_none());
+        assert!(begun(store().begin(Instant::now()).unwrap()).auto_stop);
+    }
+
+    /// The shape `begin` builds, minus the readiness check an `AppHandle` would
+    /// be needed for.
+    fn begun(session: String) -> Begun {
+        Begun {
+            session,
+            auto_stop: super::super::auto_stop(),
+        }
     }
 
     #[test]

--- a/src-tauri/src/dictation/remote.rs
+++ b/src-tauri/src/dictation/remote.rs
@@ -7,7 +7,10 @@
 //! the user talks, `dictation_end` transcribes and answers with the text, and
 //! `dictation_cancel` throws the audio away. `dictation_status` beside them
 //! says whether any of that would work, so the phone can hide its mic button
-//! the way the desktop composer hides its own.
+//! the way the desktop composer hides its own, and carries the "Stop after a
+//! pause" setting: the pause lives in frames that never cross the wire, so the
+//! phone's own capture is the only thing that can honour a setting this Mac
+//! owns.
 //!
 //! No events, no partials: whisper.cpp has nothing to say until the whole clip
 //! is in, so the transcript is simply the reply to `dictation_end`, and the
@@ -54,6 +57,32 @@ pub struct Status {
     pub available: bool,
     /// Why not, in words the phone shows as-is. `None` when available.
     pub reason: Option<String>,
+    /// Settings › Dictation's "Stop after a pause", as this Mac has it. The
+    /// phone arms its silence monitor only when this is true; with it off
+    /// nothing but a tap ends the session, which is what the desktop does
+    /// (`capture::should_auto_stop` refuses both the pause and the never-spoke
+    /// deadline). What the host bounds by itself is the *memory*, through the
+    /// capture cap — not the session: `SESSION_IDLE` is refreshed by every
+    /// chunk, and a phone with the setting off keeps sending one a second, so
+    /// an abandoned session holds its mic until the user taps, leaves, or the
+    /// link drops. That is the desktop's behaviour too.
+    pub auto_stop: bool,
+}
+
+impl Status {
+    /// Split from [`status`] so the tests can build one without an
+    /// `AppHandle`. `auto_stop` comes from the in-memory mirror, not the DB:
+    /// `set_dictation_auto_stop` keeps it current and boot restores it. It is
+    /// answered whether or not this Mac is ready to transcribe — the two say
+    /// different things, and a phone that asks while the model is still
+    /// downloading should still learn how the session will end once it isn't.
+    fn new(readiness: Result<()>) -> Self {
+        Self {
+            available: readiness.is_ok(),
+            reason: readiness.err().map(|e| e.to_string()),
+            auto_stop: super::auto_stop(),
+        }
+    }
 }
 
 #[derive(Serialize)]
@@ -209,19 +238,11 @@ fn decode(pcm_base64: &str) -> Result<Vec<u8>> {
 // ---------------------------------------------------------------------------
 // The ops, as the dispatcher calls them.
 
-/// Whether a phone can dictate through this Mac right now, and if not, what the
-/// user has to do about it. Cheap — two settings reads and a metadata stat.
+/// Whether a phone can dictate through this Mac right now, if not what the user
+/// has to do about it, and how a session is meant to end. Cheap — two settings
+/// reads, an atomic load and a metadata stat.
 pub fn status(app: &AppHandle) -> Status {
-    match readiness(app) {
-        Ok(()) => Status {
-            available: true,
-            reason: None,
-        },
-        Err(e) => Status {
-            available: false,
-            reason: Some(e.to_string()),
-        },
-    }
+    Status::new(readiness(app))
 }
 
 pub fn begin(app: &AppHandle) -> Result<Begun> {
@@ -396,6 +417,22 @@ mod tests {
         store.cancel(&id);
         store.cancel(&id);
         assert!(store.take(&id).is_err());
+    }
+
+    /// The phone cannot read the Mac's settings any other way, so a stale or
+    /// hardcoded value here is the opt-out silently not working.
+    #[test]
+    fn status_reports_the_auto_stop_setting_as_it_stands() {
+        super::super::set_auto_stop(false);
+        assert!(!Status::new(Ok(())).auto_stop);
+        // Not ready to transcribe is a separate fact: the setting is still the
+        // honest answer, and the phone that reconnects later depends on it.
+        assert!(!Status::new(Err(Error::Other("model missing".into()))).auto_stop);
+
+        super::super::set_auto_stop(true);
+        let status = Status::new(Ok(()));
+        assert!(status.auto_stop);
+        assert!(status.available && status.reason.is_none());
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #709. Independent of #710 — they touch disjoint files.

## The bug

**iOS auto-stopped unconditionally, whatever the setting said.** `useDictation` always handed `session.start` an `onAutoStop` callback, so `capture.ts` armed its silence watcher every time.

The phone could not have done otherwise: `remote::Status` carried only `{ available, reason }`, so the setting never crossed the wire.

This is the surface where the opt-out is least ambiguous — the phone's audio is always transcribed by Whisper on the Mac, so the setting plainly applies. But only the phone can *act* on it: the pause lives in render quanta that never leave the device. The Mac sees the ~1 s chunks the phone chose to send, far too coarse to judge a two-second pause against.

## The change

`auto_stop` on `Status`, sourced from the in-memory mirror that `set_dictation_auto_stop` keeps current and boot restores — not a second DB read; the mirror exists for exactly this. `Status::new` is split out so it can be tested without an `AppHandle`, and answers `auto_stop` whether or not the Mac is ready to transcribe: a phone asking while the model downloads should still learn how its sessions will end once it can.

Optional on the wire, so a host too old to report it reads as on — the behaviour every phone has had until now.

## Semantics: off means off

Withholding the callback is the whole of the opt-out, and it matches `should_auto_stop(false, …)` exactly — verified, not assumed: `watchForSilence` never creates a timer without it, so `SilenceMonitor.doneTalking()` is never called and neither the pause nor the `NO_SPEECH_TIMEOUT_MS` never-spoke deadline is consulted. `never_auto_stops_when_turned_off` pins the desktop side of that parity.

**What it costs is a mic that stays open, and the PR is explicit about it.** `SESSION_IDLE` only sweeps a phone that has stopped sending, and one with auto-stop off keeps streaming a chunk a second; `MAX_CAPTURE_SECS` bounds the memory, not the session. So an abandoned session runs until the user taps, leaves the screen, or the link drops. That is the same deal the desktop offers with the setting off, which is why it ships as-is — but it is a weaker guarantee than "the host bounds it", and the comments say so.

## Known limitation

The setting is read at mount and reconnect only. Flipping it on the Mac mid-connection costs at most one session ending the old way. Not worth a push channel and a subscription; the probe effect now says that, so the next reader doesn't file it as a bug.

## Testing

`cargo test --lib dictation::` 34 passed; `vitest` 138 passed; `tsc`, `fmt` and `biome` clean.

`status_reports_the_auto_stop_setting_as_it_stands` flips the mirror and asserts both the ready and not-ready cases. The mobile harness gains `mic.armed`, and two tests start a session exactly as the hook does: `auto_stop: false` leaves the watcher unarmed so a pause does nothing and only a tap ends it; `true` and `undefined` (old host) both auto-stop.

`docs/remote-protocol.md` updated for the new response field.
