### PR TITLE
feat(mobile): swipe to go back and to dismiss sheets

### DIFF
--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect } from "react";
+import { Stack } from "./components/Stack";
 import { useSystemTheme } from "./lib/hooks";
 import { AgentScreen } from "./screens/Agent";
 import { DiffScreen } from "./screens/Diff";
@@ -43,7 +44,6 @@ export function App() {
   const theme = useStore((s) => s.theme);
   const systemTheme = useStore((s) => s.systemTheme);
   const setSystemTheme = useStore((s) => s.setSystemTheme);
-  const nav = useStore((s) => s.nav);
   const sheet = useStore((s) => s.sheet);
   const closeSheet = useStore((s) => s.closeSheet);
   // Paired means "we hold the host's key": there is no other credential.
@@ -55,8 +55,6 @@ export function App() {
   useSystemTheme(useCallback((t) => setSystemTheme(t), [setSystemTheme]));
 
   const resolved = theme === "system" ? systemTheme : theme;
-  const live = nav.filter((i) => i.phase !== "leave");
-  const topKey = live[live.length - 1]?.key;
   const props = (name: string) => (sheet?.name === name ? sheet.props : {});
   const isOpen = (name: string) => !!(sheet?.name === name && sheet.open);
   const dimmed = !!sheet?.open && FULL_SHEETS.has(sheet.name);
@@ -65,24 +63,7 @@ export function App() {
     <div className={`m-app theme-${resolved}`}>
       {!ready ? null : hostKey ? (
         <>
-          <div className={`stack${dimmed ? " dimmed" : ""}`}>
-            {nav.map((item) => {
-              const cls =
-                item.phase === "enter"
-                  ? "enter"
-                  : item.phase === "leave"
-                    ? "leave"
-                    : item.key === topKey
-                      ? "top"
-                      : "under";
-              return (
-                <div key={item.key} className={`scr ${cls}`}>
-                  <Screen item={item} />
-                  <div className="scrim" />
-                </div>
-              );
-            })}
-          </div>
+          <Stack dimmed={dimmed} render={(item) => <Screen item={item} />} />
           <HostSheet open={isOpen("host")} onClose={closeSheet} />
           <NewAgentSheet open={isOpen("newAgent")} onClose={closeSheet} {...props("newAgent")} />
           <AddProjectSheet open={isOpen("addProject")} onClose={closeSheet} />

--- a/mobile/src/components/Stack/index.tsx
+++ b/mobile/src/components/Stack/index.tsx
@@ -1,0 +1,52 @@
+import { type ReactNode, useRef } from "react";
+import { useSwipe } from "../../lib/swipe";
+import { type NavItem, useStore } from "../../store";
+
+/** How far in from the left a swipe-back may begin, like the iOS edge pan.
+ *  Wide enough to catch a thumb, narrow enough to leave the transcript's
+ *  code blocks their own horizontal scroll. */
+const BACK_EDGE = 28;
+
+/** The pushed screens, top-most last, with the edge swipe that pops them. */
+export function Stack({
+  dimmed,
+  render,
+}: {
+  dimmed: boolean;
+  render: (item: NavItem) => ReactNode;
+}) {
+  const nav = useStore((s) => s.nav);
+  const sheet = useStore((s) => s.sheet);
+  const pop = useStore((s) => s.pop);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const live = nav.filter((i) => i.phase !== "leave");
+  const topKey = live[live.length - 1]?.key;
+  useSwipe(ref, {
+    axis: "x",
+    edge: BACK_EDGE,
+    enabled: live.length > 1 && !sheet?.open,
+    onCommit: pop,
+  });
+
+  return (
+    <div ref={ref} className={`stack${dimmed ? " dimmed" : ""}`}>
+      {nav.map((item) => {
+        const cls =
+          item.phase === "enter"
+            ? "enter"
+            : item.phase === "leave"
+              ? "leave"
+              : item.key === topKey
+                ? "top"
+                : "under";
+        return (
+          <div key={item.key} className={`scr ${cls}`}>
+            {render(item)}
+            <div className="scrim" />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/mobile/src/components/ui/index.tsx
+++ b/mobile/src/components/ui/index.tsx
@@ -4,8 +4,9 @@
 
 import type { AgentStatus, ProjectRef } from "@desktop/api/types/agent";
 import type { PrState } from "@desktop/api/types/pr";
-import { type ReactNode, useEffect, useState } from "react";
+import { type ReactNode, useEffect, useRef, useState } from "react";
 import { hueColor, projectHue, providerHue, providerShort } from "../../lib/agents";
+import { useSwipe } from "../../lib/swipe";
 import { useProviderIcon } from "../../lib/useProviderIcon";
 import { Icon, type IconName } from "../Icon";
 
@@ -66,6 +67,22 @@ export function Sheet({
 }) {
   const [mounted, setMounted] = useState(open);
   const [shown, setShown] = useState(false);
+  const root = useRef<HTMLDivElement>(null);
+  const panel = useRef<HTMLDivElement>(null);
+  useSwipe(
+    panel,
+    {
+      axis: "y",
+      enabled: shown && !!onClose,
+      // `shown` drops here, not in the `open` effect: same frame as the drag
+      // lets go, so the close transition continues from under the finger.
+      onCommit: () => {
+        setShown(false);
+        onClose?.();
+      },
+    },
+    root,
+  );
   useEffect(() => {
     if (open) {
       setMounted(true);
@@ -85,9 +102,9 @@ export function Sheet({
   }, [open]);
   if (!mounted) return null;
   return (
-    <div className={`sheet-root${shown ? " open" : ""}`}>
+    <div ref={root} className={`sheet-root${shown ? " open" : ""}`}>
       <button type="button" className="sheet-bg" onClick={onClose} aria-label="Close" />
-      <div className={`sheet${full ? " full" : ""}${stacked ? " stacked" : ""}`}>
+      <div ref={panel} className={`sheet${full ? " full" : ""}${stacked ? " stacked" : ""}`}>
         <div className="grab" />
         {(title || left || right) && (
           <div className="sheet-head">

--- a/mobile/src/lib/swipe.ts
+++ b/mobile/src/lib/swipe.ts
@@ -1,0 +1,128 @@
+import { type RefObject, useEffect, useRef } from "react";
+
+/** A drag that dismisses something: a screen swiped off to the right, a sheet
+ *  pulled down. While the finger is down, `stage` carries `.dragging` and a
+ *  `--swipe` custom property in 0..1, so the CSS that already animates the
+ *  open/close can follow the finger instead. On release the property is
+ *  cleared in the same frame the caller's own close kicks in, so the CSS
+ *  transition picks up from wherever the finger let go. */
+export interface SwipeOptions {
+  /** `x` dismisses by dragging right, `y` by dragging down. */
+  axis: "x" | "y";
+  /** Only begin when the touch lands within this many px of the leading edge
+   *  (left for `x`, top for `y`). Omit to begin anywhere on the target. */
+  edge?: number;
+  enabled?: boolean;
+  onCommit: () => void;
+  /** Injected clock for tests. */
+  now?: () => number;
+}
+
+/** A flick commits however short it was; a long drag commits unless it is
+ *  being flung back. Velocity is px/ms along the axis. */
+export const shouldCommit = (delta: number, size: number, velocity: number) =>
+  velocity > 0.4 || (delta > size * 0.3 && velocity > -0.2);
+
+/** Anything between `target` and `root` that is scrolled along `axis` owns the
+ *  gesture: a pulled-down sheet body must scroll back to top before it drags
+ *  the sheet, the way iOS sheets behave. */
+const scrolledAncestor = (target: EventTarget | null, root: HTMLElement, axis: "x" | "y") => {
+  let node = target instanceof Element ? target : null;
+  while (node && node !== root) {
+    if ((axis === "x" ? node.scrollLeft : node.scrollTop) > 0) return true;
+    node = node.parentElement;
+  }
+  return false;
+};
+
+export function attachSwipe(target: HTMLElement, stage: HTMLElement, opts: () => SwipeOptions) {
+  let start: { x: number; y: number } | null = null;
+  let active = false;
+  let last = { d: 0, t: 0 };
+  let velocity = 0;
+  const now = () => opts().now?.() ?? performance.now();
+  const size = () => (opts().axis === "x" ? target.offsetWidth : target.offsetHeight);
+
+  const onStart = (e: TouchEvent) => {
+    const o = opts();
+    if (o.enabled === false || e.touches.length !== 1) return;
+    const t = e.touches[0];
+    const rect = target.getBoundingClientRect();
+    const along = o.axis === "x" ? t.clientX - rect.left : t.clientY - rect.top;
+    if (o.edge !== undefined && along > o.edge) return;
+    if (scrolledAncestor(e.target, target, o.axis)) return;
+    start = { x: t.clientX, y: t.clientY };
+    active = false;
+    last = { d: 0, t: now() };
+    velocity = 0;
+  };
+
+  const onMove = (e: TouchEvent) => {
+    if (!start) return;
+    const o = opts();
+    const t = e.touches[0];
+    const dx = t.clientX - start.x;
+    const dy = t.clientY - start.y;
+    const along = o.axis === "x" ? dx : dy;
+    const across = o.axis === "x" ? dy : dx;
+    if (!active) {
+      if (along === 0 && across === 0) return;
+      // The first real movement decides: the wrong way or mostly across the
+      // axis, and this is a scroll, not a swipe. Deciding on the very first
+      // move is what keeps a vertical scroll that starts at the edge working.
+      if (along <= 0 || Math.abs(across) > Math.abs(along)) {
+        start = null;
+        return;
+      }
+      active = true;
+      stage.classList.add("dragging");
+    }
+    e.preventDefault();
+    const d = Math.max(0, along);
+    const t1 = now();
+    const dt = t1 - last.t;
+    if (dt > 0) velocity = 0.6 * ((d - last.d) / dt) + 0.4 * velocity;
+    last = { d, t: t1 };
+    stage.style.setProperty("--swipe", String(Math.min(1, d / size())));
+  };
+
+  const onEnd = () => {
+    if (!start) return;
+    const was = active;
+    start = null;
+    active = false;
+    if (!was) return;
+    stage.classList.remove("dragging");
+    stage.style.removeProperty("--swipe");
+    if (shouldCommit(last.d, size(), velocity)) opts().onCommit();
+  };
+
+  target.addEventListener("touchstart", onStart, { passive: true });
+  target.addEventListener("touchmove", onMove, { passive: false });
+  target.addEventListener("touchend", onEnd);
+  target.addEventListener("touchcancel", onEnd);
+  return () => {
+    target.removeEventListener("touchstart", onStart);
+    target.removeEventListener("touchmove", onMove);
+    target.removeEventListener("touchend", onEnd);
+    target.removeEventListener("touchcancel", onEnd);
+    stage.classList.remove("dragging");
+    stage.style.removeProperty("--swipe");
+  };
+}
+
+/** `attachSwipe` for the life of `target`. `stage` receives the `--swipe`
+ *  property and defaults to the target itself. */
+export function useSwipe(
+  target: RefObject<HTMLElement | null>,
+  opts: SwipeOptions,
+  stage?: RefObject<HTMLElement | null>,
+) {
+  const latest = useRef(opts);
+  latest.current = opts;
+  useEffect(() => {
+    const el = target.current;
+    if (!el) return;
+    return attachSwipe(el, stage?.current ?? el, () => latest.current);
+  }, [target, stage]);
+}

--- a/mobile/src/styles/base.css
+++ b/mobile/src/styles/base.css
@@ -163,12 +163,20 @@ a {
 .scr.leave {
   transform: translateX(100%);
 }
+/* `--swipe` (0..1, set on `.stack` by lib/swipe.ts while a finger drags the
+   top screen back) parks every layer part-way along its own transition, so a
+   release just lets the transition finish from there. */
 .scr.under {
-  transform: translateX(-26%);
+  transform: translateX(calc(-26% * (1 - var(--swipe, 0))));
   pointer-events: none;
 }
 .scr.top {
+  transform: translateX(calc(100% * var(--swipe, 0)));
   box-shadow: -10px 0 34px rgba(0, 0, 0, 0.45);
+}
+.stack.dragging .scr,
+.stack.dragging .scr .scrim {
+  transition: none;
 }
 .scr.enter,
 .scr.top,
@@ -185,10 +193,10 @@ a {
   z-index: 30;
 }
 .scr.under .scrim {
-  opacity: 0.45;
+  opacity: calc(0.45 * (1 - var(--swipe, 0)));
 }
 .theme-light .scr.under .scrim {
-  opacity: 0.12;
+  opacity: calc(0.12 * (1 - var(--swipe, 0)));
 }
 
 /* nav bar */
@@ -323,11 +331,17 @@ a {
 .sheet.stacked {
   max-height: calc(100% - var(--safe-top) - 60px);
 }
+/* Same `--swipe` scheme as `.stack`: a pull on the sheet drags it down and
+   thins the scrim in step. */
 .sheet-root.open .sheet-bg {
-  opacity: 1;
+  opacity: calc(1 - var(--swipe, 0));
 }
 .sheet-root.open .sheet {
-  transform: none;
+  transform: translateY(calc(100% * var(--swipe, 0)));
+}
+.sheet-root.dragging .sheet,
+.sheet-root.dragging .sheet-bg {
+  transition: none;
 }
 .grab {
   width: 36px;

--- a/mobile/tests/swipe.test.ts
+++ b/mobile/tests/swipe.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from "vitest";
+import { attachSwipe, shouldCommit } from "../src/lib/swipe";
+
+describe("shouldCommit", () => {
+  it("commits a slow drag once it has covered enough of the element", () => {
+    expect(shouldCommit(100, 400, 0)).toBe(false);
+    expect(shouldCommit(140, 400, 0)).toBe(true);
+  });
+  it("commits a flick however short, and refuses a long drag flung back", () => {
+    expect(shouldCommit(30, 400, 0.6)).toBe(true);
+    expect(shouldCommit(300, 400, -0.5)).toBe(false);
+  });
+});
+
+/** jsdom has no `Touch`; a plain event with a `touches` array is all the
+ *  gesture reads. */
+function touch(type: string, x: number, y: number, target: Element) {
+  const e = new Event(type, { bubbles: true, cancelable: true });
+  Object.defineProperty(e, "touches", { value: [{ clientX: x, clientY: y }] });
+  target.dispatchEvent(e);
+  return e;
+}
+
+function mount(width = 400, height = 800) {
+  const target = document.createElement("div");
+  const inner = document.createElement("div");
+  target.appendChild(inner);
+  document.body.appendChild(target);
+  Object.defineProperty(target, "offsetWidth", { value: width });
+  Object.defineProperty(target, "offsetHeight", { value: height });
+  target.getBoundingClientRect = () =>
+    ({ left: 0, top: 0, right: width, bottom: height, width, height, x: 0, y: 0 }) as DOMRect;
+  return { target, inner };
+}
+
+describe("attachSwipe", () => {
+  it("drives --swipe from an edge drag and pops on release", () => {
+    const { target, inner } = mount();
+    const onCommit = vi.fn();
+    let t = 0;
+    attachSwipe(target, target, () => ({ axis: "x", edge: 28, onCommit, now: () => t }));
+
+    touch("touchstart", 10, 300, inner);
+    t = 50;
+    const move = touch("touchmove", 60, 302, inner);
+    expect(move.defaultPrevented).toBe(true);
+    expect(target.classList.contains("dragging")).toBe(true);
+    t = 200;
+    touch("touchmove", 210, 305, inner);
+    expect(target.style.getPropertyValue("--swipe")).toBe("0.5");
+
+    touch("touchend", 210, 305, inner);
+    expect(target.classList.contains("dragging")).toBe(false);
+    expect(target.style.getPropertyValue("--swipe")).toBe("");
+    expect(onCommit).toHaveBeenCalledOnce();
+  });
+
+  it("snaps back without committing when the drag falls short", () => {
+    const { target, inner } = mount();
+    const onCommit = vi.fn();
+    let t = 0;
+    attachSwipe(target, target, () => ({ axis: "x", edge: 28, onCommit, now: () => t }));
+    touch("touchstart", 10, 300, inner);
+    for (const x of [20, 30, 40, 50, 60]) {
+      t += 100;
+      touch("touchmove", x, 300, inner);
+    }
+    touch("touchend", 60, 300, inner);
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(target.style.getPropertyValue("--swipe")).toBe("");
+  });
+
+  it("ignores touches that start away from the edge", () => {
+    const { target, inner } = mount();
+    const onCommit = vi.fn();
+    attachSwipe(target, target, () => ({ axis: "x", edge: 28, onCommit }));
+    touch("touchstart", 100, 300, inner);
+    const move = touch("touchmove", 300, 300, inner);
+    expect(move.defaultPrevented).toBe(false);
+    touch("touchend", 300, 300, inner);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("yields to a scroll: the first move decides the axis", () => {
+    const { target, inner } = mount();
+    const onCommit = vi.fn();
+    attachSwipe(target, target, () => ({ axis: "x", edge: 28, onCommit }));
+    touch("touchstart", 10, 300, inner);
+    const move = touch("touchmove", 14, 330, inner);
+    expect(move.defaultPrevented).toBe(false);
+    // Later horizontal movement in the same touch no longer counts.
+    touch("touchmove", 300, 330, inner);
+    touch("touchend", 300, 330, inner);
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(target.classList.contains("dragging")).toBe(false);
+  });
+
+  it("leaves a scrolled sheet body to scroll back first", () => {
+    const { target, inner } = mount();
+    const onCommit = vi.fn();
+    Object.defineProperty(inner, "scrollTop", { value: 120 });
+    attachSwipe(target, target, () => ({ axis: "y", onCommit }));
+    touch("touchstart", 100, 100, inner);
+    const move = touch("touchmove", 100, 400, inner);
+    expect(move.defaultPrevented).toBe(false);
+    touch("touchend", 100, 400, inner);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("stays put while disabled", () => {
+    const { target, inner } = mount();
+    const onCommit = vi.fn();
+    attachSwipe(target, target, () => ({ axis: "x", edge: 28, enabled: false, onCommit }));
+    touch("touchstart", 10, 300, inner);
+    touch("touchmove", 300, 300, inner);
+    touch("touchend", 300, 300, inner);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds finger-driven dismiss gestures to the mobile app:

- **Swipe back**: dragging right from the left edge (28px zone) pops the top screen, iOS-style. The screen follows the finger, the screen beneath slides in from its parked -26% position and its scrim thins in step.
- **Pull down to dismiss**: dragging down on any bottom sheet dismisses it. A scrolled sheet body scrolls back to top before the sheet itself moves.

## How it works

One helper, `mobile/src/lib/swipe.ts`, tracks the touch and drives a `--swipe` custom property (0..1) plus a `.dragging` class on the stack or sheet root. The existing open/close CSS transitions are rewritten in terms of that property, so the drag parks every layer part-way along its own transition. On release the property is cleared in the same frame as `pop()` / `closeSheet()` fires, so the transition finishes from wherever the finger let go rather than snapping.

- The first `touchmove` decides the axis: vertical-dominant or wrong-way movement yields to native scrolling, so a vertical scroll that starts at the edge still scrolls.
- A flick commits however short; a slow drag commits past a third of the width unless flung back.
- Disabled when only one screen is live or a sheet is open.
- Taps in the edge zone still land normally (the back button lives there), since `touchstart` is never prevented.

The nav stack rendering moves out of `App.tsx` into `components/Stack`, which owns the gesture.

## Testing

- `bun run test`: 146 passed, including 8 new tests in `tests/swipe.test.ts` covering commit thresholds, edge zone, axis decision, scrolled-ancestor veto, and the disabled state.
- `bun run lint`: clean. `tsc` reports no errors in the mobile tree (the desktop `../src` errors are pre-existing from missing desktop deps in the checkout).
- **Not verified on a device or simulator.** The headless browser couldn't run in the sandbox, so please try it on iOS: edge-swipe from an agent back to the list, pull down a sheet, and check that vertical scrolling from the left edge still works.