### PR TITLE
feat(mobile): honest host-connection state, redesigned empty state, shared Notice

### DIFF
--- a/mobile/src/App.tsx
+++ b/mobile/src/App.tsx
@@ -66,7 +66,11 @@ export function App() {
           <Stack dimmed={dimmed} render={(item) => <Screen item={item} />} />
           <HostSheet open={isOpen("host")} onClose={closeSheet} />
           <NewAgentSheet open={isOpen("newAgent")} onClose={closeSheet} {...props("newAgent")} />
-          <AddProjectSheet open={isOpen("addProject")} onClose={closeSheet} />
+          <AddProjectSheet
+            open={isOpen("addProject")}
+            onClose={closeSheet}
+            {...props("addProject")}
+          />
           <AgentMoreSheet open={isOpen("agentMore")} onClose={closeSheet} {...props("agentMore")} />
           <ModelPickerSheet
             open={isOpen("modelPicker")}

--- a/mobile/src/components/ui/Notice.tsx
+++ b/mobile/src/components/ui/Notice.tsx
@@ -1,0 +1,62 @@
+import { Icon, type IconName } from "@desktop/components/Icon";
+import type { ReactNode } from "react";
+
+export type NoticeTone = "info" | "warn" | "error";
+
+const DEFAULT_ICON: Record<NoticeTone, IconName> = {
+  info: "dot",
+  warn: "alert",
+  error: "alert",
+};
+
+/** One inline message, the same everywhere a screen has something to say
+ *  beside the control it is about: a failed action, a link that is down, a
+ *  step in progress. A neutral surface with a tinted leading icon rather than
+ *  a tinted box, so several tones sit on one screen without shouting.
+ *
+ *  Dismissible only when given `onDismiss`: a message tied to live state (the
+ *  connection, a listing that failed) has no sensible dismiss and stays until
+ *  the state changes; one about a finished action can be swiped away. */
+export function Notice({
+  tone = "info",
+  icon,
+  children,
+  action,
+  onDismiss,
+  className,
+}: {
+  tone?: NoticeTone;
+  /** Leading glyph. Pass `null` for none; defaults per tone. */
+  icon?: IconName | ReactNode | null;
+  children: ReactNode;
+  /** One trailing action, e.g. Retry. */
+  action?: { label: string; onClick: () => void; disabled?: boolean };
+  onDismiss?: () => void;
+  className?: string;
+}) {
+  const lead =
+    icon === null ? null : icon === undefined || typeof icon === "string" ? (
+      <Icon name={(icon as IconName | undefined) ?? DEFAULT_ICON[tone]} size={15} />
+    ) : (
+      icon
+    );
+  return (
+    <div
+      className={`notice-bar ${tone}${className ? ` ${className}` : ""}`}
+      role={tone === "error" ? "alert" : "status"}
+    >
+      {lead && <span className="lead">{lead}</span>}
+      <span className="txt">{children}</span>
+      {action && (
+        <button type="button" className="act" onClick={action.onClick} disabled={action.disabled}>
+          {action.label}
+        </button>
+      )}
+      {onDismiss && (
+        <button type="button" className="x" onClick={onDismiss} aria-label="Dismiss">
+          <Icon name="close" size={14} strokeWidth={2} />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/mobile/src/remote/client.ts
+++ b/mobile/src/remote/client.ts
@@ -103,6 +103,10 @@ export class ProtocolClient implements RemoteClient {
     return this._state;
   }
 
+  get retrying(): boolean {
+    return this.retryHandle !== null;
+  }
+
   get host(): HostInfo | null {
     return this._host;
   }
@@ -374,8 +378,10 @@ export class ProtocolClient implements RemoteClient {
   /** The single failure path: report it, and schedule a retry unless the
    *  failure is one only the user can clear. */
   private fail(message: string, retryable: boolean) {
-    this.setState("error", message);
+    // Scheduled before the state is announced, so a listener reading
+    // `retrying` in its callback sees the retry that goes with this error.
     if (retryable && !this.closedByUs) this.scheduleRetry();
+    this.setState("error", message);
   }
 
   /** Every successful handshake — the first and every reconnect — hands its

--- a/mobile/src/remote/types.ts
+++ b/mobile/src/remote/types.ts
@@ -148,6 +148,10 @@ export interface RemoteClient {
    *  including reconnects. */
   onSnapshot(cb: (result: HelloResult) => void): () => void;
   readonly state: ConnectionState;
+  /** True while a retry is scheduled after a failure. False in `error` means
+   *  the failure is one only the user can clear (unpaired, remote access off,
+   *  a changed host key) — the difference between "reconnecting" and "stuck". */
+  readonly retrying: boolean;
   readonly host: HostInfo | null;
   /** The host key in use: the one the target carried, or the one pinned on
    *  first contact. */

--- a/mobile/src/screens/Home/ConnectionBanner.tsx
+++ b/mobile/src/screens/Home/ConnectionBanner.tsx
@@ -1,28 +1,43 @@
-import { Icon } from "@desktop/components/Icon";
+import { Notice } from "../../components/ui/Notice";
 import { ignore } from "../../lib/ignore";
 import { useStore } from "../../store";
 
-const LABEL: Record<string, string> = {
-  connecting: "Connecting to the host…",
-  pairing: "Pairing…",
-  disconnected: "Not connected to the host",
-};
-
-/** Shown whenever the link is anything other than connected. The client
- *  reconnects on its own; the button is for the impatient. */
+/** The slim status line over a cached project list while the link to the Mac
+ *  is down or coming back. Persistent by nature — it is the connection state,
+ *  not a message about it — so there is no dismiss; it goes when the link is
+ *  up. The client reconnects on its own; Retry is for the impatient, and is
+ *  withheld while an attempt is already running.
+ *
+ *  Home shows it only over a list. With nothing cached the whole body is the
+ *  connection state instead (`HostState`). */
 export function ConnectionBanner() {
   const connection = useStore((s) => s.connection);
   const error = useStore((s) => s.connectionError);
+  const retrying = useStore((s) => s.retrying);
   const reconnect = useStore((s) => s.reconnect);
   if (connection === "connected") return null;
-  const isError = connection === "error";
+  const busy = connection === "connecting" || connection === "pairing";
+  const text = busy
+    ? "Reconnecting to your Mac…"
+    : connection === "error"
+      ? `${error ?? "Connection lost"}${retrying ? " · reconnecting" : ""}`
+      : "Not connected to your Mac";
   return (
-    <div className={`conn${isError ? " err" : ""}`}>
-      <Icon name={isError ? "alert" : "refresh"} size={14} />
-      <span className="grow">{isError ? (error ?? "Connection lost") : LABEL[connection]}</span>
-      <button type="button" onClick={() => void reconnect().catch(ignore)}>
-        Retry
-      </button>
-    </div>
+    <Notice
+      tone={busy || retrying ? "warn" : "error"}
+      icon={
+        busy ? (
+          <span className="working-dots">
+            <i />
+            <i />
+            <i />
+          </span>
+        ) : undefined
+      }
+      className="conn"
+      action={busy ? undefined : { label: "Retry", onClick: () => void reconnect().catch(ignore) }}
+    >
+      {text}
+    </Notice>
   );
 }

--- a/mobile/src/screens/Home/EmptyProjects.tsx
+++ b/mobile/src/screens/Home/EmptyProjects.tsx
@@ -1,0 +1,49 @@
+import { Icon } from "@desktop/components/Icon";
+import { useStore } from "../../store";
+
+/** Home with a live host and nothing on it. The two ways a project gets here
+ *  from the phone are the actions, each opening Add project on its own tab;
+ *  the third way — pinning a repo in Fletch on the Mac — is mentioned so a
+ *  desktop user is not left wondering why this is empty. */
+export function EmptyProjects() {
+  const openSheet = useStore((s) => s.openSheet);
+  const host = useStore((s) => s.hostInfo?.name) ?? "your Mac";
+  return (
+    <div className="blank fade">
+      <div className="glyph accent">
+        <Icon name="folder" size={30} strokeWidth={1.5} />
+      </div>
+      <h2>No projects yet</h2>
+      <div className="body">
+        <p>A project is a Git repo on {host}. Add one, then start an agent in it.</p>
+      </div>
+      <div className="card ways">
+        <button type="button" className="row" onClick={() => openSheet("addProject")}>
+          <span className="ic">
+            <Icon name="folder" size={17} />
+          </span>
+          <div className="main">
+            <div className="lbl">Open a folder</div>
+            <div className="sub">A repo already on your Mac</div>
+          </div>
+          <Icon name="chevR" size={16} className="chev" />
+        </button>
+        <button
+          type="button"
+          className="row"
+          onClick={() => openSheet("addProject", { tab: "clone" })}
+        >
+          <span className="ic">
+            <Icon name="github" size={17} />
+          </span>
+          <div className="main">
+            <div className="lbl">Clone from GitHub</div>
+            <div className="sub">Into a folder you choose</div>
+          </div>
+          <Icon name="chevR" size={16} className="chev" />
+        </button>
+      </div>
+      <div className="hint">Repos you pin in Fletch on your Mac show up here too.</div>
+    </div>
+  );
+}

--- a/mobile/src/screens/Home/HostState.tsx
+++ b/mobile/src/screens/Home/HostState.tsx
@@ -1,0 +1,103 @@
+import { Icon } from "@desktop/components/Icon";
+import { ignore } from "../../lib/ignore";
+import { client, useStore } from "../../store";
+import { STEP_LABELS, Working } from "../Pair/Progress";
+
+/** Home's whole body while there is no workspace to show: the link to the Mac
+ *  is down, coming up, or up with the snapshot still on its way. There is
+ *  nothing to add and no agent to start until it is, so nothing here offers
+ *  to — the screen says what the connection is doing and what, if anything,
+ *  the user can do about it.
+ *
+ *  The one case that needs care is `error`: the client retries most failures
+ *  on its own (a dropped socket, the Mac asleep), and those read as
+ *  "reconnecting"; the few it cannot clear (this device unpaired, remote
+ *  access switched off, a changed host key) are stated as they are and point
+ *  at the Host sheet, where the fix lives. */
+export function HostState() {
+  const connection = useStore((s) => s.connection);
+  const error = useStore((s) => s.connectionError);
+  const retrying = useStore((s) => s.retrying);
+  const step = useStore((s) => s.pairStep);
+  const hostName = useStore((s) => s.hostInfo?.name);
+  const reconnect = useStore((s) => s.reconnect);
+  const openSheet = useStore((s) => s.openSheet);
+  const host = hostName ?? client.target?.name ?? "your Mac";
+
+  const tryNow = () => void reconnect().catch(ignore);
+  const details = (
+    <button type="button" className="lnk" onClick={() => openSheet("host")}>
+      Host details
+    </button>
+  );
+
+  let dot: string;
+  let title: string;
+  let body: React.ReactNode;
+  let acts: React.ReactNode = null;
+
+  if (connection === "connected") {
+    dot = "running";
+    title = "Loading your workspace";
+    body = <Working>Fetching projects and agents from {host}…</Working>;
+  } else if (connection === "connecting" || connection === "pairing") {
+    dot = "waiting";
+    title = connection === "pairing" ? `Pairing with ${host}` : `Connecting to ${host}`;
+    body = <Working>{step ? STEP_LABELS[step] : "This usually takes a moment…"}</Working>;
+  } else if (connection === "error" && retrying) {
+    dot = "waiting";
+    title = `Can't reach ${host}`;
+    body = (
+      <>
+        <p>{error ?? "The connection was lost."}</p>
+        <Working>Reconnecting automatically…</Working>
+      </>
+    );
+    acts = (
+      <>
+        <button type="button" className="btn ghost" onClick={tryNow}>
+          <Icon name="refresh" size={16} />
+          Try now
+        </button>
+        {details}
+      </>
+    );
+  } else if (connection === "error") {
+    dot = "error";
+    title = "Not connected";
+    body = <p>{error ?? "The connection was lost."}</p>;
+    acts = (
+      <button type="button" className="btn ghost" onClick={() => openSheet("host")}>
+        <Icon name="laptop" size={16} />
+        Host details
+      </button>
+    );
+  } else {
+    dot = "stopped";
+    title = "Not connected";
+    body = <p>Reconnect to {host} to see your projects and agents.</p>;
+    acts = (
+      <>
+        <button type="button" className="btn ghost" onClick={tryNow}>
+          <Icon name="refresh" size={16} />
+          Reconnect
+        </button>
+        {details}
+      </>
+    );
+  }
+
+  return (
+    <div className="blank fade" key={connection}>
+      <div className="glyph">
+        <Icon name="laptop" size={30} strokeWidth={1.5} />
+        <span className="badge">
+          <span className={`dot ${dot}`} />
+        </span>
+      </div>
+      <h2>{title}</h2>
+      <div className="body">{body}</div>
+      {acts && <div className="acts">{acts}</div>}
+    </div>
+  );
+}

--- a/mobile/src/screens/Home/index.tsx
+++ b/mobile/src/screens/Home/index.tsx
@@ -5,6 +5,8 @@ import { Swatch } from "../../components/ui";
 import { agentsOfProject, baseOf, isActive, isBusy, repoLabel } from "../../lib/agents";
 import { useStore } from "../../store";
 import { ConnectionBanner } from "./ConnectionBanner";
+import { EmptyProjects } from "./EmptyProjects";
+import { HostState } from "./HostState";
 import { Wordmark } from "./Wordmark";
 
 function ProjectCard({ project }: { project: ProjectRef }) {
@@ -97,74 +99,79 @@ export function HomeScreen() {
   const errored = agents.filter((a) => a.status === "error").length;
   const running = agents.filter(isBusy).length;
   const attention = pendingTotal + errored;
+  const connected = connection === "connected";
+  const settling = connection === "connecting" || connection === "pairing";
+  // What the body is: the list when there is one to show, the host's
+  // connection state when there is nothing behind it. A cached list survives a
+  // dropped link (read-only, with the status line over it); an empty one does
+  // not — "no projects" is only true of a host that has answered.
+  const showList = workspace !== null && (projects.length > 0 || connected);
+  const body = !showList ? (
+    <HostState />
+  ) : projects.length === 0 ? (
+    <EmptyProjects />
+  ) : (
+    projects.map((p) => <ProjectCard key={p.project_id} project={p} />)
+  );
 
   return (
     <>
       <div className="home-head">
         <Wordmark />
         <button type="button" className="host" onClick={() => openSheet("host")}>
-          <span className={`dot ${connection === "connected" ? "running" : "error"}`} />
+          <span className={`dot ${connected ? "running" : settling ? "waiting" : "error"}`} />
           {hostName ?? "Host"}
         </button>
       </div>
-      <ConnectionBanner />
-      <div className="scroll home-body">
-        <div className="sect">
-          Projects <span className="n">{projects.length}</span>
-          <button type="button" className="sect-add" onClick={() => openSheet("addProject")}>
-            <Icon name="plus" size={12} strokeWidth={2.2} />
-            Add
-          </button>
-          <span className="grow" />
-          {attention > 0 && (
-            <span
-              className="n"
-              style={{
-                color: "var(--warn)",
-                textTransform: "none",
-                letterSpacing: 0,
-                display: "inline-flex",
-                alignItems: "center",
-                gap: 4,
-              }}
-            >
-              <Icon name="hand" size={11} strokeWidth={1.8} />
-              {attention}
-            </span>
-          )}
-          {running > 0 && (
-            <span
-              className="n"
-              style={{ color: "var(--success)", textTransform: "none", letterSpacing: 0 }}
-            >
-              {running} running
-            </span>
-          )}
-        </div>
-        {projects.map((p) => (
-          <ProjectCard key={p.project_id} project={p} />
-        ))}
-        {projects.length === 0 && (
-          <div className="empty">
-            <b>No projects on the host</b>
-            Open a folder on your Mac, or clone one from GitHub.
-            <button
-              type="button"
-              className="btn ghost ap-empty"
-              onClick={() => openSheet("addProject")}
-            >
-              <Icon name="plus" size={16} strokeWidth={2.2} />
-              Add project
-            </button>
+      {showList && <ConnectionBanner />}
+      <div className={`scroll home-body${showList && projects.length > 0 ? "" : " is-blank"}`}>
+        {showList && projects.length > 0 && (
+          <div className="sect">
+            Projects <span className="n">{projects.length}</span>
+            {connected && (
+              <button type="button" className="sect-add" onClick={() => openSheet("addProject")}>
+                <Icon name="plus" size={12} strokeWidth={2.2} />
+                Add
+              </button>
+            )}
+            <span className="grow" />
+            {attention > 0 && (
+              <span
+                className="n"
+                style={{
+                  color: "var(--warn)",
+                  textTransform: "none",
+                  letterSpacing: 0,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  gap: 4,
+                }}
+              >
+                <Icon name="hand" size={11} strokeWidth={1.8} />
+                {attention}
+              </span>
+            )}
+            {running > 0 && (
+              <span
+                className="n"
+                style={{ color: "var(--success)", textTransform: "none", letterSpacing: 0 }}
+              >
+                {running} running
+              </span>
+            )}
           </div>
         )}
+        {body}
       </div>
-      <div className="fab-wrap">
-        <button type="button" className="btn primary" onClick={() => openSheet("newAgent")}>
-          <Icon name="plus" size={18} strokeWidth={2.2} />
-          New agent
-        </button>
-      </div>
+      {/* Starting an agent needs a live host and a project to put it in. */}
+      {showList && projects.length > 0 && connected && (
+        <div className="fab-wrap">
+          <button type="button" className="btn primary" onClick={() => openSheet("newAgent")}>
+            <Icon name="plus" size={18} strokeWidth={2.2} />
+            New agent
+          </button>
+        </div>
+      )}
     </>
   );
 }

--- a/mobile/src/screens/Pair/Progress.tsx
+++ b/mobile/src/screens/Pair/Progress.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { PairStep } from "../../remote";
 
 /** What each step of a connection attempt means to someone holding the phone.
@@ -7,7 +8,7 @@ import type { PairStep } from "../../remote";
  *  tried, so a phone away from its Mac spends its first seconds on an address
  *  that cannot answer. Saying so is the difference between a wait and a hang.
  */
-const LABELS: Record<PairStep, string> = {
+export const STEP_LABELS: Record<PairStep, string> = {
   connecting: "Starting…",
   lan: "Looking for your Mac on this network…",
   relay: "Not on this network — reaching your Mac through the relay…",
@@ -16,7 +17,9 @@ const LABELS: Record<PairStep, string> = {
   workspace: "Loading your workspace…",
 };
 
-export function Progress({ step }: { step: PairStep }) {
+/** A line of text with the working dots in front of it: something is
+ *  happening, and this is what. */
+export function Working({ children }: { children: ReactNode }) {
   return (
     <div className="pair-step">
       <span className="working-dots">
@@ -24,7 +27,11 @@ export function Progress({ step }: { step: PairStep }) {
         <i />
         <i />
       </span>
-      {LABELS[step]}
+      {children}
     </div>
   );
+}
+
+export function Progress({ step }: { step: PairStep }) {
+  return <Working>{STEP_LABELS[step]}</Working>;
 }

--- a/mobile/src/screens/Pair/index.tsx
+++ b/mobile/src/screens/Pair/index.tsx
@@ -1,5 +1,6 @@
 import { Icon } from "@desktop/components/Icon";
 import { useEffect, useState } from "react";
+import { Notice } from "../../components/ui/Notice";
 import { parseAddress, parsePairUrl } from "../../remote";
 import { useStore } from "../../store";
 import { Wordmark } from "../Home/Wordmark";
@@ -101,7 +102,7 @@ export function PairScreen() {
           onChange={(e) => absorb(e.target.value, (v) => setToken(v.toUpperCase()))}
         />
       </div>
-      {step ? <Progress step={step} /> : error && <div className="err">{error}</div>}
+      {step ? <Progress step={step} /> : error && <Notice tone="error">{error}</Notice>}
       <button
         type="button"
         className="btn primary block"

--- a/mobile/src/sheets/AddProjectSheet/CloneForm.tsx
+++ b/mobile/src/sheets/AddProjectSheet/CloneForm.tsx
@@ -2,6 +2,7 @@ import type { GhRepoSummary, GhStatus } from "@desktop/api/types/providers";
 import { Icon } from "@desktop/components/Icon";
 import { parseRepoSpec } from "@desktop/util/repoSpec";
 import { useEffect, useState } from "react";
+import { Notice } from "../../components/ui/Notice";
 import { childPath } from "../../lib/paths";
 import { useStore } from "../../store";
 import { FolderPickerSheet } from "./FolderPicker";
@@ -17,7 +18,7 @@ export function CloneForm({
 }: {
   busy: boolean;
   error: string | null;
-  setError: (text: string) => void;
+  setError: (text: string | null) => void;
   run: RunAddProject;
 }) {
   const ghStatus = useStore((s) => s.ghStatus);
@@ -147,7 +148,11 @@ export function CloneForm({
           <Icon name="chevR" size={16} className="chev" />
         </button>
       </div>
-      {error && <div className="err ap-err">{error}</div>}
+      {error && (
+        <Notice tone="error" className="ap-err" onDismiss={() => setError(null)}>
+          {error}
+        </Notice>
+      )}
       <button
         type="button"
         className="btn primary block ap-use"

--- a/mobile/src/sheets/AddProjectSheet/FolderPicker.tsx
+++ b/mobile/src/sheets/AddProjectSheet/FolderPicker.tsx
@@ -2,6 +2,7 @@ import type { DirEntry, DirListing } from "@desktop/api/types/checkout";
 import { Icon } from "@desktop/components/Icon";
 import { type ReactNode, useEffect, useState } from "react";
 import { Sheet } from "../../components/ui";
+import { Notice } from "../../components/ui/Notice";
 import { childPath, parentPath } from "../../lib/paths";
 import { useStore } from "../../store";
 
@@ -18,6 +19,7 @@ export function FolderPicker({
   onUse,
   busy,
   error,
+  onDismissError,
 }: {
   start?: string;
   actionLabel: string;
@@ -27,6 +29,9 @@ export function FolderPicker({
   /** An error from whatever the caller did with the picked folder; shown in
    *  the same place as a failed listing. */
   error?: string | null;
+  /** Lets the user put the caller's error away. A failed listing has no
+   *  dismiss: it stands until they browse somewhere that reads. */
+  onDismissError?: () => void;
 }) {
   const listDir = useStore((s) => s.listDir);
   const [path, setPath] = useState(start);
@@ -110,7 +115,11 @@ export function FolderPicker({
           </button>
         </div>
       )}
-      {shownError && <div className="err ap-err">{shownError}</div>}
+      {shownError && (
+        <Notice tone="error" className="ap-err" onDismiss={error ? onDismissError : undefined}>
+          {shownError}
+        </Notice>
+      )}
       <button
         type="button"
         className="btn primary block ap-use"

--- a/mobile/src/sheets/AddProjectSheet/OpenFolderForm.tsx
+++ b/mobile/src/sheets/AddProjectSheet/OpenFolderForm.tsx
@@ -6,10 +6,12 @@ import type { RunAddProject } from "./useAddProject";
 export function OpenFolderForm({
   busy,
   error,
+  setError,
   run,
 }: {
   busy: boolean;
   error: string | null;
+  setError: (e: string | null) => void;
   run: RunAddProject;
 }) {
   const addWorkspaceRepo = useStore((s) => s.addWorkspaceRepo);
@@ -19,6 +21,7 @@ export function OpenFolderForm({
       hint="Not a git repo yet? Fletch will run git init here."
       busy={busy}
       error={error}
+      onDismissError={() => setError(null)}
       onUse={(path) => void run(() => addWorkspaceRepo(path))}
     />
   );

--- a/mobile/src/sheets/AddProjectSheet/index.tsx
+++ b/mobile/src/sheets/AddProjectSheet/index.tsx
@@ -11,8 +11,20 @@ const TABS = [
 /** The two ways a project reaches the host from the phone (docs/remote-protocol.md,
  *  "Adding a project from the phone"). Creating a brand-new repo is not one of
  *  them yet. */
-export function AddProjectSheet({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const { tab, switchTab, busy, error, setError, run } = useAddProject(open);
+export function AddProjectSheet({
+  open,
+  onClose,
+  tab: initialTab,
+}: {
+  open: boolean;
+  onClose: () => void;
+  /** Which tab to open on; the folder browser unless the caller says `clone`. */
+  tab?: string;
+}) {
+  const { tab, switchTab, busy, error, setError, run } = useAddProject(
+    open,
+    initialTab === "clone" ? "clone" : "folder",
+  );
 
   return (
     <Sheet
@@ -30,7 +42,7 @@ export function AddProjectSheet({ open, onClose }: { open: boolean; onClose: () 
         <Segmented items={TABS} value={tab} onChange={switchTab} />
       </div>
       {tab === "folder" ? (
-        <OpenFolderForm busy={busy} error={error} run={run} />
+        <OpenFolderForm busy={busy} error={error} setError={setError} run={run} />
       ) : (
         <CloneForm busy={busy} error={error} setError={setError} run={run} />
       )}

--- a/mobile/src/sheets/AddProjectSheet/useAddProject.ts
+++ b/mobile/src/sheets/AddProjectSheet/useAddProject.ts
@@ -9,8 +9,8 @@ export type RunAddProject = (op: () => Promise<unknown>) => Promise<void>;
 
 /** State the two forms share: which one is showing, whether an op is in
  *  flight, and the error text the last one failed with. */
-export function useAddProject(open: boolean) {
-  const [tab, setTab] = useState<AddProjectTab>("folder");
+export function useAddProject(open: boolean, initialTab: AddProjectTab = "folder") {
+  const [tab, setTab] = useState<AddProjectTab>(initialTab);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const clearError = useStore((s) => s.clearError);
@@ -20,11 +20,11 @@ export function useAddProject(open: boolean) {
   // recorded this error there as well.
   useEffect(() => {
     if (!open) return;
-    setTab("folder");
+    setTab(initialTab);
     setBusy(false);
     setError(null);
     clearError();
-  }, [open, clearError]);
+  }, [open, initialTab, clearError]);
 
   const switchTab = useCallback((next: string) => {
     setTab(next as AddProjectTab);

--- a/mobile/src/sheets/NewAgentSheet/PromptField.tsx
+++ b/mobile/src/sheets/NewAgentSheet/PromptField.tsx
@@ -2,6 +2,7 @@ import { spliceTranscript } from "@desktop/components/Composer/dictation/spliceT
 import { primaryState } from "@desktop/components/Composer/PrimaryControl/primaryState";
 import { Icon } from "@desktop/components/Icon";
 import { type ReactNode, useEffect, useRef } from "react";
+import { Notice } from "../../components/ui/Notice";
 import { useDictation, VoiceRow } from "../../dictation";
 import { autosize } from "../../lib/autosize";
 
@@ -113,7 +114,11 @@ export function PromptField({
           )}
         </div>
       </div>
-      {dictation.error && <div className="err na-err">{dictation.error}</div>}
+      {dictation.error && (
+        <Notice tone="error" className="na-err">
+          {dictation.error}
+        </Notice>
+      )}
     </>
   );
 }

--- a/mobile/src/sheets/NewAgentSheet/index.tsx
+++ b/mobile/src/sheets/NewAgentSheet/index.tsx
@@ -1,6 +1,7 @@
 import { Icon } from "@desktop/components/Icon";
 import { useCallback, useEffect, useState } from "react";
 import { PickerSheet, ProviderMark, Sheet, Swatch } from "../../components/ui";
+import { Notice } from "../../components/ui/Notice";
 import { modelLabel, providerLabel } from "../../lib/agents";
 import { ignore } from "../../lib/ignore";
 import { modelsFor, useModels } from "../../lib/models";
@@ -173,7 +174,11 @@ export function NewAgentSheet({
             <Icon name="chevD" size={11} style={{ color: "var(--fg-3)" }} />
           </button>
         </PromptField>
-        {lastError && <div className="err na-err">{lastError}</div>}
+        {lastError && (
+          <Notice tone="error" className="na-err" onDismiss={clearError}>
+            {lastError}
+          </Notice>
+        )}
         <div className="na-ctx">
           <button type="button" className="chip" onClick={() => setPicker("project")}>
             <Swatch project={project} size={14} />

--- a/mobile/src/store/index.ts
+++ b/mobile/src/store/index.ts
@@ -49,6 +49,9 @@ export interface MobileState {
   ready: boolean;
   connection: ConnectionState;
   connectionError: string | null;
+  /** Mirrors the client: an `error` with a retry scheduled behind it reads as
+   *  "reconnecting", one without as something the user has to fix. */
+  retrying: boolean;
   /** How far the `connect` in flight has got, and null when none is.
    *
    *  Deliberately wider than the client's `connected`, which arrives as soon
@@ -305,6 +308,7 @@ export const useStore = create<MobileState>()((set, get) => ({
   ready: false,
   connection: "disconnected",
   connectionError: null,
+  retrying: false,
   pairStep: null,
   pairTarget: null,
   hostInfo: null,
@@ -344,6 +348,7 @@ export const useStore = create<MobileState>()((set, get) => ({
       set({
         connection: state,
         connectionError: error ?? null,
+        retrying: client.retrying,
         hostInfo: client.host,
         via: client.via,
       }),

--- a/mobile/src/styles/base.css
+++ b/mobile/src/styles/base.css
@@ -886,6 +886,82 @@ a {
   font-weight: 600;
   margin-bottom: 4px;
 }
+
+/* Inline message (components/ui/Notice). One neutral surface; the tone lives
+   in the leading glyph and the action, so a warning and an error read as
+   messages on the page rather than as boxes shouting from it. */
+.notice-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 44px;
+  padding: 8px 6px 8px 12px;
+  border-radius: 13px;
+  background: var(--bg-1);
+  border: 1px solid var(--bd-soft);
+  color: var(--fg-1);
+  font-size: 13.5px;
+  line-height: 1.4;
+  text-align: left;
+  --tone: var(--info);
+}
+.notice-bar.warn {
+  --tone: var(--warn);
+}
+.notice-bar.error {
+  --tone: var(--danger);
+  color: var(--fg-0);
+}
+.notice-bar .lead {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  flex-shrink: 0;
+  color: var(--tone);
+}
+.notice-bar .lead .working-dots i {
+  background: var(--tone);
+}
+.notice-bar .txt {
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  /* A message with no action keeps the full right padding. */
+  padding-right: 6px;
+}
+.notice-bar .act {
+  flex-shrink: 0;
+  height: 30px;
+  padding: 0 11px;
+  border-radius: 9px;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--tone);
+  background: color-mix(in oklch, var(--tone), transparent 86%);
+  transition: background 0.15s;
+}
+.notice-bar .act:active {
+  background: color-mix(in oklch, var(--tone), transparent 72%);
+}
+.notice-bar .act:disabled {
+  opacity: 0.5;
+}
+.notice-bar .x {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 9px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-3);
+  transition: background 0.15s;
+}
+.notice-bar .x:active {
+  background: var(--bg-3);
+  color: var(--fg-1);
+}
 @media (prefers-reduced-motion: reduce) {
   * {
     animation-duration: 0.01ms !important;

--- a/mobile/src/styles/screens.css
+++ b/mobile/src/styles/screens.css
@@ -724,15 +724,10 @@
   grid-template-columns: 1fr 96px;
   gap: 10px;
 }
-/* Shared inline error line: pairing, the new-agent sheet, anywhere a failed
-   action has to be readable next to the control that caused it. */
-.err {
-  font-size: 13px;
-  color: var(--danger);
-  line-height: 1.45;
-}
+/* Inline errors (the shared Notice) sit under the control that caused them:
+   the new-agent prompt, the add-project forms. */
 .na-err {
-  padding: 12px 2px 0;
+  margin-top: 12px;
 }
 .pair .hint {
   font-size: 12.5px;
@@ -750,31 +745,154 @@
   line-height: 1.45;
 }
 
-/* connection banner */
-.conn {
+/* Connection status line over a cached list (Home/ConnectionBanner): the
+   shared Notice, placed. */
+.notice-bar.conn {
+  margin: 0 16px 10px;
+  flex-shrink: 0;
+}
+
+/* Blank-slate body (Home/HostState, Home/EmptyProjects): glyph, title, a line
+   or two, then the actions. Optically centred — pulled up from the true
+   middle, which reads as low on a tall phone — and laid out with `margin:
+   auto` rather than justify-content so nothing is clipped if it ever
+   overflows the scroller. */
+.home-body.is-blank {
   display: flex;
+  flex-direction: column;
+}
+.blank {
+  margin: auto 0;
+  padding: 24px 12px 14vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+.blank .glyph {
+  position: relative;
+  width: 76px;
+  height: 76px;
+  border-radius: 24px;
+  display: grid;
+  place-items: center;
+  color: var(--fg-1);
+  background: var(--bg-1);
+  border: 1px solid var(--bd-soft);
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.05) inset,
+    0 14px 34px rgba(0, 0, 0, 0.28);
+  margin-bottom: 22px;
+}
+.theme-light .blank .glyph {
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.9) inset,
+    0 10px 28px rgba(0, 0, 0, 0.08);
+}
+.blank .glyph.accent {
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-color: var(--accent-line);
+}
+/* Connection state, worn on the glyph's shoulder in the same dot the host
+   pill and the agent rows use. */
+.blank .glyph .badge {
+  position: absolute;
+  right: -5px;
+  bottom: -5px;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: var(--bg-0);
+  display: grid;
+  place-items: center;
+}
+.blank .glyph .badge .dot {
+  width: 10px;
+  height: 10px;
+}
+.blank h2 {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+  color: var(--fg-0);
+  text-wrap: balance;
+}
+.blank .body {
+  margin-top: 8px;
+  max-width: 300px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--fg-2);
+  text-wrap: pretty;
+  display: flex;
+  flex-direction: column;
   align-items: center;
   gap: 8px;
-  margin: 0 16px 10px;
-  padding: 9px 12px;
-  border-radius: 12px;
+}
+.blank .body p {
+  margin: 0;
+}
+/* Dots above the line rather than beside it: a step label long enough to
+   wrap (the relay one) would otherwise leave them stranded at the left edge. */
+.blank .body .pair-step {
+  flex-direction: column;
+  gap: 10px;
+  color: var(--fg-3);
+  font-size: 13px;
+}
+.blank .acts {
+  margin-top: 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  max-width: 260px;
+}
+.blank .acts .btn {
+  width: 100%;
+}
+.blank .acts .lnk {
+  height: 40px;
+  padding: 0 14px;
+  border-radius: 11px;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--fg-2);
+}
+.blank .acts .lnk:active {
+  background: var(--bg-2);
+}
+/* The two ways in, as rows: each is the action, not a description of one. */
+.blank .ways {
+  margin-top: 24px;
+  width: 100%;
+  max-width: 340px;
+  text-align: left;
+}
+.blank .ways .ic {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-2);
+  color: var(--fg-1);
+  flex-shrink: 0;
+}
+.blank .ways .lbl {
+  font-weight: 500;
+}
+.blank .hint {
+  margin-top: 18px;
+  max-width: 280px;
   font-size: 12.5px;
-  background: color-mix(in oklch, var(--warn), transparent 88%);
-  color: var(--warn);
-  border: 1px solid color-mix(in oklch, var(--warn), transparent 62%);
-}
-.conn.err {
-  background: color-mix(in oklch, var(--danger), transparent 88%);
-  color: var(--danger);
-  border-color: color-mix(in oklch, var(--danger), transparent 62%);
-}
-.conn .grow {
-  flex: 1;
-}
-.conn button {
-  color: inherit;
-  font-weight: 600;
-  text-decoration: underline;
+  line-height: 1.5;
+  color: var(--fg-3);
 }
 
 /* Add project: the section-header affordance on Home, and the sheet's own
@@ -794,9 +912,6 @@
 }
 .sect-add:active {
   background: var(--bg-3);
-}
-.empty .ap-empty {
-  margin-top: 16px;
 }
 .ap-seg {
   margin: 4px 0 14px;
@@ -833,7 +948,7 @@
   margin-top: 20px;
 }
 .ap-err {
-  padding: 14px 2px 0;
+  margin-top: 14px;
 }
 .ap-use {
   margin-top: 16px;

--- a/mobile/tests/addProject.test.ts
+++ b/mobile/tests/addProject.test.ts
@@ -172,6 +172,7 @@ describe("the sheet", () => {
       createElement(OpenFolderForm, {
         busy: false,
         error: "a folder already exists at /Users/alex/Code/relay",
+        setError: () => {},
         run: noop,
       }),
     );

--- a/mobile/tests/protocol.test.ts
+++ b/mobile/tests/protocol.test.ts
@@ -487,7 +487,11 @@ describe("reconnect", () => {
       clearTimer,
     });
     const reported: (string | undefined)[] = [];
-    client.onState((_state, error) => reported.push(error));
+    const retryingSeen: boolean[] = [];
+    client.onState((_state, error) => {
+      reported.push(error);
+      retryingSeen.push(client.retrying);
+    });
     const connected = client.connect({ host: "h", port: 1, hostKey: HOST_KEY });
     await vi.waitFor(() => expect(fake.sent.length).toBe(1));
     fake.reply(helloOk(fake.sent[0].id as string));
@@ -499,6 +503,10 @@ describe("reconnect", () => {
     expect(client.state).toBe("error");
     expect(reported.at(-1)).toBe("Your Mac is offline");
     expect(timers.map((t) => t.ms)).toEqual([1000]);
+    // The retry is scheduled before the error is announced, so a listener
+    // mirroring `retrying` into UI state sees "reconnecting", not "stuck".
+    expect(client.retrying).toBe(true);
+    expect(retryingSeen.at(-1)).toBe(true);
     // The relay's other device-link closes are readable too, not bare codes.
     expect(CLOSE_REASONS[CLOSE_TOO_MANY_DEVICES]).toContain("8 remote devices");
     expect(CLOSE_REASONS[CLOSE_RELAY_THROTTLED]).toContain("throttled");
@@ -520,6 +528,8 @@ describe("reconnect", () => {
     fake.hangup(CLOSE_UNAUTHENTICATED);
     expect(timers).toHaveLength(0);
     expect(client.state).toBe("error");
+    // Not retrying: the failure is one only the user can clear.
+    expect(client.retrying).toBe(false);
   });
 
   it("rejects in-flight calls when the socket drops", async () => {


### PR DESCRIPTION
## Summary

The mobile Home screen showed "No projects on the host" with **Add** and **New agent** buttons while the host had never answered, with a generic yellow alert banner above it and a broken empty-state layout (the button wrapped mid-sentence). This PR gives the connection its own honest full-screen state, redesigns the empty state, and replaces the ad-hoc alert styling with a shared inline `Notice`.

## What changed

**Home body now branches on what the app actually knows**
- **`HostState`** — the whole body when there is no workspace. Nothing offers to add or start anything until the host is live. Laptop glyph with a status dot, a title, one honest line, and only the actions that make sense:
  - Connecting: names the Mac and shows the real step (LAN / relay / greeting / workspace).
  - Error, retrying: the error text + "Reconnecting automatically…", with **Try now** and **Host details**.
  - Error the user has to clear (unpaired, remote access off, key mismatch): the reason and **Host details** only.
  - Disconnected: **Reconnect** and **Host details**.
  - Connected but snapshot still loading: "Loading your workspace" — also removes a flash of "No projects" right after pairing.
- **`EmptyProjects`** — only when a live host reports zero projects. Accent folder glyph, "No projects yet", one line of context, then the two ways in as tappable rows (**Open a folder**, **Clone from GitHub** → opens Add project on the Clone tab). New agent is hidden since there is nothing to start one in.
- **Cached list while offline** — if projects were already loaded and the link drops, the list stays read-only, Add and New agent disappear, and a slim persistent status line with **Retry** sits above it. No dismiss: it is state, not a message.

**Honest "reconnecting"**
- `ProtocolClient` exposes `retrying`; the store mirrors it. The retry is now scheduled *before* the error state is announced, so a listener never reads a stale value. Two protocol tests pin this.
- Host pill dot is amber while connecting instead of red.

**Shared `Notice` component** (`mobile/src/components/ui/Notice.tsx`)
- Neutral surface, tinted leading icon, optional action pill, optional dismiss. Replaces the red `.err` lines in the Pair screen and the New agent / Add project sheets.
- Dismissible where the message is about a finished action (spawn error, clone / open-folder errors); not dismissible where it is live state (connection line, failed folder listing, pairing error cleared by Try again, auto-clearing dictation errors).

**Small plumbing**
- `AddProjectSheet` accepts a `tab` prop through sheet props; `useAddProject` takes an initial tab.
- `Progress` on the Pair screen split into `STEP_LABELS` + `Working` so Home can reuse the same step copy.

## Verification
- `tsc --noEmit`, `biome check`, and `vitest` (150 tests) all pass in `mobile/`.
- Every state captured in headless Chromium at 393×852 @2x in dark and light: list, list-offline (retrying / fatal / reconnecting), host connecting / error-retrying / error-fatal / disconnected / loading, empty, New agent error notice with dismiss, Add project opening on the Clone tab, Pair error notice.
- Not verified on a physical device.