### PR TITLE
fix(mobile): keep text size consistent across orientation changes

### DIFF
--- a/mobile/src/styles/base.css
+++ b/mobile/src/styles/base.css
@@ -84,6 +84,8 @@ body {
   color: var(--fg-0);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 * {
   box-sizing: border-box;


### PR DESCRIPTION
## Problem

On iOS, rotating the phone to landscape makes some UI text larger. Rotating back restores the portrait layout, but the enlarged text stays enlarged.

This is WebKit's text auto-sizing (font boosting). When the viewport widens, WebKit inflates text it judges too small in blocks it treats as primary content. The inflation is cached per block, so already-boosted blocks keep their size after rotating back until they are re-laid out from scratch.

## Fix

Set `-webkit-text-size-adjust: 100%` and `text-size-adjust: 100%` on the root element in the mobile base stylesheet. This disables the boosting so text renders at the authored pixel sizes in both orientations.

- `100%` rather than `none`: both stop boosting, but `none` is non-standard and historically interfered with pinch zoom on older WebKit.
- The prefixed form is what iOS Safari and WKWebView (Tauri mobile) honour; the unprefixed form covers Chromium on Android.
- iOS Dynamic Type is unaffected, since it scales through the system font rather than this property.

## Testing

Manual: rotate the mobile app to landscape and back on an iOS device or simulator; text sizes should match before and after.