### PR TITLE
fix(mobile): clear the stale busy flag from a fresh host snapshot

### DIFF
--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -251,6 +251,41 @@ export const projectOf = (ws: Workspace | null, agentId: string) => {
   return ws?.projects.find((p) => p.project_id === agent?.project_id);
 };
 
+/** Agents with a send in flight from this device. Their optimistic `busy` flag
+ *  is younger than any snapshot the host can answer with, so `reconcileBusy`
+ *  has to leave it alone. */
+const sending = new Set<string>();
+
+/** Run a send with its agent marked in-flight, so a snapshot landing in the
+ *  optimistic window can't clear the flag the send just set. */
+async function whileSending<T>(agentId: string, fn: () => Promise<T>): Promise<T> {
+  sending.add(agentId);
+  try {
+    return await fn();
+  } finally {
+    sending.delete(agentId);
+  }
+}
+
+/** Drop optimistic `busy` flags a fresh host snapshot contradicts.
+ *
+ *  The flag covers the gap between tapping send and the host's `running`
+ *  status; past that it is only ever cleared by a live event (a turn end, or a
+ *  status that isn't `running`). A backgrounded webview or a dropped socket
+ *  misses those silently — which used to strand the flag on `true` for the rest
+ *  of the session, leaving the Changes tab (the one surface that reads it) on
+ *  "Agent is busy…" for an agent the chat showed as finished. A snapshot saying
+ *  the agent isn't running is the authority that the gap is over. */
+function reconcileBusy(busy: Record<string, boolean>, ws: Workspace): Record<string, boolean> {
+  let next = busy;
+  for (const a of ws.agents) {
+    if (!busy[a.id] || isBusy(a) || sending.has(a.id)) continue;
+    if (next === busy) next = { ...busy };
+    next[a.id] = false;
+  }
+  return next;
+}
+
 /** Wait for a freshly spawned agent to leave `spawning` before the first
  *  message is sent — the spawn flow in docs/remote-protocol.md. */
 function waitForSpawn(get: () => MobileState, agentId: string, timeoutMs = 30_000) {
@@ -328,7 +363,11 @@ export const useStore = create<MobileState>()((set, get) => ({
     };
     client.onSnapshot((snapshot) => {
       set({ hostInfo: snapshot.host });
-      if (snapshot.workspace) set({ workspace: snapshot.workspace });
+      const ws = snapshot.workspace;
+      // The handshake's snapshot is as authoritative as `refreshWorkspace`'s
+      // read, so it reconciles the optimistic busy flags the same way — this is
+      // the path that clears them after a reconnect.
+      if (ws) set((s) => ({ workspace: ws, busy: reconcileBusy(s.busy, ws) }));
       else void get().refreshWorkspace();
       refreshOpenAgent();
       // Every handshake — the first pairing and every reconnect — is when the
@@ -544,7 +583,7 @@ export const useStore = create<MobileState>()((set, get) => ({
   async refreshWorkspace() {
     try {
       const workspace = await api.getWorkspace();
-      if (workspace) set({ workspace });
+      if (workspace) set((s) => ({ workspace, busy: reconcileBusy(s.busy, workspace) }));
     } catch {
       // Best effort; the next event or resync recovers.
     }
@@ -639,7 +678,7 @@ export const useStore = create<MobileState>()((set, get) => ({
     }));
     return guard(set, async () => {
       try {
-        await api.sendUserMessage(agentId, turnId, trimmed);
+        await whileSending(agentId, () => api.sendUserMessage(agentId, turnId, trimmed));
       } catch (e) {
         set((s) => ({ busy: { ...s.busy, [agentId]: false } }));
         throw e;
@@ -664,8 +703,10 @@ export const useStore = create<MobileState>()((set, get) => ({
       get().closeSheet();
       get().push("agent", { agentId: record.id });
       try {
-        await waitForSpawn(get, record.id);
-        await api.sendUserMessage(record.id, turnId, prompt);
+        await whileSending(record.id, async () => {
+          await waitForSpawn(get, record.id);
+          await api.sendUserMessage(record.id, turnId, prompt);
+        });
       } catch (e) {
         // The agent exists on the host but never got the prompt: drop the
         // optimistic turn and the busy flag, and let the refreshed workspace

--- a/mobile/tests/store.test.ts
+++ b/mobile/tests/store.test.ts
@@ -285,6 +285,41 @@ describe("spawn flow", () => {
   });
 });
 
+/** The optimistic `busy` flag is set on send and cleared by live events. A
+ *  backgrounded webview or a dropped socket misses those, so every fresh
+ *  snapshot reconciles it — otherwise the Changes tab sits on "Agent is busy…"
+ *  for an agent that finished while the phone was away. */
+describe("optimistic busy flag", () => {
+  it("clears against a fresh snapshot when the turn ended off-socket", async () => {
+    useStore.setState((s) => ({ busy: { ...s.busy, caspian: true } }));
+    await state().refreshWorkspace();
+    expect(agentOf(state().workspace, "caspian")?.status).not.toBe("running");
+    expect(state().busy.caspian).toBe(false);
+  });
+
+  it("leaves a send that is still in flight alone", async () => {
+    let release = () => {};
+    const send = vi.spyOn(api, "sendUserMessage").mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          release = () => resolve(false);
+        }),
+    );
+    try {
+      const pending = state().send("caspian", "hold this one open");
+      expect(state().busy.caspian).toBe(true);
+      // The host cannot have flipped the agent to running yet — the snapshot
+      // is older than the tap, so it must not clear the flag.
+      await state().refreshWorkspace();
+      expect(state().busy.caspian).toBe(true);
+      release();
+      await pending;
+    } finally {
+      send.mockRestore();
+    }
+  });
+});
+
 /** A pairing code is single use and lasts five minutes, so a second delivery
  *  of the same link — the launch URL read from the plugin, and the event it
  *  also emits — must not tear down the attempt already spending it. */


### PR DESCRIPTION
## The bug

On the phone, an agent that had finished still showed **"Agent is busy…"** on the Changes tab's delegate button — disabled — while the Chat tab showed the turn complete and the composer accepted input.

`ChangesTab` gates that button on `s.busy[agentId] || isBusy(agent)`. `isBusy` reads the host's real status; `s.busy` is an optimistic flag the store sets the moment you tap, so the button can't be double-fired during the gap before the host reports `running`. Past that gap the flag was only ever cleared by a live event — a turn-end `agent:event`, or an `agent:status` that isn't `running`.

A backgrounded webview or a dropped socket misses those events silently. The resync that follows (`onSnapshot`, and `visibilitychange` → `refreshWorkspace` + `loadAgent`) refreshed the workspace and the log but never the `busy` map, so the flag stranded on `true` for the rest of the session. Chat and the composer read status alone, which is why the agent looked done on every other screen.

## The fix

`mobile/src/store/index.ts`:

- `reconcileBusy(busy, ws)` clears the optimistic flag for any agent a fresh snapshot says isn't running or spawning — the host is the authority that the optimistic window is over.
- Applied on both authoritative paths: `refreshWorkspace()` (foreground resync, `workspace:changed`) and `client.onSnapshot` (every handshake, so a reconnect clears it too).
- A `sending` set holds out agents with a send genuinely in flight, so a snapshot older than the tap can't clear a flag younger than itself. `send` and `spawn` mark their sends through `whileSending`.

## Tests

`mobile/tests/store.test.ts` adds two, over the existing mock host:

- a stale flag clears against a fresh snapshot (verified failing without the fix),
- a send still in flight survives a concurrent refresh.

`bun run test` 148/148, `bun run lint` clean. `bun run check` reports only pre-existing errors from `../src` (the desktop's deps aren't installed in this checkout).

## Not affected

The desktop git panel doesn't share the bug: its "Agent working…" comes from the delegation record, which the app-root watcher clears via resolve/give-up, and its transient busy label is cleared in a `finally`.