### PR TITLE
feat(providers): probe whether each agent CLI is signed in

### DIFF
--- a/src-tauri/src/agent/auth_probe.rs
+++ b/src-tauri/src/agent/auth_probe.rs
@@ -1,0 +1,476 @@
+//! Per-provider "is this CLI signed in?" probing for Settings › Providers.
+//!
+//! [`super::probe`] answers whether a provider's CLI is *installed*; this module
+//! answers the next question — has the user actually logged it in? Nothing tells
+//! them otherwise today, so an installed-but-signed-out CLI just fails at spawn
+//! time.
+//!
+//! Every check is derived from **structure only**: a file's existence and
+//! non-emptiness, a JSON blob's shape, or a Keychain item's presence (looked up
+//! *without* `-w`, so the password is never read and macOS never prompts). No
+//! credential value is returned, logged, or stored in a [`ProviderAuthProbe`] —
+//! `detail` is always one of the `&'static str` reasons in this file.
+//!
+//! The layouts are the ones the container launch path already depends on (see
+//! [`crate::sandbox::container::launch_auth`]), so the two can't drift. Where a
+//! layout isn't knowable from a cheap check we return [`AuthStatus::Unknown`]
+//! rather than guess: a wrong "Not signed in" sends the user chasing a login
+//! they already have.
+
+use std::path::Path;
+
+use serde_json::Value;
+
+use super::capabilities::PER_TURN_AGENTS;
+
+/// cursor-agent's Keychain services are `<domain>-{access,refresh}-token` with
+/// account `<domain>-user`, where the domain is the compiled-in `"cursor"` (see
+/// the `@cursor/keychain` credential store in the `cursor-agent` bundle). We
+/// probe the access token's *presence* only.
+#[cfg(target_os = "macos")]
+const CURSOR_KEYCHAIN_SERVICE: &str = "cursor-access-token";
+#[cfg(target_os = "macos")]
+const CURSOR_KEYCHAIN_ACCOUNT: &str = "cursor-user";
+
+/// Whether a provider's CLI has a usable login on this host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuthStatus {
+    SignedIn,
+    SignedOut,
+    /// We can't tell — no cheap check exists for this provider's credential
+    /// store, or the store exists but says nothing about login state. The UI
+    /// shows nothing rather than a claim it can't back up.
+    Unknown,
+}
+
+/// Wire shape of `probe_provider_auth`: one entry per known provider. `detail`
+/// is a short human reason for a non-`SignedIn` status (`None` when signed in)
+/// and is always a fixed string — never a path with a username in it, and never
+/// anything read out of a credential file.
+#[derive(Debug, serde::Serialize)]
+pub struct ProviderAuthProbe {
+    pub id: String,
+    pub status: AuthStatus,
+    pub detail: Option<String>,
+}
+
+/// Probe every known provider's login state in parallel. Never errors — a
+/// provider we can't classify contributes [`AuthStatus::Unknown`].
+pub async fn probe_all_provider_auth() -> Vec<ProviderAuthProbe> {
+    // Same id set as `probe_all_providers`: claude (the lone persistent-runner
+    // agent, which has no descriptor row) plus every per-turn descriptor.
+    let mut ids: Vec<&'static str> = vec!["claude"];
+    ids.extend(PER_TURN_AGENTS.iter().map(|d| d.id));
+
+    let mut handles = Vec::new();
+    for id in ids {
+        handles.push(tokio::task::spawn_blocking(move || probe_one(id)));
+    }
+
+    let mut results = Vec::new();
+    for handle in handles {
+        if let Ok(probe) = handle.await {
+            results.push(probe);
+        }
+    }
+    results
+}
+
+fn probe_one(id: &'static str) -> ProviderAuthProbe {
+    let Some(home) = dirs::home_dir() else {
+        return entry(id, AuthStatus::Unknown, "no home directory");
+    };
+    match id {
+        "claude" => claude_probe(),
+        "codex" => codex_probe(&home),
+        "opencode" => opencode_probe(&home),
+        "pi" => pi_probe(&home),
+        "cursor" => cursor_probe(),
+        "antigravity" => antigravity_probe(&home),
+        _ => entry(id, AuthStatus::Unknown, "no credential layout wired"),
+    }
+}
+
+// ── Per-provider probes ───────────────────────────────────────────────────────
+
+/// claude reuses the host half of the container auth chain (Keychain login,
+/// `~/.claude/.credentials.json`, or an Anthropic key in the login shell). The
+/// container-only pasted setup token is excluded there — see
+/// [`crate::sandbox::container::auth::host_login_present`].
+fn claude_probe() -> ProviderAuthProbe {
+    if crate::sandbox::container::auth::host_login_present() {
+        entry_ok("claude")
+    } else {
+        entry(
+            "claude",
+            AuthStatus::SignedOut,
+            "no Keychain login, credentials file, or Anthropic key in your shell",
+        )
+    }
+}
+
+/// codex writes `$CODEX_HOME/auth.json` (default `~/.codex/auth.json`) on login;
+/// an `OPENAI_API_KEY` in the login shell authenticates it just as well.
+fn codex_probe(home: &Path) -> ProviderAuthProbe {
+    let auth = read_file(&crate::sandbox::policy::codex_home_dir(home).join("auth.json"));
+    let status = classify_codex_auth(auth.as_deref(), env_key_present("OPENAI_API_KEY"));
+    detailed(
+        "codex",
+        status,
+        "no credential in $CODEX_HOME/auth.json and no OPENAI_API_KEY",
+    )
+}
+
+/// opencode's credentials live in `auth.json` under its XDG data dir — the path
+/// its own `opencode auth list` prints as "Credentials". Note the `opencode.db`
+/// sitting beside it is the session store, *not* an account store, so its
+/// presence is deliberately ignored here (a machine that has merely run
+/// opencode has one).
+fn opencode_probe(home: &Path) -> ProviderAuthProbe {
+    let auth = read_file(&crate::sandbox::policy::opencode_data_dir(home).join("auth.json"));
+    detailed(
+        "opencode",
+        classify_provider_map_auth(auth.as_deref()),
+        "no credentials in the opencode data dir's auth.json",
+    )
+}
+
+/// pi writes one provider-keyed credential map at `~/.pi/agent/auth.json` — the
+/// same file the container launch path treats as its login.
+fn pi_probe(home: &Path) -> ProviderAuthProbe {
+    let auth = read_file(&home.join(".pi/agent/auth.json"));
+    detailed(
+        "pi",
+        classify_provider_map_auth(auth.as_deref()),
+        "no ~/.pi/agent/auth.json",
+    )
+}
+
+/// `cursor-agent login` stores its tokens in the OS keychain, not on disk
+/// (`~/.cursor` carries only identity metadata) — so on macOS we check for the
+/// Keychain item's *presence*, and elsewhere we can't tell. `CURSOR_API_KEY`
+/// is the keyless alternative, same as the container path uses.
+fn cursor_probe() -> ProviderAuthProbe {
+    if env_key_present("CURSOR_API_KEY") {
+        return entry_ok("cursor");
+    }
+    cursor_keychain_probe()
+}
+
+#[cfg(target_os = "macos")]
+fn cursor_keychain_probe() -> ProviderAuthProbe {
+    if cursor_keychain_login() {
+        entry_ok("cursor")
+    } else {
+        entry(
+            "cursor",
+            AuthStatus::SignedOut,
+            "no cursor-agent login in the macOS Keychain and no CURSOR_API_KEY",
+        )
+    }
+}
+
+/// Off macOS there is no cheap check: the login is in whatever keychain the
+/// platform offers, and nothing lands on disk. `cursor-agent status` would
+/// answer it, but it makes a network call (~4s here) — too slow and too
+/// offline-fragile for a probe that runs on every providers rescan.
+#[cfg(not(target_os = "macos"))]
+fn cursor_keychain_probe() -> ProviderAuthProbe {
+    entry(
+        "cursor",
+        AuthStatus::Unknown,
+        "cursor-agent keeps its login in the OS keychain; only macOS is probed",
+    )
+}
+
+/// The antigravity CLI drops an OAuth token beside its state in
+/// `~/.gemini/antigravity-cli`. Presence is conclusive; absence is *not* — a
+/// Google-account login may live elsewhere under `~/.gemini`, so we say
+/// `Unknown` rather than claim the user is signed out.
+fn antigravity_probe(home: &Path) -> ProviderAuthProbe {
+    if non_empty_file(&home.join(".gemini/antigravity-cli/antigravity-oauth-token")) {
+        entry_ok("antigravity")
+    } else {
+        entry(
+            "antigravity",
+            AuthStatus::Unknown,
+            "no antigravity-cli OAuth token file; other login paths unverified",
+        )
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn cursor_keychain_login() -> bool {
+    // No `-w`: we ask whether the item exists, never for its password, so this
+    // neither reads a secret nor triggers a Keychain access prompt.
+    std::process::Command::new("security")
+        .args([
+            "find-generic-password",
+            "-s",
+            CURSOR_KEYCHAIN_SERVICE,
+            "-a",
+            CURSOR_KEYCHAIN_ACCOUNT,
+        ])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|s| s.success())
+}
+
+// ── Classifiers (pure, so the shapes are unit-testable) ───────────────────────
+
+/// codex's `auth.json`: an OAuth login populates a `tokens` object, an
+/// API-key login populates `OPENAI_API_KEY`. A key in the environment
+/// authenticates the CLI without any file at all, hence the separate flag.
+/// Malformed or missing JSON is a signed-out state, not an error — a half-written
+/// file is indistinguishable from no login as far as the CLI is concerned.
+fn classify_codex_auth(json: Option<&[u8]>, env_key_present: bool) -> AuthStatus {
+    if env_key_present {
+        return AuthStatus::SignedIn;
+    }
+    let Some(value) = parse_json(json) else {
+        return AuthStatus::SignedOut;
+    };
+    let has_tokens = value
+        .get("tokens")
+        .and_then(Value::as_object)
+        .is_some_and(|t| !t.is_empty());
+    // Emptiness only — the value is never copied out or logged.
+    let has_key = value
+        .get("OPENAI_API_KEY")
+        .and_then(Value::as_str)
+        .is_some_and(|k| !k.trim().is_empty());
+    signed_in_if(has_tokens || has_key)
+}
+
+/// The `auth.json` shape both multi-provider CLIs use (opencode, pi): a map of
+/// provider id → credential object. One entry is a login; an empty object is
+/// what a logged-out CLI leaves behind. Only the map's *arity* is inspected —
+/// the entries are never looked inside.
+fn classify_provider_map_auth(json: Option<&[u8]>) -> AuthStatus {
+    match parse_json(json) {
+        Some(Value::Object(map)) => signed_in_if(!map.is_empty()),
+        _ => AuthStatus::SignedOut,
+    }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn parse_json(bytes: Option<&[u8]>) -> Option<Value> {
+    serde_json::from_slice(bytes?).ok()
+}
+
+fn signed_in_if(yes: bool) -> AuthStatus {
+    if yes {
+        AuthStatus::SignedIn
+    } else {
+        AuthStatus::SignedOut
+    }
+}
+
+fn read_file(path: &Path) -> Option<Vec<u8>> {
+    std::fs::read(path).ok()
+}
+
+fn non_empty_file(path: &Path) -> bool {
+    std::fs::metadata(path).is_ok_and(|m| m.is_file() && m.len() > 0)
+}
+
+/// Whether `var` is set non-blank in the app's process env or the user's login
+/// shell — the same two sources the container auth chain consults, so a key that
+/// only exists in `~/.zshrc` still counts. The value is tested for emptiness and
+/// dropped; it is never returned or logged.
+fn env_key_present(var: &str) -> bool {
+    let non_blank = |v: &String| !v.trim().is_empty();
+    std::env::var(var).ok().is_some_and(|v| non_blank(&v))
+        || crate::bin_resolve::login_shell_env()
+            .and_then(|env| env.get(var))
+            .is_some_and(non_blank)
+}
+
+fn entry_ok(id: &str) -> ProviderAuthProbe {
+    ProviderAuthProbe {
+        id: id.to_string(),
+        status: AuthStatus::SignedIn,
+        detail: None,
+    }
+}
+
+fn entry(id: &str, status: AuthStatus, detail: &'static str) -> ProviderAuthProbe {
+    ProviderAuthProbe {
+        id: id.to_string(),
+        status,
+        detail: Some(detail.to_string()),
+    }
+}
+
+/// `entry`/`entry_ok` in one: a signed-in probe carries no detail, anything else
+/// carries `detail`.
+fn detailed(id: &str, status: AuthStatus, detail: &'static str) -> ProviderAuthProbe {
+    match status {
+        AuthStatus::SignedIn => entry_ok(id),
+        _ => entry(id, status, detail),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Synthetic fixtures only — no real credential file is ever read in tests.
+    const CODEX_OAUTH: &[u8] = br#"{"OPENAI_API_KEY":null,"tokens":{"access_token":"x","refresh_token":"y"},"auth_mode":"chatgpt"}"#;
+    const CODEX_API_KEY: &[u8] = br#"{"OPENAI_API_KEY":"sk-fake","tokens":null}"#;
+    const CODEX_LOGGED_OUT: &[u8] = br#"{"OPENAI_API_KEY":"","tokens":{}}"#;
+
+    #[test]
+    fn codex_oauth_tokens_count_as_signed_in() {
+        assert_eq!(
+            classify_codex_auth(Some(CODEX_OAUTH), false),
+            AuthStatus::SignedIn
+        );
+    }
+
+    #[test]
+    fn codex_api_key_in_file_counts_as_signed_in() {
+        assert_eq!(
+            classify_codex_auth(Some(CODEX_API_KEY), false),
+            AuthStatus::SignedIn
+        );
+    }
+
+    #[test]
+    fn codex_blank_key_and_empty_tokens_are_signed_out() {
+        assert_eq!(
+            classify_codex_auth(Some(CODEX_LOGGED_OUT), false),
+            AuthStatus::SignedOut
+        );
+        assert_eq!(
+            classify_codex_auth(Some(b"{}"), false),
+            AuthStatus::SignedOut
+        );
+    }
+
+    #[test]
+    fn codex_malformed_or_missing_file_is_signed_out() {
+        assert_eq!(
+            classify_codex_auth(Some(b"{not json"), false),
+            AuthStatus::SignedOut
+        );
+        assert_eq!(classify_codex_auth(None, false), AuthStatus::SignedOut);
+        // A JSON scalar is well-formed but not the expected object.
+        assert_eq!(
+            classify_codex_auth(Some(b"7"), false),
+            AuthStatus::SignedOut
+        );
+    }
+
+    #[test]
+    fn codex_env_key_alone_is_signed_in() {
+        assert_eq!(classify_codex_auth(None, true), AuthStatus::SignedIn);
+        // The env key wins even over a file that says logged out.
+        assert_eq!(
+            classify_codex_auth(Some(CODEX_LOGGED_OUT), true),
+            AuthStatus::SignedIn
+        );
+    }
+
+    #[test]
+    fn provider_map_needs_at_least_one_entry() {
+        assert_eq!(
+            classify_provider_map_auth(Some(br#"{"anthropic":{"type":"oauth"}}"#)),
+            AuthStatus::SignedIn
+        );
+        assert_eq!(
+            classify_provider_map_auth(Some(b"{}")),
+            AuthStatus::SignedOut
+        );
+    }
+
+    #[test]
+    fn provider_map_rejects_malformed_missing_and_non_object() {
+        assert_eq!(
+            classify_provider_map_auth(Some(b"{oops")),
+            AuthStatus::SignedOut
+        );
+        assert_eq!(classify_provider_map_auth(None), AuthStatus::SignedOut);
+        assert_eq!(
+            classify_provider_map_auth(Some(b"[\"anthropic\"]")),
+            AuthStatus::SignedOut
+        );
+    }
+
+    /// Real shapes from both CLIs that share [`classify_provider_map_auth`]:
+    /// opencode's `~/.local/share/opencode/auth.json` and pi's
+    /// `~/.pi/agent/auth.json`. The multi-entry case is what a user with two
+    /// providers configured has.
+    #[test]
+    fn multi_provider_auth_files_classify_from_their_entry_count() {
+        assert_eq!(
+            classify_provider_map_auth(Some(
+                br#"{"anthropic":{"type":"oauth","refresh":"x"},"openai":{"type":"api","key":"y"}}"#
+            )),
+            AuthStatus::SignedIn
+        );
+        // What `opencode auth logout` of the last provider leaves behind.
+        assert_eq!(
+            classify_provider_map_auth(Some(b"{}")),
+            AuthStatus::SignedOut
+        );
+    }
+
+    #[test]
+    fn status_serializes_snake_case_for_the_frontend_union() {
+        let json = serde_json::to_string(&entry(
+            "codex",
+            AuthStatus::SignedOut,
+            "no credential in $CODEX_HOME/auth.json and no OPENAI_API_KEY",
+        ))
+        .unwrap();
+        assert!(json.contains(r#""status":"signed_out""#), "{json}");
+        assert_eq!(
+            serde_json::to_string(&AuthStatus::SignedIn).unwrap(),
+            r#""signed_in""#
+        );
+        assert_eq!(
+            serde_json::to_string(&AuthStatus::Unknown).unwrap(),
+            r#""unknown""#
+        );
+    }
+
+    #[test]
+    fn signed_in_probes_carry_no_detail() {
+        let probe = detailed("pi", AuthStatus::SignedIn, "no ~/.pi/agent/auth.json");
+        assert_eq!(probe.status, AuthStatus::SignedIn);
+        assert!(probe.detail.is_none());
+    }
+
+    #[test]
+    fn non_empty_file_rejects_dirs_empty_files_and_absent_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!non_empty_file(dir.path()));
+        assert!(!non_empty_file(&dir.path().join("nope")));
+        let empty = dir.path().join("empty");
+        std::fs::write(&empty, b"").unwrap();
+        assert!(!non_empty_file(&empty));
+        let token = dir.path().join("antigravity-oauth-token");
+        std::fs::write(&token, b"not-a-real-token").unwrap();
+        assert!(non_empty_file(&token));
+    }
+
+    #[test]
+    fn every_known_provider_gets_exactly_one_entry() {
+        let mut ids: Vec<&str> = vec!["claude"];
+        ids.extend(PER_TURN_AGENTS.iter().map(|d| d.id));
+        // Nothing in the id set falls through to the "no layout wired" arm by
+        // accident — a new provider descriptor should be a deliberate decision.
+        for id in ["claude", "codex", "cursor", "opencode", "pi", "antigravity"] {
+            assert!(ids.contains(&id), "{id} missing from the probe id set");
+        }
+        assert_eq!(
+            ids.len(),
+            6,
+            "provider set changed: wire up its auth layout"
+        );
+    }
+}

--- a/src-tauri/src/agent/auth_probe.rs
+++ b/src-tauri/src/agent/auth_probe.rs
@@ -6,10 +6,13 @@
 //! time.
 //!
 //! Every check is derived from **structure only**: a file's existence and
-//! non-emptiness, a JSON blob's shape, or a Keychain item's presence (looked up
-//! *without* `-w`, so the password is never read and macOS never prompts). No
-//! credential value is returned, logged, or stored in a [`ProviderAuthProbe`] —
-//! `detail` is always one of the `&'static str` reasons in this file.
+//! non-emptiness, a JSON blob's shape, or a Keychain item's presence. Keychain
+//! lookups all go through [`crate::keychain::item_present`], which never passes
+//! `-w` — the password is never read and macOS never prompts, which matters
+//! because the providers pane re-runs these probes on a timer while it is open.
+//! No credential value is returned, logged, or stored in a
+//! [`ProviderAuthProbe`] — `detail` is always one of the `&'static str` reasons
+//! in this file.
 //!
 //! The layouts are the ones the container launch path already depends on (see
 //! [`crate::sandbox::container::launch_auth`]), so the two can't drift. Where a
@@ -96,7 +99,8 @@ fn probe_one(id: &'static str) -> ProviderAuthProbe {
 
 /// claude reuses the host half of the container auth chain (Keychain login,
 /// `~/.claude/.credentials.json`, or an Anthropic key in the login shell). The
-/// container-only pasted setup token is excluded there — see
+/// container-only pasted setup token is excluded there, and the Keychain step is
+/// a presence check that never reads the credential — see
 /// [`crate::sandbox::container::auth::host_login_present`].
 fn claude_probe() -> ProviderAuthProbe {
     if crate::sandbox::container::auth::host_login_present() {
@@ -160,7 +164,7 @@ fn cursor_probe() -> ProviderAuthProbe {
 
 #[cfg(target_os = "macos")]
 fn cursor_keychain_probe() -> ProviderAuthProbe {
-    if cursor_keychain_login() {
+    if crate::keychain::item_present(CURSOR_KEYCHAIN_SERVICE, Some(CURSOR_KEYCHAIN_ACCOUNT)) {
         entry_ok("cursor")
     } else {
         entry(
@@ -198,24 +202,6 @@ fn antigravity_probe(home: &Path) -> ProviderAuthProbe {
             "no antigravity-cli OAuth token file; other login paths unverified",
         )
     }
-}
-
-#[cfg(target_os = "macos")]
-fn cursor_keychain_login() -> bool {
-    // No `-w`: we ask whether the item exists, never for its password, so this
-    // neither reads a secret nor triggers a Keychain access prompt.
-    std::process::Command::new("security")
-        .args([
-            "find-generic-password",
-            "-s",
-            CURSOR_KEYCHAIN_SERVICE,
-            "-a",
-            CURSOR_KEYCHAIN_ACCOUNT,
-        ])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .is_ok_and(|s| s.success())
 }
 
 // ── Classifiers (pure, so the shapes are unit-testable) ───────────────────────

--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -15,6 +15,7 @@
 //!   Codex sandboxes itself rather than running under sandbox-exec.
 
 mod args;
+mod auth_probe;
 mod capabilities;
 mod probe;
 mod providers;
@@ -28,6 +29,7 @@ use crate::exec_session::ExecSession;
 use crate::managed_session::ManagedSession;
 use crate::pty_session::PtySession;
 
+pub use auth_probe::{probe_all_provider_auth, ProviderAuthProbe};
 pub use capabilities::{
     capabilities, injection_mode, mcp_delivery, per_turn_descriptor, transcript_reader,
     PerTurnDescriptor,

--- a/src-tauri/src/commands/tooling.rs
+++ b/src-tauri/src/commands/tooling.rs
@@ -6,7 +6,7 @@ use serde::Serialize;
 use std::sync::Arc;
 use tauri::{AppHandle, State};
 
-use crate::agent::{BinValidation, ProviderProbe, ToolStatus};
+use crate::agent::{BinValidation, ProviderAuthProbe, ProviderProbe, ToolStatus};
 use crate::error::{Error, Result};
 use crate::supervisor::Supervisor;
 
@@ -154,4 +154,14 @@ pub async fn validate_agent_bin(path: String) -> BinValidation {
 #[tauri::command]
 pub async fn discover_supported_models() -> Vec<crate::model_catalog::AgentModels> {
     crate::model_catalog::discover_supported_models().await
+}
+
+/// Probe whether each provider's CLI is *signed in* — the question
+/// [`probe_provider_versions`] doesn't answer. Structural checks only (file
+/// presence, JSON shape, Keychain item presence); no credential value is read
+/// out or returned. Providers whose credential store can't be classified
+/// cheaply report `unknown`, which the UI renders as nothing.
+#[tauri::command]
+pub async fn probe_provider_auth() -> Vec<ProviderAuthProbe> {
+    crate::agent::probe_all_provider_auth().await
 }

--- a/src-tauri/src/keychain.rs
+++ b/src-tauri/src/keychain.rs
@@ -1,0 +1,61 @@
+//! Presence-only macOS Keychain lookups.
+//!
+//! [`item_present`] answers "does an item exist for this service?" by running
+//! `security find-generic-password` **without** `-w`. Omitting `-w` is the whole
+//! point: `security` then reports metadata and an exit status only, so the
+//! password is never read, never returned, and macOS never raises the "… wants
+//! to use your confidential information stored in your keychain" prompt. That
+//! matters because the providers settings pane polls the auth probe every few
+//! seconds while it is open.
+//!
+//! A caller that genuinely needs the secret must ask for it explicitly and
+//! elsewhere — see [`crate::sandbox::container::auth::resolve`], which reads the
+//! credential once per container launch. Nothing on a polling path may do that.
+//!
+//! Off macOS there is no equally cheap check, so the answer is always `false`;
+//! callers treat that as "no Keychain login to find here", not "signed out".
+
+/// Whether a generic-password item exists for `service`, optionally narrowed to
+/// `account`. Exit status 0 means the item exists; a missing item, a locked
+/// keychain, or an unavailable `security` binary all read as `false`.
+///
+/// Never passes `-w`, so no secret is read and no Keychain prompt appears.
+#[cfg(target_os = "macos")]
+pub(crate) fn item_present(service: &str, account: Option<&str>) -> bool {
+    let mut command = std::process::Command::new("security");
+    command.args(["find-generic-password", "-s", service]);
+    if let Some(account) = account {
+        command.args(["-a", account]);
+    }
+    command
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(crate) fn item_present(_service: &str, _account: Option<&str>) -> bool {
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A real Keychain *hit* isn't unit-testable — it would need an item
+    /// planted in the developer's login keychain — so only the miss is covered.
+    /// A service nobody has registered exits non-zero and, because no `-w` is
+    /// passed, does so without touching or prompting for any secret.
+    #[test]
+    fn absent_item_reads_as_missing() {
+        assert!(!item_present(
+            "fletch-keychain-probe-service-that-does-not-exist",
+            None
+        ));
+        assert!(!item_present(
+            "fletch-keychain-probe-service-that-does-not-exist",
+            Some("nobody")
+        ));
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2063,6 +2063,7 @@ pub fn run() {
             commands::install_agent,
             commands::validate_agent_bin,
             commands::discover_supported_models,
+            commands::probe_provider_auth,
             commands::reveal_logs,
             commands::start_docker_desktop,
             commands::detect_editors,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ mod git_state;
 mod github;
 mod instructions;
 mod issues;
+mod keychain;
 mod linear;
 mod managed_session;
 mod message_queue;

--- a/src-tauri/src/sandbox/container/auth.rs
+++ b/src-tauri/src/sandbox/container/auth.rs
@@ -142,6 +142,27 @@ fn credentials_config_dir(config_dir_env: Option<&OsStr>, home: Option<&Path>) -
 /// Walk the auth chain (first hit wins). May block on the first call: loading
 /// the login-shell env runs a shell if nothing populated `bin_resolve`'s cache.
 pub fn resolve() -> ContainerAuth {
+    let (keychain, env, credentials_file) = chain_inputs();
+    resolve_from(keychain, stored_token(), env.as_ref(), credentials_file)
+}
+
+/// Whether the *host* has a usable claude login — the same chain as [`resolve`]
+/// minus [`AuthSource::StoredToken`], which is a token pasted into Fletch's
+/// settings for containers to use and says nothing about whether the `claude`
+/// CLI on this machine is signed in. Drives the providers settings' sign-in
+/// status (see `crate::agent::auth_probe`).
+pub fn host_login_present() -> bool {
+    let (keychain, env, credentials_file) = chain_inputs();
+    !matches!(
+        resolve_from(keychain, None, env.as_ref(), credentials_file),
+        ContainerAuth::Unavailable
+    )
+}
+
+/// Read the chain's three environment inputs. Shared by [`resolve`] and
+/// [`host_login_present`] so the two can't drift on *what* they look at — only
+/// on whether the stored token counts.
+fn chain_inputs() -> (Option<String>, Option<HashMap<String, String>>, bool) {
     let keychain = keychain_token();
     // The dir claude will actually read — and the one the engine mounts (see
     // `nondefault_claude_config_dir`); hardcoding `~/.claude` would refuse a
@@ -158,7 +179,7 @@ pub fn resolve() -> ContainerAuth {
         .filter_map(|var| std::env::var(var).ok().map(|v| (var.to_string(), v)))
         .collect();
     let env = merge_auth_env(&process_env, bin_resolve::login_shell_env());
-    resolve_from(keychain, stored_token(), env.as_ref(), credentials_file)
+    (keychain, env, credentials_file)
 }
 
 /// The live host login token from the macOS Keychain, read fresh on every

--- a/src-tauri/src/sandbox/container/auth.rs
+++ b/src-tauri/src/sandbox/container/auth.rs
@@ -23,7 +23,6 @@ const OAUTH_TOKEN_VAR: &str = "CLAUDE_CODE_OAUTH_TOKEN";
 
 /// macOS Keychain service Claude Code stores its login under; the password
 /// payload is the same JSON as `~/.claude/.credentials.json`.
-#[cfg(target_os = "macos")]
 const KEYCHAIN_SERVICE: &str = "Claude Code-credentials";
 
 /// Shell vars that constitute a chain hit on their own — the gateway bearer
@@ -141,29 +140,53 @@ fn credentials_config_dir(config_dir_env: Option<&OsStr>, home: Option<&Path>) -
 
 /// Walk the auth chain (first hit wins). May block on the first call: loading
 /// the login-shell env runs a shell if nothing populated `bin_resolve`'s cache.
+///
+/// This is the container *launch* path, so it does read the Keychain password:
+/// the token has to be handed to the CLI inside the container. Status/probe
+/// callers must use [`host_login_present`] instead.
 pub fn resolve() -> ContainerAuth {
-    let (keychain, env, credentials_file) = chain_inputs();
-    resolve_from(keychain, stored_token(), env.as_ref(), credentials_file)
+    let (env, credentials_file) = chain_inputs();
+    resolve_from(
+        keychain_token(),
+        stored_token(),
+        env.as_ref(),
+        credentials_file,
+    )
 }
 
-/// Whether the *host* has a usable claude login — the same chain as [`resolve`]
-/// minus [`AuthSource::StoredToken`], which is a token pasted into Fletch's
-/// settings for containers to use and says nothing about whether the `claude`
-/// CLI on this machine is signed in. Drives the providers settings' sign-in
-/// status (see `crate::agent::auth_probe`).
+/// Whether the *host* has a usable claude login. Drives the providers settings'
+/// sign-in status (see `crate::agent::auth_probe`), which polls while the pane
+/// is open, so this differs from [`resolve`] in two ways:
+///
+/// - The Keychain step is **presence-only**: [`crate::keychain::item_present`]
+///   runs `security find-generic-password` without `-w`, so the credential is
+///   never read and macOS never prompts. An item under [`KEYCHAIN_SERVICE`] is
+///   taken as a login; deciding otherwise would mean reading the payload, which
+///   is exactly what this path must not do.
+/// - [`AuthSource::StoredToken`] is excluded: that token is pasted into Fletch's
+///   settings for containers to use and says nothing about whether the `claude`
+///   CLI on this machine is signed in.
+///
+/// The remaining steps — a usable `.credentials.json` and the shell/process auth
+/// vars — are evaluated by the same [`resolve_from`] chain [`resolve`] uses, so
+/// the two can't drift on what counts as a login.
 pub fn host_login_present() -> bool {
-    let (keychain, env, credentials_file) = chain_inputs();
+    if crate::keychain::item_present(KEYCHAIN_SERVICE, None) {
+        return true;
+    }
+    let (env, credentials_file) = chain_inputs();
     !matches!(
-        resolve_from(keychain, None, env.as_ref(), credentials_file),
+        resolve_from(None, None, env.as_ref(), credentials_file),
         ContainerAuth::Unavailable
     )
 }
 
-/// Read the chain's three environment inputs. Shared by [`resolve`] and
-/// [`host_login_present`] so the two can't drift on *what* they look at — only
-/// on whether the stored token counts.
-fn chain_inputs() -> (Option<String>, Option<HashMap<String, String>>, bool) {
-    let keychain = keychain_token();
+/// Read the chain's non-Keychain inputs. Shared by [`resolve`] and
+/// [`host_login_present`] so the two can't drift on *what* they look at. The
+/// Keychain is deliberately not one of them: it is the one input the two read
+/// differently (secret vs. presence), and folding it in here is what previously
+/// made the probe path call [`keychain_token`].
+fn chain_inputs() -> (Option<HashMap<String, String>>, bool) {
     // The dir claude will actually read — and the one the engine mounts (see
     // `nondefault_claude_config_dir`); hardcoding `~/.claude` would refuse a
     // container whose only credential lives in a custom config dir.
@@ -179,12 +202,17 @@ fn chain_inputs() -> (Option<String>, Option<HashMap<String, String>>, bool) {
         .filter_map(|var| std::env::var(var).ok().map(|v| (var.to_string(), v)))
         .collect();
     let env = merge_auth_env(&process_env, bin_resolve::login_shell_env());
-    (keychain, env, credentials_file)
+    (env, credentials_file)
 }
 
 /// The live host login token from the macOS Keychain, read fresh on every
 /// [`resolve`] so a `claude` re-login lands on the next spawn. `None` when
 /// there's no readable/usable login (Keychain locked or empty, non-macOS host).
+///
+/// `-w` is what makes this *read the password*, which can raise a Keychain
+/// access prompt — acceptable once per container launch, not on a polling
+/// probe. Call this only from [`resolve`]; presence questions go to
+/// [`crate::keychain::item_present`].
 #[cfg(target_os = "macos")]
 fn keychain_token() -> Option<String> {
     let out = std::process::Command::new("security")
@@ -640,6 +668,43 @@ mod tests {
         ));
         assert!(matches!(
             resolve_from(None, None, Some(&shell_env(&[("PATH", "/usr/bin")])), false),
+            ContainerAuth::Unavailable
+        ));
+    }
+
+    #[test]
+    fn host_login_chain_excludes_stored_token_but_honors_file_and_shell() {
+        // Models what `host_login_present` evaluates once its Keychain presence
+        // check misses. The Keychain half itself is a `security` subprocess and
+        // so isn't unit-testable — passing `None` for the keychain slot is
+        // exactly the "no Keychain item" case, and the probe never supplies a
+        // token there.
+        //
+        // A pasted container token is not a host login…
+        assert!(matches!(
+            resolve_from(None, None, None, false),
+            ContainerAuth::Unavailable
+        ));
+        // …even though `resolve` still accepts it for container launches.
+        assert!(!matches!(
+            resolve_from(None, Some("sk-ant-oat-stored".into()), None, false),
+            ContainerAuth::Unavailable
+        ));
+        // A usable credentials file alone is a host login.
+        assert!(!matches!(
+            resolve_from(None, None, None, true),
+            ContainerAuth::Unavailable
+        ));
+        // So is a key in the shell/process env.
+        let shell = shell_env(&[("ANTHROPIC_API_KEY", "sk-ant-api-key")]);
+        assert!(!matches!(
+            resolve_from(None, None, Some(&shell), false),
+            ContainerAuth::Unavailable
+        ));
+        // A proxy endpoint on its own can't authenticate anything.
+        let proxy_only = shell_env(&[("ANTHROPIC_BASE_URL", "https://proxy.example.com")]);
+        assert!(matches!(
+            resolve_from(None, None, Some(&proxy_only), false),
             ContainerAuth::Unavailable
         ));
     }

--- a/src/api/domains/providers.ts
+++ b/src/api/domains/providers.ts
@@ -1,6 +1,11 @@
 import type { AgentModels } from "@/data/modelCatalog/types";
 import { invoke } from "../invoke";
-import type { BinValidation, ProviderProbe, ToolStatus } from "../types/providers";
+import type {
+  BinValidation,
+  ProviderAuthProbe,
+  ProviderProbe,
+  ToolStatus,
+} from "../types/providers";
 
 export const providersApi = {
   probeProviderVersions: () => invoke<ProviderProbe[]>("probe_provider_versions"),
@@ -23,4 +28,9 @@ export const providersApi = {
   /** Per-agent supported-model discovery (raw ids + any cheap CLI metadata).
    *  The frontend enriches these against models.dev. */
   discoverSupportedModels: () => invoke<AgentModels[]>("discover_supported_models"),
+  /** Probe whether each provider's CLI is signed in — the question
+   *  `probeProviderVersions` doesn't answer. Structural checks only; no
+   *  credential value crosses IPC. Providers with no cheap check report
+   *  `"unknown"`. */
+  probeProviderAuth: () => invoke<ProviderAuthProbe[]>("probe_provider_auth"),
 };

--- a/src/api/types/providers.ts
+++ b/src/api/types/providers.ts
@@ -53,3 +53,17 @@ export interface AgentInstallEvent {
   line?: string;
   error?: string;
 }
+
+/** Whether a provider's CLI has a usable login on this host. `"unknown"` means
+ *  the backend has no cheap check for that CLI's credential store — the UI shows
+ *  nothing rather than a claim it can't back up. */
+export type ProviderAuthStatus = "signed_in" | "signed_out" | "unknown";
+
+/** Result of the per-provider sign-in probe (`api.probeProviderAuth`). `detail`
+ *  is a short fixed reason for a non-`signed_in` status (null when signed in) —
+ *  never a credential value or a path containing the username. */
+export interface ProviderAuthProbe {
+  id: string;
+  status: ProviderAuthStatus;
+  detail: string | null;
+}

--- a/src/components/SettingsScreen/ProviderAuthBadge.tsx
+++ b/src/components/SettingsScreen/ProviderAuthBadge.tsx
@@ -1,0 +1,35 @@
+import type { ProviderAuthStatus } from "@/api/types/providers";
+import { Badge } from "@/components/ui";
+
+/** Tone and label per sign-in state. `signed_out` is a warning, not an error:
+ *  the CLI is installed and one `Sign in` away from working, so it shouldn't
+ *  read like something broke. */
+const LABELS: Record<"signed_in" | "signed_out", { text: string; variant: "neutral" | "warn" }> = {
+  signed_in: { text: "Signed in", variant: "neutral" },
+  signed_out: { text: "Not signed in", variant: "warn" },
+};
+
+/** Whether a provider's CLI is logged in, as a compact pill for its row in
+ *  Settings › Providers. Renders **nothing** for `unknown` and for a provider
+ *  we haven't probed yet: the backend only reports `unknown` when it has no
+ *  cheap check for that CLI's credential store, and a wrong "Not signed in"
+ *  would send the user chasing a login they already have.
+ *
+ *  `detail` is the backend's short reason for a non-signed-in status; it rides
+ *  on the native `title` tooltip (Badge's `hint`) so the OS positions it. It is
+ *  always a fixed backend string — never a credential value. */
+export function ProviderAuthBadge({
+  status,
+  detail,
+}: {
+  status?: ProviderAuthStatus;
+  detail?: string | null;
+}) {
+  const label = status && status !== "unknown" ? LABELS[status] : null;
+  if (!label) return null;
+  return (
+    <Badge variant={label.variant} hint={detail ?? undefined}>
+      {label.text}
+    </Badge>
+  );
+}

--- a/src/store/providerAuth.test.ts
+++ b/src/store/providerAuth.test.ts
@@ -1,0 +1,87 @@
+// The sign-in probe's store wiring. What matters to the user is that the
+// Providers pane never *claims* a provider is signed out when we don't know: a
+// failed IPC call or an absent entry has to read as "no claim", not as "log in
+// again". The other invariant is that the existing rescan refreshes sign-in
+// state too, so a fresh version can't sit beside a stale auth status.
+
+import { describe, expect, it, vi } from "vitest";
+import { create } from "zustand";
+
+const { probeProviderAuth, probeProviderVersions } = vi.hoisted(() => ({
+  probeProviderAuth: vi.fn(),
+  probeProviderVersions: vi.fn(),
+}));
+vi.mock("@/api", () => ({ api: { probeProviderAuth, probeProviderVersions } }));
+// The slice seeds the model catalog from localStorage at module load; none of
+// that is under test here.
+vi.mock("@/data/modelCatalog", () => ({
+  loadCachedCatalog: () => ({ byId: {}, byAgent: {} }),
+  refreshCatalog: vi.fn(),
+}));
+vi.mock("@/storage/settings", () => ({ setSetting: vi.fn() }));
+
+import type { ProviderAuthProbe } from "@/api/types/providers";
+import { createProvidersSlice } from "./providers";
+import type { AppState } from "./types";
+
+const makeStore = () =>
+  create<AppState>()((...a) => ({ ...createProvidersSlice(...a) }) as AppState);
+
+const probe = (id: string, status: ProviderAuthProbe["status"]): ProviderAuthProbe => ({
+  id,
+  status,
+  detail: status === "signed_in" ? null : "synthetic reason",
+});
+
+describe("provider sign-in status in the store", () => {
+  it("starts empty, so no provider is claimed signed in or out before a probe", () => {
+    expect(makeStore().getState().providerAuth).toEqual({});
+  });
+
+  it("keys each provider's status by id and keeps `unknown` as its own state", async () => {
+    probeProviderAuth.mockResolvedValueOnce([
+      probe("claude", "signed_in"),
+      probe("codex", "signed_out"),
+      probe("cursor", "unknown"),
+    ]);
+    const store = makeStore();
+    await store.getState().refreshProviderAuth();
+    // `unknown` must survive into the map rather than collapsing to signed_out —
+    // the row renders nothing for it.
+    expect(store.getState().providerAuth).toEqual({
+      claude: "signed_in",
+      codex: "signed_out",
+      cursor: "unknown",
+    });
+  });
+
+  it("keeps the last good statuses when a probe fails instead of claiming signed out", async () => {
+    probeProviderAuth.mockResolvedValueOnce([probe("claude", "signed_in")]);
+    const store = makeStore();
+    await store.getState().refreshProviderAuth();
+
+    probeProviderAuth.mockRejectedValueOnce(new Error("ipc exploded"));
+    await expect(store.getState().refreshProviderAuth()).resolves.toBeUndefined();
+    expect(store.getState().providerAuth).toEqual({ claude: "signed_in" });
+  });
+
+  it("rides along with the existing version rescan", async () => {
+    probeProviderVersions.mockResolvedValueOnce([
+      { id: "codex", version: "v1.2.3", path: "/usr/local/bin/codex" },
+    ]);
+    probeProviderAuth.mockResolvedValueOnce([probe("codex", "signed_out")]);
+    const store = makeStore();
+    await store.getState().refreshProviderVersions();
+    expect(store.getState().providerVersions).toEqual({ codex: "v1.2.3" });
+    expect(store.getState().providerAuth).toEqual({ codex: "signed_out" });
+  });
+
+  it("still refreshes sign-in state when the version probe fails", async () => {
+    probeProviderVersions.mockRejectedValueOnce(new Error("no"));
+    probeProviderAuth.mockResolvedValueOnce([probe("claude", "signed_in")]);
+    const store = makeStore();
+    await store.getState().refreshProviderVersions();
+    expect(store.getState().providersProbed).toBe(false);
+    expect(store.getState().providerAuth).toEqual({ claude: "signed_in" });
+  });
+});

--- a/src/store/providers.ts
+++ b/src/store/providers.ts
@@ -1,4 +1,5 @@
 import { api } from "@/api";
+import type { ProviderAuthStatus } from "@/api/types/providers";
 import {
   loadCachedCatalog,
   type ModelMeta,
@@ -31,11 +32,21 @@ export interface ProvidersSlice {
   /** Supported models grouped by agent — the `byAgent` view, for the model
    *  picker. Same provenance and refresh cadence as `modelCatalog`. */
   modelsByAgent: Record<string, ModelMeta[]>;
+  /** Whether each provider's CLI is signed in, keyed by provider id. Refreshed
+   *  alongside `providerVersions`. A provider is absent until its first probe
+   *  resolves, and `"unknown"` when the backend has no cheap check for that
+   *  CLI's credential store — both render as no claim either way. */
+  providerAuth: Record<string, ProviderAuthStatus>;
 
   setProviderEnabled: (id: string, enabled: boolean) => void;
-  /** Re-probe installed provider CLIs for versions + binary paths. Runs once
-   *  on init and again when the user re-scans from the Providers settings. */
+  /** Re-probe installed provider CLIs for versions + binary paths, then their
+   *  sign-in state. Runs once on init and again when the user re-scans from the
+   *  Providers settings. */
   refreshProviderVersions: () => Promise<void>;
+  /** Re-probe whether each provider CLI is signed in. Called at the tail of
+   *  `refreshProviderVersions`, so every existing rescan/poll refreshes both;
+   *  exposed separately for a sign-in flow that wants to re-check on its own. */
+  refreshProviderAuth: () => Promise<void>;
   /** Set (path) or clear (null) a provider's custom binary path. Persists the
    *  override, updates local state, and re-probes so the version/path refresh. */
   setProviderPathOverride: (id: string, path: string | null) => Promise<void>;
@@ -56,6 +67,7 @@ export const createProvidersSlice: SliceCreator<ProvidersSlice> = (set, get) => 
   providerPathOverrides: {},
   modelCatalog: cachedCatalog.byId,
   modelsByAgent: cachedCatalog.byAgent,
+  providerAuth: {},
 
   setProviderEnabled: (id, enabled) =>
     set((s) => {
@@ -79,6 +91,22 @@ export const createProvidersSlice: SliceCreator<ProvidersSlice> = (set, get) => 
       // it false and install-aware UI fails OPEN (treats install state as
       // unknown — agents stay selectable) instead of disabling every agent. A
       // prior success's results are kept as last-known-good.
+    }
+    // Sign-in state rides along with every version rescan, so the providers UI
+    // can't show a fresh version beside a stale "Not signed in". Runs even when
+    // the version probe failed — the two are independent IPC calls.
+    await get().refreshProviderAuth();
+  },
+  refreshProviderAuth: async () => {
+    try {
+      const probes = await api.probeProviderAuth();
+      const auth: Record<string, ProviderAuthStatus> = {};
+      for (const probe of probes) auth[probe.id] = probe.status;
+      set({ providerAuth: auth });
+    } catch {
+      // Non-fatal, same reasoning as `refreshProviderVersions`: a failed probe
+      // keeps the last-known-good map rather than claiming every provider is
+      // signed out. Absent/`unknown` entries render as no claim either way.
     }
   },
   setProviderPathOverride: async (id, path) => {


### PR DESCRIPTION
## Summary
Adds a per-provider **sign-in probe** so Settings › Providers can tell the user whether an installed agent CLI is actually signed in, not just whether its binary exists. This PR is backend + store only; the provider-row UI ("Signed in" / "Not signed in" beside a Sign in action) lands in a follow-up once the install-from-Settings pane restructure merges.

## What
- New `probe_provider_auth` Tauri command returning `Vec<ProviderAuthProbe { id, status: signed_in | signed_out | unknown, detail }>`, fanning out per provider like `probe_provider_versions` (`src-tauri/src/agent/auth_probe.rs`).
- **Structural checks only**: file presence, JSON shape, Keychain item presence (probed without `-w`). No credential value is read out, returned, or logged. `detail` is a fixed reason string.
- Per provider:
  - **claude**: the existing host auth chain (Keychain ∪ `~/.claude/.credentials.json` ∪ shell key vars) via a new `host_login_present()` in `sandbox/container/auth.rs`, which shares `chain_inputs()` with `resolve()` and excludes the container-only stored token.
  - **codex**: `$CODEX_HOME/auth.json` with a non-empty `tokens` object or `OPENAI_API_KEY`, or `OPENAI_API_KEY` in the login-shell env.
  - **opencode**: `${XDG_DATA_HOME:-~/.local/share}/opencode/auth.json` with ≥1 provider entry. The `opencode.db` beside it is the session store, not accounts, so it is deliberately ignored.
  - **pi**: `~/.pi/agent/auth.json` with ≥1 provider entry (same shape as opencode; one shared classifier).
  - **cursor**: `CURSOR_API_KEY` env, else macOS Keychain item `cursor-access-token` / `cursor-user` (service names confirmed in the `cursor-agent` bundle). Presence probe takes ~8 ms; `cursor-agent status` was rejected because it makes a ~4 s network call. Non-macOS → `unknown`.
  - **antigravity**: non-empty `~/.gemini/antigravity-cli/antigravity-oauth-token` → `signed_in`; absence → `unknown`, since a Google-account login may live elsewhere under `~/.gemini` (unverified).
- Store: `providerAuth` map and `refreshProviderAuth()`, called at the tail of `refreshProviderVersions` so every existing rescan/poll refreshes both. Non-fatal on IPC error (keeps last-known-good).
- `ProviderAuthBadge` presentational component, unused until the row wiring.

## Verification
- 12 Rust unit tests for the classifiers (valid / empty / malformed / missing / env-only); 5 vitest cases for the slice.
- `tsc --noEmit`, `biome check`, `vitest` (1143 passed), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, full `cargo test` (1640 passed) all green.
- A live run on this machine matched `cursor-agent status` ("Logged in") and `opencode auth list` ("0 credentials"); whole fan-out took 0.67 s cold.

## Follow-ups (out of scope here)
- Row wiring after the install PR merges.
- An opencode credential stored only in `opencode.db` reads as `signed_out`; `opencode auth list` (~0.6 s, local) would be the fallback if that configuration is real.
- `launch_auth.rs::prepare_opencode_launch` treats `opencode.db` as a credential, which is over-permissive; flagged, not changed.