### PR TITLE
chore(release): bump version to 0.7.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fletch",
   "private": true,
-  "version": "0.7.27",
+  "version": "0.7.28",
   "license": "AGPL-3.0-only",
   "author": "Alex Chaplinsky and fwdai.org",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1351,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "fletch"
-version = "0.7.27"
+version = "0.7.28"
 dependencies = [
  "base64 0.22.1",
  "block2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fletch"
-version = "0.7.27"
+version = "0.7.28"
 description = "Spawn coding agents in isolated sandboxes"
 authors = ["Alex Chaplinsky", "fwdai.org"]
 license = "AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Fletch",
   "mainBinaryName": "Fletch",
-  "version": "0.7.27",
+  "version": "0.7.28",
   "identifier": "com.fletch.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
Bumps the desktop app from 0.7.27 to 0.7.28 (patch), following the same pattern as the previous release commit.

Files updated:
- `package.json`
- `src-tauri/tauri.conf.json`
- `src-tauri/Cargo.toml`
- `src-tauri/Cargo.lock` (the `fletch` package entry)

`mobile/` is versioned independently (0.1.0) and is intentionally untouched.