### PR TITLE
fix(mobile): race IPv6 and IPv4 when dialling the relay

### DIFF
--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -168,6 +168,9 @@ repo); anyone can run their own and point both apps at it.
   connections, as on the LAN.
 - **Phone side.** Connection candidates in order: `addr` over `ws://` with a
   3 s open timeout, then `wss://<relay>/v1/device/<hostId>` with a 15 s one.
+  A dial races the host's IPv6 and IPv4 addresses, interleaved by family and
+  started 300 ms apart (RFC 8305), so a cellular network whose IPv6 path to
+  the relay blackholes cannot spend the whole budget before IPv4 is tried.
   Both budgets cover the dial and the Noise handshake together; the first
   frame after the handshake (`pair` or `hello`, and the snapshot request that
   follows a `pair`) has its own 15 s bound, so a relay that accepted the

--- a/mobile/src-tauri/Cargo.toml
+++ b/mobile/src-tauri/Cargo.toml
@@ -38,7 +38,8 @@ tokio-tungstenite = { version = "0.27", features = ["rustls-tls-webpki-roots"] }
 # cmake. `run()` also installs it explicitly, so a future dependency that
 # drags in aws-lc-rs cannot reintroduce the ambiguity.
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
-tokio = { version = "1", features = ["sync", "time"] }
+# `net`: the relay dial resolves and races addresses itself (src/remote/dial.rs).
+tokio = { version = "1", features = ["sync", "time", "net"] }
 futures-util = "0.3"
 base64 = "0.22"
 serde = { version = "1", features = ["derive"] }

--- a/mobile/src-tauri/src/remote/dial.rs
+++ b/mobile/src-tauri/src/remote/dial.rs
@@ -1,0 +1,195 @@
+// Opening the WebSocket's TCP socket with both address families in the race.
+//
+// `tokio_tungstenite::connect_async` resolves the host, then tries the
+// addresses one at a time with no bound on any of them. On a cellular network
+// the phone holds a global IPv6 address, so the resolver lists the relay's
+// AAAA records first — and when the carrier's IPv6 path to the relay
+// blackholes, that first SYN sits until the caller's whole open budget is
+// gone and the IPv4 addresses are never dialled. The symptom was a relay that
+// worked from any IPv4-only Wi-Fi and "timed out after 15000 ms" on LTE.
+//
+// This dials the way a browser does (RFC 8305, "Happy Eyeballs"): addresses
+// interleaved by family, each attempt started a short stagger after the last,
+// the first socket to connect wins and the rest are dropped. TLS and the
+// WebSocket upgrade then run on the winner exactly as `connect_async` would
+// have done.
+
+use std::io;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use futures_util::stream::{FuturesUnordered, StreamExt};
+use tokio::net::TcpStream;
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::handshake::client::Request;
+use tokio_tungstenite::{client_async_tls, MaybeTlsStream, WebSocketStream};
+
+pub type Ws = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+/// RFC 8305 suggests 250 ms between attempts. A little more here: the
+/// cellular round trip this exists for is often that long by itself, and a
+/// working first address should not be undercut by the second.
+pub const STAGGER: Duration = Duration::from_millis(300);
+
+/// Dial `url` and complete the WebSocket upgrade (TLS included for `wss://`).
+/// The caller bounds the whole thing; nothing here waits on its own account
+/// beyond the stagger between attempts.
+pub async fn connect(url: &str) -> Result<Ws, String> {
+    let request = url.into_client_request().map_err(|e| e.to_string())?;
+    let (host, port) = host_port(&request)?;
+    let addrs: Vec<SocketAddr> = tokio::net::lookup_host((host.as_str(), port))
+        .await
+        .map_err(|e| format!("cannot resolve {host}: {e}"))?
+        .collect();
+    let stream = race(interleave(addrs)).await.map_err(|e| e.to_string())?;
+    let (ws, _) = client_async_tls(request, stream)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(ws)
+}
+
+/// The host to resolve and the port to dial, with the scheme's default port
+/// when the URL names none — the same rule `connect_async` applies.
+fn host_port(request: &Request) -> Result<(String, u16), String> {
+    let uri = request.uri();
+    let host = uri.host().ok_or("the URL names no host")?;
+    // `host()` keeps the brackets of an IPv6 literal; the resolver wants them off.
+    let host = host
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .to_string();
+    let port = uri
+        .port_u16()
+        .or_else(|| match uri.scheme_str() {
+            Some("wss") => Some(443),
+            Some("ws") => Some(80),
+            _ => None,
+        })
+        .ok_or_else(|| format!("unsupported URL scheme in {uri}"))?;
+    Ok((host, port))
+}
+
+/// RFC 8305 §4: alternate address families, leading with the resolver's own
+/// first choice, so the second attempt is always on the other family.
+fn interleave(addrs: Vec<SocketAddr>) -> Vec<SocketAddr> {
+    let Some(first) = addrs.first() else {
+        return addrs;
+    };
+    let lead = first.is_ipv6();
+    let total = addrs.len();
+    let (lead_family, other): (Vec<_>, Vec<_>) =
+        addrs.into_iter().partition(|addr| addr.is_ipv6() == lead);
+    let mut lead_family = lead_family.into_iter();
+    let mut other = other.into_iter();
+    let mut out = Vec::with_capacity(total);
+    loop {
+        match (lead_family.next(), other.next()) {
+            (None, None) => return out,
+            (a, b) => {
+                out.extend(a);
+                out.extend(b);
+            }
+        }
+    }
+}
+
+/// Start one connect per address, `STAGGER` apart, and take the first that
+/// succeeds. Returning drops the set, which abandons every attempt still in
+/// flight. When all of them fail the last error is the one reported, as
+/// `TcpStream::connect` does for a list.
+async fn race(addrs: Vec<SocketAddr>) -> io::Result<TcpStream> {
+    let mut attempts: FuturesUnordered<_> = addrs
+        .into_iter()
+        .enumerate()
+        .map(|(i, addr)| async move {
+            tokio::time::sleep(STAGGER * i as u32).await;
+            TcpStream::connect(addr).await
+        })
+        .collect();
+    let mut last = None;
+    while let Some(result) = attempts.next().await {
+        match result {
+            Ok(stream) => return Ok(stream),
+            Err(e) => last = Some(e),
+        }
+    }
+    Err(last.unwrap_or_else(|| {
+        io::Error::new(io::ErrorKind::NotFound, "the host resolved to no address")
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::{Ipv4Addr, Ipv6Addr};
+
+    fn v4(n: u8) -> SocketAddr {
+        SocketAddr::from((Ipv4Addr::new(10, 0, 0, n), 443))
+    }
+
+    fn v6(n: u16) -> SocketAddr {
+        SocketAddr::from((Ipv6Addr::new(0xfd00, 0, 0, 0, 0, 0, 0, n), 443))
+    }
+
+    #[test]
+    fn interleaves_families_leading_with_the_resolvers_first_choice() {
+        assert_eq!(
+            interleave(vec![v6(1), v6(2), v4(1), v4(2)]),
+            vec![v6(1), v4(1), v6(2), v4(2)]
+        );
+        assert_eq!(
+            interleave(vec![v4(1), v4(2), v6(1)]),
+            vec![v4(1), v6(1), v4(2)]
+        );
+        // One family, or nothing: untouched.
+        assert_eq!(interleave(vec![v4(1), v4(2)]), vec![v4(1), v4(2)]);
+        assert!(interleave(vec![]).is_empty());
+    }
+
+    #[test]
+    fn host_port_applies_the_scheme_default_and_strips_ipv6_brackets() {
+        let req = "wss://relay.fletch.sh/v1/device/k"
+            .into_client_request()
+            .unwrap();
+        assert_eq!(host_port(&req).unwrap(), ("relay.fletch.sh".into(), 443));
+        let req = "ws://192.168.1.24:47285/ws".into_client_request().unwrap();
+        assert_eq!(host_port(&req).unwrap(), ("192.168.1.24".into(), 47285));
+        let req = "ws://[::1]:8080/ws".into_client_request().unwrap();
+        assert_eq!(host_port(&req).unwrap(), ("::1".into(), 8080));
+    }
+
+    /// The point of the race: an address that does not answer must not cost
+    /// the addresses after it their turn.
+    #[test]
+    fn a_refused_first_address_falls_through_to_one_that_answers() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let live = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+                .await
+                .unwrap();
+            let live_addr = live.local_addr().unwrap();
+            // A port that was ours a moment ago and is now closed: refused.
+            let dead_addr = {
+                let l = std::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+                l.local_addr().unwrap()
+            };
+            let stream = race(vec![dead_addr, live_addr]).await.unwrap();
+            assert_eq!(stream.peer_addr().unwrap(), live_addr);
+            let (_, peer) = live.accept().await.unwrap();
+            assert_eq!(peer, stream.local_addr().unwrap());
+        });
+    }
+
+    #[test]
+    fn no_address_at_all_is_an_error_not_a_hang() {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let err = rt.block_on(race(vec![])).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::NotFound);
+    }
+}

--- a/mobile/src-tauri/src/remote/mod.rs
+++ b/mobile/src-tauri/src/remote/mod.rs
@@ -9,8 +9,10 @@
 // is connected right now": a wrapper that was superseded while its handshake
 // was in flight cannot close its successor, send on it, or hear its events.
 
+mod dial;
 mod secure;
 
+use dial::Ws;
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
 use secure::{Channel, DeviceKey, Handshake, HOST_KEY_MISMATCH};
@@ -19,15 +21,12 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, Manager, State};
-use tokio::net::TcpStream;
 use tokio::sync::Mutex;
 use tokio::time::Instant;
 use tokio_tungstenite::tungstenite::protocol::frame::coding::CloseCode;
 use tokio_tungstenite::tungstenite::protocol::CloseFrame;
 use tokio_tungstenite::tungstenite::Message;
-use tokio_tungstenite::{connect_async, MaybeTlsStream, WebSocketStream};
 
-type Ws = WebSocketStream<MaybeTlsStream<TcpStream>>;
 type Writer = SplitSink<Ws, Message>;
 type Reader = SplitStream<Ws>;
 type Slot = Arc<Mutex<Option<Connection>>>;
@@ -134,10 +133,12 @@ pub async fn remote_connect(
     close_current(&state.slot).await;
     let key = device_key(&app, &state)?;
     let deadline = timeout_ms.map(|ms| Instant::now() + Duration::from_millis(ms));
-    let dialled = within(deadline, connect_async(&url))
+    // Both address families race inside `dial::connect` (see dial.rs), so one
+    // that blackholes cannot spend the budget on behalf of the other.
+    let dialled = within(deadline, dial::connect(&url))
         .await
         .ok_or_else(|| timed_out(&url, timeout_ms))?;
-    let (mut ws, _) = dialled.map_err(|e| format!("cannot reach {url}: {e}"))?;
+    let mut ws = dialled.map_err(|e| format!("cannot reach {url}: {e}"))?;
     // The borrow of `ws` ends with the statement, so the socket is ours again
     // whether the handshake finished, failed or ran out of time.
     let handshaken = within(deadline, handshake(&mut ws, &key, host_key.as_deref())).await;


### PR DESCRIPTION
## Problem

Connecting the phone to the Mac through the relay failed on cellular (LTE and Edge) with `cannot reach wss://relay.fletch.sh/...: timed out after 15000 ms`, while the same phone connected fine from any remote Wi-Fi.

`tokio_tungstenite::connect_async` resolves the host and then tries the returned addresses strictly one at a time, with no per-address bound. On cellular the phone has a global IPv6 address, so the resolver lists the relay's AAAA records first; when the carrier's IPv6 path to Cloudflare blackholes, that first SYN sits until the caller's whole 15 s dial budget expires, and the IPv4 addresses are never dialled. IPv4-only Wi-Fi never hits this because the resolver returns only A records there.

## Fix

New `mobile/src-tauri/src/remote/dial.rs` dials the way a browser does (RFC 8305, Happy Eyeballs):

- resolve the host, interleave the addresses by family, leading with the resolver's first choice
- start one connect attempt every 300 ms; the first socket to connect wins and the rest are dropped
- run TLS and the WebSocket upgrade on the winner via `client_async_tls`

`remote_connect` calls it in place of `connect_async`. The existing 15 s deadline still bounds dial plus Noise handshake together and every error message is unchanged. Tokio's `net` feature is enabled explicitly, and the protocol doc's "Phone side" section notes the race.

## Tests

- family interleaving
- host/port parsing, including scheme default ports and IPv6 literal brackets
- a refused first address falls through to a live one
- an empty address list errors instead of hanging

`cargo test --lib remote::` passes (17 tests); clippy and rustfmt clean.

## Caveat

If a carrier's IPv6 path connects at the TCP level but drops large packets, the TLS handshake would still stall on the winning IPv6 socket. Racing the TLS handshakes too is the follow-up if cellular still fails after this build.