### PR TITLE
feat(providers): sign in to an agent CLI from Settings via an embedded terminal

### DIFF
--- a/src-tauri/src/agent/mod.rs
+++ b/src-tauri/src/agent/mod.rs
@@ -30,15 +30,16 @@ use crate::managed_session::ManagedSession;
 use crate::pty_session::PtySession;
 
 pub use auth_probe::{probe_all_provider_auth, ProviderAuthProbe};
+pub(crate) use capabilities::provider_bin_label;
 pub use capabilities::{
     capabilities, injection_mode, mcp_delivery, per_turn_descriptor, transcript_reader,
     PerTurnDescriptor,
 };
-pub(crate) use probe::parse_semver;
 pub use probe::{
     cached_provider_version, check_cli, probe_all_providers, validate_bin, BinValidation,
     ProviderProbe, ToolStatus,
 };
+pub(crate) use probe::{parse_semver, resolve_agent_bin};
 pub use spawn::{PerTurnSpec, SpawnSpec};
 pub use transcript::{read_jsonl_tail, ReadDiagnostics};
 

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,6 +12,7 @@ mod git_ops;
 mod git_state;
 mod github;
 mod issues;
+mod provider_login;
 // Paired-device remote access is a desktop feature; the module it drives is
 // gated the same way.
 #[cfg(desktop)]
@@ -30,6 +31,7 @@ pub use git_ops::*;
 pub use git_state::*;
 pub use github::*;
 pub use issues::*;
+pub use provider_login::*;
 #[cfg(desktop)]
 pub use remote::*;
 pub use run::*;

--- a/src-tauri/src/commands/provider_login.rs
+++ b/src-tauri/src/commands/provider_login.rs
@@ -1,0 +1,146 @@
+//! Provider sign-in PTY: open, write stdin, resize, and close.
+//!
+//! The command each one runs is pinned in [`crate::provider_login`]; the
+//! renderer only ever names a provider.
+
+use tauri::{AppHandle, Emitter, Manager, State};
+
+use crate::error::{Error, Result};
+use crate::provider_login::{login_args, ProviderLoginSessions};
+use crate::pty_session::{serialize_bytes_b64, PtySession, PtySpawn};
+
+#[derive(Clone, serde::Serialize)]
+struct LoginOutputPayload {
+    id: String,
+    #[serde(serialize_with = "serialize_bytes_b64")]
+    bytes: Vec<u8>,
+}
+
+#[derive(Clone, serde::Serialize)]
+struct LoginExitPayload {
+    id: String,
+    success: bool,
+    message: String,
+}
+
+/// Run a provider's pinned sign-in command under a PTY so the user can complete
+/// it inside Settings. Output streams as `provider-login:output` (raw bytes,
+/// base64) and the end of the flow as `provider-login:exit`.
+///
+/// Idempotent: while a sign-in for `id` is live this does nothing, so
+/// re-opening the row re-attaches to the flow already in progress rather than
+/// starting a second one. Errors when the provider has no login command or its
+/// binary can't be resolved.
+#[tauri::command]
+pub fn open_provider_login(
+    app: AppHandle,
+    sessions: State<'_, ProviderLoginSessions>,
+    id: String,
+    cols: u16,
+    rows: u16,
+) -> Result<()> {
+    let args =
+        login_args(&id).ok_or_else(|| Error::Other(format!("`{id}` has no in-app sign-in.")))?;
+    let (bin, label) = crate::agent::provider_bin_label(&id)
+        .ok_or_else(|| Error::Other(format!("unknown provider `{id}`")))?;
+    let home = dirs::home_dir()
+        .ok_or_else(|| Error::Other("Could not determine your home directory.".into()))?;
+    // Honours a custom binary path override, so the CLI that gets signed in is
+    // the same one the app will spawn for turns.
+    let program = crate::agent::resolve_agent_bin(&id, bin, label, &home)?;
+    let args: Vec<String> = args.iter().map(|a| (*a).to_string()).collect();
+
+    let app_out = app.clone();
+    let id_out = id.clone();
+    let id_exit = id.clone();
+
+    // Held across the spawn so a login that dies immediately (unusable binary,
+    // instant refusal) can't have its `on_exit` removal race ahead of the
+    // insert below and leave a dead session parked in the map.
+    let mut live = sessions.lock();
+    if live.contains_key(&id) {
+        return Ok(());
+    }
+    let session = PtySession::spawn(
+        PtySpawn {
+            program: std::path::Path::new(&program),
+            args: &args,
+            cwd: &home,
+            // `PtySession` already layers the user's login-shell environment
+            // (plus TERM) over the inherited one — which is what these flows
+            // need for PATH, HOME and BROWSER.
+            env: &[],
+            cols,
+            rows,
+            kill_plan: crate::sandbox::KillHandle::ProcessGroup,
+        },
+        move |bytes| {
+            let _ = app_out.emit(
+                "provider-login:output",
+                LoginOutputPayload {
+                    id: id_out.clone(),
+                    bytes,
+                },
+            );
+        },
+        move |exit| {
+            tracing::info!(
+                success = exit.success,
+                message = %exit.message,
+                provider = %id_exit,
+                "provider sign-in exited"
+            );
+            if let Some(sessions) = app.try_state::<ProviderLoginSessions>() {
+                sessions.lock().remove(&id_exit);
+            }
+            let _ = app.emit(
+                "provider-login:exit",
+                LoginExitPayload {
+                    id: id_exit.clone(),
+                    success: exit.success,
+                    message: exit.message,
+                },
+            );
+        },
+    )?;
+    live.insert(id, session);
+    Ok(())
+}
+
+/// Write bytes to a live sign-in PTY's stdin.
+#[tauri::command]
+pub fn write_provider_login(
+    sessions: State<'_, ProviderLoginSessions>,
+    id: String,
+    data: String,
+) -> Result<()> {
+    sessions
+        .lock()
+        .get(&id)
+        .ok_or_else(|| Error::Other(format!("no sign-in running for `{id}`")))?
+        .write(data.as_bytes())
+}
+
+/// Resize a live sign-in PTY to match its terminal.
+#[tauri::command]
+pub fn resize_provider_login(
+    sessions: State<'_, ProviderLoginSessions>,
+    id: String,
+    cols: u16,
+    rows: u16,
+) -> Result<()> {
+    sessions
+        .lock()
+        .get(&id)
+        .ok_or_else(|| Error::Other(format!("no sign-in running for `{id}`")))?
+        .resize(cols, rows)
+}
+
+/// Kill a provider's sign-in PTY. Idempotent: does nothing when none is
+/// running. Unmounting the terminal deliberately does *not* call this — a
+/// collapsed row must not abort a login in progress.
+#[tauri::command]
+pub fn close_provider_login(sessions: State<'_, ProviderLoginSessions>, id: String) -> Result<()> {
+    sessions.lock().remove(&id); // Drop impl kills the PTY
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -29,6 +29,7 @@ mod native_input;
 mod new_project;
 mod oauth;
 mod power;
+mod provider_login;
 mod pty_session;
 mod publish_prefs;
 // Paired-device remote access (Settings → Remote control). Desktop-only: the
@@ -1753,6 +1754,9 @@ pub fn run() {
             // At most one `claude setup-token` capture runs at a time; the
             // code-submit / cancel commands reach it through this slot.
             app.manage(ClaudeSetupState::default());
+            // Live provider sign-in PTYs (Settings → Providers), one per
+            // provider. Empty until the user starts one.
+            app.manage(provider_login::ProviderLoginSessions::default());
 
             // Paired-device remote access. The event taps go in unconditionally
             // (with nothing connected, forwarding short-circuits before it
@@ -2025,6 +2029,10 @@ pub fn run() {
             commands::close_agent_shell,
             commands::write_to_shell,
             commands::resize_shell,
+            commands::open_provider_login,
+            commands::close_provider_login,
+            commands::write_provider_login,
+            commands::resize_provider_login,
             commands::run_start,
             commands::run_stop,
             commands::run_state,
@@ -2141,6 +2149,11 @@ pub fn run() {
                 // quitting mid-run orphans the processes.
                 if let Some(supervisor) = app.try_state::<Arc<Supervisor>>() {
                     supervisor.shutdown();
+                }
+                // Same reasoning for a sign-in left open in Settings: clearing
+                // the map drops each session, which kills its PTY.
+                if let Some(logins) = app.try_state::<provider_login::ProviderLoginSessions>() {
+                    logins.lock().clear();
                 }
                 // Give in-flight telemetry sends a brief, bounded chance to
                 // finish before the runtime tears down, rather than dropping

--- a/src-tauri/src/provider_login.rs
+++ b/src-tauri/src/provider_login.rs
@@ -1,0 +1,67 @@
+//! Signing an agent CLI in from inside the app: the pinned login command per
+//! provider, plus the live PTY sessions driving them.
+//!
+//! Detecting a binary is not the same as being signed in, and every CLI does
+//! auth differently (browser OAuth, device codes, an interactive provider
+//! picker). Rather than model each flow, we run the vendor's own login command
+//! under a PTY and show it in an embedded terminal — whatever it asks for, the
+//! user answers in place.
+//!
+//! The commands are pinned here rather than passed from the renderer, so the UI
+//! can only ever launch a known vendor login. Each mirrors the string shown
+//! beside the terminal in the UI (`src/data/providerDetail.ts`) — keep the two
+//! in sync.
+
+use std::collections::HashMap;
+
+use parking_lot::Mutex;
+
+use crate::pty_session::PtySession;
+
+/// argv (after the binary itself) for a provider's interactive sign-in, or
+/// `None` when its CLI has no login command — antigravity and pi authenticate
+/// out of band, so their rows offer the docs link and the hint only.
+///
+/// Verified against the installed CLIs' `--help` output; the binary each runs
+/// is whatever `resolve_agent_bin` resolves for the provider, so a custom
+/// binary path override is honoured here too.
+pub fn login_args(id: &str) -> Option<&'static [&'static str]> {
+    match id {
+        "claude" => Some(&["auth", "login"]),
+        "codex" => Some(&["login"]),
+        "cursor" => Some(&["login"]),
+        "opencode" => Some(&["auth", "login"]),
+        _ => None,
+    }
+}
+
+/// The sign-in PTYs running right now, keyed by provider id — at most one per
+/// provider, so a second click on "Sign in" attaches to the flow already in
+/// progress instead of racing a second one. Removing an entry drops the
+/// [`PtySession`], which kills the PTY.
+pub type ProviderLoginSessions = Mutex<HashMap<String, PtySession>>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pins_the_login_command_for_every_signable_provider() {
+        assert_eq!(login_args("claude"), Some(&["auth", "login"][..]));
+        assert_eq!(login_args("codex"), Some(&["login"][..]));
+        assert_eq!(login_args("cursor"), Some(&["login"][..]));
+        assert_eq!(login_args("opencode"), Some(&["auth", "login"][..]));
+    }
+
+    #[test]
+    fn has_no_login_for_providers_that_authenticate_out_of_band() {
+        assert_eq!(login_args("antigravity"), None);
+        assert_eq!(login_args("pi"), None);
+    }
+
+    #[test]
+    fn has_no_login_for_an_unknown_provider() {
+        assert_eq!(login_args(""), None);
+        assert_eq!(login_args("not-a-provider"), None);
+    }
+}

--- a/src-tauri/src/pty_session.rs
+++ b/src-tauri/src/pty_session.rs
@@ -49,6 +49,18 @@ pub struct PtyExit {
     pub message: String,
 }
 
+/// Serialize raw PTY bytes as a base64 string rather than serde's default JSON
+/// number array (`[27,91,...]`), which inflates the payload ~3.5×. Shared by
+/// every event that carries PTY output; the frontend decodes back to the
+/// identical byte stream (`src/pty/decode.ts`).
+pub(crate) fn serialize_bytes_b64<S: serde::Serializer>(
+    bytes: &[u8],
+    s: S,
+) -> std::result::Result<S::Ok, S::Error> {
+    use base64::Engine;
+    s.serialize_str(&base64::engine::general_purpose::STANDARD.encode(bytes))
+}
+
 impl PtySession {
     pub fn spawn<F, G>(spec: PtySpawn<'_>, on_output: F, on_exit: G) -> Result<Self>
     where

--- a/src-tauri/src/supervisor/events.rs
+++ b/src-tauri/src/supervisor/events.rs
@@ -7,6 +7,9 @@ use serde_json::Value;
 use tauri::{AppHandle, Emitter};
 
 use crate::github::PrState;
+// Shared with the other PTY-carrying events (see `provider_login` commands),
+// so the base64 wire format is defined once next to the sessions producing it.
+use crate::pty_session::serialize_bytes_b64;
 use crate::run_session::RunPhase;
 use crate::workspace::{AgentStatus, AgentView, TrackedRepo};
 
@@ -16,17 +19,6 @@ fn emit<T: serde::Serialize + Clone>(app: &AppHandle, event: &str, payload: T) {
     if let Err(e) = app.emit(event, payload) {
         tracing::warn!(error = %e, event, "emit failed");
     }
-}
-
-/// Serialize raw PTY bytes as a base64 string rather than serde's default
-/// JSON number array (`[27,91,...]`), which inflates the payload ~3.5×. The
-/// frontend base64-decodes back to the identical byte stream.
-fn serialize_bytes_b64<S: serde::Serializer>(
-    bytes: &[u8],
-    s: S,
-) -> std::result::Result<S::Ok, S::Error> {
-    use base64::Engine;
-    s.serialize_str(&base64::engine::general_purpose::STANDARD.encode(bytes))
 }
 
 #[derive(Clone, serde::Serialize)]

--- a/src/api/domains/providers.ts
+++ b/src/api/domains/providers.ts
@@ -33,4 +33,19 @@ export const providersApi = {
    *  credential value crosses IPC. Providers with no cheap check report
    *  `"unknown"`. */
   probeProviderAuth: () => invoke<ProviderAuthProbe[]>("probe_provider_auth"),
+  /** Run an agent CLI's pinned sign-in command under a PTY so the user can
+   *  complete it in an embedded terminal. Output arrives as
+   *  `provider-login:output`, the end of the flow as `provider-login:exit`.
+   *  Idempotent while one is live: re-opening attaches to it. */
+  openProviderLogin: (id: string, cols: number, rows: number) =>
+    invoke<void>("open_provider_login", { id, cols, rows }),
+  /** Send keystrokes to a live sign-in PTY. */
+  writeProviderLogin: (id: string, data: string) =>
+    invoke<void>("write_provider_login", { id, data }),
+  /** Match a live sign-in PTY to its terminal's size. */
+  resizeProviderLogin: (id: string, cols: number, rows: number) =>
+    invoke<void>("resize_provider_login", { id, cols, rows }),
+  /** Kill a provider's sign-in PTY. Only for an explicit Close — unmounting the
+   *  terminal must not abort a login in progress. */
+  closeProviderLogin: (id: string) => invoke<void>("close_provider_login", { id }),
 };

--- a/src/api/events.ts
+++ b/src/api/events.ts
@@ -19,7 +19,11 @@ import type {
   DictationTranscriptEvent,
 } from "./types/dictation";
 import type { PrStateChangedEvent } from "./types/pr";
-import type { AgentInstallEvent } from "./types/providers";
+import type {
+  AgentInstallEvent,
+  ProviderLoginExitEvent,
+  ProviderLoginOutputEvent,
+} from "./types/providers";
 import type {
   RoadmapBrief,
   RoadmapBriefProposal,
@@ -321,4 +325,17 @@ export function onPublishApprovalRequested(cb: (e: PublishApproval) => void): Pr
  *  image builds on a cold first spawn — feeds the build progress toast. */
 export function onDockerBuildProgress(cb: (e: DockerBuildEvent) => void): Promise<UnlistenFn> {
   return listen<DockerBuildEvent>("docker:build-progress", (event) => cb(event.payload));
+}
+
+/** Raw PTY bytes from a provider's in-app sign-in (Settings → Providers). */
+export function onProviderLoginOutput(
+  cb: (e: ProviderLoginOutputEvent) => void,
+): Promise<UnlistenFn> {
+  return listen<ProviderLoginOutputEvent>("provider-login:output", (event) => cb(event.payload));
+}
+
+/** A provider's sign-in process ended — cleanly, with an error, or because it
+ *  was closed. */
+export function onProviderLoginExit(cb: (e: ProviderLoginExitEvent) => void): Promise<UnlistenFn> {
+  return listen<ProviderLoginExitEvent>("provider-login:exit", (event) => cb(event.payload));
 }

--- a/src/api/types/providers.ts
+++ b/src/api/types/providers.ts
@@ -67,3 +67,20 @@ export interface ProviderAuthProbe {
   status: ProviderAuthStatus;
   detail: string | null;
 }
+
+/** Payload of `provider-login:output`: raw PTY bytes from a provider's in-app
+ *  sign-in, base64-encoded (decode with `decodeBase64`, as for every PTY
+ *  stream — see src/pty/decode.ts). */
+export interface ProviderLoginOutputEvent {
+  id: string;
+  bytes: string;
+}
+
+/** Payload of `provider-login:exit`: a provider's sign-in process ended.
+ *  `success` is a clean exit; `message` describes a non-zero exit or signal
+ *  (including the kill that an explicit Close causes). */
+export interface ProviderLoginExitEvent {
+  id: string;
+  success: boolean;
+  message: string;
+}

--- a/src/app.css
+++ b/src/app.css
@@ -62,3 +62,5 @@
 @import "./components/ui/DeviceCode.css";
 @import "./components/ReviewSurface/ReviewSurface.css";
 @import "./components/Feedback/Feedback.css";
+/* After terminal.css, whose `.xterm-slot` sizing the login terminal overrides. */
+@import "./components/SettingsScreen/ProviderLogin/ProviderLogin.css";

--- a/src/components/SettingsScreen/ProviderLogin/ProviderLogin.css
+++ b/src/components/SettingsScreen/ProviderLogin/ProviderLogin.css
@@ -1,0 +1,63 @@
+/* In-row sign-in terminal (Settings → Providers). A framed strip inside the
+   provider's detail: the command being run, then the live PTY, then its
+   outcome. Composes on the shared `.xterm-slot` / `.xterm-host` pair
+   (styles/shared/terminal.css) for the terminal itself. */
+.prov-login {
+  display: flex;
+  flex-direction: column;
+  margin-top: 10px;
+  border: 0.5px solid var(--bd-soft);
+  border-radius: var(--r-sm);
+  background: var(--bg-1);
+  overflow: hidden;
+}
+
+.prov-login-head,
+.prov-login-foot {
+  gap: 10px;
+  padding: 6px 8px;
+  background: var(--bg-2);
+  flex-shrink: 0;
+}
+.prov-login-head {
+  border-bottom: 1px solid var(--bd-soft);
+}
+.prov-login-foot {
+  border-top: 1px solid var(--bd-soft);
+}
+
+.prov-login-cmd {
+  font-family: var(--font-mono);
+  font-size: var(--fs-sm);
+  color: var(--fg-1);
+  white-space: nowrap;
+}
+
+/* The hint takes the slack so the Close button sits hard right. */
+.prov-login-hint {
+  flex: 1;
+  min-width: 0;
+  color: var(--fg-3);
+}
+
+.prov-login-exit {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.prov-login-exit.ok {
+  color: var(--fg-2);
+}
+.prov-login-exit.bad {
+  color: var(--danger);
+}
+
+/* A login flow is a handful of lines; a fixed height keeps the provider row
+   from jumping as output arrives. `.xterm-slot` is `flex: 1`, which would
+   otherwise collapse it inside this auto-height column. */
+.prov-login-term {
+  flex: none;
+  height: 220px;
+}

--- a/src/components/SettingsScreen/ProviderLogin/index.tsx
+++ b/src/components/SettingsScreen/ProviderLogin/index.tsx
@@ -1,0 +1,64 @@
+import { Button } from "@/components/ui/Button";
+import { loginCommand, PROVIDER_DETAIL } from "@/data/providerDetail";
+import type { ProviderId } from "@/data/providers";
+import { useProviderLogin } from "./useProviderLogin";
+
+interface Props {
+  providerId: ProviderId;
+  /** Product name, for the terminal's label ("Signing in to Codex CLI"). */
+  providerLabel: string;
+  /** Dismiss the terminal. Called after the sign-in PTY has been killed. */
+  onClose: () => void;
+}
+
+/** An embedded terminal running an agent CLI's own sign-in command, so the user
+ *  completes auth without leaving Settings. Every CLI does this differently
+ *  (browser OAuth, a device code, an interactive provider picker) — a real PTY
+ *  is the one surface that works for all of them.
+ *
+ *  Only render this for a provider that has a `loginCommand`; antigravity and
+ *  pi have none and show their `signIn` hint alone. */
+export function ProviderLoginTerminal({ providerId, providerLabel, onClose }: Props) {
+  const { containerRef, exit, runAgain, close } = useProviderLogin(providerId);
+  const command = loginCommand(providerId);
+  const hint = PROVIDER_DETAIL[providerId].signIn;
+
+  return (
+    <div className="prov-login">
+      <div className="prov-login-head flex-center">
+        <code className="prov-login-cmd">$ {command}</code>
+        {hint && <span className="prov-login-hint text-sm">{hint}</span>}
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            close();
+            onClose();
+          }}
+        >
+          Close
+        </Button>
+      </div>
+
+      <div className="prov-login-term xterm-slot">
+        <div
+          ref={containerRef}
+          className="xterm-host"
+          style={{ inset: "8px 4px 8px 10px" }}
+          aria-label={`Signing in to ${providerLabel}`}
+        />
+      </div>
+
+      {exit && (
+        <div className="prov-login-foot flex-center">
+          <span className={`prov-login-exit text-sm ${exit.success ? "ok" : "bad"}`}>
+            {exit.success ? "Finished" : exit.message}
+          </span>
+          <Button variant="outline" size="sm" onClick={runAgain}>
+            Run again
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SettingsScreen/ProviderLogin/index.tsx
+++ b/src/components/SettingsScreen/ProviderLogin/index.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { loginCommand, PROVIDER_DETAIL } from "@/data/providerDetail";
 import type { ProviderId } from "@/data/providers";
@@ -7,7 +8,8 @@ interface Props {
   providerId: ProviderId;
   /** Product name, for the terminal's label ("Signing in to Codex CLI"). */
   providerLabel: string;
-  /** Dismiss the terminal. Called after the sign-in PTY has been killed. */
+  /** Dismiss the terminal. Called once the sign-in PTY has actually been
+   *  killed (the Close button awaits that), never before. */
   onClose: () => void;
 }
 
@@ -22,21 +24,28 @@ export function ProviderLoginTerminal({ providerId, providerLabel, onClose }: Pr
   const { containerRef, exit, runAgain, close } = useProviderLogin(providerId);
   const command = loginCommand(providerId);
   const hint = PROVIDER_DETAIL[providerId].signIn;
+  // Close is awaited before the row collapses: dismissing first would let a
+  // quick re-open attach to the PTY this close is still about to kill. The
+  // controls lock meanwhile so nothing else can act on the dying session.
+  const [closing, setClosing] = useState(false);
+
+  const closeAndDismiss = async () => {
+    if (closing) return;
+    setClosing(true);
+    try {
+      await close();
+    } finally {
+      onClose();
+    }
+  };
 
   return (
     <div className="prov-login">
       <div className="prov-login-head flex-center">
         <code className="prov-login-cmd">$ {command}</code>
         {hint && <span className="prov-login-hint text-sm">{hint}</span>}
-        <Button
-          variant="ghost"
-          size="sm"
-          onClick={() => {
-            close();
-            onClose();
-          }}
-        >
-          Close
+        <Button variant="ghost" size="sm" disabled={closing} onClick={() => void closeAndDismiss()}>
+          {closing ? "Closing…" : "Close"}
         </Button>
       </div>
 
@@ -54,7 +63,7 @@ export function ProviderLoginTerminal({ providerId, providerLabel, onClose }: Pr
           <span className={`prov-login-exit text-sm ${exit.success ? "ok" : "bad"}`}>
             {exit.success ? "Finished" : exit.message}
           </span>
-          <Button variant="outline" size="sm" onClick={runAgain}>
+          <Button variant="outline" size="sm" disabled={closing} onClick={runAgain}>
             Run again
           </Button>
         </div>

--- a/src/components/SettingsScreen/ProviderLogin/loginSessions.test.ts
+++ b/src/components/SettingsScreen/ProviderLogin/loginSessions.test.ts
@@ -94,8 +94,74 @@ describe("loginSessions", () => {
       calls.push("write");
       return Promise.resolve();
     });
-    closeProviderLogin.mockResolvedValue(undefined);
+    closeProviderLogin.mockImplementation(() => {
+      calls.push("close");
+      return Promise.resolve();
+    });
     sessions = await import("./loginSessions");
+  });
+
+  it("a Close still waiting on the open it closes runs before a quick re-open", async () => {
+    // Sign in, then Close while the open is still waiting on the taps, then
+    // "Sign in" again straight away — the sequence a fast double-click makes.
+    sessions.runLogin(ID, 80, 24);
+    const close = sessions.closeLogin(ID);
+    const reopen = sessions.runLogin(ID, 80, 24);
+    await flush();
+    expect(calls).toEqual([]);
+
+    registerTaps();
+    // The first open lands and the close is issued against it…
+    await vi.waitFor(() => expect(calls).toEqual(["open", "close"]));
+    // …then its kill's exit arrives, which releases the close and only then
+    // the re-open.
+    emitExit?.({ id: ID, success: false, message: "killed (SIGHUP)" });
+    await Promise.all([close, reopen]);
+
+    // The stale close lands between the two opens, never after the second one,
+    // so the session the user is now looking at is the one that survives.
+    expect(calls).toEqual(["open", "close", "open"]);
+    expect(sessions.getLoginExit(ID)).toBeUndefined();
+  });
+
+  it("a Close waits for the kill's exit and keeps it off the next sign-in", async () => {
+    registerTaps();
+    await sessions.runLogin(ID, 80, 24);
+    const seen: (ProviderLoginExitEvent | undefined)[] = [];
+    sessions.subscribeLoginExit(ID, (e) => seen.push(e));
+
+    let closed = false;
+    const close = sessions.closeLogin(ID).then(() => {
+      closed = true;
+    });
+    await flush();
+    // The backend has been told to kill, but the exit hasn't arrived yet.
+    expect(calls).toEqual(["open", "close"]);
+    expect(closed).toBe(false);
+
+    // The kill lands: it belongs to the closed flow, so it is not an outcome.
+    emitExit?.({ id: ID, success: false, message: "killed (SIGHUP)" });
+    await close;
+    expect(closed).toBe(true);
+    expect(sessions.getLoginExit(ID)).toBeUndefined();
+    expect(seen.filter(Boolean)).toEqual([]);
+
+    // A fresh sign-in afterwards starts clean and its own exit is recorded.
+    await sessions.runLogin(ID, 80, 24);
+    emitExit?.({ id: ID, success: true, message: "" });
+    expect(sessions.getLoginExit(ID)).toEqual({ id: ID, success: true, message: "" });
+  });
+
+  it("closing settles even when the open it waited on failed", async () => {
+    openProviderLogin.mockRejectedValue(new Error("spawn failed"));
+    registerTaps();
+    sessions.runLogin(ID, 80, 24);
+    await sessions.closeLogin(ID);
+
+    expect(calls).toEqual(["close"]);
+    // The close discarded the session, so the open's failure must not
+    // resurrect it as an outcome the row would then display.
+    expect(sessions.getLoginExit(ID)).toBeUndefined();
   });
 
   it("does not open the PTY until both event taps are registered", async () => {

--- a/src/components/SettingsScreen/ProviderLogin/loginSessions.test.ts
+++ b/src/components/SettingsScreen/ProviderLogin/loginSessions.test.ts
@@ -1,0 +1,179 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const {
+  openProviderLogin,
+  writeProviderLogin,
+  resizeProviderLogin,
+  closeProviderLogin,
+  onProviderLoginOutput,
+  onProviderLoginExit,
+} = vi.hoisted(() => ({
+  openProviderLogin: vi.fn(),
+  writeProviderLogin: vi.fn(),
+  resizeProviderLogin: vi.fn(),
+  closeProviderLogin: vi.fn(),
+  onProviderLoginOutput: vi.fn(),
+  onProviderLoginExit: vi.fn(),
+}));
+vi.mock("@/api", () => ({
+  api: { openProviderLogin, writeProviderLogin, resizeProviderLogin, closeProviderLogin },
+  onProviderLoginOutput,
+  onProviderLoginExit,
+}));
+
+import type { ProviderLoginExitEvent, ProviderLoginOutputEvent } from "@/api";
+
+const ID = "claude";
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (err: unknown) => void;
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (err: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Let every already-settled promise chain run to completion. */
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+type Sessions = typeof import("./loginSessions");
+
+describe("loginSessions", () => {
+  let sessions: Sessions;
+  /** The pending `listen(...)` registrations — a real tap only exists once
+   *  these resolve, which is the whole point of the ordering under test. */
+  let outputTap: Deferred<() => void>;
+  let exitTap: Deferred<() => void>;
+  /** The handlers the module passed to `listen`, i.e. the backend's side. */
+  let emitOutput: ((e: ProviderLoginOutputEvent) => void) | undefined;
+  let emitExit: ((e: ProviderLoginExitEvent) => void) | undefined;
+  /** Backend calls in the order they were made. */
+  let calls: string[];
+
+  const registerTaps = () => {
+    outputTap.resolve(() => {});
+    exitTap.resolve(() => {});
+  };
+
+  beforeEach(async () => {
+    vi.resetModules(); // the module holds per-session state at module level
+    vi.clearAllMocks();
+    calls = [];
+    emitOutput = undefined;
+    emitExit = undefined;
+    outputTap = deferred();
+    exitTap = deferred();
+    // Tauri's `listen` only attaches the handler when its promise resolves;
+    // until then the backend has nowhere to deliver an event, so the mocks
+    // publish their emitter at exactly that moment.
+    onProviderLoginOutput.mockImplementation((cb: (e: ProviderLoginOutputEvent) => void) =>
+      outputTap.promise.then((unlisten) => {
+        emitOutput = cb;
+        return unlisten;
+      }),
+    );
+    onProviderLoginExit.mockImplementation((cb: (e: ProviderLoginExitEvent) => void) =>
+      exitTap.promise.then((unlisten) => {
+        emitExit = cb;
+        return unlisten;
+      }),
+    );
+    openProviderLogin.mockImplementation(() => {
+      calls.push("open");
+      return Promise.resolve();
+    });
+    writeProviderLogin.mockImplementation(() => {
+      calls.push("write");
+      return Promise.resolve();
+    });
+    closeProviderLogin.mockResolvedValue(undefined);
+    sessions = await import("./loginSessions");
+  });
+
+  it("does not open the PTY until both event taps are registered", async () => {
+    const run = sessions.runLogin(ID, 80, 24);
+    await flush();
+    expect(openProviderLogin).not.toHaveBeenCalled();
+
+    outputTap.resolve(() => {});
+    await flush();
+    expect(openProviderLogin).not.toHaveBeenCalled(); // the exit tap is still pending
+
+    exitTap.resolve(() => {});
+    await run;
+    expect(openProviderLogin).toHaveBeenCalledWith(ID, 80, 24);
+  });
+
+  it("applies output and an exit that arrive the instant the PTY opens", async () => {
+    openProviderLogin.mockImplementation(() => {
+      // A CLI that is already signed in prints and exits immediately: these
+      // land before the caller of `openProviderLogin` is resumed.
+      emitOutput?.({ id: ID, bytes: btoa("already signed in\r\n") });
+      emitExit?.({ id: ID, success: true, message: "" });
+      return Promise.resolve();
+    });
+    const seen: (ProviderLoginExitEvent | undefined)[] = [];
+    sessions.subscribeLoginExit(ID, (e) => seen.push(e));
+
+    registerTaps();
+    await sessions.runLogin(ID, 80, 24);
+
+    expect(sessions.getLoginExit(ID)).toEqual({ id: ID, success: true, message: "" });
+    expect(seen).toContainEqual({ id: ID, success: true, message: "" });
+    expect(new TextDecoder().decode(sessions.readLoginBuffer(ID))).toBe("already signed in\r\n");
+  });
+
+  it("reports a failed tap registration as the session outcome and retries next run", async () => {
+    outputTap.reject(new Error("listen failed"));
+    exitTap.resolve(() => {});
+
+    await sessions.runLogin(ID, 80, 24);
+
+    expect(openProviderLogin).not.toHaveBeenCalled();
+    expect(sessions.getLoginExit(ID)).toEqual({
+      id: ID,
+      success: false,
+      message: "Error: listen failed",
+    });
+    expect(onProviderLoginOutput).toHaveBeenCalledTimes(1);
+
+    // "Run again" re-registers rather than inheriting the rejected promise.
+    outputTap = deferred();
+    exitTap = deferred();
+    registerTaps();
+    await sessions.runLogin(ID, 80, 24);
+
+    expect(onProviderLoginOutput).toHaveBeenCalledTimes(2);
+    expect(onProviderLoginExit).toHaveBeenCalledTimes(2);
+    expect(openProviderLogin).toHaveBeenCalledTimes(1);
+    expect(sessions.getLoginExit(ID)).toBeUndefined();
+  });
+
+  it("queues a keystroke behind the whole open, tap registration included", async () => {
+    sessions.runLogin(ID, 80, 24);
+    const write = sessions.writeLogin(ID, "y\r");
+    await flush();
+    expect(calls).toEqual([]);
+
+    registerTaps();
+    await write;
+    expect(calls).toEqual(["open", "write"]);
+  });
+
+  it("re-attaching does not reopen a sign-in this session already started", async () => {
+    registerTaps();
+    await sessions.runLogin(ID, 80, 24);
+    sessions.attachLogin(ID, 100, 30);
+    await flush();
+
+    expect(openProviderLogin).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/SettingsScreen/ProviderLogin/loginSessions.ts
+++ b/src/components/SettingsScreen/ProviderLogin/loginSessions.ts
@@ -62,16 +62,28 @@ function setExit(id: string, exit?: ProviderLoginExitEvent) {
   for (const listener of exitListeners.get(id) ?? []) listener(exit);
 }
 
-let taps: Promise<unknown> | undefined;
+let taps: Promise<void> | undefined;
 
-function ensureTaps() {
+/** Attach the output and exit taps, once, shared by every caller. Resolves only
+ *  after *both* listeners are live: a sign-in that prints or exits the moment
+ *  it spawns (an unusable binary, or a CLI that is already signed in) would
+ *  otherwise emit before anything is listening, leaving the terminal blank or
+ *  the session running forever. A failed registration clears the memo so the
+ *  next sign-in retries instead of inheriting the rejected promise. */
+function ensureTaps(): Promise<void> {
   taps ??= Promise.all([
     onProviderLoginOutput((e) => output.push(e.id, decodeBase64(e.bytes))),
     onProviderLoginExit((e) => {
       live.delete(e.id);
       setExit(e.id, e);
     }),
-  ]);
+  ]).then(
+    () => undefined,
+    (err) => {
+      taps = undefined;
+      throw err;
+    },
+  );
   return taps;
 }
 
@@ -85,19 +97,32 @@ const opening = new Map<string, Promise<void>>();
  *  that hasn't been signed in during this session, and "Run again" after one
  *  finished. */
 export function runLogin(id: string, cols: number, rows: number): Promise<void> {
-  ensureTaps();
   output.drop(id);
   setExit(id, undefined);
   started.add(id);
   live.add(id);
-  const open = api.openProviderLogin(id, cols, rows).catch((err) => {
-    // The open failed, so there is nothing to attach to: report it through the
-    // same channel an exit uses and let the row offer "Run again".
-    live.delete(id);
-    setExit(id, { id, success: false, message: String(err) });
-  });
+  const open = openPty(id, cols, rows);
+  // Recorded synchronously, so keystrokes and the first resize queue behind the
+  // *whole* open — tap registration included — and not just behind the spawn.
   opening.set(id, open);
   return open;
+}
+
+/** The open itself: taps first, PTY second, so nothing the flow emits can be
+ *  missed. A failure of either step becomes the session's outcome — the row
+ *  shows it and offers "Run again" rather than sitting in a running state — so
+ *  the returned promise always resolves and callers can await it safely. */
+async function openPty(id: string, cols: number, rows: number): Promise<void> {
+  try {
+    await ensureTaps();
+    await api.openProviderLogin(id, cols, rows);
+  } catch (err) {
+    // Nothing is attached, so report it through the same channel an exit uses.
+    live.delete(id);
+    // Unless a Close landed while this was in flight: that session is gone and
+    // must not be resurrected by a stale failure.
+    if (started.has(id)) setExit(id, { id, success: false, message: String(err) });
+  }
 }
 
 /** The mount-time call: pick up a sign-in this session already opened, or start
@@ -125,11 +150,15 @@ export async function resizeLogin(id: string, cols: number, rows: number) {
 /** Kill a provider's sign-in and forget it — the explicit Close only. The next
  *  "Sign in" then starts a fresh flow rather than re-attaching to this one. */
 export async function closeLogin(id: string) {
+  const open = opening.get(id);
   started.delete(id);
   live.delete(id);
   output.drop(id);
   setExit(id, undefined);
   opening.delete(id);
+  // Let an in-flight open land first: a close that overtakes it would be a
+  // no-op on the backend and leave the PTY it then spawns running unattended.
+  await open;
   await api.closeProviderLogin(id).catch((err) => {
     console.error("closeProviderLogin failed", err);
   });

--- a/src/components/SettingsScreen/ProviderLogin/loginSessions.ts
+++ b/src/components/SettingsScreen/ProviderLogin/loginSessions.ts
@@ -74,7 +74,16 @@ function ensureTaps(): Promise<void> {
   taps ??= Promise.all([
     onProviderLoginOutput((e) => output.push(e.id, decodeBase64(e.bytes))),
     onProviderLoginExit((e) => {
+      // An exit during a Close is the flow being torn down — the kill landing,
+      // or a natural exit racing it. It is not an outcome to show, and it must
+      // not reach whatever sign-in the user starts next; it only tells the
+      // Close that the PTY is gone.
+      if (closing.has(e.id)) {
+        closeWaiters.get(e.id)?.();
+        return;
+      }
       live.delete(e.id);
+      spawned.delete(e.id);
       setExit(e.id, e);
     }),
   ]).then(
@@ -91,6 +100,27 @@ function ensureTaps(): Promise<void> {
  *  fires as soon as it fits its host) wait for the PTY to exist instead of
  *  racing it and being dropped. */
 const opening = new Map<string, Promise<void>>();
+
+/** Per-provider close in flight. A close waits for the open it is closing, so a
+ *  "Sign in" clicked right after Close would otherwise reach the backend first,
+ *  attach to the PTY the close is about to kill, and then lose it. The next
+ *  open waits here instead, so Close always means "this flow is gone" and a
+ *  reopen always starts fresh. */
+const closing = new Map<string, Promise<void>>();
+
+/** Providers whose PTY we believe exists on the backend: added when an open
+ *  lands, removed by its exit or by the Close that kills it. Tells a Close
+ *  whether an exit event is still owed. */
+const spawned = new Set<string>();
+
+/** Per-provider resolver a Close parks to learn that its kill has landed (see
+ *  the exit tap). */
+const closeWaiters = new Map<string, () => void>();
+
+/** How long a Close waits for the killed flow's exit event before giving up.
+ *  The kill escalates HUP → TERM → KILL over well under a second; this is only
+ *  a ceiling so a lost event can't wedge the button. */
+const CLOSE_EXIT_GRACE_MS = 3000;
 
 /** Run a provider's sign-in from the top: clears what the last run printed and
  *  its outcome, so the terminal starts blank. This is "Sign in" on a provider
@@ -114,10 +144,18 @@ export function runLogin(id: string, cols: number, rows: number): Promise<void> 
  *  the returned promise always resolves and callers can await it safely. */
 async function openPty(id: string, cols: number, rows: number): Promise<void> {
   try {
+    // A Close still tearing down the previous flow goes first (see `closing`).
+    await closing.get(id);
     await ensureTaps();
+    // Marked before the call, not after: a CLI that exits the instant it
+    // spawns delivers its exit while the open is still resolving, and that
+    // exit must find the mark to clear it — or a later Close would wait for an
+    // exit that already came.
+    spawned.add(id);
     await api.openProviderLogin(id, cols, rows);
   } catch (err) {
     // Nothing is attached, so report it through the same channel an exit uses.
+    spawned.delete(id);
     live.delete(id);
     // Unless a Close landed while this was in flight: that session is gone and
     // must not be resurrected by a stale failure.
@@ -148,18 +186,46 @@ export async function resizeLogin(id: string, cols: number, rows: number) {
 }
 
 /** Kill a provider's sign-in and forget it — the explicit Close only. The next
- *  "Sign in" then starts a fresh flow rather than re-attaching to this one. */
-export async function closeLogin(id: string) {
+ *  "Sign in" then starts a fresh flow rather than re-attaching to this one.
+ *
+ *  Resolves once the flow is truly gone: the open it may still be waiting on
+ *  has landed, the backend has killed the PTY, and the exit that kill produces
+ *  has been received (or given up on after a grace period). Callers dismiss
+ *  the terminal only after this, and the next open queues behind it, so no
+ *  later sign-in can attach to, or inherit the outcome of, the flow closed here. */
+export function closeLogin(id: string): Promise<void> {
   const open = opening.get(id);
   started.delete(id);
   live.delete(id);
   output.drop(id);
   setExit(id, undefined);
   opening.delete(id);
-  // Let an in-flight open land first: a close that overtakes it would be a
-  // no-op on the backend and leave the PTY it then spawns running unattended.
-  await open;
-  await api.closeProviderLogin(id).catch((err) => {
-    console.error("closeProviderLogin failed", err);
+  // Parked before anything is awaited, so an exit that races the close is
+  // still caught (the tap only signals a waiter while `closing` has the id).
+  let exited!: () => void;
+  const exit = new Promise<void>((resolve) => {
+    exited = resolve;
+  });
+  closeWaiters.set(id, exited);
+  const done = (async () => {
+    // Let an in-flight open land first: a close that overtakes it would be a
+    // no-op on the backend and leave the PTY it then spawns running unattended.
+    await open;
+    // Only a PTY that actually came up owes us an exit event.
+    const expectExit = spawned.delete(id);
+    await api.closeProviderLogin(id).catch((err) => {
+      console.error("closeProviderLogin failed", err);
+    });
+    if (expectExit) {
+      await Promise.race([exit, new Promise((r) => setTimeout(r, CLOSE_EXIT_GRACE_MS))]);
+    }
+  })();
+  // Recorded synchronously so an open issued before this settles queues behind
+  // it (see `openPty`). A later close for the same id replaces the entry, so
+  // only the newest one is ever awaited.
+  closing.set(id, done);
+  return done.finally(() => {
+    if (closing.get(id) === done) closing.delete(id);
+    if (closeWaiters.get(id) === exited) closeWaiters.delete(id);
   });
 }

--- a/src/components/SettingsScreen/ProviderLogin/loginSessions.ts
+++ b/src/components/SettingsScreen/ProviderLogin/loginSessions.ts
@@ -1,0 +1,136 @@
+// Module-level state for in-app provider sign-ins, deliberately outside both
+// React and the store: a login flow has to survive its terminal unmounting.
+// Collapsing the provider row (or leaving Settings) mid-login must not abort
+// the flow, so the output buffer and the exit result are held here and the
+// terminal re-attaches to them on the next mount.
+//
+// The event taps are attached lazily on the first sign-in rather than in the
+// app-wide `registerEventListeners`: nothing can arrive on these channels until
+// a login is opened, and keeping them here makes the feature self-contained.
+
+import type { ProviderLoginExitEvent } from "@/api";
+import { api, onProviderLoginExit, onProviderLoginOutput } from "@/api";
+import { createPtyChannel, type OutputHandler } from "@/pty/channel";
+import { decodeBase64 } from "@/pty/decode";
+
+/** Sign-in output per provider id. A login flow prints a URL, a code and a
+ *  confirmation — 64 KiB is far more than enough to replay. */
+const output = createPtyChannel(64 * 1024);
+
+/** Everything a provider's sign-in has printed so far, to replay into a
+ *  terminal that has just (re)mounted. */
+export function readLoginBuffer(id: string): Uint8Array | undefined {
+  return output.get(id);
+}
+
+export function registerLoginSink(id: string, handler: OutputHandler): () => void {
+  return output.registerSink(id, handler);
+}
+
+/** Sign-ins opened in this app session, still running or already finished.
+ *  What keeps a re-mount (the row was collapsed and re-expanded) from silently
+ *  starting a second flow or wiping the outcome of the last one. Cleared only
+ *  by an explicit `closeLogin`. */
+const started = new Set<string>();
+
+/** The subset of `started` still running. Frontend-side bookkeeping only — the
+ *  backend is the authority and is idempotent either way. */
+const live = new Set<string>();
+
+/** The last exit of each provider's sign-in, kept so a terminal that mounts
+ *  after the flow ended still shows the outcome. */
+const exits = new Map<string, ProviderLoginExitEvent | undefined>();
+const exitListeners = new Map<string, Set<(exit?: ProviderLoginExitEvent) => void>>();
+
+export function getLoginExit(id: string): ProviderLoginExitEvent | undefined {
+  return exits.get(id);
+}
+
+/** Subscribe to a provider's sign-in outcome; returns an unsubscribe fn. */
+export function subscribeLoginExit(
+  id: string,
+  listener: (exit?: ProviderLoginExitEvent) => void,
+): () => void {
+  const set = exitListeners.get(id) ?? new Set();
+  set.add(listener);
+  exitListeners.set(id, set);
+  return () => set.delete(listener);
+}
+
+function setExit(id: string, exit?: ProviderLoginExitEvent) {
+  exits.set(id, exit);
+  for (const listener of exitListeners.get(id) ?? []) listener(exit);
+}
+
+let taps: Promise<unknown> | undefined;
+
+function ensureTaps() {
+  taps ??= Promise.all([
+    onProviderLoginOutput((e) => output.push(e.id, decodeBase64(e.bytes))),
+    onProviderLoginExit((e) => {
+      live.delete(e.id);
+      setExit(e.id, e);
+    }),
+  ]);
+  return taps;
+}
+
+/** Per-provider open promise, so keystrokes and the first resize (which xterm
+ *  fires as soon as it fits its host) wait for the PTY to exist instead of
+ *  racing it and being dropped. */
+const opening = new Map<string, Promise<void>>();
+
+/** Run a provider's sign-in from the top: clears what the last run printed and
+ *  its outcome, so the terminal starts blank. This is "Sign in" on a provider
+ *  that hasn't been signed in during this session, and "Run again" after one
+ *  finished. */
+export function runLogin(id: string, cols: number, rows: number): Promise<void> {
+  ensureTaps();
+  output.drop(id);
+  setExit(id, undefined);
+  started.add(id);
+  live.add(id);
+  const open = api.openProviderLogin(id, cols, rows).catch((err) => {
+    // The open failed, so there is nothing to attach to: report it through the
+    // same channel an exit uses and let the row offer "Run again".
+    live.delete(id);
+    setExit(id, { id, success: false, message: String(err) });
+  });
+  opening.set(id, open);
+  return open;
+}
+
+/** The mount-time call: pick up a sign-in this session already opened, or start
+ *  one if it hasn't. Re-attaching must not restart a flow still in progress,
+ *  nor re-run one that already finished — the terminal replays the buffer and
+ *  shows the recorded outcome instead. */
+export function attachLogin(id: string, cols: number, rows: number) {
+  if (started.has(id)) return;
+  runLogin(id, cols, rows);
+}
+
+export async function writeLogin(id: string, data: string) {
+  await opening.get(id);
+  await api.writeProviderLogin(id, data).catch((err) => {
+    console.error("writeProviderLogin failed", err);
+  });
+}
+
+export async function resizeLogin(id: string, cols: number, rows: number) {
+  await opening.get(id);
+  // A resize that lands after the flow exited is expected, not an error.
+  await api.resizeProviderLogin(id, cols, rows).catch(() => {});
+}
+
+/** Kill a provider's sign-in and forget it — the explicit Close only. The next
+ *  "Sign in" then starts a fresh flow rather than re-attaching to this one. */
+export async function closeLogin(id: string) {
+  started.delete(id);
+  live.delete(id);
+  output.drop(id);
+  setExit(id, undefined);
+  opening.delete(id);
+  await api.closeProviderLogin(id).catch((err) => {
+    console.error("closeProviderLogin failed", err);
+  });
+}

--- a/src/components/SettingsScreen/ProviderLogin/useProviderLogin.ts
+++ b/src/components/SettingsScreen/ProviderLogin/useProviderLogin.ts
@@ -1,0 +1,83 @@
+import { open } from "@tauri-apps/plugin-shell";
+import { WebLinksAddon } from "@xterm/addon-web-links";
+import type { Terminal } from "@xterm/xterm";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { ProviderLoginExitEvent } from "@/api";
+import { useXterm } from "@/util/useXterm";
+import {
+  attachLogin,
+  closeLogin,
+  getLoginExit,
+  readLoginBuffer,
+  registerLoginSink,
+  resizeLogin,
+  runLogin,
+  subscribeLoginExit,
+  writeLogin,
+} from "./loginSessions";
+
+/** Mount a terminal running a provider's sign-in command and keep it wired to
+ *  the live PTY: replay what the flow has already printed, stream new output,
+ *  forward keystrokes and resizes, and open any URL it prints in the browser
+ *  (OAuth flows print one when they can't launch a browser themselves).
+ *
+ *  `exit` is the flow's outcome once it ends, `undefined` while it runs.
+ *  `runAgain` restarts it on a cleared screen; `close` is the only path that
+ *  kills the PTY — unmounting leaves it running so collapsing the row
+ *  mid-login doesn't abort it. */
+export function useProviderLogin(providerId: string) {
+  const [exit, setExit] = useState<ProviderLoginExitEvent | undefined>(() =>
+    getLoginExit(providerId),
+  );
+  const termRef = useRef<Terminal | null>(null);
+
+  useEffect(() => {
+    setExit(getLoginExit(providerId));
+    return subscribeLoginExit(providerId, setExit);
+  }, [providerId]);
+
+  const containerRef = useXterm(
+    { fontSize: 12, lineHeight: 1.2, scrollback: 5000 },
+    (term) => {
+      termRef.current = term;
+      term.loadAddon(new WebLinksAddon((_, url) => open(url)));
+
+      const buffered = readLoginBuffer(providerId);
+      if (buffered && buffered.length > 0) term.write(buffered);
+
+      // The PTY opens at the terminal's pre-fit size; xterm's first fit fires
+      // `onResize` right after this, which corrects it (and waits for the open
+      // to land — see `resizeLogin`).
+      attachLogin(providerId, term.cols, term.rows);
+
+      const onResize = term.onResize(({ cols, rows }) => {
+        resizeLogin(providerId, cols, rows);
+      });
+      const onData = term.onData((data) => {
+        writeLogin(providerId, data);
+      });
+      const unregister = registerLoginSink(providerId, (bytes) => term.write(bytes));
+
+      return () => {
+        unregister();
+        onResize.dispose();
+        onData.dispose();
+        termRef.current = null;
+        // NOTE: no closeProviderLogin here — a user who collapses the row
+        // mid-login must not abort it. Only the Close button kills the PTY.
+      };
+    },
+    [providerId],
+  );
+
+  const runAgain = useCallback(() => {
+    const term = termRef.current;
+    term?.reset();
+    runLogin(providerId, term?.cols ?? 80, term?.rows ?? 24);
+    term?.focus();
+  }, [providerId]);
+
+  const close = useCallback(() => closeLogin(providerId), [providerId]);
+
+  return { containerRef, exit, runAgain, close };
+}

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -38,6 +38,12 @@ export interface ProviderDetail {
   /** One-line hint for signing in after install. We detect the binary, not
    *  auth (which varies per CLI), so this nudges the user to complete it. */
   signIn?: string;
+  /** The CLI's own sign-in command, shown above the embedded terminal that
+   *  runs it. Omit when the CLI has no login command (antigravity, pi) — those
+   *  rows offer the `signIn` hint and the docs link only. Read through
+   *  `loginCommand()`; must mirror the pinned argv the backend runs
+   *  (src-tauri/src/provider_login.rs). */
+  login?: string;
   /** Thinking/reasoning effort levels supported by this provider's CLI.
    *  Empty means the provider has no effort flag — the picker hides. */
   thinkingLevels: ThinkingLevel[];
@@ -61,6 +67,13 @@ export function installCommand(id: ProviderId): string | undefined {
   return IS_WINDOWS ? d.installWindows : d.install;
 }
 
+/** The sign-in command for a provider, or undefined when its CLI has none — the
+ *  gate for offering in-app sign-in at all. Mirrors the backend's pinned table
+ *  (`login_args` in src-tauri/src/provider_login.rs). */
+export function loginCommand(id: ProviderId): string | undefined {
+  return PROVIDER_DETAIL[id].login;
+}
+
 export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
   claude: {
     path: "/opt/homebrew/bin/claude",
@@ -69,7 +82,8 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     install: "curl -fsSL https://claude.ai/install.sh | bash",
     installWindows: "irm https://claude.ai/install.ps1 | iex",
     docs: "https://docs.anthropic.com/en/docs/claude-code",
-    signIn: "Run `claude` once in a terminal to sign in.",
+    signIn: "Run `claude auth login` to sign in.",
+    login: "claude auth login",
     // `claude --effort <level>` is a session-level spawn flag (not per-message):
     // persisted on the session record and re-applied on every spawn. Changing it
     // mid-session restarts the process (--resume) to re-apply the flag, so it's
@@ -91,7 +105,8 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     install: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
     installWindows: "irm https://chatgpt.com/codex/install.ps1 | iex",
     docs: "https://github.com/openai/codex",
-    signIn: "Run `codex` once in a terminal to sign in.",
+    signIn: "Run `codex login` to sign in.",
+    login: "codex login",
     // `codex exec -c reasoning_effort="<value>"`
     thinkingLevels: [
       { label: "Low", value: "low" },
@@ -106,6 +121,7 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     install: "curl -fsSL https://cursor.com/install | bash",
     docs: "https://cursor.com",
     signIn: "Run `cursor-agent login` to sign in.",
+    login: "cursor-agent login",
     // Cursor encodes effort in model names — no standalone flag.
     thinkingLevels: [],
   },
@@ -123,6 +139,7 @@ export const PROVIDER_DETAIL: Record<ProviderId, ProviderDetail> = {
     install: "curl -fsSL https://opencode.ai/install | bash",
     docs: "https://opencode.ai",
     signIn: "Run `opencode auth login` to connect a provider.",
+    login: "opencode auth login",
     // `opencode run --variant <value>`
     thinkingLevels: [
       { label: "Low", value: "minimal" },

--- a/src/pty/buffers.ts
+++ b/src/pty/buffers.ts
@@ -4,23 +4,20 @@
 //
 // Two parallel channels — the agent's own PTY and its side shell — each pair a
 // ring buffer (replayed when a view mounts for the first time) with an optional
-// live sink (the view's writer).
+// live sink (the view's writer). Both are plain ./channel instances; what lives
+// here is the per-agent lifecycle layered over them.
 //
 // This module also owns the lifecycle of the live-terminal cache in
 // ./terminals, because "an agent's PTY state" is one thing: the ring buffer and
 // the terminal rendering it are cleared, reset and released together.
 
-export type OutputHandler = (bytes: Uint8Array) => void;
-
-const MAX_BUFFER_BYTES = 256 * 1024;
+import { createPtyChannel, type OutputHandler } from "./channel";
 
 // ---- Agent PTY ----------------------------------------------------------------
-const outputSinks = new Map<string, OutputHandler>();
-const outputBuffers = new Map<string, Uint8Array>();
+const agentPty = createPtyChannel();
 
 // ---- Side shell PTY -----------------------------------------------------------
-const shellSinks = new Map<string, OutputHandler>();
-const shellBuffers = new Map<string, Uint8Array>();
+const shellPty = createPtyChannel();
 
 // ---- Live terminal cache ------------------------------------------------------
 
@@ -43,32 +40,13 @@ export function setTerminalCacheHooks(hooks: TerminalCacheHooks) {
   terminalCache = hooks;
 }
 
-/** Append a chunk to an agent's ring buffer, trimming the oldest bytes once it
- *  grows past the cap so a long-lived session can't grow without bound. */
-function appendToRing(buffers: Map<string, Uint8Array>, agentId: string, chunk: Uint8Array) {
-  const existing = buffers.get(agentId);
-  let next: Uint8Array;
-  if (!existing) {
-    next = chunk;
-  } else {
-    next = new Uint8Array(existing.length + chunk.length);
-    next.set(existing, 0);
-    next.set(chunk, existing.length);
-  }
-  if (next.length > MAX_BUFFER_BYTES) {
-    next = next.slice(next.length - MAX_BUFFER_BYTES);
-  }
-  buffers.set(agentId, next);
-}
-
 /** Buffer an agent-output chunk and forward it to the live view sink (if any). */
 export function pushAgentOutput(agentId: string, chunk: Uint8Array) {
-  appendToRing(outputBuffers, agentId, chunk);
-  outputSinks.get(agentId)?.(chunk);
+  agentPty.push(agentId, chunk);
 }
 
 export function getOutputBuffer(agentId: string): Uint8Array | undefined {
-  return outputBuffers.get(agentId);
+  return agentPty.get(agentId);
 }
 
 /** Drop an agent's replay history because its PTY restarted (view switch,
@@ -76,18 +54,16 @@ export function getOutputBuffer(agentId: string): Uint8Array | undefined {
  *  dropped, so wipe its screen too — otherwise the next mount would re-attach a
  *  dead session's frame instead of the blank one a restart used to produce. */
 export function clearOutputBuffer(agentId: string) {
-  outputBuffers.delete(agentId);
+  agentPty.clear(agentId);
   terminalCache?.reset(agentId);
 }
 
 /** Release everything held for an agent that is gone (discarded, archived).
- *  Nothing else clears `shellBuffers` or the terminal cache, so without this
+ *  Nothing else clears the shell buffer or the terminal cache, so without this
  *  both grow for the life of the app session. */
 export function dropAgentPty(agentId: string) {
-  outputBuffers.delete(agentId);
-  shellBuffers.delete(agentId);
-  outputSinks.delete(agentId);
-  shellSinks.delete(agentId);
+  agentPty.drop(agentId);
+  shellPty.drop(agentId);
   terminalCache?.evict(agentId);
 }
 
@@ -98,25 +74,18 @@ export function dropAgentPty(agentId: string) {
  *  native view keeps feeding its cached screen in the background and no second
  *  view can ever be contending for the same slot. */
 export function registerOutputSink(agentId: string, handler: OutputHandler): () => void {
-  outputSinks.set(agentId, handler);
-  return () => {
-    if (outputSinks.get(agentId) === handler) outputSinks.delete(agentId);
-  };
+  return agentPty.registerSink(agentId, handler);
 }
 
 /** Buffer a shell-output chunk and forward it to the live TermPanel sink. */
 export function pushShellOutput(agentId: string, chunk: Uint8Array) {
-  appendToRing(shellBuffers, agentId, chunk);
-  shellSinks.get(agentId)?.(chunk);
+  shellPty.push(agentId, chunk);
 }
 
 export function getShellBuffer(agentId: string): Uint8Array | undefined {
-  return shellBuffers.get(agentId);
+  return shellPty.get(agentId);
 }
 
 export function registerShellSink(agentId: string, handler: OutputHandler): () => void {
-  shellSinks.set(agentId, handler);
-  return () => {
-    if (shellSinks.get(agentId) === handler) shellSinks.delete(agentId);
-  };
+  return shellPty.registerSink(agentId, handler);
 }

--- a/src/pty/channel.ts
+++ b/src/pty/channel.ts
@@ -1,0 +1,68 @@
+// The buffer-plus-sink pattern every PTY stream in the app needs: raw bytes
+// arrive at high frequency from the backend, are appended to a per-key ring
+// buffer (replayed when a view mounts), and are forwarded to the live view's
+// writer if one is attached.
+//
+// Kept generic and outside any store on purpose: routing terminal bytes through
+// React state would be wasteful, and the same shape serves an agent's PTY, its
+// side shell (./buffers) and a provider sign-in alike.
+
+export type OutputHandler = (bytes: Uint8Array) => void;
+
+const DEFAULT_MAX_BUFFER_BYTES = 256 * 1024;
+
+export interface PtyChannel {
+  /** Buffer a chunk and forward it to the live sink (if any). */
+  push(key: string, chunk: Uint8Array): void;
+  /** Everything buffered for `key`, to replay into a freshly mounted view. */
+  get(key: string): Uint8Array | undefined;
+  /** Forget the replay history for `key`, keeping any sink attached. */
+  clear(key: string): void;
+  /** Forget the history *and* the sink — `key` is gone for good. */
+  drop(key: string): void;
+  /** Point `key`'s live output at `handler`, replacing any previous one — a
+   *  single sink per key, by design. Returns an unregister fn that only clears
+   *  the slot if `handler` is still the one in it. */
+  registerSink(key: string, handler: OutputHandler): () => void;
+}
+
+/** An independent buffer+sink channel. `maxBytes` caps each key's ring buffer,
+ *  trimming the oldest bytes once it overflows so a long-lived session can't
+ *  grow without bound. */
+export function createPtyChannel(maxBytes: number = DEFAULT_MAX_BUFFER_BYTES): PtyChannel {
+  const buffers = new Map<string, Uint8Array>();
+  const sinks = new Map<string, OutputHandler>();
+
+  return {
+    push(key, chunk) {
+      const existing = buffers.get(key);
+      let next: Uint8Array;
+      if (!existing) {
+        next = chunk;
+      } else {
+        next = new Uint8Array(existing.length + chunk.length);
+        next.set(existing, 0);
+        next.set(chunk, existing.length);
+      }
+      if (next.length > maxBytes) next = next.slice(next.length - maxBytes);
+      buffers.set(key, next);
+      sinks.get(key)?.(chunk);
+    },
+    get(key) {
+      return buffers.get(key);
+    },
+    clear(key) {
+      buffers.delete(key);
+    },
+    drop(key) {
+      buffers.delete(key);
+      sinks.delete(key);
+    },
+    registerSink(key, handler) {
+      sinks.set(key, handler);
+      return () => {
+        if (sinks.get(key) === handler) sinks.delete(key);
+      };
+    },
+  };
+}


### PR DESCRIPTION
## Summary
Installing an agent CLI isn't enough — it has to be signed in, and every CLI does auth differently (browser OAuth, device codes, an interactive provider picker). This PR adds the plumbing for an in-app **Sign in**: the vendor's own login command runs under a PTY and streams into an embedded xterm inside the provider row, so the user answers whatever it asks without leaving Settings.

Backend + API + a standalone `ProviderLoginTerminal` component. Wiring it into the provider row lands in a follow-up stacked on the install-from-Settings PR.

## What
- `src-tauri/src/provider_login.rs`: pinned login argv per provider, so the renderer only ever names a provider: claude `auth login`, codex `login`, cursor `login`, opencode `auth login`; pi and antigravity have none (hint + docs only). All four verified against the installed CLIs' `--help` output on this machine; no login was ever run.
- `src-tauri/src/commands/provider_login.rs`: `open_provider_login(id, cols, rows)` (idempotent per provider; resolves the binary through `resolve_agent_bin` so a custom path override is honoured; the sessions lock is held across spawn+insert so an instantly-dying login can't race its own removal and leave a dead entry), `write_provider_login`, `resize_provider_login`, `close_provider_login`. Output streams as `provider-login:output` (base64 bytes) and the end of the flow as `provider-login:exit`. Sessions live in Tauri managed state and are dropped (PTY killed) at quit.
- DRY: `serialize_bytes_b64` moved into `pty_session.rs` and shared with the agent-shell emitter; new `createPtyChannel` (`src/pty/channel.ts`) now backs both existing channels in `buffers.ts` plus the login one.
- Frontend API: `api.openProviderLogin / writeProviderLogin / resizeProviderLogin / closeProviderLogin`, `onProviderLoginOutput / onProviderLoginExit`; `PROVIDER_DETAIL[id].login` + `loginCommand(id)` mirroring the Rust table. The `signIn` hints for claude and codex now name the real commands.
- `src/components/SettingsScreen/ProviderLogin/`: `ProviderLoginTerminal` — xterm via `useXterm`, clickable URLs, a `$ <command>` header with the sign-in hint, Close, and the exit outcome with "Run again". Mounting re-attaches to a live or finished flow (buffer replay, 64 KiB cap per provider); only an explicit Close kills the PTY, so collapsing the row mid-login does not abort it. Exported and unused until the wiring PR.

## Verification
- `tsc --noEmit`, `biome check` (one import-sort error of ours fixed; the 122 pre-existing warnings are untouched), `vitest` (1138 passed), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test provider_login` (3 passed), full `cargo test` (1631 passed) — all green.

## Deferred
- Dev-only: an HMR reload loses the frontend's attach bookkeeping while the backend PTY survives, leaving a blank terminal until new output arrives. Not reachable in a production build.
- `PROVIDER_DETAIL.login` and `login_args` are mirrored by convention with cross-referencing comments (same as `install_command`); no test asserts they agree.