### PR TITLE
fix(antigravity): raise agy --print-timeout past its 5m default

### DIFF
--- a/src-tauri/src/agent/providers/antigravity.rs
+++ b/src-tauri/src/agent/providers/antigravity.rs
@@ -4,6 +4,9 @@
 //! as a `plaintext` per-turn agent: the runner drains stdout, the turn's process
 //! exit ends the turn, and history comes entirely from its on-disk transcript.
 //! The conversation id (== session id) lives in agy's filesystem, not its output.
+//! Because the process exit *is* the turn end, agy's own print-mode deadline
+//! (`--print-timeout`) must be raised past any real turn — see
+//! [`ANTIGRAVITY_PRINT_TIMEOUT`].
 
 use std::path::{Path, PathBuf};
 
@@ -13,6 +16,15 @@ use crate::agent::args::push_opt;
 use crate::agent::transcript::{RawRecord, ReadDiagnostics};
 use crate::agent::TurnArgs;
 use crate::instructions;
+
+/// How long agy may spend on one `--print` turn before it aborts the turn
+/// itself (`Error: timeout waiting for response`, exit 1). agy's default is
+/// 5m, which an agentic turn routinely exceeds; the abort then surfaces as
+/// "Agent stopped unexpectedly" while the agent was mid-task (#636). The other
+/// per-turn agents have no turn cap at all, so this is set far past any real
+/// turn — it exists only so a truly hung process still exits. Go
+/// `time.Duration` syntax.
+pub(crate) const ANTIGRAVITY_PRINT_TIMEOUT: &str = "24h";
 
 // `_model` is intentionally unused: agy's `--print` runner ignores model
 // selection (the `--model` flag is inert in print mode), so the picker offers
@@ -27,7 +39,11 @@ pub(crate) fn antigravity_build_args(turn: &TurnArgs) -> Vec<String> {
     // `--print` takes the prompt as its *value* (i.e. `--print <prompt>`), so the
     // prompt must come last, directly after `--print`. Putting another flag
     // between them makes that flag the prompt (agy then "answers" the flag name).
-    let mut args = vec!["--dangerously-skip-permissions".to_string()];
+    let mut args = vec![
+        "--dangerously-skip-permissions".to_string(),
+        "--print-timeout".to_string(),
+        ANTIGRAVITY_PRINT_TIMEOUT.to_string(),
+    ];
     push_opt(&mut args, "--conversation", session_id);
     args.push("--print".into());
     args.push(instructions::prepend_to_prompt(prompt, session_id, extra));

--- a/src-tauri/src/agent/tests.rs
+++ b/src-tauri/src/agent/tests.rs
@@ -4,7 +4,10 @@ use serde_json::json;
 
 use super::args::effort_args;
 use super::capabilities::{provider_bin_label, PER_TURN_AGENTS};
-use super::providers::antigravity::{antigravity_conv_id_from_map, antigravity_read};
+use super::providers::antigravity::{
+    antigravity_build_args, antigravity_conv_id_from_map, antigravity_read,
+    ANTIGRAVITY_PRINT_TIMEOUT,
+};
 use super::providers::codex::{codex_build_args, codex_pty_args, codex_session_id};
 use super::providers::cursor::{cursor_build_args, cursor_pty_args, cursor_session_id};
 use super::providers::opencode::{opencode_build_args, opencode_pty_args, opencode_session_id};
@@ -270,6 +273,42 @@ fn transcript_reader_dispatch() {
     assert!(transcript_reader("antigravity").is_some());
     // Unknown providers have none.
     assert!(transcript_reader("nope").is_none());
+}
+
+#[test]
+fn antigravity_args_raise_print_timeout_and_keep_prompt_last() {
+    // agy aborts a `--print` turn after its own 5m default (#636), so every
+    // turn must carry a longer `--print-timeout`. It has to sit *before*
+    // `--print`: `--print` takes the prompt as its value, so anything placed
+    // between them would become the prompt.
+    let args = antigravity_build_args(&TurnArgs {
+        prompt: "hi",
+        session_id: Some("conv-1"),
+        ..Default::default()
+    });
+    let timeout = args
+        .iter()
+        .position(|a| a == "--print-timeout")
+        .expect("--print-timeout flag");
+    assert_eq!(
+        args.get(timeout + 1).map(String::as_str),
+        Some(ANTIGRAVITY_PRINT_TIMEOUT)
+    );
+    let print = args
+        .iter()
+        .position(|a| a == "--print")
+        .expect("--print flag");
+    assert!(
+        timeout < print,
+        "timeout flag must precede --print: {args:?}"
+    );
+    assert_eq!(print + 2, args.len(), "prompt is the last arg: {args:?}");
+    assert!(args.last().unwrap().ends_with("hi"));
+    let conv = args
+        .iter()
+        .position(|a| a == "--conversation")
+        .expect("--conversation flag");
+    assert_eq!(args.get(conv + 1).map(String::as_str), Some("conv-1"));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Antigravity turns that ran longer than 5 minutes ended with **"Agent stopped unexpectedly — Agent process exited: exit status: 1: Error: timeout waiting for response"** even though the agent was still working (#636). Pressing Resume appeared to do nothing.

## Root cause

Fletch runs Antigravity as a plaintext per-turn agent: each user message is one `agy --print <prompt>` process, and the process exit *is* the turn end. agy caps a print-mode turn with its own `--print-timeout`, which defaults to **5m0s**. Fletch never passed the flag, so agy aborted any longer turn with exit 1, and the per-turn exit handler correctly surfaced a non-zero, non-interrupted exit as a crash.

Both error strings (`timeout waiting for response`, `The stream was interrupted…`) live in the agy binary, not in this repo. Resume was working as designed for a per-turn provider — it re-registers the agent as Idle — but there is no in-flight turn to continue, so nothing visible happened.

## Fix

- Pass `--print-timeout 24h` on every print turn, via a documented constant in `agent/providers/antigravity.rs`. The other per-turn agents have no turn cap at all; this value exists only so a truly hung process still exits.
- The flag is placed **before** `--print`, since `--print` takes the prompt as its value and anything between them would become the prompt.
- New test `antigravity_args_raise_print_timeout_and_keep_prompt_last` pins the flag, its value, its position, and that the prompt remains the last argument.

## Verification

- `cargo test --lib agent::tests` — 38 passed
- `cargo fmt --check` clean on both files
- Confirmed against the installed agy 1.0.16 that `--print-timeout` is a Go duration (`30m` accepted, `abc` rejected).

## Not changed (deliberately)

- No special handling of agy's timeout stderr. With a 24h cap, only genuinely hung processes hit it, and the existing Error + Resume path (which already triggers transcript sync) is the right outcome. String-matching a vendor's stderr would be brittle.

## Follow-ups noticed, out of scope

- In the reporter's screenshot every `run_command` ran with cwd set to agy's own `~/.gemini/antigravity-cli/scratch`, not the workspace checkout — worth its own issue.
- An unauthenticated agy hangs indefinitely in print mode regardless of `--print-timeout`; Fletch has no login check for Antigravity.

Fixes #636