### PR TITLE
fix(mobile): make swipe-back work on device and attach sheet swipe

### DIFF
--- a/mobile/src/components/ui/index.tsx
+++ b/mobile/src/components/ui/index.tsx
@@ -67,22 +67,6 @@ export function Sheet({
 }) {
   const [mounted, setMounted] = useState(open);
   const [shown, setShown] = useState(false);
-  const root = useRef<HTMLDivElement>(null);
-  const panel = useRef<HTMLDivElement>(null);
-  useSwipe(
-    panel,
-    {
-      axis: "y",
-      enabled: shown && !!onClose,
-      // `shown` drops here, not in the `open` effect: same frame as the drag
-      // lets go, so the close transition continues from under the finger.
-      onCommit: () => {
-        setShown(false);
-        onClose?.();
-      },
-    },
-    root,
-  );
   useEffect(() => {
     if (open) {
       setMounted(true);
@@ -101,6 +85,68 @@ export function Sheet({
     return () => clearTimeout(t);
   }, [open]);
   if (!mounted) return null;
+  return (
+    <SheetFrame
+      shown={shown}
+      // `shown` drops here, not in the `open` effect: same frame as the drag
+      // lets go, so the close transition continues from under the finger.
+      onSwipeClose={
+        onClose &&
+        (() => {
+          setShown(false);
+          onClose();
+        })
+      }
+      onClose={onClose}
+      full={full}
+      stacked={stacked}
+      title={title}
+      left={left}
+      right={right}
+      foot={foot}
+    >
+      {children}
+    </SheetFrame>
+  );
+}
+
+/** The mounted sheet. Its own component so the pull-down swipe attaches to
+ *  elements that exist: `Sheet` renders nothing until mounted, and a swipe
+ *  hooked there would bind to empty refs and never retry. */
+function SheetFrame({
+  shown,
+  onSwipeClose,
+  onClose,
+  full,
+  stacked,
+  title,
+  left,
+  right,
+  children,
+  foot,
+}: {
+  shown: boolean;
+  onSwipeClose?: () => void;
+  onClose?: () => void;
+  full?: boolean;
+  stacked?: boolean;
+  title?: ReactNode;
+  left?: ReactNode;
+  right?: ReactNode;
+  children?: ReactNode;
+  foot?: ReactNode;
+}) {
+  const root = useRef<HTMLDivElement>(null);
+  const panel = useRef<HTMLDivElement>(null);
+  useSwipe(
+    panel,
+    {
+      axis: "y",
+      enabled: shown && !!onSwipeClose,
+      onCommit: () => onSwipeClose?.(),
+    },
+    root,
+  );
   return (
     <div ref={root} className={`sheet-root${shown ? " open" : ""}`}>
       <button type="button" className="sheet-bg" onClick={onClose} aria-label="Close" />

--- a/mobile/src/lib/swipe.ts
+++ b/mobile/src/lib/swipe.ts
@@ -10,7 +10,10 @@ export interface SwipeOptions {
   /** `x` dismisses by dragging right, `y` by dragging down. */
   axis: "x" | "y";
   /** Only begin when the touch lands within this many px of the leading edge
-   *  (left for `x`, top for `y`). Omit to begin anywhere on the target. */
+   *  (left for `x`, top for `y`), and own such a touch outright like the iOS
+   *  edge pan: nothing underneath scrolls while it lasts. Omit to begin
+   *  anywhere on the target, in which case the first move decides between a
+   *  swipe and a scroll. */
   edge?: number;
   enabled?: boolean;
   onCommit: () => void;
@@ -22,6 +25,11 @@ export interface SwipeOptions {
  *  being flung back. Velocity is px/ms along the axis. */
 export const shouldCommit = (delta: number, size: number, velocity: number) =>
   velocity > 0.4 || (delta > size * 0.3 && velocity > -0.2);
+
+/** How far an edge touch travels along the axis before it counts as a swipe.
+ *  A finger's first reported move is a point or so of noise in any direction,
+ *  so an edge gesture waits this long rather than reading the first sample. */
+export const EDGE_SLOP = 10;
 
 /** Anything between `target` and `root` that is scrolled along `axis` owns the
  *  gesture: a pulled-down sheet body must scroll back to top before it drags
@@ -66,13 +74,21 @@ export function attachSwipe(target: HTMLElement, stage: HTMLElement, opts: () =>
     const along = o.axis === "x" ? dx : dy;
     const across = o.axis === "x" ? dy : dx;
     if (!active) {
-      if (along === 0 && across === 0) return;
-      // The first real movement decides: the wrong way or mostly across the
-      // axis, and this is a scroll, not a swipe. Deciding on the very first
-      // move is what keeps a vertical scroll that starts at the edge working.
-      if (along <= 0 || Math.abs(across) > Math.abs(along)) {
-        start = null;
-        return;
+      // WebKit lets only the first touchmove of a touch veto native scrolling,
+      // so whatever is decided here is final for the whole touch.
+      if (o.edge !== undefined) {
+        // An edge touch is ours from its first move, scroll or not; it starts
+        // dragging once it has clearly travelled the right way.
+        e.preventDefault();
+        if (along < EDGE_SLOP) return;
+      } else {
+        if (along === 0 && across === 0) return;
+        // Anywhere else the first real movement decides: the wrong way or
+        // mostly across the axis, and this is a scroll, not a swipe.
+        if (along <= 0 || Math.abs(across) > Math.abs(along)) {
+          start = null;
+          return;
+        }
       }
       active = true;
       stage.classList.add("dragging");

--- a/mobile/tests/swipe.test.ts
+++ b/mobile/tests/swipe.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { attachSwipe, shouldCommit } from "../src/lib/swipe";
+import { attachSwipe, EDGE_SLOP, shouldCommit } from "../src/lib/swipe";
 
 describe("shouldCommit", () => {
   it("commits a slow drag once it has covered enough of the element", () => {
@@ -81,16 +81,50 @@ describe("attachSwipe", () => {
     expect(onCommit).not.toHaveBeenCalled();
   });
 
-  it("yields to a scroll: the first move decides the axis", () => {
+  it("owns an edge touch from its first, noisy move and swipes once it travels", () => {
+    const { target, inner } = mount();
+    const onCommit = vi.fn();
+    let t = 0;
+    attachSwipe(target, target, () => ({ axis: "x", edge: 28, onCommit, now: () => t }));
+    touch("touchstart", 10, 300, inner);
+    // A thumb's first sample: a point or two, mostly the wrong way.
+    const first = touch("touchmove", 9, 302, inner);
+    expect(first.defaultPrevented).toBe(true);
+    expect(target.classList.contains("dragging")).toBe(false);
+    t = 30;
+    const second = touch("touchmove", 15, 303, inner);
+    expect(second.defaultPrevented).toBe(true);
+    expect(target.classList.contains("dragging")).toBe(false);
+    t = 60;
+    touch("touchmove", 10 + EDGE_SLOP, 303, inner);
+    expect(target.classList.contains("dragging")).toBe(true);
+    t = 300;
+    touch("touchmove", 250, 310, inner);
+    touch("touchend", 250, 310, inner);
+    expect(onCommit).toHaveBeenCalledOnce();
+  });
+
+  it("holds an edge touch that turns into a scroll without dragging", () => {
     const { target, inner } = mount();
     const onCommit = vi.fn();
     attachSwipe(target, target, () => ({ axis: "x", edge: 28, onCommit }));
     touch("touchstart", 10, 300, inner);
-    const move = touch("touchmove", 14, 330, inner);
+    for (const y of [310, 340, 400]) touch("touchmove", 12, y, inner);
+    expect(target.classList.contains("dragging")).toBe(false);
+    touch("touchend", 12, 400, inner);
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+
+  it("yields to a scroll away from an edge: the first move decides the axis", () => {
+    const { target, inner } = mount();
+    const onCommit = vi.fn();
+    attachSwipe(target, target, () => ({ axis: "y", onCommit }));
+    touch("touchstart", 100, 100, inner);
+    const move = touch("touchmove", 130, 104, inner);
     expect(move.defaultPrevented).toBe(false);
-    // Later horizontal movement in the same touch no longer counts.
-    touch("touchmove", 300, 330, inner);
-    touch("touchend", 300, 330, inner);
+    // Later movement along the axis in the same touch no longer counts.
+    touch("touchmove", 130, 500, inner);
+    touch("touchend", 130, 500, inner);
     expect(onCommit).not.toHaveBeenCalled();
     expect(target.classList.contains("dragging")).toBe(false);
   });


### PR DESCRIPTION
## Why

Swipe-back from PR #727 shipped in 0.7.30 but does not work on device. Two causes:

1. **Edge swipe decided on a single noisy sample.** WebKit on iOS lets only the *first* `touchmove` of a touch veto native scrolling (`WebPageProxy::m_touchMovePreventionState` goes `None -> Waiting -> Prevented/Allowed` once per touch). `swipe.ts` honoured that by reading direction off the first move, but a real finger's first reported move is a point or so in a random direction, so most genuine swipes were classified as vertical scrolls and dropped. A mouse in the simulator produces a clean horizontal first delta, which is why it looked fine in dev.
2. **Sheet swipe-to-dismiss never attached.** `Sheet` returns `null` until mounted, so `useSwipe` ran against empty refs and, with stable ref deps, never retried.

## What

- An edge touch now owns the gesture from its first `touchmove` (always `preventDefault`), like the iOS edge pan, and starts dragging once it has travelled `EDGE_SLOP` (10px) rightward. Touches away from an edge (sheets) keep the first-move rule so sheet bodies still scroll.
- The mounted sheet markup moved into a `SheetFrame` child that owns the refs and the swipe hook, so it binds to elements that exist.
- Tests: noisy edge start still swipes once it travels; an edge touch that turns vertical stays inert; the first-move rule still applies away from an edge.

## Trade-off

Vertical scrolling that begins in the outer 28px of the left edge yields to the back gesture, matching native iOS.

## Verification

- `bun run test`: 148 passed
- `bun run lint`: clean
- `bun run check`: same 54 pre-existing errors with and without this change, all in the desktop tree (deps not installed in this checkout); none in `mobile/`
- Still needs a run on a real device.