### PR TITLE
feat(providers): show sign-in status and an in-row Sign in for installed agents

### DIFF
--- a/src/components/SettingsScreen/ProviderAuthBadge.tsx
+++ b/src/components/SettingsScreen/ProviderAuthBadge.tsx
@@ -1,11 +1,11 @@
 import type { ProviderAuthStatus } from "@/api/types/providers";
-import { Badge } from "@/components/ui";
+import { Badge, type BadgeVariant } from "@/components/ui";
 
 /** Tone and label per sign-in state. `signed_out` is a warning, not an error:
  *  the CLI is installed and one `Sign in` away from working, so it shouldn't
  *  read like something broke. */
-const LABELS: Record<"signed_in" | "signed_out", { text: string; variant: "neutral" | "warn" }> = {
-  signed_in: { text: "Signed in", variant: "neutral" },
+const LABELS: Record<"signed_in" | "signed_out", { text: string; variant: BadgeVariant }> = {
+  signed_in: { text: "Signed in", variant: "ok" },
   signed_out: { text: "Not signed in", variant: "warn" },
 };
 

--- a/src/components/SettingsScreen/ProviderLogin/ProviderLogin.css
+++ b/src/components/SettingsScreen/ProviderLogin/ProviderLogin.css
@@ -33,7 +33,9 @@
   white-space: nowrap;
 }
 
-/* The hint takes the slack so the Close button sits hard right. */
+/* The per-provider sign-in hint, in the terminal's head and in the offer row
+   that precedes it (ProvidersPane/SignInSection). Takes the slack either way,
+   so the trailing button sits hard right. */
 .prov-login-hint {
   flex: 1;
   min-width: 0;

--- a/src/components/SettingsScreen/ProviderLogin/index.tsx
+++ b/src/components/SettingsScreen/ProviderLogin/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { loginCommand, PROVIDER_DETAIL } from "@/data/providerDetail";
 import type { ProviderId } from "@/data/providers";
@@ -11,6 +11,10 @@ interface Props {
   /** Dismiss the terminal. Called once the sign-in PTY has actually been
    *  killed (the Close button awaits that), never before. */
   onClose: () => void;
+  /** The sign-in flow ended cleanly. The caller re-probes auth from here, so
+   *  the row's badge flips without a manual re-scan. Must be referentially
+   *  stable (a store action or a `useCallback`) — it fires once per outcome. */
+  onFinished?: () => void;
 }
 
 /** An embedded terminal running an agent CLI's own sign-in command, so the user
@@ -20,7 +24,7 @@ interface Props {
  *
  *  Only render this for a provider that has a `loginCommand`; antigravity and
  *  pi have none and show their `signIn` hint alone. */
-export function ProviderLoginTerminal({ providerId, providerLabel, onClose }: Props) {
+export function ProviderLoginTerminal({ providerId, providerLabel, onClose, onFinished }: Props) {
   const { containerRef, exit, runAgain, close } = useProviderLogin(providerId);
   const command = loginCommand(providerId);
   const hint = PROVIDER_DETAIL[providerId].signIn;
@@ -38,6 +42,13 @@ export function ProviderLoginTerminal({ providerId, providerLabel, onClose }: Pr
       onClose();
     }
   };
+
+  // `exit` is the recorded outcome object, replaced (not mutated) once per run
+  // and cleared to undefined by "Run again" — so this fires exactly once per
+  // successful flow, not on every render.
+  useEffect(() => {
+    if (exit?.success) onFinished?.();
+  }, [exit, onFinished]);
 
   return (
     <div className="prov-login">

--- a/src/components/SettingsScreen/ProvidersPane/ProviderRow.tsx
+++ b/src/components/SettingsScreen/ProvidersPane/ProviderRow.tsx
@@ -18,9 +18,11 @@ import type { Provider } from "@/data/providers";
 import { useAppStore } from "@/store";
 import type { InstallState } from "@/store/types";
 import { BinaryPathRow } from "../BinaryPathRow";
+import { ProviderAuthBadge } from "../ProviderAuthBadge";
 import { SetToggle } from "../primitives";
 import { InstallLog } from "./InstallLog";
 import { InstallOptions } from "./InstallOptions";
+import { SignInSection } from "./SignInSection";
 
 type RowState = "installed" | "fresh" | "missing" | "installing" | "cancelling" | "failed";
 
@@ -31,6 +33,7 @@ export function ProviderRow({ provider }: { provider: Provider }) {
   const livePath = useAppStore((s) => s.providerPaths[id]);
   const override = useAppStore((s) => s.providerPathOverrides[id]);
   const install = useAppStore((s) => s.installs[id]);
+  const auth = useAppStore((s) => s.providerAuth[id]);
   const setProviderEnabled = useAppStore((s) => s.setProviderEnabled);
   const setProviderPathOverride = useAppStore((s) => s.setProviderPathOverride);
   const installAgent = useAppStore((s) => s.installAgent);
@@ -125,6 +128,10 @@ export function ProviderRow({ provider }: { provider: Provider }) {
             {state === "fresh" && (
               <span className="set-badge ok mono text-xs">Installed just now</span>
             )}
+            {/* A binary is not an account: only a row with a live binary can
+                say anything about sign-in, and only when the probe classified
+                it — `unknown` renders nothing rather than a guess. */}
+            {live && <ProviderAuthBadge status={auth} />}
           </div>
           <div className={`set-prov-sub flex-center truncate mono text-sm ${sub.tone}`}>
             {sub.text}
@@ -208,6 +215,7 @@ export function ProviderRow({ provider }: { provider: Provider }) {
                     : `Installed. Flip the toggle to show ${label} in the composer's model picker.`}
                 </p>
               )}
+              <SignInSection providerId={id} providerLabel={label} />
               <div className="set-prov-detail-actions flex-center">
                 <Button variant="ghost" size="sm">
                   View logs

--- a/src/components/SettingsScreen/ProvidersPane/SignInSection.tsx
+++ b/src/components/SettingsScreen/ProvidersPane/SignInSection.tsx
@@ -1,0 +1,82 @@
+// The sign-in half of an installed provider's detail: an offer to run the
+// CLI's own login, and the embedded terminal that runs it.
+//
+// Detecting a binary is not detecting an account, so this is the one place in
+// the row that acts on `providerAuth`. It shows one thing at a time — the
+// offer, or the terminal (which carries its own Close and hint) — so the
+// detail never grows two competing sign-in controls.
+
+import { useCallback, useState } from "react";
+import { Button } from "@/components/ui/Button";
+import { DocsLink } from "@/components/ui/DocsLink";
+import { loginCommand, PROVIDER_DETAIL } from "@/data/providerDetail";
+import type { ProviderId } from "@/data/providers";
+import { useAppStore } from "@/store";
+import { ProviderLoginTerminal } from "../ProviderLogin";
+
+export function SignInSection({
+  providerId,
+  providerLabel,
+}: {
+  providerId: ProviderId;
+  providerLabel: string;
+}) {
+  const status = useAppStore((s) => s.providerAuth[providerId]);
+  // Stable across renders (a zustand action), so the terminal's one-shot
+  // outcome effect isn't re-armed by a parent re-render.
+  const refreshProviderAuth = useAppStore((s) => s.refreshProviderAuth);
+  const [open, setOpen] = useState(false);
+
+  const d = PROVIDER_DETAIL[providerId];
+  const command = loginCommand(providerId);
+
+  // Re-probe on both endings: a clean exit is the usual one, but a user who
+  // closes the terminal after completing auth in a browser tab gets the same
+  // refresh rather than having to hit Re-scan.
+  const refresh = useCallback(() => void refreshProviderAuth(), [refreshProviderAuth]);
+  const close = useCallback(() => {
+    setOpen(false);
+    refresh();
+  }, [refresh]);
+
+  if (open && command) {
+    return (
+      <ProviderLoginTerminal
+        providerId={providerId}
+        providerLabel={providerLabel}
+        onClose={close}
+        onFinished={refresh}
+      />
+    );
+  }
+
+  // No login command (antigravity, pi): there is nothing to run in-app, so the
+  // row offers the hint — or, lacking one, the docs, mirroring how the missing
+  // state falls back from Install to an install guide.
+  if (!command) {
+    return (
+      <div className="set-prov-detail-actions flex-center">
+        {d.signIn ? (
+          <span className="prov-login-hint text-sm">{d.signIn}</span>
+        ) : (
+          <DocsLink url={d.docs} label="Sign-in guide" />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="set-prov-detail-actions flex-center">
+      {/* A signed-out CLI is installed but unusable, so its sign-in is the
+          row's primary action; an already-signed-in one keeps it quiet. */}
+      <Button
+        variant={status === "signed_out" ? "primary" : "outline"}
+        size="sm"
+        onClick={() => setOpen(true)}
+      >
+        Sign in
+      </Button>
+      {d.signIn && <span className="prov-login-hint text-sm">{d.signIn}</span>}
+    </div>
+  );
+}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 export type BadgeVariant =
   | "neutral"
   | "new"
+  | "ok"
   | "err"
   | "warn"
   | "docker"

--- a/src/styles/shared/badge.css
+++ b/src/styles/shared/badge.css
@@ -31,10 +31,15 @@
 .ag-badge.pr-closed,
 .ag-badge.pr-pass,
 .ag-badge.pr-fail,
+.ag-badge.ok,
 .ag-badge.warn,
 .ag-badge.err {
   background: color-mix(in oklch, var(--badge-color), transparent 86%);
   color: var(--badge-color);
+}
+/* generic success tone — the peer of `warn`/`err` (e.g. "Signed in") */
+.ag-badge.ok {
+  --badge-color: var(--success);
 }
 /* paused workflow run — amber, names the reason (e.g. "needs approval") */
 .ag-badge.warn {


### PR DESCRIPTION
## Summary
The last piece of the Settings › Providers install + sign-in work: installed provider rows now show whether the CLI is **signed in**, and offer a **Sign in** action that runs the CLI's own login in an embedded terminal inside the row's detail.

**Stacked on #720** (install from Settings). It also contains #719 (sign-in terminal) and #718 (signed-in probe) as merged ancestors, because the wiring needs all three; their commits disappear from this diff as they merge. Review only the top commit here: `feat(providers): show sign-in status and an in-row Sign in for installed agents` (7 files, +115 / −5).

## What
- `ProvidersPane/SignInSection.tsx` (new): the sign-in half of an installed row's detail. Shows one control at a time — the offer (Sign in button + the provider's `signIn` hint) or the `ProviderLoginTerminal`, which carries its own Close and hint. Sign in is the **primary** button when the probe says `signed_out`, outline otherwise. Re-probes auth (`refreshProviderAuth`) both on a clean exit and on Close, so the badge flips without a manual Re-scan. Providers with no login command (antigravity, pi) get the hint, or a "Sign-in guide" docs link when there is none — mirroring how the missing state falls back from Install to an install guide.
- `ProvidersPane/ProviderRow.tsx`: reads `providerAuth[id]`; renders `ProviderAuthBadge` in the name line (after the "Installed just now" chip) only for rows with a live binary — a binary is not an account, and `unknown` renders nothing. Renders `SignInSection` in the installed detail above the existing actions row. Row geometry unchanged.
- `ProviderLogin/index.tsx`: optional `onFinished` prop, fired once per successful flow from an effect keyed on the exit outcome object.
- `ProviderAuthBadge`: "Signed in" uses a success tone. `ui/Badge` + `styles/shared/badge.css` gain a generic `ok` variant (peer of the existing `warn` / `err`; the only success-toned badge before was the PR-specific `pr-pass`).

## Merge notes
#720 merged with zero conflicts. #718 had three adjacent-append conflicts (`agent/mod.rs` re-exports, `api/domains/providers.ts`, `api/types/providers.ts`), each resolved by keeping both sides. `lib.rs` was checked to carry every registration from all three branches (`mod provider_login`, `.manage(ProviderLoginSessions)`, the four `provider_login` commands, `cancel_agent_install`, `probe_provider_auth`).

## Verification
Run on the merged tree **before** wiring (to attribute any breakage to the merge) and again after:
- `tsc --noEmit`, `biome check` (0 errors; 124 pre-existing warnings), `vitest` 111 files / 1154 tests, `cargo fmt --check`, `RUSTFLAGS=-Dwarnings cargo clippy --all-targets`, full `cargo test` (1643 passed) — all green both times.

## Not verified
The app was not launched, so the badge flipping after a real login, the inline terminal's layout inside the detail, and row-height invariance are covered by types, tests and CSS review only. Worth eyeballing: a `fresh` row showing label + version + "Installed just now" + "Signed in" in a narrow window, since `.set-prov-name` is `nowrap` with non-shrinking children.

## Decisions to sanity-check
- The shared `Badge` gained an `ok` variant, and "Signed in" moved from #718's `neutral` to that success tone.
- The pane header count was left alone (a signed-in count wasn't a one-line change).