### PR TITLE
fix(dictation): say what "Stop after a pause" actually does

### DIFF
--- a/src/components/Composer/PrimaryControl/index.tsx
+++ b/src/components/Composer/PrimaryControl/index.tsx
@@ -24,9 +24,10 @@ interface Props {
    *  local engine) or the composer has no dictation at all: the mic is never
    *  offered, and the empty pill degrades to a plain send arrow. */
   dictationAvailable: boolean;
-  /** The local engine ends the session itself once the user pauses, and the
-   *  tooltip has to say so — a mic that stops on its own otherwise reads as a
-   *  bug. */
+  /** The "Stop after a pause" setting: dictation ends the session itself once
+   *  the user pauses, and the tooltip has to say so — a mic that stops on its
+   *  own otherwise reads as a bug, and one that doesn't leaves the user waiting
+   *  on it. */
   autoStops?: boolean;
   /** Recent microphone levels, oldest first, each 0–1. */
   levels?: number[];
@@ -226,7 +227,9 @@ function SegButton({
   );
 }
 
-function tipFor(
+/** Exported for its tests: the tooltip is the only place the auto-stop setting
+ *  reaches the user mid-session, so both of its branches are worth pinning. */
+export function tipFor(
   state: PrimaryState,
   o: {
     dictationAvailable: boolean;

--- a/src/components/Composer/PrimaryControl/tipFor.test.ts
+++ b/src/components/Composer/PrimaryControl/tipFor.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { tipFor } from "./index";
+
+const base = {
+  dictationAvailable: true,
+  autoStops: true,
+  error: null,
+  sendLabel: "Send",
+};
+
+describe("tipFor", () => {
+  it("promises the pause while listening only when the setting is on", () => {
+    expect(tipFor("listening", base)).toContain("stops when you pause");
+  });
+
+  it("offers the manual stop when the setting is off", () => {
+    const tip = tipFor("listening", { ...base, autoStops: false });
+    expect(tip).toContain("Stop & transcribe");
+    expect(tip).not.toContain("stops when you pause");
+  });
+});

--- a/src/components/Composer/index.tsx
+++ b/src/components/Composer/index.tsx
@@ -205,6 +205,10 @@ export function Composer({
   const modelsByAgent = useAppStore((s) => s.modelsByAgent);
   const customAgents = useAppStore((s) => s.customAgents);
   const sandboxEngine = useAppStore((s) => s.sandboxEngine);
+  // The listening tooltip promises one of two things — "stops when you pause"
+  // or "stop it yourself" — and which is true is the user's setting, not the
+  // engine's doing: both engines honour it.
+  const dictationAutoStop = useAppStore((s) => s.dictationAutoStop);
 
   // Hide the thinking-effort picker for a model the catalog knows can't reason.
   // When the model is unknown (a new session before the first turn, or one the
@@ -495,7 +499,7 @@ export function Composer({
           <PrimaryControl
             state={state}
             dictationAvailable={dictationAvailable}
-            autoStops={dictation.availability?.engine === "whisper"}
+            autoStops={dictationAutoStop}
             levels={dictation.levels}
             startedAt={dictation.startedAt}
             sendBlocked={sendBlocked}

--- a/src/components/SettingsScreen/Dictation/index.tsx
+++ b/src/components/SettingsScreen/Dictation/index.tsx
@@ -36,14 +36,14 @@ export function DictationPane() {
         >
           <SetToggle on={enabled} onClick={() => setEnabled(!enabled)} />
         </SetRow>
-        {/* Only the local engine measures the audio it captures; Apple's
-            recognizer ends an utterance on its own terms. So the switch is
-            offered under Whisper and greyed out while Apple's engine is in use. */}
+        {/* Both engines now end an utterance on the same measured pause, so this
+            is a property of dictation rather than of the choice above it — it
+            stays live whether or not the local engine is switched on. */}
         <SetRow
           title="Stop after a pause"
-          sub="Local recognition ends on its own after a two-second pause. Off, you stop it with the mic button."
+          sub="Dictation ends on its own after a two-second pause. Off, you stop it with the mic button."
         >
-          <SetToggle on={autoStop} disabled={!enabled} onClick={() => setAutoStop(!autoStop)} />
+          <SetToggle on={autoStop} onClick={() => setAutoStop(!autoStop)} />
         </SetRow>
         {/* Always offered, engine on or off: the choice has to be makeable
             before the opt-in, or enabling would fetch the platform default out


### PR DESCRIPTION
Stacked on #710 — its copy is only true once auto-stop works on both engines. Merge #709 → #710 → this.

## The bug

Two pieces of UI described the old, engine-dependent behaviour.

**Settings greyed the row out whenever the local engine was off**, on the grounds that only Whisper measured its own audio. With #710 both engines end an utterance on the same measured pause, so the setting is a property of dictation rather than of the engine choice above it.

The disabled state was the worse half of this. `SetToggle` renders a disabled switch **fully lit in the ON position** at `opacity: 0.4`, and `dictationAutoStop` defaults to `true` — so the row read "on" while being completely inert. That is exactly what makes a setting that does nothing hard to diagnose, and it cost real time on this bug hunt.

**The composer's listening tooltip keyed on the engine, not the setting:**

```tsx
autoStops={dictation.availability?.engine === "whisper"}
```

So it promised "Listening… stops when you pause" even to someone who had turned that off and was waiting for a mic that would never let go.

## The change

Settings: drop `disabled`, rewrite the `sub` so it no longer says "Local recognition", replace the comment that explained the old gating.

> Dictation ends on its own after a two-second pause. Off, you stop it with the mic button.

Tooltip: read `dictationAutoStop` from the store, with **no engine term left**. The listening branch is only reachable while dictation is actually running, and the two other `PrimaryControl` call sites (`WorkflowComposer`, `Roadmap/Thread/Composer`) pass `dictationAvailable={false}` and never render it — so there is nothing an engine guard would protect.

`tipFor` becomes exported so both branches can be tested directly. It is a pure function, so the test needs no harness.

## Flagged, not fixed

`SetToggle`'s `disabled` prop has this same trap anywhere it is used — a lit switch at 40% opacity with no explanation of why it is inert. Worth auditing the other call sites, but that is a primitives change and not this PR.

## Testing

`bun run test` 1138 passed, `tsc --noEmit` and `biome` clean. New `tipFor.test.ts` covers setting-on → the pause promise, setting-off → "Stop & transcribe" and *not* the pause promise.
