### PR TITLE
refactor(onboarding): single exit, no Esc, per-step skips only

### DIFF
--- a/src/components/Onboarding/GitStep.tsx
+++ b/src/components/Onboarding/GitStep.tsx
@@ -14,7 +14,7 @@ import type { OnboardingSetup } from "./useSetup";
 
 const GIT_DOCS = "https://git-scm.com/downloads";
 
-export function GitStep({ setup }: { setup: OnboardingSetup }) {
+export function GitStep({ setup, onSkip }: { setup: OnboardingSetup; onSkip: () => void }) {
   const { git, gitDist, gitReady, gitDownloading, gitInstallError, installingGit, installGit } =
     setup;
 
@@ -110,6 +110,16 @@ export function GitStep({ setup }: { setup: OnboardingSetup }) {
           </div>
         )}
       </div>
+      {showInstall && (
+        <button
+          type="button"
+          className="ob-skiplink ob-reveal"
+          style={{ "--d": ".6s" } as CSSProperties}
+          onClick={onSkip}
+        >
+          I'll install Git myself — skip for now
+        </button>
+      )}
     </SetupStep>
   );
 }

--- a/src/components/Onboarding/index.tsx
+++ b/src/components/Onboarding/index.tsx
@@ -65,7 +65,7 @@ export function Onboarding() {
   }, [firstRun]);
 
   // The funnel. One event per step reveal gives the whole drop-off curve;
-  // the skip/abandon/complete events below say *how* each user left.
+  // the abandon/complete events below say *how* each user left.
   useEffect(() => {
     track("onboarding_step_viewed", { step: STEPS[idx], index: idx, first_run: firstRun });
   }, [idx, firstRun]);
@@ -105,10 +105,11 @@ export function Onboarding() {
   const showNext = step === "git" || step === "github" || step === "agents";
 
   // Exactly one terminal event per onboarding session, whichever exit the user
-  // takes: Esc, ✕, and "Enter Fletch" all funnel through `leave`. A ref (not
+  // takes: the ✕ and "Enter Fletch" both funnel through `leave`. A ref (not
   // state) guards it, so a second call during the closing render can't
   // double-count. `completed` carries what the user actually finished with —
-  // the handoff is reachable with gaps via Skip, so the flags are the point.
+  // the handoff is reachable with gaps via the per-step skips, so the flags
+  // are the point.
   const leftRef = useRef(false);
   const leave = useCallback(
     (reason: "completed" | "abandoned") => {
@@ -151,8 +152,9 @@ export function Onboarding() {
   // add their first repo from the sidebar — no auto-picker.
   const onEnter = useCallback(() => leave("completed"), [leave]);
 
-  // A step's own opt-out ("I use GitLab…", "Set up later"), distinct from the
-  // title-bar Skip: it declines one requirement rather than the whole flow.
+  // A step's own opt-out ("I use GitLab…", "Set up later"). The only way to
+  // decline a requirement: it skips one step, not the whole flow, so the user
+  // still reaches the handoff and sees what's left unmet.
   const skipStep = useCallback(() => {
     track("onboarding_step_skipped", { step, first_run: firstRun });
     next();
@@ -163,9 +165,10 @@ export function Onboarding() {
     const onKey = (e: KeyboardEvent) => {
       const tag = (e.target as HTMLElement | null)?.tagName;
       const inField = tag === "TEXTAREA" || tag === "INPUT";
-      if (e.key === "Escape") {
-        leave(step === "ready" ? "completed" : "abandoned");
-      } else if (e.key === "Enter" && step === "welcome" && !busy) {
+      // Deliberately no Escape binding: closing is a one-way door (it persists
+      // `onboardingComplete`, and only Settings › Developer can reopen it), so
+      // a stray Esc must not end first-run setup. The ✕ is always visible.
+      if (e.key === "Enter" && step === "welcome" && !busy) {
         onAuth("github");
       } else if ((e.key === "ArrowRight" || e.key === "Enter") && showNext && !inField) {
         if (!canContinue) return;
@@ -178,7 +181,7 @@ export function Onboarding() {
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [idx, busy, step, showNext, canContinue, next, back, leave]);
+  }, [idx, busy, step, showNext, canContinue, next, back]);
 
   let content = null;
   if (step === "welcome")
@@ -191,7 +194,7 @@ export function Onboarding() {
       ) : (
         <WelcomeStep onAuth={onAuth} busy={busy} />
       );
-  else if (step === "git") content = <GitStep setup={setup} />;
+  else if (step === "git") content = <GitStep setup={setup} onSkip={skipStep} />;
   else if (step === "github") content = <GithubStep setup={setup} onSkip={skipStep} />;
   else if (step === "agents") content = <AgentsStep setup={setup} onSkip={skipStep} />;
   else if (step === "ready") content = <ReadyStep setup={setup} onEnter={onEnter} />;
@@ -212,20 +215,9 @@ export function Onboarding() {
               <b>{Math.min(idx + 1, RAIL_LEN)}</b> / {RAIL_LEN}
             </span>
           )}
-          {step !== "ready" && (
-            <button
-              className="ob-skip text-sm"
-              onClick={() => {
-                track("onboarding_skipped", { step, first_run: firstRun });
-                go(STEPS.length - 1);
-              }}
-            >
-              Skip
-            </button>
-          )}
           <button
             className="ob-close"
-            title="Close (Esc)"
+            title="Close onboarding"
             aria-label="Close onboarding"
             onClick={() => leave(step === "ready" ? "completed" : "abandoned")}
           >

--- a/src/components/Onboarding/onboarding.css
+++ b/src/components/Onboarding/onboarding.css
@@ -73,19 +73,6 @@
   color: var(--fg-1);
   font-weight: 500;
 }
-.ob-skip {
-  color: var(--fg-3);
-  padding: 4px 8px;
-  border-radius: var(--r-sm);
-  cursor: pointer;
-  transition:
-    color 0.12s,
-    background 0.12s;
-}
-.ob-skip:hover {
-  color: var(--fg-1);
-  background: var(--hover);
-}
 .ob-close {
   display: grid;
   place-items: center;

--- a/src/util/track.ts
+++ b/src/util/track.ts
@@ -54,14 +54,14 @@ interface EventMap {
   // ── onboarding funnel ────────────────────────────────────────────────────
   /** A step came on screen. The whole drop-off curve is derivable from this. */
   onboarding_step_viewed: OnboardingCommon & { step: OnboardingStep; index: number };
-  /** A per-step opt-out ("I use GitLab…", "Set up later"). */
+  /** A per-step opt-out ("I use GitLab…", "Set up later") — the only way to
+   *  decline a requirement, and the sole skip signal now that the title-bar
+   *  Skip is gone. */
   onboarding_step_skipped: OnboardingCommon & { step: OnboardingStep };
-  /** The title-bar Skip, which jumps straight to the handoff. */
-  onboarding_skipped: OnboardingCommon & { step: OnboardingStep };
-  /** Esc / ✕ before reaching the handoff — the "gave up here" signal. */
+  /** The ✕ before reaching the handoff — the "gave up here" signal. */
   onboarding_abandoned: OnboardingCommon & { step: OnboardingStep };
   /** "Enter Fletch", with what the user actually finished with. Reachable with
-   *  gaps via Skip, so the flags matter. */
+   *  gaps via the per-step skips, so the flags matter. */
   onboarding_completed: OnboardingCommon & {
     git_ready: boolean;
     gh_connected: boolean;


### PR DESCRIPTION
## What

Onboarding had three overlapping ways out, two of them adjacent in the title bar:

| Control | Behaviour |
|---|---|
| **Skip** (title bar) | Jumped to the `ready` handoff, tracked `onboarding_skipped`. Did not close. |
| **✕** (title bar) | Closed immediately, tracked `onboarding_abandoned`. Esc did the same. |
| Per-step skip links | Advanced one step, tracked `onboarding_step_skipped`. |

Skip and ✕ both read as "get me out of here" and nobody would guess that one secretly routes through a summary of what's unfinished. This collapses to **one global exit (✕) plus the per-step opt-outs**.

## Changes

- **Removed the title-bar Skip.** The ✕ is the sole global exit.
- **Removed the Escape binding.** Closing is a one-way door: it persists `onboardingComplete` (`store/ui.ts:192`) and the only reopen path is Settings › Developer (`DeveloperPane.tsx:57`), so a stray Esc permanently ended first-run setup. Esc also shadowed the device-code panel's own Cancel on the welcome step. The Esc-to-dismiss convention is for `role="dialog"` modals — this is a full-screen takeover with no dialog role and no focus trap, so the always-visible ✕ is what keeps the user from being trapped. Arrows and Enter still navigate.
- **Added a per-step skip to `GitStep`** — "I'll install Git myself — skip for now". Load-bearing: Git was the only step with no opt-out and gated Continue on `gitReady`, so with the global Skip gone a failed or offline install would have left no route to the summary, only a blind ✕. Renders on the same condition as the Install button, so it's absent in the normal case where Git is already detected.
- **Cleanup:** dropped the unused `onboarding_skipped` event from `track.ts` and the dead `.ob-skip` CSS; refreshed the comments describing the old three-exit model.

## Analytics

`onboarding_step_skipped` becomes the single skip signal, with per-step granularity. This also fixes a funnel bug: a user who hit Skip then "Enter Fletch" previously fired both `onboarding_skipped` and `onboarding_completed`, inflating any read of `onboarding_completed` as a completion rate.

## Testing

- `tsc --noEmit` passes.
- Biome reports 13 warnings across the touched files — identical count before and after the change (verified against HEAD), all pre-existing.

## Note, not addressed here

The header comment in `Onboarding/index.tsx:3` says the flow is "re-openable from Settings › General", but the entry point actually lives in Settings › Developer. Out of scope for this PR, but worth moving into General as a follow-up — a recoverable flow is what makes the single ✕ safe rather than merely visible.