### PR TITLE
feat(providers): live-discovered models on settings rows; drop dead View logs button

### DIFF
--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "@/components/Icon";
 import { IconButton } from "@/components/ui/IconButton";
 import { Scrim } from "@/components/ui/Scrim";
+import { modelSummary } from "@/data/modelCatalog";
 import { PROVIDER_DETAIL } from "@/data/providerDetail";
 import { ACCENTS, PROVIDERS } from "@/data/providers";
 import type { FeatureFlags, ThemeMode } from "@/storage/preferences";
@@ -56,6 +57,7 @@ function Popover({ onClose }: { onClose: () => void }) {
   const accent = useAppStore((s) => s.accent);
   const setAccent = useAppStore((s) => s.setAccent);
   const providerVersions = useAppStore((s) => s.providerVersions);
+  const modelsByAgent = useAppStore((s) => s.modelsByAgent);
   const openSettingsScreen = useAppStore((s) => s.openSettingsScreen);
 
   return (
@@ -107,11 +109,11 @@ function Popover({ onClose }: { onClose: () => void }) {
 
       <SettingsSection title="Providers">
         {PROVIDERS.map((p) => {
-          // Honest, non-user-specific model routing, plus the live-probed
-          // version when the backend has resolved it — never a fabricated plan
-          // name or version string.
+          // Live-discovered models (static description until the catalog has
+          // data), plus the live-probed version when the backend has resolved
+          // it — never a fabricated plan name or version string.
           const version = providerVersions[p.id];
-          const models = PROVIDER_DETAIL[p.id].models;
+          const models = modelSummary(modelsByAgent[p.id]) ?? PROVIDER_DETAIL[p.id].models;
           const description = [models, version].filter(Boolean).join(" · ");
           return (
             <SettingsRow key={p.id} label={p.label} description={description}>

--- a/src/components/SettingsScreen/ProvidersPane/ProviderRow.tsx
+++ b/src/components/SettingsScreen/ProvidersPane/ProviderRow.tsx
@@ -13,6 +13,7 @@ import { Icon } from "@/components/Icon";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { Button } from "@/components/ui/Button";
 import { DocsLink } from "@/components/ui/DocsLink";
+import { modelSummary } from "@/data/modelCatalog";
 import { installCommand, PROVIDER_DETAIL } from "@/data/providerDetail";
 import type { Provider } from "@/data/providers";
 import { useAppStore } from "@/store";
@@ -34,6 +35,7 @@ export function ProviderRow({ provider }: { provider: Provider }) {
   const override = useAppStore((s) => s.providerPathOverrides[id]);
   const install = useAppStore((s) => s.installs[id]);
   const auth = useAppStore((s) => s.providerAuth[id]);
+  const liveModels = useAppStore((s) => s.modelsByAgent[id]);
   const setProviderEnabled = useAppStore((s) => s.setProviderEnabled);
   const setProviderPathOverride = useAppStore((s) => s.setProviderPathOverride);
   const installAgent = useAppStore((s) => s.installAgent);
@@ -207,7 +209,10 @@ export function ProviderRow({ provider }: { provider: Provider }) {
           {live && (
             <>
               {locate}
-              <ProvDetailRow k="Models" v={d.models} />
+              {/* Live-discovered models (same curated list as the composer's
+                  picker), falling back to the static description until the
+                  catalog has data for this agent. */}
+              <ProvDetailRow k="Models" v={modelSummary(liveModels) ?? d.models} />
               {state === "fresh" && (
                 <p className="set-prov-hint ok text-sm">
                   {enabled
@@ -216,11 +221,6 @@ export function ProviderRow({ provider }: { provider: Provider }) {
                 </p>
               )}
               <SignInSection providerId={id} providerLabel={label} />
-              <div className="set-prov-detail-actions flex-center">
-                <Button variant="ghost" size="sm">
-                  View logs
-                </Button>
-              </div>
             </>
           )}
         </div>

--- a/src/data/modelCatalog/build.ts
+++ b/src/data/modelCatalog/build.ts
@@ -80,6 +80,18 @@ export function capPerGroup<G extends string>(
   });
 }
 
+/** Compact one-line summary of an agent's models for settings rows: the first
+ *  `max` names joined with " · ", plus a count of the rest. Null when the
+ *  catalog has nothing for this agent (offline first run, discovery failed, or
+ *  an agent with no list command) — callers fall back to their static
+ *  description. Expects the curated `byAgent` list, which is newest-first. */
+export function modelSummary(models: ModelMeta[] | undefined, max = 3): string | null {
+  if (!models?.length) return null;
+  const names = models.slice(0, max).map((m) => m.name);
+  const rest = models.length - names.length;
+  return rest > 0 ? `${names.join(" · ")} +${rest} more` : names.join(" · ");
+}
+
 function cleanModelName(name: string): string {
   return name.replace(/(?:\s*\((?:default|latest)\))*\s*$/gi, "").trim();
 }

--- a/src/data/modelCatalog/index.ts
+++ b/src/data/modelCatalog/index.ts
@@ -10,6 +10,7 @@ import { buildCatalog } from "./build";
 import { fetchModelsDevIndex } from "./modelsDev";
 import type { AgentModels, UnifiedCatalog } from "./types";
 
+export { modelSummary } from "./build";
 export { lookupModel, lookupModelInList } from "./normalize";
 export type { ModelMeta, SlimCatalog } from "./types";
 

--- a/src/data/providerDetail.ts
+++ b/src/data/providerDetail.ts
@@ -17,7 +17,10 @@ export interface ThinkingLevel {
 export interface ProviderDetail {
   /** Fallback binary path, shown before the live probe resolves. */
   path: string;
-  /** Models exposed by this agent. */
+  /** Fallback one-line model description. Settings surfaces prefer the live
+   *  catalog (`modelsByAgent` + `modelSummary`); this shows until discovery has
+   *  produced data for the agent, and in onboarding, which runs before any
+   *  catalog exists. */
   models: string;
   /** Detected & configured on this machine — drives the "Installed" list. */
   installed: boolean;

--- a/tests/data/modelCatalog/modelCatalog.test.ts
+++ b/tests/data/modelCatalog/modelCatalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCatalog, capPerGroup, dedupeBest } from "@/data/modelCatalog/build";
+import { buildCatalog, capPerGroup, dedupeBest, modelSummary } from "@/data/modelCatalog/build";
 import { indexModelsDev } from "@/data/modelCatalog/modelsDev";
 import { lookupModel, lookupModelInList, modelIdCandidates } from "@/data/modelCatalog/normalize";
 import type { AgentModels, ModelMeta, SlimCatalog } from "@/data/modelCatalog/types";
@@ -717,5 +717,18 @@ describe("capPerGroup", () => {
   it("drops every model in a group capped at zero", () => {
     const out = capPerGroup([model("a-1"), model("b-1")], byPrefix, { a: 0, b: 1 });
     expect(out.map((m) => m.id)).toEqual(["b-1"]);
+  });
+});
+
+describe("modelSummary", () => {
+  it("joins up to three names and counts the rest", () => {
+    const models = [model("a", "A"), model("b", "B"), model("c", "C"), model("d", "D")];
+    expect(modelSummary(models)).toBe("A · B · C +1 more");
+    expect(modelSummary(models.slice(0, 2))).toBe("A · B");
+  });
+
+  it("is null for an empty or absent list, so callers fall back", () => {
+    expect(modelSummary(undefined)).toBeNull();
+    expect(modelSummary([])).toBeNull();
   });
 });


### PR DESCRIPTION
## What

The **Models** line on provider cards (Settings › Providers) and in the quick-settings popover was a hardcoded string per agent (e.g. `Opus 4.7 · Sonnet 4.6 · Haiku 4`) that went stale with every model release. Both surfaces now show live-discovered models from the hybrid model catalog — the same curated per-agent lists the composer's model picker already uses (CLI discovery + models.dev enrichment, localStorage cache, 1h TTL).

Also removes the dead **View logs** button from provider cards: a leftover placeholder from the original static settings mockup (#57) that never had an `onClick` and has no backend log surface to point at.

## How

- New `modelSummary(models, max = 3)` in `src/data/modelCatalog/build.ts` (re-exported from the catalog entrypoint): joins the newest few model names, appends `+N more`, returns `null` for an empty/absent list so callers fall back.
- `ProviderRow` and the quick-settings popover render `modelSummary(modelsByAgent[id]) ?? PROVIDER_DETAIL[id].models` — live catalog first, static string until discovery produces data (offline first run, agents with no list command).
- `ProviderDetail.models` doc updated to mark it as the fallback. Onboarding keeps the static string on purpose — it runs before any catalog exists.

## Testing

- `tsc --noEmit` clean, biome clean.
- Catalog tests pass (33), including two new ones pinning `modelSummary`'s join/count and null-fallback behavior.